### PR TITLE
fix Amazon copyright statements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Amazon Web Services
+Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/demos/common/devmode_key_provisioning/CertificateConfigurationTool/CertificateConfigurator.html
+++ b/demos/common/devmode_key_provisioning/CertificateConfigurationTool/CertificateConfigurator.html
@@ -60,7 +60,7 @@
                         </div>
                     </div>
                     <div class="text-center">
-                        Copyright (C) 2017 Amazon Web Services.
+                        Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The Amazon copyright statement was incorrect in a few places, including in the top level LICENSE file.