### PR TITLE
Fix spelling mistake of comments

### DIFF
--- a/lib/include/task.h
+++ b/lib/include/task.h
@@ -301,7 +301,7 @@ is used in assert() statements. */
  TaskHandle_t xHandle = NULL;
 
 	 // Create the task, storing the handle.  Note that the passed parameter ucParameterToPass
-	 // must exist for the lifetime of the task, so in this case is declared static.  If it was just an
+	 // must exist for the lifetime of the task, so in this case is declared static.  If it was just 
 	 // an automatic stack variable it might no longer exist, or at least have been corrupted, by the time
 	 // the new task attempts to access it.
 	 xTaskCreate( vTaskCode, "NAME", STACK_SIZE, &ucParameterToPass, tskIDLE_PRIORITY, &xHandle );


### PR DESCRIPTION
Delete a redundant ‘an’ in the comments about the function that creates a task.