### PR TITLE
FreeRTOS_DNS: Repair LLMNR and FreeRTOS_gethostbyname_a function

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
+++ b/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
@@ -789,7 +789,6 @@ BaseType_t xIsCallingFromIPTask( void );
 typedef struct xSOCKET_SET
 {
 	EventGroupHandle_t xSelectGroup;
-	BaseType_t bApiCalled;	/* True if the API was calling  the private vSocketSelect */
 	FreeRTOS_Socket_t *pxSocket;
 } SocketSelect_t;
 

--- a/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
+++ b/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
@@ -789,7 +789,6 @@ BaseType_t xIsCallingFromIPTask( void );
 typedef struct xSOCKET_SET
 {
 	EventGroupHandle_t xSelectGroup;
-	FreeRTOS_Socket_t *pxSocket;
 } SocketSelect_t;
 
 extern void vSocketSelect( SocketSelect_t *pxSocketSelect );

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -446,7 +446,8 @@ TickType_t xIdentifier = 0;
 	/* Generate a unique identifier. */
 	if( 0 == ulIPAddress )
 	{
-		xIdentifier = ( TickType_t )ipconfigRAND32( );
+		/* DNS identifiers are 16-bit. */
+		xIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffff );
 	}
 
 	#if( ipconfigDNS_USE_CALLBACKS != 0 )
@@ -824,12 +825,9 @@ DNSMessage_t *pxDNSMessageHeader;
 	pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
 
-	if( pxNetworkBuffer->xDataLength > sizeof( UDPPacket_t ) )
-	{
-		prvParseDNSReply( pucUDPPayloadBuffer,
-			xPlayloadBufferLength,
-			( uint32_t )pxDNSMessageHeader->usIdentifier );
-	}
+	prvParseDNSReply( pucUDPPayloadBuffer,
+		xPlayloadBufferLength,
+		( uint32_t )pxDNSMessageHeader->usIdentifier );
 
 	/* The packet was not consumed. */
 	return pdFAIL;

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -830,6 +830,7 @@ DNSMessage_t *pxDNSMessageHeader;
 			xPlayloadBufferLength,
 			( uint32_t )pxDNSMessageHeader->usIdentifier );
 	}
+
 	/* The packet was not consumed. */
 	return pdFAIL;
 }

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -446,8 +446,7 @@ TickType_t xIdentifier = 0;
 	/* Generate a unique identifier. */
 	if( 0 == ulIPAddress )
 	{
-		/* DNS identifiers are 16-bit. */
-		xIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffff );
+		xIdentifier = ( TickType_t )ipconfigRAND32( );
 	}
 
 	#if( ipconfigDNS_USE_CALLBACKS != 0 )
@@ -825,10 +824,12 @@ DNSMessage_t *pxDNSMessageHeader;
 	pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
 
-	prvParseDNSReply( pucUDPPayloadBuffer, 
-		xPlayloadBufferLength,
-		( uint32_t )pxDNSMessageHeader->usIdentifier );
-
+	if( pxNetworkBuffer->xDataLength > sizeof( UDPPacket_t ) )
+	{
+		prvParseDNSReply( pucUDPPayloadBuffer, 
+			xPlayloadBufferLength,
+			( uint32_t )pxDNSMessageHeader->usIdentifier );
+	}
 	/* The packet was not consumed. */
 	return pdFAIL;
 }

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -826,7 +826,7 @@ DNSMessage_t *pxDNSMessageHeader;
 
 	if( pxNetworkBuffer->xDataLength > sizeof( UDPPacket_t ) )
 	{
-		prvParseDNSReply( pucUDPPayloadBuffer, 
+		prvParseDNSReply( pucUDPPayloadBuffer,
 			xPlayloadBufferLength,
 			( uint32_t )pxDNSMessageHeader->usIdentifier );
 	}

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -416,68 +416,68 @@ uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
 
-    /* If the supplied hostname is IP address, convert it to uint32_t
-    and return. */
-    #if( ipconfigINCLUDE_FULL_INET_ADDR == 1 )
-    {
-        ulIPAddress = FreeRTOS_inet_addr( pcHostName );
-    }
-    #endif /* ipconfigINCLUDE_FULL_INET_ADDR == 1 */
+	/* If the supplied hostname is IP address, convert it to uint32_t
+	and return. */
+	#if( ipconfigINCLUDE_FULL_INET_ADDR == 1 )
+	{
+		ulIPAddress = FreeRTOS_inet_addr( pcHostName );
+	}
+	#endif /* ipconfigINCLUDE_FULL_INET_ADDR == 1 */
 
-    /* If a DNS cache is used then check the cache before issuing another DNS
-    request. */
-    #if( ipconfigUSE_DNS_CACHE == 1 )
-    {
-        if( ulIPAddress == 0UL )
-        {
-            ulIPAddress = FreeRTOS_dnslookup( pcHostName );
-            if( ulIPAddress != 0 )
-            {
-                FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
-            }
-            else
-            {
-                /* prvGetHostByName will be called to start a DNS lookup */
-            }
-        }
-    }
-    #endif /* ipconfigUSE_DNS_CACHE == 1 */
+	/* If a DNS cache is used then check the cache before issuing another DNS
+	request. */
+	#if( ipconfigUSE_DNS_CACHE == 1 )
+	{
+		if( ulIPAddress == 0UL )
+		{
+			ulIPAddress = FreeRTOS_dnslookup( pcHostName );
+			if( ulIPAddress != 0 )
+			{
+				FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
+			}
+			else
+			{
+				/* prvGetHostByName will be called to start a DNS lookup */
+			}
+		}
+	}
+	#endif /* ipconfigUSE_DNS_CACHE == 1 */
 
-    /* Generate a unique identifier. */
-    if( 0 == ulIPAddress )
-    {
+	/* Generate a unique identifier. */
+	if( 0 == ulIPAddress )
+	{
 		/* DNS identifiers are 16-bit. */
-        xIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffff );
-    }
+		xIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffff );
+	}
 
-    #if( ipconfigDNS_USE_CALLBACKS != 0 )
-    {
-        if( pCallback != NULL )
-        {
-            if( ulIPAddress == 0UL )
-            {
-                /* The user has provided a callback function, so do not block on recvfrom() */
-                if( 0 != xIdentifier )
-                {
-                    xReadTimeOut_ms = 0;
-                    vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )xIdentifier );
-                }
-            }
-            else
-            {
-                /* The IP address is known, do the call-back now. */
-                pCallback( pcHostName, pvSearchID, ulIPAddress );
-            }
-        }
-    }
-    #endif
+	#if( ipconfigDNS_USE_CALLBACKS != 0 )
+	{
+		if( pCallback != NULL )
+		{
+			if( ulIPAddress == 0UL )
+			{
+				/* The user has provided a callback function, so do not block on recvfrom() */
+				if( 0 != xIdentifier )
+				{
+					xReadTimeOut_ms = 0;
+					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )xIdentifier );
+				}
+			}
+			else
+			{
+				/* The IP address is known, do the call-back now. */
+				pCallback( pcHostName, pvSearchID, ulIPAddress );
+			}
+		}
+	}
+	#endif
 
-    if( ulIPAddress == 0UL && 0 != xIdentifier )
-    {
-        ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
-    }
+	if( ( ulIPAddress == 0UL ) && ( 0 != xIdentifier ) )
+	{
+		ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
+	}
 
-    return ulIPAddress;
+	return ulIPAddress;
 }
 /*-----------------------------------------------------------*/
 

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
@@ -420,10 +420,7 @@ Socket_t xReturn;
 			pxSocket->pxSocketSet = ( SocketSelect_t * ) xSocketSet;
 
 			/* Now have the IP-task call vSocketSelect() to see if the set contains
-			any sockets which are 'ready' and set the proper bits.
-			By setting 'bApiCalled = false', vSocketSelect() knows that it was
-			not called from a user API */
-			pxSocketSet->bApiCalled = pdFALSE;
+			any sockets which are 'ready' and set the proper bits. */
 			prvFindSelectedSocket( pxSocketSet );
 		}
 	}
@@ -522,7 +519,6 @@ Socket_t xReturn;
 			#endif /* ipconfigSUPPORT_SIGNALS */
 
 			/* Have the IP-task find the socket which had an event */
-			pxSocketSet->bApiCalled = pdTRUE;
 			prvFindSelectedSocket( pxSocketSet );
 
 			xResult = ( BaseType_t ) xEventGroupGetBits( pxSocketSet->xSelectGroup );

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_UDP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_UDP_IP.c
@@ -347,6 +347,19 @@ UDPPacket_t *pxUDPPacket = (UDPPacket_t *) pxNetworkBuffer->pucEthernetBuffer;
 		/* There is no socket listening to the target port, but still it might
 		be for this node. */
 
+		#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+			/* A DNS reply, check for the source port.  Although the DNS client
+			does open a UDP socket to send a messages, this socket will be
+			closed after a short timeout.  Messages that come late (after the
+			socket is closed) will be treated here. */
+			if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ipDNS_PORT )
+			{
+				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+				xReturn = ( BaseType_t )ulDNSHandlePacket( pxNetworkBuffer );
+			}
+			else
+		#endif
+
 		#if( ipconfigUSE_LLMNR == 1 )
 			/* a LLMNR request, check for the destination port. */
 			if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||


### PR DESCRIPTION
With these changes, the non-blocking function FreeRTOS_gethostbyname_a() will work properly again.
A DNS ID is 16 bits, and not 32-bits ( see xIdentifier = ipconfigRAND32 in FreeRTOS_DNS ).
ulDNSHandlePacket() must be called for incoming DNS replies ( in FreeRTOS_UDP_IP ).
And also LLMNR requests will be responded to correctly.

Signed-off-by: Hein Tibosch <hein@htibosch.net>