### PR TITLE
Fixed error in return type of xTaskCreateStatic

### DIFF
--- a/lib/include/task.h
+++ b/lib/include/task.h
@@ -375,9 +375,9 @@ is used in assert() statements. */
  * memory to be allocated dynamically.
  *
  * @return If neither pxStackBuffer or pxTaskBuffer are NULL, then the task will
- * be created and pdPASS is returned.  If either pxStackBuffer or pxTaskBuffer
- * are NULL then the task will not be created and
- * errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY is returned.
+ * be created and a task handle will be returned by which the created task
+ * can be referenced.  If either pxStackBuffer or pxTaskBuffer
+ * are NULL then the task will not be created and NULL is returned.
  *
  * Example usage:
    <pre>


### PR DESCRIPTION
The xTaskCreateStatic claimed that it return pdPASS or an error value depending on success, but what they it returns is an TaskHandle_t.

This error is also in official FreeRTOS.