### PR TITLE
fix: Microchip demo project build failure on Mac

### DIFF
--- a/demos/common/ota/bootloader/utility/binary_image_generator.py
+++ b/demos/common/ota/bootloader/utility/binary_image_generator.py
@@ -1,0 +1,29 @@
+import os
+import argparse
+
+
+def parseParams():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-d', '--dir', required=True, help="Directory containing objcopy tool.")
+    parser.add_argument('-b', '--bin', required=True, help="Name of objcopy tool.")
+    parser.add_argument('-p', '--params', required=True, help="parameters to be passed to objcopy tool.")
+
+    args = vars(parser.parse_args())
+    return args
+
+
+def main():
+    args = parseParams()
+
+    objcopy_dir = args['dir']
+    objcopy_bin = args['bin']
+    objcopy_full_path = os.path.join(objcopy_dir, objcopy_bin)
+
+    bin_converter_command = '"' + objcopy_full_path + '"' + ' ' + args['params']
+    print('Executing.. {}'.format(bin_converter_command))
+    os.system(bin_converter_command)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/common/ota/bootloader/utility/ota_image_generator.py
+++ b/demos/common/ota/bootloader/utility/ota_image_generator.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+import struct
 from collections import namedtuple
 
 from util import validateFilePath \
@@ -31,29 +32,28 @@ def printOTADescriptorImageStruct(processedImagePath, imageLines, offset):
     try:
         print(cuttingLine + "Generated OTA descriptor" + cuttingLine)
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> sequence number")
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> sequence number")
 
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> start address")
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> start address")
+        byte = f.read(4)
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> end address")
 
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> end address")
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> execution address")
 
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> execution address")
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> hardware ID")
 
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> hardware ID")
-
-        byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))), " -> reserved bytes")
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])), " -> reserved bytes")
 
         print(cuttingLine + "Image Content" + cuttingLine)
         time = imageLines
         while time > 0:
             byte = f.read(4)  # Every time print 32 bits
             time -= 1
-            print(format32BitHexStr(hex(int.from_bytes(byte, "little"))))
+            print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])))
         print("...")
         print("...")
     finally:

--- a/demos/common/ota/bootloader/utility/util.py
+++ b/demos/common/ota/bootloader/utility/util.py
@@ -93,7 +93,7 @@ def toLitteEndianByte(hexStr):
     byteData = binascii.unhexlify(hexStr)
 
     # convert to unsigned int
-    x = int.from_bytes(byteData, byteorder='big', signed=False)
+    x = struct.unpack('>I', byteData)[0]
 
     # pack it into little endian format
     return struct.pack('<I', x)
@@ -114,7 +114,7 @@ def printHeaderFromLittleEndian(imagePath, numLines):
         while time > 0:
             byte = f.read(4)  # 32 bit machine uses 4 bytes
             time -= 1
-            print(format32BitHexStr(hex(int.from_bytes(byte, "little"))))
+            print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])))
 
     finally:
         f.close()

--- a/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
+++ b/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
@@ -1794,7 +1794,7 @@
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
         <makeCustomizationPreStep></makeCustomizationPreStep>
         <makeCustomizationPostStepEnabled>true</makeCustomizationPostStepEnabled>
-        <makeCustomizationPostStep>${MP_CC_DIR}\xc32-objcopy -I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin &amp;&amp; python ../../../common/ota/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
+        <makeCustomizationPostStep>python ../../../common/ota/bootloader/utility/binary_image_generator.py -d ${MP_CC_DIR} -b xc32-objcopy -p "-I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin" &amp;&amp; python ../../../common/ota/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
         <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
         <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
         <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>


### PR DESCRIPTION
Description
-----------
There were two problems:

1. MPLab IDE's Post Build step invokes python 2.7 and we were using
python 3 constructs in some of our scripts which caused build failure.
This commit removes those python 3 constructs and uses python 2.7 ones
instead.

2. Post Build command was {MP_CC_DIR}\xc32-objcopy which failed on mac
because of backslash. Changing it to forward slash i.e.
{MP_CC_DIR}/xc32-objcopy caused it to fail windows. This commit adds a
python script which is invoked in Post Build step. This script handles
this path issue in a platform agnostic way.

Testing
----------
Compared the generated binaries using diff both with and without changes:
```
$ diff -r -s b1/ b2/
Files b1/memoryfile.xml and b2/memoryfile.xml are identical
Files b1/mplab.production.bin and b2/mplab.production.bin are identical
Files b1/mplab.production.elf and b2/mplab.production.elf are identical
Files b1/mplab.production.hex and b2/mplab.production.hex are identical
Files b1/mplab.production.map and b2/mplab.production.map are identical
Files b1/mplab.production.ota.bin and b2/mplab.production.ota.bin are identical
Files b1/mplab.production.unified.hex and b2/mplab.production.unified.hex are identical
```
Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
