### PR TITLE
Fix git secrets checks in git hooks

### DIFF
--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -100,7 +100,7 @@ def is_ignored_file_pattern(file_name):
 
 
 def check_secrets(changed_files):
-    if subprocess.call("git secrets --scan", shell=True):
+    if subprocess.call("git secrets --scan " + " ".join(changed_files), shell=True):
         return ['git_secrets']
     return []
 

--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -100,7 +100,7 @@ def is_ignored_file_pattern(file_name):
 
 
 def check_secrets(changed_files):
-    if subprocess.call("git-secrets --scan", shell=True):
+    if subprocess.call("git secrets --scan", shell=True):
         return ['git_secrets']
     return []
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR fixes 2 problems:

- `git-secrets` won't work on Windows since it's not an executable but a script that can be picked up by git, so that you can call `git secrets`. This PR fix the the commit check hook.
- staged files were not passed to git secrets checks.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have tested my changes. No regression in existing tests.~~
- [ ] ~~My code is Linted.~~
