### PR TITLE
fix: Update nargs parameter in afqp_check argparse

### DIFF
--- a/tools/checks/afqp/afqp_check/src/afqp_check.py
+++ b/tools/checks/afqp/afqp_check/src/afqp_check.py
@@ -374,7 +374,7 @@ def main():
     parser = argparse.ArgumentParser(description='AFQP File System Check')
     parser.add_argument('--root', action='store', required=False, dest='root', default=AFR_ROOT, help='Amazon FreeRTOS Root Path. This path is relative to the /afqp_check folder by default ({}).'.format(AFR_ROOT))
     parser.add_argument('--rules', action='store', required=False, dest='rules_path', default='rules.json', help='The path to the rules json file. This path is relative to the /afqp_check folder by default.')
-    parser.add_argument('--files', nargs='*', action='append', required=False, dest='files', help='List of files changed.')
+    parser.add_argument('--files', nargs='+', required=False, dest='files', help='List of files changed.')
     parser.add_argument('--vendor', action='store', required=True, dest='vendor', help='Expected vendor directory name.')
     parser.add_argument('--board', action='store', required=True, dest='board', help='Expected board directory name.')
     parser.add_argument('--ide', action='store', required=True, dest='ide', help='Expected IDE directory name.')


### PR DESCRIPTION
Why:
The argparse add_argument parameter must be nargs='+' for a flat list input.

The input argument for --files was not being properly handled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~I have tested my changes. No regression in existing tests.~
- [ ] ~My code is Linted.~
