### PR TITLE
fix: Do not run git secrets if no file changed

### DIFF
--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -100,6 +100,8 @@ def is_ignored_file_pattern(file_name):
 
 
 def check_secrets(changed_files):
+    if not changed_files:
+        return []
     if subprocess.call("git secrets --scan " + " ".join(changed_files), shell=True):
         return ['git_secrets']
     return []

--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -23,8 +23,7 @@ def commit_is_ready(file_names=""):
     if not file_names:
         file_names = get_modified_files()
 
-    existing_files = filter(file_exists, file_names)
-    source_file_names = filter(file_is_checkable, existing_files)
+    files_to_check = [f for f in file_names if file_exists(f) and file_is_checkable(f)]
 
     checks = [
         check_secrets,
@@ -33,7 +32,7 @@ def commit_is_ready(file_names=""):
         check_whitespace,
     ]
     for check in checks:
-        failed_files = check(source_file_names)
+        failed_files = check(files_to_check)
         if failed_files:
             return failed_files
     return []


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
If staged files are in ignore list, git secrets will check the entire working tree. Instead, it should simply return and pass the check.

Testing:
----------
Local unit tests passed, result:
`81 passed in 0.43 seconds`

Also tested with repo set up in a same way described in description,
```
On branch fix/git_hook
Your branch is up to date with 'origin/fix/git_hook'.

Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	modified:   lib/ota/portable/ti/cc3220_launchpad/aws_ota_pal.c

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   tests/common/include/aws_clientcredential.h
	modified:   tests/common/include/aws_clientcredential_keys.h
```
With this fix, the pre-commit check will pass.
Without this fix, the pre-commit check will fail.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~My code is Linted.~~
