### PR TITLE
fix: Use symbolic links for git hooks

### DIFF
--- a/tools/git/hooks/install_hooks.ps1
+++ b/tools/git/hooks/install_hooks.ps1
@@ -1,2 +1,3 @@
-New-Item -ItemType HardLink -Name ../../../.git/hooks/pre-commit -Value src/pre_commit.py
-New-Item -ItemType HardLink -Name ../../../.git/hooks/commit-msg -Value src/commit_msg.py
+Remove-Item -Recurse -Force ..\..\..\.git\hooks\*
+cmd /c mklink ..\..\..\.git\hooks\pre-commit ..\..\tools\git\hooks\src\pre_commit.py
+cmd /c mklink ..\..\..\.git\hooks\commit-msg ..\..\tools\git\hooks\src\commit_msg.py

--- a/tools/git/hooks/install_hooks.sh
+++ b/tools/git/hooks/install_hooks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 rm -rf ../../../.git/hooks/*
-ln src/pre_commit.py ../../../.git/hooks/pre-commit
-ln src/commit_msg.py ../../../.git/hooks/commit-msg
+ln -s ../../tools/git/hooks/src/pre_commit.py ../../../.git/hooks/pre-commit
+ln -s ../../tools/git/hooks/src/commit_msg.py ../../../.git/hooks/commit-msg


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Git hooks were set up with hard link before. However, git checkout will remove local file and replace it with a new file, thus breaking the hard link. We should use symbolic links instead.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have tested my changes. No regression in existing tests.~~
- [ ] ~~My code is Linted.~~
