### PR TITLE
Fix bug in OTA PALs for Microchip & ESP

### DIFF
--- a/demos/common/ota/bootloader/utility/codesigner_cert_utility/codesigner_cert_utility.py
+++ b/demos/common/ota/bootloader/utility/codesigner_cert_utility/codesigner_cert_utility.py
@@ -49,7 +49,10 @@ def main():
                 header_file.write("\n" + indentation)
             else:
                 header_file.write(" ")
-            header_file.write("0x{:02x},".format(b))
+            if sys.version_info[0] == 2:
+                header_file.write("0x{:02x},".format(ord(b)))
+            else:
+                header_file.write("0x{:02x},".format(b))
         header_file.write("\n" + indentation + end)
         header_file.write(var_length_name + str(len(pubkeybytes)) + ";")
 	

--- a/demos/common/ota/bootloader/utility/factory_image_generator.py
+++ b/demos/common/ota/bootloader/utility/factory_image_generator.py
@@ -1,9 +1,9 @@
-import argparse
 import os
 import sys
+import struct
+import argparse
 
 from OpenSSL import crypto
-
 from ota_image_generator import printOTADescriptorImageStruct \
     , generateOTADescriptorImage
 from util import validateFilePath \
@@ -54,7 +54,7 @@ def printFactoryImageStruct(processedImagePath, trailerSize, numLinesImageConten
 
         print(subCuttingLine + " signature size " + subCuttingLine)
         byte = f.read(4)
-        print(format32BitHexStr(hex(int.from_bytes(byte, "little"))))
+        print(format32BitHexStr(hex(struct.unpack('<I', byte)[0])))
 
         byte = f.read()
         print(subCuttingLine + " signature " + subCuttingLine)
@@ -214,7 +214,7 @@ def addFactoryMagicCode(inputImagePath, outputPath):
     magicCode = bytearray("@AFRTOS".encode('ASCII'))
 
     # end byte is 0xFC
-    endByte = bytes.fromhex("FC")
+    endByte = bytearray.fromhex("FC")
 
     magicCode.extend(endByte)
 

--- a/lib/ota/portable/microchip/curiosity_pic32mzef/aws_ota_pal.c
+++ b/lib/ota/portable/microchip/curiosity_pic32mzef/aws_ota_pal.c
@@ -552,32 +552,37 @@ static CK_RV prvGetCertificate( const char * pcLabelName,
         xTemplate.type = CKA_VALUE;
         xTemplate.pValue = NULL;
         xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        pucCert = pvPortMalloc( xTemplate.ulValueLen );
-    }
-
-    if( ( xResult == CKR_OK ) && ( pucCert == NULL ) )
-    {
-        xResult = CKR_HOST_MEMORY;
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xTemplate.pValue = pucCert;
-        xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
 
         if( xResult == CKR_OK )
         {
-            *ppucData = pucCert;
-            *pulDataSize = xTemplate.ulValueLen;
+            pucCert = pvPortMalloc( xTemplate.ulValueLen );
         }
-        else
+
+        if( ( xResult == CKR_OK ) && ( pucCert == NULL ) )
         {
-            vPortFree( pucCert );
+            xResult = CKR_HOST_MEMORY;
         }
+
+        if( xResult == CKR_OK )
+        {
+            xTemplate.pValue = pucCert;
+            xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
+
+            if( xResult == CKR_OK )
+            {
+                *ppucData = pucCert;
+                *pulDataSize = xTemplate.ulValueLen;
+            }
+            else
+            {
+                vPortFree( pucCert );
+            }
+        }
+    }
+    else /* Certificate was not found. */
+    {
+        *ppucData = NULL;
+        *pulDataSize = 0;
     }
 
     if( xSessionOpen == CK_TRUE )
@@ -599,8 +604,11 @@ static uint8_t * prvPAL_ReadAndAssumeCertificate( const uint8_t * const pucCertN
     uint8_t * pucCertData;
     uint32_t ulCertSize;
     uint8_t * pucSignerCert = NULL;
+    CK_RV xResult;
 
-    if( prvGetCertificate( ( const char * ) pucCertName, &pucSignerCert, &ulCertSize ) == CKR_OK )
+    xResult = prvGetCertificate( ( const char * ) pucCertName, &pucSignerCert, ulSignerCertSize );
+
+    if( ( xResult == CKR_OK ) && ( pucSignerCert != NULL ) )
     {
         OTA_LOG_L1( "[%s] Using cert with label: %s OK\r\n", OTA_METHOD_NAME, ( const char * ) pucCertName );
     }


### PR DESCRIPTION
git issue #90

aws_ota_pal.c for Microchip and ESP did not check if valid
code verification certificate handle was found, and proceeds to
malloc a 0-length buffer for a non-existent certificate.  This
caused OTA code verification to fail for OTAs relyng on certificate
located in aws_ota_codesigner_certificate.h.

This fix makes sure the prvGetCertificate checks if the certificate
handle is valid before mallocing memory for it, and implements a
check for a non-null certificate value in prvPAL_ReadAndAssumeCertificate.

Small updates to factory_image_generator.py script to make it agnostic of
Python version 2 or 3.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
