### PR TITLE
Add FreeRTOS.h include warning to library headers

### DIFF
--- a/demos/common/include/aws_logging_task.h
+++ b/demos/common/include/aws_logging_task.h
@@ -26,11 +26,17 @@
 #ifndef AWS_LOGGING_TASK_H
 #define AWS_LOGGING_TASK_H
 
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include aws_logging_task.h"
+#endif
+
 /*
  * Called once to create the logging task and queue.  Must be called before any
  * calls to vLoggingPrintf().
-*/
-BaseType_t xLoggingTaskInitialize( uint16_t usStackSize, UBaseType_t uxPriority, UBaseType_t uxQueueLength );
+ */
+BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
+                                   UBaseType_t uxPriority,
+                                   UBaseType_t uxQueueLength );
 
 /*
  * Uses the same semantics as printf().  How the print is performed depends on
@@ -39,6 +45,7 @@ BaseType_t xLoggingTaskInitialize( uint16_t usStackSize, UBaseType_t uxPriority,
  * output in the background should the output device be too slow for output to
  * be performed inline.
  */
-void vLoggingPrintf( const char *pcFormat, ... );
+void vLoggingPrintf( const char * pcFormat,
+                     ... );
 
 #endif /* AWS_LOGGING_TASK_H */

--- a/lib/include/aws_system_init.h
+++ b/lib/include/aws_system_init.h
@@ -22,9 +22,13 @@
  * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
  */
- 
+
 #ifndef _AWS_SYSTEM_INIT_H_
 #define _AWS_SYSTEM_INIT_H_
+
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include aws_system_init.h"
+#endif
 
 BaseType_t SYSTEM_Init();
 

--- a/lib/include/aws_tls.h
+++ b/lib/include/aws_tls.h
@@ -27,6 +27,10 @@
 #ifndef __AWS__TLS__H__
 #define __AWS__TLS__H__
 
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include aws_tls.h"
+#endif
+
 /**
  * @brief Defines callback type for receiving bytes from the network.
  *

--- a/lib/include/message_buffer.h
+++ b/lib/include/message_buffer.h
@@ -62,6 +62,10 @@
 #ifndef FREERTOS_MESSAGE_BUFFER_H
 #define FREERTOS_MESSAGE_BUFFER_H
 
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include message_buffer.h"
+#endif
+
 /* Message buffers are built onto of stream buffers. */
 #include "stream_buffer.h"
 

--- a/lib/include/stream_buffer.h
+++ b/lib/include/stream_buffer.h
@@ -51,6 +51,10 @@
 #ifndef STREAM_BUFFER_H
 #define STREAM_BUFFER_H
 
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include stream_buffer.h"
+#endif
+
 #if defined( __cplusplus )
 extern "C" {
 #endif


### PR DESCRIPTION
In order to guarantee correct include order, FreeRTOS.h must be
included before FreeRTOS library headers that rely on FreeRTOS
kernel types and prototypes.  These changes add an error with
instructions to include the required header.

Resolves issue #93

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
