### PR TITLE
fix: Delete extra headers in aws_pkcs11_mbedtls.c.

### DIFF
--- a/lib/pkcs11/mbedtls/aws_pkcs11_mbedtls.c
+++ b/lib/pkcs11/mbedtls/aws_pkcs11_mbedtls.c
@@ -33,10 +33,7 @@
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
-#include "FreeRTOSIPConfig.h"
 #include "aws_pkcs11_config.h"
-#include "task.h"
-#include "semphr.h"
 #include "aws_crypto.h"
 #include "aws_pkcs11.h"
 


### PR DESCRIPTION
fix: Delete extra headers in aws_pkcs11_mbedtls.c.

Header files:
#include "FreeRTOSIPConfig.h"
#include "task.h"
#include "semphr.h"
Were not being used.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
