### PR TITLE
Resolve warnings in TI's test project

### DIFF
--- a/tests/ti/cc3220_launchpad/common/application_code/ti_code/network_if.c
+++ b/tests/ti/cc3220_launchpad/common/application_code/ti_code/network_if.c
@@ -58,6 +58,12 @@
 #include "network_if.h"
 #include "uart_term.h"
 
+/* Redefine UART_PRINT to no-op so that test output is not clobbered. */
+#ifdef UART_PRINT
+#undef UART_PRINT
+#define UART_PRINT(X, ...) do {} while(0)
+#endif
+
 //*****************************************************************************
 //                          LOCAL DEFINES
 //*****************************************************************************
@@ -524,7 +530,7 @@ long Network_IF_ConnectAP(char *pcSsid, SlWlanSecParams_t SecurityParams)
                 ucRecvdAPDetails = 0;
 
                 UART_PRINT("\n\r\n\rPlease enter the AP(open) SSID name # ");
-                
+
                 /* Get the AP name to connect over the UART                       */
                 lRetVal = GetCmd(acCmdStore, sizeof(acCmdStore));
                 if (lRetVal > 0)
@@ -589,7 +595,7 @@ long Network_IF_ConnectAP(char *pcSsid, SlWlanSecParams_t SecurityParams)
             /* Send the information                                                   */
             UART_PRINT("Device IP Address is %d.%d.%d.%d \n\r\n\r", SL_IPV4_BYTE(ulIP, 3), SL_IPV4_BYTE(ulIP, 2), SL_IPV4_BYTE(ulIP, 1), SL_IPV4_BYTE(ulIP, 0));
             return 0;
-            
+
     #ifdef AMAZON_FREERTOS_ENABLE_UNIT_TESTS
         }
         else {

--- a/tests/ti/cc3220_launchpad/common/application_code/ti_code/uart_term.h
+++ b/tests/ti/cc3220_launchpad/common/application_code/ti_code/uart_term.h
@@ -7,8 +7,7 @@
 
 //Defines
 
-/* UART_PRINT is undefined so that test output is not clobbered. */
-#define UART_PRINT
+#define UART_PRINT Report
 #define DBG_PRINT  Report
 #define ERR_PRINT(x) Report("Error [%d] at line [%d] in function [%s]  \n\r",x,__LINE__,__FUNCTION__)
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
2 Warnings resolved in this commit:
- FreeRTOS.h redefine UART_PRINT from uart_term.h
- No effect statement in network_if.c

Previously UART_PRINT was defined to nothing so that test output is not
clobbered. This commit moves the redefine from uart_term.h to network_if.c
and redefine it to do {} while(0) to resolve 2 warnings introduced above.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
