### PR TITLE
Remove unused configs from aws_pkcs11_config.h

### DIFF
--- a/demos/xilinx/microzed/common/config_files/aws_pkcs11_config.h
+++ b/demos/xilinx/microzed/common/config_files/aws_pkcs11_config.h
@@ -32,12 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
- /**
- * @brief File storage location definitions.
- */
-#define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
-#define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
-
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 /* #define pkcs11configC_INITIALIZE_ALT */
 

--- a/tests/espressif/esp32_devkitc_esp_wrover_kit/common/config_files/aws_pkcs11_config.h
+++ b/tests/espressif/esp32_devkitc_esp_wrover_kit/common/config_files/aws_pkcs11_config.h
@@ -33,12 +33,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/**
- * @brief File storage location definitions.
- */
-//#define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "ESP_P11_Cert"
-//#define pkcs11configFILE_NAME_KEY                   "ESP_P11_Key"
-
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 /* #define pkcs11configC_INITIALIZE_ALT */
 

--- a/tests/infineon/xmc4800_iotkit/common/config_files/aws_pkcs11_config.h
+++ b/tests/infineon/xmc4800_iotkit/common/config_files/aws_pkcs11_config.h
@@ -32,12 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/**
- * @brief File storage location definitions.
- */
-#define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
-#define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
-
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 #define pkcs11configC_INITIALIZE_ALT
 

--- a/tests/ti/cc3220_launchpad/common/config_files/aws_pkcs11_config.h
+++ b/tests/ti/cc3220_launchpad/common/config_files/aws_pkcs11_config.h
@@ -32,12 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/**
- * @brief File storage location definitions.
- */
-#define pkcs11FILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
-#define pkcs11FILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
-
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 /* #define pkcs11configC_INITIALIZE_ALT */
 

--- a/tests/vendor/board/common/config_files/aws_pkcs11_config.h
+++ b/tests/vendor/board/common/config_files/aws_pkcs11_config.h
@@ -32,12 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/**
- * @brief File storage location definitions.
- */
-#define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
-#define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
-
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 /* #define pkcs11configC_INITIALIZE_ALT */
 

--- a/tests/xilinx/microzed/common/config_files/aws_pkcs11_config.h
+++ b/tests/xilinx/microzed/common/config_files/aws_pkcs11_config.h
@@ -32,11 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/**
- * @brief File storage location definitions.
- */
-#define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
-#define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 
 /* A non-standard version of C_INITIALIZE should be used by this port. */
 /* #define pkcs11configC_INITIALIZE_ALT */


### PR DESCRIPTION
In release 1.4.3, PKCS #11 objects switched from being
accessed by file name to being accessed by label name.

As a result, pkcs11configFILE_NAME_* configs are now a property
of the portable PAL layer and are unused in the config file.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
