### PR TITLE
Modify style checker for PKCS #11 types

### DIFF
--- a/tools/checks/style/hn_check/readme.md
+++ b/tools/checks/style/hn_check/readme.md
@@ -9,6 +9,8 @@
 #### Testing
 Run ```py.test``` from the ```.../git/hooks``` directory
 
+If that doesn't work you can also try running ```python -m pytest .\test\test_hn_check.py``` from this directory.
+
 ##### Dependencies
 * ```mock```
 * ```pytest```

--- a/tools/checks/style/hn_check/src/hn_check.py
+++ b/tools/checks/style/hn_check/src/hn_check.py
@@ -233,8 +233,7 @@ def get_base_prefix(type_name):
 def get_identifier_prefix(identifier):
     direct_identifier = re.sub(r"^p+", "", identifier)
     indirection = "p" * (len(identifier) - len(direct_identifier))
-    for key in TYPE_PREFIXES:
-        prefix = TYPE_PREFIXES[key]
+    for prefix in TYPE_PREFIXES.values():
         if re.match(r"^" + prefix + r"[0-9,A-Z]", direct_identifier):
             return indirection + prefix
     return ''

--- a/tools/checks/style/hn_check/src/hn_check.py
+++ b/tools/checks/style/hn_check/src/hn_check.py
@@ -182,9 +182,20 @@ def get_prefix(line):
     prefix = "p" * indirection + "u" * unsigned + base_prefix
     return prefix
 
+# PKCS #11 types may have the format
+# CK_TYPE_PTR or CK_TYPE_PTR_PTR
+def count_pkcs11_indirection(line):
+    base_prefix = get_base_type(line)
+    if (re.search("_PTR_PTR$", base_prefix)):
+        return 2
+    elif (re.search("_PTR$", base_prefix)):
+        return 1
+    else:
+        return 0
 
 def count_indirection(line):
     pointer_count = line.count('*')
+    pointer_count += count_pkcs11_indirection(line)
     return pointer_count
 
 
@@ -224,7 +235,7 @@ def get_identifier_prefix(identifier):
     indirection = "p" * (len(identifier) - len(direct_identifier))
     for key in TYPE_PREFIXES:
         prefix = TYPE_PREFIXES[key]
-        if re.match(r"^" + prefix + r"[A-Z]", direct_identifier):
+        if re.match(r"^" + prefix + r"[0-9,A-Z]", direct_identifier):
             return indirection + prefix
     return ''
 

--- a/tools/checks/style/hn_check/test/test_hn_check.py
+++ b/tools/checks/style/hn_check/test/test_hn_check.py
@@ -139,12 +139,29 @@ count_indirection_params = [
     ("int x[2]", 0),
     ("int x[2][3]", 0),
     ("int * x[2][3]", 1),
+    ("CK_FUNCTION_LIST_PTR", 1),
+    ("CK_FUNCTION_LIST_PTR *", 2),
+    ("CK_FUNCTION_LIST_PTR_PTR", 2),
 ]
 @pytest.mark.parametrize("input, expected", count_indirection_params)
 def test_count_indirection(input, expected):
     result = hn_check.count_indirection(input)
     assert expected == result
 
+# PKCS #11 indirection only counts indirection from _PTR
+# in type name, and not due to *
+count_pkcs11_indirection_params = [
+    ("int x", 0),
+    ("int * x", 0),
+    ("int ** x", 0),
+    ("CK_FUNCTION_LIST_PTR", 1),
+    ("CK_FUNCTION_LIST_PTR *", 1),
+    ("CK_FUNCTION_LIST_PTR_PTR", 2),
+]
+@pytest.mark.parametrize("input, expected", count_pkcs11_indirection_params)
+def test_count_pkcs11_indirection(input, expected):
+    result = hn_check.count_pkcs11_indirection(input)
+    assert expected == result
 
 get_prefix_params = [
     ("char * topic;", "pc"),
@@ -195,6 +212,7 @@ get_identifier_prefix_params = [
     ("success", ""),
     ("sVar", "s"),
     ("xVar", "x"),
+    ("px123", "px"),
 ]
 @pytest.mark.parametrize("input, expected", get_identifier_prefix_params)
 def test_get_identifier_prefix(input, expected):


### PR DESCRIPTION
PKCS #11 types may follow the format CK_TYPE_PTR or CK_TYPE_PTR_PTR.
This change updates the style checker to recognize _PTR and _PTR_PTR
line endings as pointer types.

This change also allows variables to start with a number.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~I have tested my changes. No regression in existing tests.~
- [ ] ~My code is Linted.~
