### PR TITLE
Fix:Removing old ACE name from the APIs

### DIFF
--- a/lib/include/bluetooth_low_energy/bt_hal_avsrc_profile.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_avsrc_profile.h
@@ -25,15 +25,15 @@
 
 
 
-#ifndef ACEHAL_BT_HAL_AVSRC_PROFILE_H
-#define ACEHAL_BT_HAL_AVSRC_PROFILE_H
+#ifndef BT_HAL_AVSRC_PROFILE_H
+#define BT_HAL_AVSRC_PROFILE_H
 
 #include <stdint.h>
 #include "bt_hal_gatt_types.h"
 #include "hardware/bluetooth.h"
 #include "hardware/bt_av.h"
 
-/* Bluetooth AV connection states */
+/** Bluetooth AV connection states */
 typedef enum
 {
     eBTAvsrcConnectionStateDisconnected = 0,
@@ -42,7 +42,7 @@ typedef enum
     eBTAvsrcConnectionStateDisconnecting
 } BTAvConnectionState_t;
 
-/* Bluetooth AV datapath states */
+/** Bluetooth AV data path states */
 typedef enum
 {
     eBTAvsrcAudioStateRemoteSuspend = 0,
@@ -50,10 +50,11 @@ typedef enum
     eBTAvsrcAudioStateStarted,
 } BTAvAudioState_t;
 
+/** Callback invoked in to notifiy AV connection state change */
 typedef void (* BTAvsrcConnectionStateCallback_t)( BTAvConnectionState_t xState,
                                                    BTBdaddr_t * pxBdAddr );
 
-
+/** Callback invoked in to notifiy AV Audio state change */
 typedef void (* BTAvsrcAudioStateCallback_t)( BTAvAudioState_t xState,
                                               BTBdaddr_t * pxBdAddr );
 
@@ -64,43 +65,40 @@ typedef struct
     BTAvsrcAudioStateCallback_t xAudioStateCback;
 } BTAvsrcCallbacks_t;
 
-/** Represents the standard SAL device management interface. */
+/** Represents the standard AV connection interface. */
 typedef struct
 {
-    /** Set this to size of  aceBtHal_avsrc_interface_t*/
+    /** Set this to size of  BTAvsrcInterface_t*/
     size_t xSize;
 
     /**
-     * Initializes ACE SAL A2DP module.
-     *
-     * @param callbacks, aceBtHal_avsrc_callbacks_t callbacks.
+     * @brief Initializes A2DP module.
+     * @param[in] callbacks, BTAvsrcCallbacks_t callbacks.
      * @return  BTHAL_STATUS_SUCCESS if init is successful. Or any other error code
      */
     BTStatus_t ( * pxAvsrcInit )( BTAvsrcCallbacks_t * pxCallbacks );
 
     /**
-     * Cleans to ACE SAL A2DP module
-     *
+     * @brief Cleans up A2DP module
      * @param None
      * @return  BT_STATUS_SUCCESS if cleanup is successful
      */
     BTStatus_t ( * pxAvsrcCleanup )();
 
     /**
-     * Starts connect for A2DP Source profile
-     *
-     * @param : aceBtHal_bdaddr_t :BT Address of remote device
+     * @brief Starts connect for A2DP Source profile
+     * @param[in] BTBdaddr_t :BT Address of remote device
      * @return BTHAL_STATUS_SUCCESS if the operation is successful, else error code.
      */
     BTStatus_t ( * pxAvsrcConnect )( BTBdaddr_t * pxRemote_addr );
 
     /**
-     * Starts disconnect for A2DP Source profile
+     * @brief Starts disconnect for A2DP Source profile
      *
-     * @param : aceBtHal_bdaddr_t :BT Address of remote device
+     * @param[in] BTBdaddr_t :BT Address of remote device
      * @return BTHAL_STATUS_SUCCESS if the operation is successful, else error code.
      */
     BTStatus_t ( * pxAvsrcDisconnect )( BTBdaddr_t * pxRemote_addr );
 } BTAvsrcInterface_t;
 
-#endif /* ACEHAL_BT_A2DP_PROFILE_H */
+#endif /* BT_HAL_AVSRC_PROFILE_H */

--- a/lib/include/bluetooth_low_energy/bt_hal_gatt_client.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_gatt_client.h
@@ -27,8 +27,7 @@
 /**
  * @file bt_hal_gatt_client.h
  *
- * @brief ACE BT GATT Client provides the interfaces to control the Bluetooth device.
- * ,local device control and device discovery functionalities
+ * @brief BT GATT Server provides the interfaces to use Bluetooth GATT client feature
  * USAGE
  * -----
  *
@@ -232,7 +231,7 @@ typedef struct
     BTServicesAddedCallback_t pxServicesAddedCb;
 } BTGattClientCallbacks_t;
 
-/** Represents the standard ACE BT-GATT client interface. */
+/** Represents the standard  BT-GATT client interface. */
 
 typedef struct
 {

--- a/lib/include/bluetooth_low_energy/bt_hal_gatt_server.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_gatt_server.h
@@ -27,8 +27,7 @@
 /**
  * @file bt_hal_gatt_server.h
  *
- * @brief ACE BT GATT Server provides the interfaces to control the Bluetooth device.
- * ,local device control and device discovery functionalities
+ * @brief BT GATT Server provides the interfaces to use Bluetooth GATT server feature
  *
  * Before calling any GATT server function, the Generic Access Profile needs to be initialized (see bt_hal_manager.h and bt_hal_manager_adapter*.h).
  * bt_hal_manager.h give the starting point.
@@ -400,7 +399,7 @@ typedef struct
     BTMtuChangedCallback_t pxMtuChangedCb;
 } BTGattServerCallbacks_t;
 
-/** Represents the standard ACE BT-GATT server interface. */
+/** Represents the standard BT-GATT server interface. */
 typedef struct
 {
     /**

--- a/lib/include/bluetooth_low_energy/bt_hal_gatt_types.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_gatt_types.h
@@ -27,8 +27,7 @@
 /**
  * @file bt_hal_gatt_types.h
  *
- * @brief ACE BT HAL provides the interfaces to control the Bluetooth power states
- * ,local device control and device discovery functionalities
+ * @brief T HAL provides the standard defintions used by BT GATT interfaces.
  * USAGE
  * -----
  *

--- a/lib/include/bluetooth_low_energy/bt_hal_manager.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_manager.h
@@ -613,7 +613,7 @@ typedef struct
                                                  BTSecurityLevel_t xSecurityLevel,
                                                  bool bBonding );
 
-    /*ACEBT_TODO : Handle out of band pairing in better way */
+    /* TODO:Handle out of band pairing in better way */
 
     /**
      * @brief Cancels an on going bonding procedure for the given device.

--- a/lib/include/bluetooth_low_energy/bt_hal_manager_adapter_ble.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_manager_adapter_ble.h
@@ -505,7 +505,7 @@ typedef struct
     BTPhyUpdatedCallback_t pxPhyUpdatedCb;
 } BTBleAdapterCallbacks_t;
 
-/** Represents the standard ACE BT-GATT client interface. */
+/** Represents the standard BT-GATT client interface. */
 
 /**
  * @brief BLE adapter API.

--- a/lib/include/bluetooth_low_energy/bt_hal_manager_types.h
+++ b/lib/include/bluetooth_low_energy/bt_hal_manager_types.h
@@ -26,7 +26,7 @@
 /**
  * @file bt_hal_manager_types.h
  *
- * @brief ACE BT HAL provides the interfaces to control the Bluetooth power states
+ * @brief This BT HAL provides the interfaces to control the Bluetooth power states
  * ,local device control and device discovery functionalities
  * USAGE
  * -----
@@ -136,4 +136,4 @@ typedef enum
     eBTIOKeyboardDisplay, /**< Keyboard and Display. */
 } BTIOtypes_t;
 
-#endif /* ACE_SDK_HAL_BTTYPES_H_ */
+#endif /* _BT_HAL_MANAGER_TYPES_H_ */


### PR DESCRIPTION
Removing old ACE name from the APIs

Description
-----------
This PR remove left over of the old ACE name

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
