### PR TITLE
Fix: Bug in BLE automated tests

### DIFF
--- a/tests/common/ble/aws_test_ble.c
+++ b/tests/common/ble/aws_test_ble.c
@@ -656,7 +656,7 @@ TEST( Full_BLE, BLE_Connection_BondedReconnectAndPair )
 	TEST_ASSERT_EQUAL(eBTStatusSuccess, xStatus);
 	TEST_ASSERT_EQUAL(eBTStatusSuccess, xPairingStateChangedEvent.xStatus);
 	TEST_ASSERT_EQUAL(0, memcmp(&xPairingStateChangedEvent.xRemoteBdAddr, &xAddressConnectedDevice, sizeof(BTBdaddr_t) ));
-	TEST_ASSERT_EQUAL(eBTSecLevelUnauthenticatedPairing, xPairingStateChangedEvent.xSecurityLevel);
+	TEST_ASSERT_EQUAL(eBTSecLevelSecureConnect, xPairingStateChangedEvent.xSecurityLevel);
 
 	xStatus = prvWaitEventFromQueue(eBLEHALEventBondedCb, (void *)&xBondedEvent, sizeof(BLETESTBondedCallback_t), BLE_TESTS_WAIT);
 	TEST_ASSERT_EQUAL(eBTStatusSuccess, xStatus);


### PR DESCRIPTION
Bug in BLE automated tests

Description
-----------
This commit fix a bug in BLE automated test.
It would expect a mode 1 level 2 on a reconnect after bonding in mode 1 level 4 which is a mistake.

After bonding, a reconnect should re-establish the same level of security.

Also, fixed default secure connection enforcement in ESP32

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
