### PR TITLE
Fix: Secure connection in HAL

### DIFF
--- a/lib/bluetooth_low_energy/portable/espressif/aws_ble_hal_gap.c
+++ b/lib/bluetooth_low_energy/portable/espressif/aws_ble_hal_gap.c
@@ -294,6 +294,7 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
     uint8_t xKeySize = 16;
     uint8_t xInitKey = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
     uint8_t xRspKey = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+	uint8_t xAuthOption;
     esp_ble_auth_req_t xAuthReq;
 
     /* set default properties */
@@ -324,6 +325,12 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
     {
         xAuthReq = prvConvertPropertiesToESPAuth(xProperties.bBondable);
         xESPstatus = esp_ble_gap_set_security_param( ESP_BLE_SM_AUTHEN_REQ_MODE, &xAuthReq, sizeof( uint8_t ) );
+
+        if( xESPstatus == ESP_OK )
+        {
+        	xAuthOption = ESP_BLE_ONLY_ACCEPT_SPECIFIED_AUTH_ENABLE;
+        	xESPstatus = esp_ble_gap_set_security_param(ESP_BLE_SM_ONLY_ACCEPT_SPECIFIED_SEC_AUTH, &xAuthOption, sizeof(uint8_t));
+        }
     }
 
     if( xESPstatus == ESP_OK )


### PR DESCRIPTION
Fix: Secure connection in HAL

Description
-----------
This commit fix secure connection that was not automatically activated in the lower layer.
This is a minor fixed as secure connection is enforced by upper layers.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
