### PR TITLE
Fix/ble large obj transfer

### DIFF
--- a/demos/common/include/aws_iot_demo_network.h
+++ b/demos/common/include/aws_iot_demo_network.h
@@ -39,21 +39,49 @@
 
 #include "aws_iot_mqtt.h"
 
+/**
+ * @brief Handle to an IoT network connection used by the demo.
+ */
 typedef void* AwsIotDemoNetworkConnection_t;
 
+/**
+ *  Callback Invoked when the underlying transport is disconnected.
+ *
+ * @param[in] Handle to the IoT Network connection
+ */
 typedef void ( *NetworkDisconnectedCallback_t ) ( AwsIotDemoNetworkConnection_t );
-
-
-void ulCreateNetworkConnectionWithRetry(
-        uint32_t ulConnIntervalSec,
-        uint32_t ulConnRetryLimit,
+/**
+ * @brief Creates an IoT network connection for demo
+ *
+ * Function creates a  IoT network connection which can be then used by demo applications with MQTT library APIs.
+ *
+ * @param[in] pxNetworkInterface Network Interface for the connection
+ * @param[in] pxMqttConnection Handle to the MQTT connection
+ * @param[in] xDisconnectCallback Callback invoked when the underlying network is disconnected.
+ * @param[out] pxIoTNetworkConnection Handle to the Network Connection
+ * @param[in] ulConnRetryIntervalSeconds Connection retry Interval in seconds
+ * @param[in] ulConnRetryLimit Connection Retry limit
+ */
+void AwsIotDemo_CreateNetworkConnection(
         AwsIotMqttNetIf_t* pxNetworkInterface,
         AwsIotMqttConnection_t* pxMqttConnection,
-        NetworkDisconnectedCallback_t xCallback,
-        AwsIotDemoNetworkConnection_t* pxIotNetworkConnection );
+        NetworkDisconnectedCallback_t xDisconnectCallback,
+        AwsIotDemoNetworkConnection_t* pxIoTNetworkConnection,
+        uint32_t ulConnRetryIntervalSeconds,
+        uint32_t ulConnRetryLimit );
 
-uint32_t ulGetConnectedNetworkType( AwsIotDemoNetworkConnection_t xNetworkConnection );
+/**
+ * @brief Get the type of transport associated with the network connection
+ * @param xIoTNetworkConnection Handle to the IoT Network Connection
+ * @return The type of network connection
+ */
+uint32_t AwsIotDemo_GetNetworkType( AwsIotDemoNetworkConnection_t xIoTNetworkConnection );
 
-void vDeleteNetworkConnection( AwsIotDemoNetworkConnection_t xNetworkConnection );
+/**
+ * @brief Deletes an Iot Network Connection.
+ *
+ * @param xIotNetworkConnection
+ */
+void AwsIotDemo_DeleteNetworkConnection( AwsIotDemoNetworkConnection_t xIoTNetworkConnection );
 
 #endif /* AWS_IOT_DEMO_NETWORK_H_ */

--- a/demos/common/network_manager/aws_iot_demo_network.c
+++ b/demos/common/network_manager/aws_iot_demo_network.c
@@ -51,16 +51,36 @@ typedef struct NetworkConnection
     void *pvConnection;
 } NetworkConnection_t;
 
+/**
+ * @brief Callback wrapper which pass a network disconnect event to the demo application.
+ * @param[in] ulNetworkType Type of network to register the callback.
+ * @param[in] xNetworkState State of the network passed in.
+ * @param[in] pvContext Pointer to the application context.
+ */
 static void prvNetworkSubscriptionWrapper ( uint32_t ulNetworkType, AwsIotNetworkState_t xNetworkState, void* pvContext );
 
 #if BLE_ENABLED
-static bool prbCreateMqttBLEConnection(
+/**
+ * @brief Creates a network connection over BLE to transfer MQTT messages.
+ * @param[in] pxNetworkInterface Network Interface for the connection
+ * @param[in] pxMqttConnection Handle to the MQTT
+ * @param[out] ppvConnection Pointer to a connection
+ * @return true if the connection was created successfully
+ */
+static bool prbCreateBLEConnection(
         AwsIotMqttNetIf_t* pxNetworkInterface,
         AwsIotMqttConnection_t* pxMqttConnection,
         void** ppvCpnnection );
 #endif
 
 #if WIFI_ENABLED
+/**
+ * @brief Creates a secure socket Connection
+ * @param[in] pxNetworkInterface Network Interface for the connection.
+ * @param[in] pxMqttConnection Handle to the connection
+ * @param[out] ppvConnection Pointer to the Connection
+ * @return true if the connection was created successfully
+ */
 static bool prbCreateSecureSocketConnection(
         AwsIotMqttNetIf_t* pxNetworkInterface,
         AwsIotMqttConnection_t* pxMqttConnection,
@@ -71,7 +91,9 @@ static uint32_t prxCreateNetworkConnection(
         AwsIotMqttNetIf_t* pxNetworkInterface,
         AwsIotMqttConnection_t* pxMqttConnection,
         void** ppvConnection );
-
+/**
+ * @brief Used to initialize the network interface.
+ */
 static AwsIotMqttNetIf_t xDefaultNetworkInterface = AWS_IOT_MQTT_NETIF_INITIALIZER;
 
 static uint32_t prxCreateNetworkConnection(
@@ -89,7 +111,7 @@ static uint32_t prxCreateNetworkConnection(
 #if BLE_ENABLED
     if( ( ulConnectedNetworks & AWSIOT_NETWORK_TYPE_BLE ) == AWSIOT_NETWORK_TYPE_BLE )
     {
-        if( prbCreateMqttBLEConnection( pxNetworkInterface, pxMqttConnection, ppvConnection ) == true )
+        if( prbCreateBLEConnection( pxNetworkInterface, pxMqttConnection, ppvConnection ) == true )
         {
             return AWSIOT_NETWORK_TYPE_BLE;
         }
@@ -171,7 +193,7 @@ static bool prbCreateSecureSocketConnection(
 #endif
 
 #if BLE_ENABLED
-static bool prbCreateMqttBLEConnection(
+static bool prbCreateBLEConnection(
         AwsIotMqttNetIf_t* pxNetworkInterface,
         AwsIotMqttConnection_t* pxMqttConnection,
         void** ppvConnection )
@@ -205,13 +227,13 @@ static void prvNetworkSubscriptionWrapper( uint32_t ulNetworkType, AwsIotNetwork
     }
 }
 
-void ulCreateNetworkConnectionWithRetry(
-        uint32_t ulConnIntervalSec,
-        uint32_t ulConnRetryLimit,
-        AwsIotMqttNetIf_t* pxNetworkInterface,
-        AwsIotMqttConnection_t* pxMqttConnection,
-        NetworkDisconnectedCallback_t xDisconnectCallback,
-        AwsIotDemoNetworkConnection_t* pxIotNetworkConnection )
+void AwsIotDemo_CreateNetworkConnection(
+		AwsIotMqttNetIf_t* pxNetworkInterface,
+		AwsIotMqttConnection_t* pxMqttConnection,
+		NetworkDisconnectedCallback_t xDisconnectCallback,
+		AwsIotDemoNetworkConnection_t* pxIotNetworkConnection,
+		uint32_t ulConnIntervalSec,
+		uint32_t ulConnRetryLimit)
 {
     size_t xRetryCount = 0;
     struct timespec xDelay =
@@ -265,7 +287,7 @@ void ulCreateNetworkConnectionWithRetry(
 
 }
 
-uint32_t ulGetConnectedNetworkType( AwsIotDemoNetworkConnection_t xNetworkConnection )
+uint32_t AwsIotDemo_GetNetworkType( AwsIotDemoNetworkConnection_t xNetworkConnection )
 {
     NetworkConnection_t* pxConn = ( NetworkConnection_t* ) xNetworkConnection;
     if( pxConn != NULL )
@@ -276,7 +298,7 @@ uint32_t ulGetConnectedNetworkType( AwsIotDemoNetworkConnection_t xNetworkConnec
     return AWSIOT_NETWORK_TYPE_NONE;
 }
 
-void vDeleteNetworkConnection( AwsIotDemoNetworkConnection_t xNetworkConnection )
+void AwsIotDemo_DeleteNetworkConnection( AwsIotDemoNetworkConnection_t xNetworkConnection )
 {
     NetworkConnection_t* pxNetwork = ( NetworkConnection_t* ) xNetworkConnection;
 

--- a/lib/include/aws_ble_wifi_provisioning.h
+++ b/lib/include/aws_ble_wifi_provisioning.h
@@ -228,6 +228,32 @@ typedef struct WifiProvService
 #define wifiProvMAX_SAVED_NETWORKS    ( 8 )
 
 /**
+ * @brief Delay between connecting to the saved list of WiFi networks
+ */
+#define wifiProvSAVED_NETWORKS_CONNECTION_INTERVAL_MS ( 1000 )
+
+/**
+ * @brief Base priority for all the tasks
+ */
+#define wifiProvTASK_PRIORITY_BASE      ( tskIDLE_PRIORITY )
+
+/**
+ * @brief Task priority for background task to connect to saved networks.
+ */
+#define wifiProvCONNECT_AP_TASK_PRIORITY  ( wifiProvTASK_PRIORITY_BASE )
+
+/**
+ * @brief Priority for the task to list all the WiFi networks.
+ */
+#define wifiProvLIST_NETWORK_TASK_PRIORITY  ( wifiProvTASK_PRIORITY_BASE + 1 )
+
+/**
+ * @brief Priority for the task to modify WiFi networks.
+ */
+#define wifiProvMODIFY_NETWORK_TASK_PRIORITY  ( wifiProvTASK_PRIORITY_BASE + 2 )
+
+
+/**
  * @brief Initialize the wifi provisioning service.
  *
  * Creates GATT service and characteristics required for WiFi provisioning over BLE. User needs to call it once


### PR DESCRIPTION
Fixes bugs within WiFi provisioning service and Large Object Transfer

Description
-----------
1. Fixes a bug in WiFi provisioning service, where the background task to connect to saved networks blocks a list network request.
 - Added priorities for each task and changed lock to a mutex.
 - Introduced delay between re-connection to the saved networks.
2. Fixes a possible deadlock in closing Mqtt Connection while a large object transfer is ongoing.
3. Renamed demo network connection APIs and added more docs.

Checklist:
----------
- [X ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
