### PR TITLE
Repairing the DNS asynchronous lookup

### DIFF
--- a/demos/pc/windows/common/application_code/aws_demo_logging.c
+++ b/demos/pc/windows/common/application_code/aws_demo_logging.c
@@ -113,6 +113,13 @@ static DWORD WINAPI prvWin32LoggingThread( void * pvParam );
 static void prvCreatePrintSocket( void * pvParameter1,
                                   uint32_t ulParameter2 );
 
+/*
+ * Write a messages to stdout, either with or without a time-stamp.
+ * A Windows thread will finally call printf() and fflush().
+ */
+
+static int prvLoggingPrintf( BaseType_t xFormatted, const char *pcFormat, va_list xArgs );
+
 /*-----------------------------------------------------------*/
 
 /* Windows event used to wake the Win32 thread which performs any logging that
@@ -273,12 +280,28 @@ static void prvCreatePrintSocket( void * pvParameter1,
 void vLoggingPrintf( const char * pcFormat,
                      ... )
 {
+	va_list xArgs;
+	va_start( xArgs, pcFormat );
+	prvLoggingPrintf( pdTRUE, pcFormat, xArgs );
+	va_end( xArgs );
+}
+/*-----------------------------------------------------------*/
+
+void vLoggingPrint( const char * pcFormat )
+{
+	prvLoggingPrintf( pdFALSE, pcFormat, NULL );
+}
+/*-----------------------------------------------------------*/
+
+static int prvLoggingPrintf( BaseType_t xFormatted,
+							 const char *pcFormat,
+							 va_list xArgs )
+{
     char cPrintString[ dlMAX_PRINT_STRING_LENGTH ];
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, xLength2, rc;
     static BaseType_t xMessageNumber = 0;
-    va_list args;
     uint32_t ulIPAddress;
     const char * pcTaskName;
     const char * pcNoTask = "None";
@@ -289,9 +312,6 @@ void vLoggingPrintf( const char * pcFormat,
         ( xDiskFileLoggingUsed != pdFALSE ) ||
         ( xUDPLoggingUsed != pdFALSE ) )
     {
-        /* There are a variable number of parameters. */
-        va_start( args, pcFormat );
-
         /* Additional info to place at the start of the log. */
         if( xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED )
         {
@@ -302,7 +322,7 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
-        if( strcmp( pcFormat, "\n" ) != 0 )
+        if( ( strcmp( pcFormat, "\n" ) != 0 ) && ( xFormatted != pdFALSE ) )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,
@@ -314,12 +334,21 @@ void vLoggingPrintf( const char * pcFormat,
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
         }
-
-        xLength2 = vsnprintf(
-            cPrintString + xLength,
-            dlMAX_PRINT_STRING_LENGTH - xLength,
-            pcFormat,
-            args );
+		if( xArgs != NULL )
+		{
+			xLength2 = vsnprintf(
+	            cPrintString + xLength,
+				dlMAX_PRINT_STRING_LENGTH - xLength,
+				pcFormat,
+				xArgs );
+		}
+		else
+		{
+			xLength2 = snprintf(
+	            cPrintString + xLength,
+				dlMAX_PRINT_STRING_LENGTH - xLength,
+				pcFormat );
+		}
 
         if( xLength2 < 0 )
         {
@@ -329,7 +358,6 @@ void vLoggingPrintf( const char * pcFormat,
         }
 
         xLength += xLength2;
-        va_end( args );
 
         /* For ease of viewing, copy the string into another buffer, converting
          * IP addresses to dot notation on the way. */
@@ -463,13 +491,6 @@ void vLoggingPrintf( const char * pcFormat,
             }
         }
     }
-}
-/*-----------------------------------------------------------*/
-
-void vLoggingPrint( const char * pcMessage )
-{
-    printf( "%s", pcMessage );
-    fflush(stdout);
 }
 /*-----------------------------------------------------------*/
 

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -817,10 +817,6 @@ DNSMessage_t *pxDNSMessageHeader;
 	/* In this context, 'pxNetworkBuffer->xDataLength' is the
 	length of the UDP payload buffer. */
 	xPlayloadBufferLength = pxNetworkBuffer->xDataLength;
-	if ( xPlayloadBufferLength < sizeof( DNSMessage_t ) )
-	{
-		return pdFAIL;
-	}
 
 	pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -437,7 +437,7 @@ TickType_t xIdentifier = 0;
 			}
 			else
 			{
-				/* prvGetHostByName will be called to start a DNS lookup */
+				/* prvGetHostByName will be called to start a DNS lookup. */
 			}
 		}
 	}
@@ -446,7 +446,8 @@ TickType_t xIdentifier = 0;
 	/* Generate a unique identifier. */
 	if( 0 == ulIPAddress )
 	{
-		xIdentifier = ( TickType_t )ipconfigRAND32( );
+		/* DNS identifiers are 16-bit. */
+		xIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffff );
 	}
 
 	#if( ipconfigDNS_USE_CALLBACKS != 0 )
@@ -567,7 +568,7 @@ TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
 					if( lBytes > 0 )
 					{
 						/* The reply was received.  Process it. */
-						ulIPAddress = prvParseDNSReply( pucUDPPayloadBuffer, lBytes, xIdentifier );
+						ulIPAddress = prvParseDNSReply( pucUDPPayloadBuffer, ( size_t )lBytes, xIdentifier );
 
 						/* Finished with the buffer.  The zero copy interface
 						is being used, so the buffer must be freed by the
@@ -813,7 +814,9 @@ uint8_t *pucUDPPayloadBuffer;
 size_t xPlayloadBufferLength;
 DNSMessage_t *pxDNSMessageHeader;
 
-	xPlayloadBufferLength = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+	/* In this context, 'pxNetworkBuffer->xDataLength' is the
+	length of the UDP payload buffer. */
+	xPlayloadBufferLength = pxNetworkBuffer->xDataLength;
 	if ( xPlayloadBufferLength < sizeof( DNSMessage_t ) )
 	{
 		return pdFAIL;
@@ -822,12 +825,9 @@ DNSMessage_t *pxDNSMessageHeader;
 	pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
 
-	if( pxNetworkBuffer->xDataLength > sizeof( UDPPacket_t ) )
-	{
-		prvParseDNSReply( pucUDPPayloadBuffer,
-			xPlayloadBufferLength,
-			( uint32_t )pxDNSMessageHeader->usIdentifier );
-	}
+	prvParseDNSReply( pucUDPPayloadBuffer, 
+		xPlayloadBufferLength,
+		( uint32_t )pxDNSMessageHeader->usIdentifier );
 
 	/* The packet was not consumed. */
 	return pdFAIL;
@@ -1340,7 +1340,7 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 	{
 	BaseType_t x;
 	BaseType_t xFound = pdFALSE;
-	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000;
+	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000UL;
 	static BaseType_t xFreeEntry = 0;
 
 		/* For each entry in the DNS cache table. */

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_UDP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_UDP_IP.c
@@ -347,6 +347,19 @@ UDPPacket_t *pxUDPPacket = (UDPPacket_t *) pxNetworkBuffer->pucEthernetBuffer;
 		/* There is no socket listening to the target port, but still it might
 		be for this node. */
 
+		#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+			/* A DNS reply, check for the source port.  Although the DNS client
+			does open a UDP socket to send a messages, this socket will be
+			closed after a short timeout.  Messages that come late (after the
+			socket is closed) will be treated here. */
+			if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ipDNS_PORT )
+			{
+				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+				xReturn = ( BaseType_t )ulDNSHandlePacket( pxNetworkBuffer );
+			}
+			else
+		#endif
+
 		#if( ipconfigUSE_LLMNR == 1 )
 			/* a LLMNR request, check for the destination port. */
 			if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||


### PR DESCRIPTION
<!--- Title -->

The API `FreeRTOS_gethostbyname_a()` is the asynchronous version of `FreeRTOS_gethostbyname()`. It makes a call-back as soon as an answer from a DNS server is received, or after a time-out was reached.

-----------
<!--- Describe your changes in detail -->

Due to a regression ( commit v1.3.2 on august 23, 2018 ), `FreeRTOS_gethostbyname_a()` stopped working.

In `xProcessReceivedUDPPacket()`, `ulDNSHandlePacket()` must be called to process the ( asynchronous ) DNS-reply.

The function `ulDNSHandlePacket()` now has two packet-length checks that are misplaced. These checks would be OK if the field `xDataLength` contains the total packet length. However, in line 1615 in FreeRTPS_IP.c :

    pxNetworkBuffer->xDataLength -= sizeof( UDPPacket_t );

Within `ulDNSHandlePacket()`, `xDataLength` represents the length of the UDP payload. The only test needed is this one:

    if ( xPlayloadBufferLength < sizeof( DNSMessage_t ) )
    {
        return pdFAIL;
    }

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
