### PR TITLE
Update specificity on which board needs the Root CA updated for MQTT connections on other development stage endpoints.

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -82,8 +82,8 @@ class OtaTestRunner:
                 self._otaProject.setCodesignerCertificate(self._otaAwsAgent.getCodeSignerCertificateFromArn(self._otaConfig['aws_signer_certificate_arn']))
             if self._stageParams:
                 self._otaProject.setOtaDemoRunnerForSNIDisabled()
-                # FIXME: We need all boards to have the same behavior here.
-                if 'ti' in self._boardConfig['name']:
+                # Currently 12/13/2018 only the TI CC3220SF LaunchpadXL needs the Root CA to connect to other internal Amazon development stage endpoints.
+                if 'cc3220' in self._boardConfig['name']:
                     self._otaProject.setOtaUpdateDemoForRootCA()
                     self._otaProject.addRootCAToClientCredentialKeys(self._stageParams['certificate'])
                 else:


### PR DESCRIPTION
Only the TI CC3220SF LaunchpadXL needs the RootCA to connect to other internal Amazon development stage IoT Core MQTT endpoints.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
