### PR TITLE
fix: Remove pragma in aws_application32.h

### DIFF
--- a/lib/include/aws_appversion32.h
+++ b/lib/include/aws_appversion32.h
@@ -29,7 +29,6 @@
 #include <stdint.h>
 
 /* Application version structure. */
-#pragma pack(push,1)
 typedef struct {
 	union {
 #if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || (__little_endian__ == 1) || WIN32 || (__BYTE_ORDER == __LITTLE_ENDIAN)
@@ -51,6 +50,5 @@ typedef struct {
 		int32_t  lVersion32;
 	} u;
 } AppVersion32_t;
-#pragma pack(pop)
 
 #endif


### PR DESCRIPTION
* #pragma pack(push, 1) and #pragma pack(pop) are not portable compiler directives.

The structure AppVersion32_t is extern'ed as xAppFirmwareVersion and used throughout the code only to access each of it's member individually. 
Amazon FreeRTOS reference bootloader was going to read the version from the image, but that was decided against and so it not the current behavior. These directives are residual from the development process.

OTA Happy-path tests were performed on all supported platforms. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [] My code is Linted.
