### PR TITLE
fix: updated pthread_mutexattr_t

### DIFF
--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
@@ -138,7 +138,7 @@ int pthread_mutex_init( pthread_mutex_t * mutex,
         /* Otherwise, use provided attributes. */
         else
         {
-            pxMutex->xAttr = *( ( pthread_mutexattr_internal_t * ) ( *attr ) );
+            pxMutex->xAttr = *( ( pthread_mutexattr_internal_t * ) ( attr ) );
         }
 
         /* Call the correct FreeRTOS mutex creation function based on mutex type. */
@@ -309,9 +309,6 @@ int pthread_mutex_unlock( pthread_mutex_t * mutex )
 
 int pthread_mutexattr_destroy( pthread_mutexattr_t * attr )
 {
-    /* Free mutex attributes object. */
-    vPortFree( *attr );
-
     return 0;
 }
 
@@ -320,7 +317,7 @@ int pthread_mutexattr_destroy( pthread_mutexattr_t * attr )
 int pthread_mutexattr_gettype( const pthread_mutexattr_t * attr,
                                int * type )
 {
-    pthread_mutexattr_internal_t * pxAttr = ( pthread_mutexattr_internal_t * ) ( *attr );
+    pthread_mutexattr_internal_t * pxAttr = ( pthread_mutexattr_internal_t * ) ( attr );
 
     *type = pxAttr->iType;
 
@@ -333,19 +330,16 @@ int pthread_mutexattr_init( pthread_mutexattr_t * attr )
 {
     int iStatus = 0;
 
-    /* Allocate memory for new mutex attributes object. */
-    *attr = pvPortMalloc( sizeof( pthread_mutexattr_internal_t ) );
-
     if( attr == NULL )
     {
-        /* No memory. */
-        iStatus = ENOMEM;
+        /* Invalid Attribute. */
+        iStatus = EINVAL;
     }
 
     /* Set the mutex attributes to default values. */
     if( iStatus == 0 )
     {
-        *( ( pthread_mutexattr_internal_t * ) ( *attr ) ) = xDefaultMutexAttributes;
+        *( ( pthread_mutexattr_internal_t * ) ( attr ) ) = xDefaultMutexAttributes;
     }
 
     return iStatus;
@@ -357,7 +351,7 @@ int pthread_mutexattr_settype( pthread_mutexattr_t * attr,
                                int type )
 {
     int iStatus = 0;
-    pthread_mutexattr_internal_t * pxAttr = ( pthread_mutexattr_internal_t * ) ( *attr );
+    pthread_mutexattr_internal_t * pxAttr = ( pthread_mutexattr_internal_t * ) ( attr );
 
     switch( type )
     {

--- a/lib/include/FreeRTOS_POSIX/sys/types.h
+++ b/lib/include/FreeRTOS_POSIX/sys/types.h
@@ -108,7 +108,9 @@ typedef void                * pthread_barrierattr_t;
  * @brief Used to identify a mutex attribute object.
  */
 #if !defined( posixconfigENABLE_PTHREAD_MUTEXATTR_T ) || ( posixconfigENABLE_PTHREAD_MUTEXATTR_T == 1 )
-    typedef void            * pthread_mutexattr_t;
+    typedef struct pthread_mutexattr {
+          uint32_t        ulpthreadMutexAttrStorage;
+    } pthread_mutexattr_t;
 #endif
 
 /**


### PR DESCRIPTION
Changed internal pthread_mutexattr_t allocation from dynamic to stack based.
This will reduce memory fragmentation and malloc/free overhead

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have tested my changes. No regression in existing tests.
- [X ] My code is Linted.
