### PR TITLE
Fix: Posix utils timespec overflow

### DIFF
--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_mqueue.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_mqueue.c
@@ -172,15 +172,23 @@ static int prvCalculateTickTimeout( long lMessageQueueFlags,
         }
         else
         {
+            struct timespec xCurrentTime = { 0 };
+
             /* Check that the given timespec is valid. */
             if( UTILS_ValidateTimespec( pxAbsoluteTimeout ) == false )
             {
                 iStatus = EINVAL;
             }
 
+            /* Get current time */
+            if( ( iStatus == 0 ) && ( clock_gettime( CLOCK_REALTIME, &xCurrentTime ) != 0 ) )
+            {
+                iStatus = EINVAL;
+            }
+
             /* Convert absolute timespec to ticks. */
             if( ( iStatus == 0 ) &&
-                ( UTILS_AbsoluteTimespecToTicks( pxAbsoluteTimeout, pxTimeoutTicks ) != 0 ) )
+                ( UTILS_AbsoluteTimespecToDeltaTicks( pxAbsoluteTimeout, &xCurrentTime, pxTimeoutTicks ) != 0 ) )
             {
                 iStatus = ETIMEDOUT;
             }

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
@@ -203,7 +203,17 @@ int pthread_cond_timedwait( pthread_cond_t * cond,
     /* Convert abstime to a delay in TickType_t if provided. */
     if( abstime != NULL )
     {
-        iStatus = UTILS_AbsoluteTimespecToTicks( abstime, &xDelay );
+        struct timespec xCurrentTime = { 0 };
+
+        /* Get current time */
+        if( clock_gettime( CLOCK_REALTIME, &xCurrentTime ) != 0 )
+        {
+            iStatus = EINVAL;
+        }
+        else
+        {
+            iStatus = UTILS_AbsoluteTimespecToDeltaTicks( abstime, &xCurrentTime, &xDelay );
+        }
     }
 
     /* Increase the counter of threads blocking on condition variable, then

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
@@ -197,7 +197,17 @@ int pthread_mutex_timedlock( pthread_mutex_t * mutex,
     /* Convert abstime to a delay in TickType_t if provided. */
     if( abstime != NULL )
     {
-        iStatus = UTILS_AbsoluteTimespecToTicks( abstime, &xDelay );
+        struct timespec xCurrentTime = { 0 };
+
+        /* Get current time */
+        if( clock_gettime( CLOCK_REALTIME, &xCurrentTime ) != 0 )
+        {
+            iStatus = EINVAL;
+        }
+        else
+        {
+            iStatus = UTILS_AbsoluteTimespecToDeltaTicks( abstime, &xCurrentTime, &xDelay );
+        }
 
         /* If abstime was in the past, still attempt to lock the mutex without
          * blocking, per POSIX spec. */

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_semaphore.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_semaphore.c
@@ -146,7 +146,17 @@ int sem_timedwait( sem_t * sem,
         }
         else
         {
-            iStatus = UTILS_AbsoluteTimespecToTicks( abstime, &xDelay );
+            struct timespec xCurrentTime = { 0 };
+
+            /* Get current time */
+            if( clock_gettime( CLOCK_REALTIME, &xCurrentTime ) != 0 )
+            {
+                iStatus = EINVAL;
+            }
+            else
+            {
+                iStatus = UTILS_AbsoluteTimespecToDeltaTicks( abstime, &xCurrentTime, &xDelay );
+            }
 
             /* If abstime was in the past, still attempt to take the semaphore without
              * blocking, per POSIX spec. */

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_utils.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_utils.c
@@ -30,6 +30,7 @@
 
 /* C standard library includes. */
 #include <stddef.h>
+#include <limits.h>
 
 /* FreeRTOS+POSIX includes. */
 #include "FreeRTOS_POSIX.h"
@@ -58,34 +59,32 @@ size_t UTILS_strnlen( const char * const pcString,
 
 /*-----------------------------------------------------------*/
 
-int UTILS_AbsoluteTimespecToTicks( const struct timespec * const pxAbsoluteTime,
+int UTILS_AbsoluteTimespecToDeltaTicks( const struct timespec * const pxAbsoluteTime,
+                                   const struct timespec * const pxCurrentTime,
                                    TickType_t * const pxResult )
 {
     int iStatus = 0;
-    struct timespec xCurrentTime = { 0 }, xDifference = { 0 };
+    struct timespec xDifference = { 0 };
 
     /* Check parameters. */
-    if( ( pxAbsoluteTime == NULL ) || ( pxResult == NULL ) )
+    if( ( pxAbsoluteTime == NULL ) || ( pxCurrentTime == NULL ) || ( pxResult == NULL ) )
     {
         iStatus = EINVAL;
     }
 
-    /* Get the current time. */
+    /* Calculate the difference between the current time and absolute time. */
     if( iStatus == 0 )
     {
-        if( clock_gettime( CLOCK_REALTIME, &xCurrentTime ) != 0 )
-        {
-            iStatus = errno;
-        }
-    }
-
-    /* Calculate the difference between the current time and pxAbsoluteTime. */
-    if( iStatus == 0 )
-    {
-        if( UTILS_TimespecSubtract( &xDifference, pxAbsoluteTime, &xCurrentTime ) != 0 )
+        iStatus = UTILS_TimespecSubtract( pxAbsoluteTime, pxCurrentTime, &xDifference );
+        if( iStatus == 1 )
         {
             /* pxAbsoluteTime was in the past. */
             iStatus = ETIMEDOUT;
+        }
+        else if( iStatus == -1 )
+        {
+            /* error */
+            iStatus = EINVAL;
         }
     }
 
@@ -104,7 +103,7 @@ int UTILS_TimespecToTicks( const struct timespec * const pxTimespec,
                            TickType_t * const pxResult )
 {
     int iStatus = 0;
-    uint64_t ullTotalTicks = 0;
+    int64_t llTotalTicks = 0;
     long lNanoseconds = 0;
 
     /* Check parameters. */
@@ -112,7 +111,7 @@ int UTILS_TimespecToTicks( const struct timespec * const pxTimespec,
     {
         iStatus = EINVAL;
     }
-    else if( ( pxTimespec != NULL ) && ( UTILS_ValidateTimespec( pxTimespec ) == false ) )
+    else if( ( iStatus == 0 ) && ( UTILS_ValidateTimespec( pxTimespec ) == false ) )
     {
         iStatus = EINVAL;
     }
@@ -120,7 +119,7 @@ int UTILS_TimespecToTicks( const struct timespec * const pxTimespec,
     if( iStatus == 0 )
     {
         /* Convert timespec.tv_sec to ticks. */
-        ullTotalTicks = ( uint64_t ) configTICK_RATE_HZ * ( uint64_t ) ( pxTimespec->tv_sec );
+        llTotalTicks = ( int64_t ) configTICK_RATE_HZ * ( pxTimespec->tv_sec );
 
         /* Convert timespec.tv_nsec to ticks. This value does not have to be checked
          * for overflow because a valid timespec has 0 <= tv_nsec < 1000000000 and
@@ -129,10 +128,29 @@ int UTILS_TimespecToTicks( const struct timespec * const pxTimespec,
                        ( long ) ( pxTimespec->tv_nsec % ( long ) NANOSECONDS_PER_TICK != 0 ); /* Add 1 to round up if needed. */
 
         /* Add the nanoseconds to the total ticks. */
-        ullTotalTicks += ( uint64_t ) lNanoseconds;
+        llTotalTicks += ( int64_t ) lNanoseconds;
+
+        /* Check for overflow */
+        if( llTotalTicks < 0 )
+        {
+            iStatus = EINVAL;
+        }
+        else
+        {
+            /* check if TickType_t is 32 bit or 64 bit */
+            uint32_t ulTickTypeSize = sizeof( TickType_t );
+            /* check for downcast overflow */
+            if ( ulTickTypeSize == sizeof( uint32_t ) )
+            {
+                if ( llTotalTicks > UINT_MAX )
+                {
+                    iStatus = EINVAL;
+                }
+            }
+        }
 
         /* Write result. */
-        *pxResult = ( TickType_t ) ullTotalTicks;
+        *pxResult = ( TickType_t ) llTotalTicks;
     }
 
     return iStatus;
@@ -162,71 +180,189 @@ void UTILS_NanosecondsToTimespec( int64_t llSource,
 
 /*-----------------------------------------------------------*/
 
-int UTILS_TimespecAdd( struct timespec * const pxResult,
-                       const struct timespec * const x,
-                       const struct timespec * const y )
+int UTILS_TimespecAdd( const struct timespec * const x,
+                       const struct timespec * const y,
+                       struct timespec * const pxResult )
 {
-    int64_t llResult64 = 0;
+    int64_t llPartialSec = 0;
+    int iStatus = 0;
 
     /* Check parameters. */
     if( ( pxResult == NULL ) || ( x == NULL ) || ( y == NULL ) )
     {
-        return -1;
+        iStatus = -1;
     }
 
-    /* Perform addition. */
-    llResult64 = ( ( ( int64_t ) ( x->tv_sec ) * NANOSECONDS_PER_SECOND ) + ( int64_t ) ( x->tv_nsec ) )
-                 + ( ( ( int64_t ) ( y->tv_sec ) * NANOSECONDS_PER_SECOND ) + ( int64_t ) ( y->tv_nsec ) );
+    if( iStatus == 0 )
+    {
+        /* Perform addition. */
+        pxResult->tv_nsec = x->tv_nsec + y->tv_nsec;
 
-    /* Convert result to timespec. */
-    UTILS_NanosecondsToTimespec( llResult64, pxResult );
+        /* check for overflow in case nsec value was invalid */
+        if( pxResult->tv_nsec < 0 )
+        {
+            iStatus = 1;
+        }
+        else
+        {
+            llPartialSec = ( pxResult->tv_nsec ) / NANOSECONDS_PER_SECOND;
+            pxResult->tv_nsec = ( pxResult->tv_nsec ) % NANOSECONDS_PER_SECOND;
+            pxResult->tv_sec = x->tv_sec + y->tv_sec + llPartialSec;
 
-    return ( int ) ( llResult64 < 0LL );
+            /* check for overflow */
+            if(  pxResult->tv_sec < 0 )
+            {
+                iStatus = 1;
+            }
+        }
+    }
+
+    return iStatus;
 }
 
 /*-----------------------------------------------------------*/
 
-int UTILS_TimespecAddNanoseconds( struct timespec * const pxResult,
-                                  const struct timespec * const x,
-                                  int64_t llNanoseconds )
+int UTILS_TimespecAddNanoseconds( const struct timespec * const x,
+                                  int64_t llNanoseconds,
+                                  struct timespec * const pxResult )
 {
-    struct timespec y = { .tv_sec = ( time_t ) 0, .tv_nsec = 0L };
+    int64_t llTotalNSec = 0;
+    int iStatus = 0;
 
     /* Check parameters. */
     if( ( pxResult == NULL ) || ( x == NULL ) )
     {
-        return -1;
+        iStatus =  -1;
     }
 
-    /* Convert llNanoseconds to a timespec. */
-    UTILS_NanosecondsToTimespec( llNanoseconds, &y );
+    if( iStatus == 0 )
+    {
+        /* add nano seconds */
+        llTotalNSec = x->tv_nsec + llNanoseconds;
 
-    /* Perform addition. */
-    return UTILS_TimespecAdd( pxResult, x, &y );
+        /* check for nano seconds overflow */
+        if ( llTotalNSec < 0 )
+        {
+            iStatus = 1;
+        }
+        else
+        {
+
+            pxResult->tv_nsec =  llTotalNSec % NANOSECONDS_PER_SECOND;
+            pxResult->tv_sec =  x->tv_sec + ( llTotalNSec / NANOSECONDS_PER_SECOND );
+
+            /* check for seconds overflow */
+            if(  pxResult->tv_sec < 0 )
+            {
+                iStatus = 1;
+            }
+        }
+    }
+
+    return iStatus;
 }
 
 /*-----------------------------------------------------------*/
 
-int UTILS_TimespecSubtract( struct timespec * const pxResult,
-                            const struct timespec * const x,
-                            const struct timespec * const y )
+int UTILS_TimespecSubtract( const struct timespec * const x,
+                            const struct timespec * const y,
+                            struct timespec * const pxResult )
 {
-    int64_t llResult64 = 0;
+
+    int iCompareResult = 0;
+    int iStatus = 0;
 
     /* Check parameters. */
     if( ( pxResult == NULL ) || ( x == NULL ) || ( y == NULL ) )
     {
-        return -1;
+        iStatus = -1;
     }
 
-    /* Perform addition. */
-    llResult64 = ( ( ( int64_t ) ( x->tv_sec ) * NANOSECONDS_PER_SECOND ) + ( int64_t ) ( x->tv_nsec ) )
-                 - ( ( ( int64_t ) ( y->tv_sec ) * NANOSECONDS_PER_SECOND ) + ( int64_t ) ( y->tv_nsec ) );
+    if( iStatus == 0 )
+    {
+        iCompareResult = UTILS_TimespecCompare( x, y );
 
-    /* Convert result to timespec. */
-    UTILS_NanosecondsToTimespec( llResult64, pxResult );
+        /* if x < y then result would be negative, return 1 */
+        if( iCompareResult == -1 )
+        {
+            iStatus = 1;
+        }
+        else if( iCompareResult == 0 )
+        {
+            /* if times are the same return zero */
+            pxResult->tv_sec = 0;
+            pxResult->tv_nsec = 0;
+        }
+        else
+        {
+            /* If x > y Perform subtraction. */
+            pxResult->tv_sec = x->tv_sec - y->tv_sec;
+            pxResult->tv_nsec = x->tv_nsec - y->tv_nsec;
 
-    return ( int ) ( llResult64 < 0LL );
+            /* check if nano seconds value needs to borrow */
+            if( pxResult->tv_nsec < 0 )
+            {
+                /* Based on comparison, tv_sec > 0 */
+                pxResult->tv_sec--;
+                pxResult->tv_nsec += (long) NANOSECONDS_PER_SECOND;
+            }
+
+            /* if nano second is negative after borrow, it is an overflow error */
+            if( pxResult->tv_nsec < 0 )
+            {
+                iStatus = -1;
+            }
+        }
+    }
+
+    return iStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+int UTILS_TimespecCompare( const struct timespec * const x,
+                               const struct timespec * const y)
+{
+    int iStatus = 0;
+    /* Check parameters */
+    if( ( x == NULL ) && ( y == NULL ) )
+    {
+        iStatus = 0;
+    }
+    else if( y == NULL )
+    {
+        iStatus = 1;
+    }
+    else if( x == NULL )
+    {
+        iStatus = -1;
+    }
+    else if( x->tv_sec > y->tv_sec )
+    {
+        iStatus = 1;
+    }
+    else if( x->tv_sec < y->tv_sec )
+    {
+        iStatus = -1;
+    }
+    else
+    {
+        /* seconds are equal compare nano seconds */
+        if( x->tv_nsec > y->tv_nsec )
+        {
+            iStatus = 1;
+        }
+        else if(x->tv_nsec < y->tv_nsec)
+        {
+            iStatus = -1;
+        }
+        else
+        {
+            iStatus = 0;
+        }
+    }
+
+    return iStatus;
 }
 
 /*-----------------------------------------------------------*/

--- a/lib/include/FreeRTOS_POSIX/utils.h
+++ b/lib/include/FreeRTOS_POSIX/utils.h
@@ -55,13 +55,16 @@ size_t UTILS_strnlen( const char * const pcString,
  *
  * @param[in] pxAbsoluteTime A time in the future, specified as seconds and
  * nanoseconds since CLOCK_REALTIME's 0.
+ * @param[in] pxCurrentTime current time, specified as seconds and
+ * nanoseconds.
  * @param[out] pxResult Where the result of the conversion is stored. The result
  * is rounded up for fractional ticks.
  *
  * @return 0 on success. Otherwise, ETIMEDOUT if pxAbsoluteTime is in the past,
  * or EINVAL for invalid parameters.
  */
-int UTILS_AbsoluteTimespecToTicks( const struct timespec * const pxAbsoluteTime,
+int UTILS_AbsoluteTimespecToDeltaTicks( const struct timespec * const pxAbsoluteTime,
+                                   const struct timespec * const pxCurrentTime,
                                    TickType_t * const pxResult );
 
 /**
@@ -90,41 +93,53 @@ void UTILS_NanosecondsToTimespec( int64_t llSource,
 /**
  * @brief Calculates pxResult = x + y.
  *
- * @param[out] pxResult Where the result of the calculation is stored.
  * @param[in] x The first argument for addition.
  * @param[in] y The second argument for addition.
+ * @param[out] pxResult Where the result of the calculation is stored.
  *
- * @return -1 if any argument was NULL; 1 if result is negative; otherwise, 0.
+ * @return -1 if any argument was NULL; 1 if result is negative (overflow); otherwise, 0.
  */
-int UTILS_TimespecAdd( struct timespec * const pxResult,
-                       const struct timespec * const x,
-                       const struct timespec * const y );
+int UTILS_TimespecAdd( const struct timespec * const x,
+                       const struct timespec * const y,
+                       struct timespec * const pxResult );
 
 /**
  * @brief Calculates pxResult = x + ( struct timespec ) nanosec.
  *
- * @param[out] pxResult Where the result of the calculation is stored.
  * @param[in] x The first argument for addition.
  * @param[in] llNanoseconds The second argument for addition.
+ * @param[out] pxResult Where the result of the calculation is stored.
  *
  * @return -1 if pxResult or x was NULL; 1 if result is negative; otherwise, 0.
  */
-int UTILS_TimespecAddNanoseconds( struct timespec * const pxResult,
-                                  const struct timespec * const x,
-                                  int64_t llNanoseconds );
+int UTILS_TimespecAddNanoseconds( const struct timespec * const x,
+                                  int64_t llNanoseconds,
+                                  struct timespec * const pxResult );
 
 /**
- * @brief Calculates pxResult = x - y.
+ * @brief Calculates pxResult = x - y. If the result is negative contents of
+ * pResult are undefined
  *
- * @param[out] pxResult Where the result of the calculation is stored.
  * @param[in] x The first argument for subtraction.
  * @param[in] y The second argument for subtraction.
+ * @param[out] pxResult Where the result of the calculation is stored.
  *
  * @return -1 if any argument was NULL; 1 if result is negative; otherwise, 0.
  */
-int UTILS_TimespecSubtract( struct timespec * const pxResult,
-                            const struct timespec * const x,
-                            const struct timespec * const y );
+int UTILS_TimespecSubtract( const struct timespec * const x,
+                            const struct timespec * const y,
+                            struct timespec * const pxResult);
+
+/**
+ * @brief Compare  x == y.
+ *
+ * @param[in] x The first argument for comparison.
+ * @param[in] y The second argument for comparison.
+ *
+ * @return 0 if x == y; 1 if x > y; -1 if x < y or any argument was NULL
+ */
+int UTILS_TimespecCompare( const struct timespec * const x,
+                           const struct timespec * const y);
 
 /**
 * @brief Checks that a timespec conforms to POSIX.

--- a/tests/common/posix/aws_test_posix_clock.c
+++ b/tests/common/posix/aws_test_posix_clock.c
@@ -74,7 +74,7 @@ static void prvClockSleep( const struct timespec * const pxSleepTime,
     TEST_ASSERT_EQUAL_INT( true, UTILS_ValidateTimespec( &xEndTime ) );
 
     /* Verify that xEndTime > xStartTime. Also calculates elapsed time. */
-    TEST_ASSERT_EQUAL_INT( 0, UTILS_TimespecSubtract( pxElapsedTime, &xEndTime, &xStartTime ) );
+    TEST_ASSERT_EQUAL_INT( 0, UTILS_TimespecSubtract( &xEndTime, &xStartTime, pxElapsedTime ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -153,7 +153,7 @@ TEST( Full_POSIX_CLOCK, clock_nanosleep_absolute )
     TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
     /* Wake up 5 ms from now. */
-    iStatus = UTILS_TimespecAddNanoseconds( &xWakeTime, &xWakeTime, 5000000 );
+    iStatus = UTILS_TimespecAddNanoseconds( &xWakeTime, 5000000, &xWakeTime );
     TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
     prvClockSleep( &xWakeTime, &xElapsedTime, TIMER_ABSTIME );
@@ -185,8 +185,8 @@ TEST( Full_POSIX_CLOCK, clock_nanosleep_min_resolution )
      * sleep for smaller than the minimum resolution slept for the minimum
      * resolution. */
     TEST_ASSERT_EQUAL_INT( 0, UTILS_TimespecSubtract( &xElapsedTime,
-                                                      &xElapsedTime,
-                                                      &xResolution ) );
+                                                      &xResolution,
+                                                      &xElapsedTime ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -223,7 +223,7 @@ TEST( Full_POSIX_CLOCK, clock_nanosleep_absolute_in_past )
     TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
     /* Set a timeout 5 ms in the past. */
-    iStatus = UTILS_TimespecAddNanoseconds( &xWakeTime, &xWakeTime, -5000000 );
+    iStatus = UTILS_TimespecAddNanoseconds( &xWakeTime, -5000000, &xWakeTime );
     TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
     prvClockSleep( &xWakeTime, &xElapsedTime, TIMER_ABSTIME );
@@ -254,7 +254,7 @@ TEST( Full_POSIX_CLOCK, nanosleep )
     TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
     /* Verify that xEndTime > xStartTime. Also calculates elapsed time. */
-    TEST_ASSERT_EQUAL_INT( 0, UTILS_TimespecSubtract( &xElapsedTime, &xEndTime, &xStartTime ) );
+    TEST_ASSERT_EQUAL_INT( 0, UTILS_TimespecSubtract( &xEndTime, &xStartTime, &xElapsedTime ) );
 
     /* Verify that at least 1 ms elapsed. */
     TEST_ASSERT_TRUE( 0 <= xElapsedTime.tv_sec );

--- a/tests/common/posix/aws_test_posix_pthread.c
+++ b/tests/common/posix/aws_test_posix_pthread.c
@@ -452,7 +452,7 @@ TEST( Full_POSIX_PTHREAD, pthread_mutex_trylock_timedlock )
 
         /* Set an absolute timeout of 100 ms. */
         ( void ) clock_gettime( CLOCK_REALTIME, &xTimeout );
-        ( void ) UTILS_TimespecAddNanoseconds( &xTimeout, &xTimeout, 100000000LL );
+        ( void ) UTILS_TimespecAddNanoseconds( &xTimeout, 100000000LL, &xTimeout );
 
         /* Attempt to lock mutex with timeout while mutex is still locked. */
         iStatus = pthread_mutex_timedlock( &xMutex, &xTimeout );
@@ -564,7 +564,7 @@ TEST( Full_POSIX_PTHREAD, pthread_cond_signal )
 
         /* Set an absolute timeout of 100 ms. */
         ( void ) clock_gettime( CLOCK_REALTIME, &xWaitTime );
-        ( void ) UTILS_TimespecAddNanoseconds( &xWaitTime, &xWaitTime, 100000000LL );
+        ( void ) UTILS_TimespecAddNanoseconds( &xWaitTime, 100000000LL, &xWaitTime );
 
         /* Waiting on a condition variable that is never signaled should time out. */
         iStatus = pthread_cond_timedwait( &xCond, &xMutex, &xWaitTime );

--- a/tests/common/posix/aws_test_posix_timer.c
+++ b/tests/common/posix/aws_test_posix_timer.c
@@ -260,13 +260,13 @@ TEST( Full_POSIX_TIMER, timer_settime_min_resolution )
 
         /* Calculate the elapsed time since the timer was started. Ensure that
          * it's positive. */
-        iStatus = UTILS_TimespecSubtract( &xElapsedTime, &xThreadReturnValues.xExpirationTime, &xStartTime );
+        iStatus = UTILS_TimespecSubtract( &xThreadReturnValues.xExpirationTime, &xStartTime, &xElapsedTime );
         TEST_ASSERT_EQUAL_INT( 0, iStatus );
         TEST_ASSERT_TRUE( ( xElapsedTime.tv_sec > 0 ) || ( xElapsedTime.tv_nsec > 0 ) );
 
         /* Ensure the timer did not fire before the minimum sleep resolution. */
-        iStatus = UTILS_TimespecSubtract( &xElapsedTime, &xElapsedTime, &xInterval.it_value );
-        TEST_ASSERT_TRUE( iStatus >= 0 );
+        iStatus = UTILS_TimespecSubtract( &xElapsedTime, &xInterval.it_value, &xElapsedTime );
+        TEST_ASSERT_TRUE( iStatus == 0 );
     }
 
     /* Delete timer. */
@@ -383,8 +383,8 @@ TEST( Full_POSIX_TIMER, timer_settime_abstime )
         TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
         iStatus = UTILS_TimespecAddNanoseconds( &xAbsoluteTimeout.it_value,
-                                                &xAbsoluteTimeout.it_value,
-                                                posixtestSHORT_TIMER_DELAY_NANOSECONDS );
+                                                posixtestSHORT_TIMER_DELAY_NANOSECONDS,
+                                                &xAbsoluteTimeout.it_value );
         TEST_ASSERT_EQUAL_INT( 0, iStatus );
 
         iStatus = timer_settime( xTimer, TIMER_ABSTIME, &xAbsoluteTimeout, NULL );
@@ -401,7 +401,7 @@ TEST( Full_POSIX_TIMER, timer_settime_abstime )
 
         /* Calculate the difference between the timeout expiration and the absolute
          * timeout. Ensure that it's small and positive. */
-        iStatus = UTILS_TimespecSubtract( &xTimeDifference, &xThreadReturnValues.xExpirationTime, &xAbsoluteTimeout.it_value );
+        iStatus = UTILS_TimespecSubtract( &xThreadReturnValues.xExpirationTime, &xAbsoluteTimeout.it_value, &xTimeDifference );
         TEST_ASSERT_EQUAL_INT( 0, iStatus );
         TEST_ASSERT_TRUE( ( xTimeDifference.tv_sec == 0 ) && ( xTimeDifference.tv_nsec >= 0 ) );
     }
@@ -452,7 +452,7 @@ TEST( Full_POSIX_TIMER, timer_settime_abstime_in_past )
 
         /* Calculate the difference between the timeout expiration and the start time.
          * Ensure that it's small and positive. */
-        iStatus = UTILS_TimespecSubtract( &xTimeDifference, &xThreadReturnValues.xExpirationTime, &xStartTime );
+        iStatus = UTILS_TimespecSubtract( &xThreadReturnValues.xExpirationTime, &xStartTime, &xTimeDifference );
         TEST_ASSERT_EQUAL_INT( 0, iStatus );
         TEST_ASSERT_TRUE( ( xTimeDifference.tv_sec == 0 ) && ( xTimeDifference.tv_nsec >= 0 ) );
     }

--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -91,6 +91,7 @@ def is_ignored_file_pattern(file_name):
         "lib/secure_sockets/portable",
         "lib/third_party/",
         "lib/wifi/portable",
+        "tests/common/posix",
     ]
     for ignored_pattern in ignored_patterns:
         if re.findall(ignored_pattern, file_name):


### PR DESCRIPTION
Fixed potential UTILS_TimespecSubtract overflow
Updated UTILS_AbsoluteTimespecToTicks to get rid of call to posix function
Added unit tests
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
