### PR TITLE
Fix/ble wifi provisioning

### DIFF
--- a/demos/common/network_manager/aws_iot_network_manager.c
+++ b/demos/common/network_manager/aws_iot_network_manager.c
@@ -691,24 +691,26 @@ uint32_t AwsIotNetworkManager_WaitForNetworkConnection( void )
 
 uint32_t AwsIotNetworkManager_EnableNetwork( uint32_t ulNetworkTypes )
 {
-	uint32_t ulEnabled = AWSIOT_NETWORK_TYPE_NONE;
+    uint32_t ulEnabled = AWSIOT_NETWORK_TYPE_NONE;
 
-	if( ( ulNetworkTypes & AWSIOT_NETWORK_TYPE_WIFI ) == AWSIOT_NETWORK_TYPE_WIFI )
-	{
-		if( prvWIFIEnable() == true )
-		{
-			ulEnabled  |= AWSIOT_NETWORK_TYPE_WIFI;
-		}
-	}
-	if( ( ulNetworkTypes & AWSIOT_NETWORK_TYPE_BLE ) == AWSIOT_NETWORK_TYPE_BLE )
-	{
-		if( prvBLEEnable() == true )
-		{
-			ulEnabled |= AWSIOT_NETWORK_TYPE_BLE;
-		}
-	}
+    if( ( ulNetworkTypes & AWSIOT_NETWORK_TYPE_BLE ) == AWSIOT_NETWORK_TYPE_BLE )
+    {
+        if( prvBLEEnable() == true )
+        {
+            ulEnabled |= AWSIOT_NETWORK_TYPE_BLE;
+        }
+    }
 
-	return ulEnabled;
+    if( ( ulNetworkTypes & AWSIOT_NETWORK_TYPE_WIFI ) == AWSIOT_NETWORK_TYPE_WIFI )
+    {
+        if( prvWIFIEnable() == true )
+        {
+            ulEnabled  |= AWSIOT_NETWORK_TYPE_WIFI;
+        }
+    }
+
+
+    return ulEnabled;
 }
 
 uint32_t AwsIotNetworkManager_DisableNetwork( uint32_t ulNetworkTypes )

--- a/demos/espressif/esp32_devkitc_esp_wrover_kit/common/config_files/aws_ble_config.h
+++ b/demos/espressif/esp32_devkitc_esp_wrover_kit/common/config_files/aws_ble_config.h
@@ -38,9 +38,6 @@
 /* Enable WIFI provisioning GATT service. */
 #define bleconfigENABLE_WIFI_PROVISIONING         ( 1 )
 
-/*Preferred MTU size. */
-#define  bleconfigPREFERRED_MTU_SIZE               ( 180 )
-
 /* Include BLE default config at bottom to set the default values for the configurations which are not overridden */
 #include "aws_ble_config_defaults.h"
 


### PR DESCRIPTION
Fix  Network Manager: Change order of initialization of networks
Description
-----------
Wifi network  couldn't be provisioned as BLE stack was enabled after WIFI was enabled. The PR fixes the order of network intialization. 

Also reverts the  preferred mtu size for esp32 to default value 512.

Checklist:
-----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
