### PR TITLE
performance counter -- driver for st.

### DIFF
--- a/lib/hal/include/aws_hal_perf_cntr.h
+++ b/lib/hal/include/aws_hal_perf_cntr.h
@@ -1,0 +1,76 @@
+/*
+* Amazon FreeRTOS V1.x.x
+* Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* http://aws.amazon.com/freertos
+* http://www.FreeRTOS.org
+*/
+
+/**
+* @file aws_hal_perf_cntr.h
+* @brief File for the APIs of performance counter called by application layer.
+*
+* Performance counter uses a hardware peripheral timer to track time elapsed since
+* the start of the counter. The interface implementation is MCU specific, and counter
+* resolution is configurable via FreeRTOSConfig.h.
+*
+* To use the interfaces, application code needs to:
+* - Initialize counter by calling aws_hal_perfcounter_open().
+* - Get counter value for as many times as you want in whatever thread context
+*   by calling aws_hal_perfcounter_get_value().
+* - Time elapsed can be derived by ( counter value / counter frequency ),
+*   where counter frequency can be acquired by calling aws_hal_perfcounter_get_frequency_hz().
+* - Once completely done with performance measurement,
+*   free resources by calling aws_hal_perfcounter_close().
+*
+* @warning It's not recommended to repurpose the hardware timer, nor have timer vector interrupt
+*          priority lower than other peripheral vector interrupt priorities. Please refer to implementation
+*          specific details.
+*/
+
+#ifndef _AWS_HAL_PERF_CNTR_H_
+#define _AWS_HAL_PERF_CNTR_H_
+
+/**
+ * @brief Initialize a hardware timer which is to be used as performance counter.
+ */
+void aws_hal_perfcounter_open(void);
+
+/**
+ * @brief Deinitialize the hardware timer.
+ */
+void aws_hal_perfcounter_close( void);
+
+/**
+ * @brief Get current count from the performance counter.
+ *
+ * @return Total count since counter started.
+ */
+uint64_t aws_hal_perfcounter_get_value(void);
+
+/**
+ * @brief Get configured frequency of the performance counter.
+ *
+ * @return Frequency which the counter is configured to run at.
+ */
+uint32_t aws_hal_perfcounter_get_frequency_hz(void);
+
+#endif /* _AWS_HAL_PERF_CNTR_H_ */

--- a/lib/hal/portable/st/aws_hal_perf_cntr.c
+++ b/lib/hal/portable/st/aws_hal_perf_cntr.c
@@ -1,0 +1,233 @@
+/*
+* Amazon FreeRTOS V1.x.x
+* Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* http://aws.amazon.com/freertos
+* http://www.FreeRTOS.org
+*/
+
+/**
+* @file aws_hal_perf_cntr.c
+* @brief File of the implementation for performance counter APIs calling STM drivers.
+*/
+
+#include <stdint.h>
+
+/* ST HAL APIs to be called in this file. */
+#include "stm32l4xx_hal.h"
+
+/* API definition to be implemented in this file. */
+#include "aws_hal_perf_cntr.h"
+
+/* Load FreeRTOS user defined performance counter configurations. */
+#include "FreeRTOSConfig.h"
+
+/**
+ * @brief Default performance counter frequency.
+ *
+ * Default is set to 10MHz ==> (uint32_t) 0xffffffff / 10MHz = 429.4967s.
+ * So roughly every 7 mins, kernel needs to serve an overflow IRQ.
+ */
+#define PERF_COUNTER_FREQ_DEFAULT           ( 10000000 )
+
+/**
+ * @brief Maximum performance counter frequency.
+ *
+ * Maximum frequency for APB1 is 80MHz. Kernel needs to serve and overflow
+ * IRQ in each ~53.6870s.
+ */
+#define PERF_COUNTER_FREQ_MAX               ( 80000000 )
+
+
+/**
+ * User suggested performance counter frequency.
+ *
+ * @warning The value of configHAL_PERF_COUNTER_FREQ needs to be smaller than
+ * TIM clock.
+ *
+ * @warning TIM prescaler only takes integer. configHAL_PERF_COUNTER_FREQ can
+ * be any value, but prescaler is (uint32_t)(PCLK1 frequency / configHAL_PERF_COUNTER_FREQ).
+ */
+#ifdef configHAL_PERF_COUNTER_FREQ
+    #define HAL_PERF_COUNTER_FREQ       ( configHAL_PERF_COUNTER_FREQ )
+#else
+    #define HAL_PERF_COUNTER_FREQ       ( PERF_COUNTER_FREQ_MAX )
+#endif
+
+/**
+ * @brief Timer width and counter period.
+ */
+#define HW_TIMER_32_WIDTH           ( sizeof( uint32_t ) * 8 )
+#define HW_TIMER_32_CONST_PERIOD    ( INT32_MAX )
+
+
+/*-----------------------------------------------------------*/
+
+static TIM_HandleTypeDef xTimerHandle = { 0 };
+static uint64_t ullTimerOverflow = 0;
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Enable interrupt for the timer.
+ */
+
+void HAL_TIM_Base_MspInit( TIM_HandleTypeDef * pxTimerHandle )
+{
+
+    if ( TIM5 == pxTimerHandle->Instance )
+    {
+        /* Enable timer clock. */
+        __HAL_RCC_TIM5_CLK_ENABLE();
+
+        /* Set interrupt priority, and enable counter overflow interrupt. */
+        HAL_NVIC_SetPriority(TIM5_IRQn, configHAL_PERF_COUNTER_INTERRUPT_PRIORITY, 0 );
+        HAL_NVIC_EnableIRQ(TIM5_IRQn);
+    }
+}
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Clean up
+ */
+
+void HAL_TIM_Base_MspDeInit( TIM_HandleTypeDef * pxTimerHandle )
+{
+    if (TIM5 == pxTimerHandle->Instance )
+    {
+        /* Disable counter overflow interrupt. */
+        HAL_NVIC_DisableIRQ(TIM5_IRQn);
+
+        /* Stop TIM5 source clock. */
+        __HAL_RCC_TIM5_CLK_DISABLE();
+    }
+
+}
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Implement overflow ISR for TIM5
+ */
+void HAL_TIM5_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+    ullTimerOverflow++;
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief TIM5 ISR
+ *
+ * @note a cleaner way to handle timer IRQ for ST is to implement a branch for
+ * .Instance == TIM5 in HAL_TIM_PeriodElapsedCallback(). Yet, to not expose static
+ * variable ullTimerOverflow, enabling USE_HAL_TIM_REGISTER_CALLBACKS and use
+ * .PeriodElapsedCallback for TIM5.
+ */
+
+void TIM5_IRQHandler(void)
+{
+    HAL_TIM_IRQHandler( &xTimerHandle );
+}
+/*-----------------------------------------------------------*/
+
+void aws_hal_perfcounter_open(void)
+{
+    uint32_t ulTimClock = 0;
+
+    /* Clear static variable which tracks total number of timer overflow. */
+    ullTimerOverflow = 0;
+
+    /* Get timer clock frequency. */
+    ulTimClock = HAL_RCC_GetPCLK1Freq();
+
+    /* Check user input frequency is valid. */
+    configASSERT( HAL_PERF_COUNTER_FREQ <= ulTimClock );
+
+    /* From STM32L475xx chip datasheet:
+     * - TIM2 and TIM5 are 32-bit general purpose timers, while others are all 16-bit.
+     * - Peripheral current consumption (Range 1/Range 2/Low power and sleep):
+     *   TIM2: 6.8/6.5/6.3 (uA/MHZ)
+     *   TIM5: 6.5/5.5/6.1 (uA/MHZ)
+     * To minimize the need for handling timer overflow interrupt with relative low cost,
+     * prefer to use TIM5 as the hardware timer for performance counter.
+     */
+    xTimerHandle.Instance = TIM5;
+
+    /* To minimize the need for serving overflow IRQ,
+     * .Period is always set to the max value the counter allows.
+     * Performance counter resolution is adjusted with .Prescaler.
+     */
+    xTimerHandle.Init.Prescaler = ulTimClock / HAL_PERF_COUNTER_FREQ;
+    xTimerHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    xTimerHandle.Init.Period = HW_TIMER_32_CONST_PERIOD;
+    xTimerHandle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    xTimerHandle.Init.RepetitionCounter = 0x00;
+    xTimerHandle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+
+    xTimerHandle.Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+
+    xTimerHandle.Lock = HAL_UNLOCKED;
+
+    xTimerHandle.State = HAL_TIM_STATE_RESET;
+
+    HAL_TIM_Base_Init( &xTimerHandle );
+
+    /* Only generate interrupt when overflow. */
+    __HAL_TIM_URS_ENABLE( &xTimerHandle );
+
+    /* Clear the initial SR.UIF bit before timer starts. */
+    __HAL_TIM_CLEAR_FLAG( &xTimerHandle, TIM_FLAG_UPDATE);
+
+    /* Register overflow IRQ callback. */
+    HAL_TIM_RegisterCallback( &xTimerHandle, HAL_TIM_PERIOD_ELAPSED_CB_ID, HAL_TIM5_PeriodElapsedCallback );
+
+    /* Timer and interrupt are configured. Now start timer. */
+    HAL_TIM_Base_Start_IT( &xTimerHandle );
+}
+
+/*-----------------------------------------------------------*/
+
+void aws_hal_perfcounter_close( void)
+{
+    HAL_TIM_Base_Stop_IT( &xTimerHandle );
+
+    HAL_TIM_Base_DeInit( &xTimerHandle );
+}
+
+/*-----------------------------------------------------------*/
+
+uint64_t aws_hal_perfcounter_get_value(void)
+{
+    return ( uint64_t ) ( ( ullTimerOverflow << HW_TIMER_32_WIDTH ) | __HAL_TIM_GET_COUNTER( &xTimerHandle ) );
+}
+
+/*-----------------------------------------------------------*/
+
+uint32_t aws_hal_perfcounter_get_frequency_hz(void)
+{
+    uint32_t ulTimClock = 0;
+
+    /* Get timer clock frequency. */
+    ulTimClock = HAL_RCC_GetPCLK1Freq();
+
+    return ( ulTimClock / ( uint32_t )( ulTimClock / HAL_PERF_COUNTER_FREQ ) );
+}
+
+/*-----------------------------------------------------------*/

--- a/tests/common/commonio/aws_test_hal_perf_cntr.c
+++ b/tests/common/commonio/aws_test_hal_perf_cntr.c
@@ -1,0 +1,78 @@
+/*
+ * Amazon FreeRTOS V1.x.x
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/*******************************************************************************
+ * @file aws_test_hal_perf_cntr.c
+ * @brief Functional Unit Test - Performance Counter
+ *******************************************************************************
+ */
+
+/* Test includes */
+#include "unity.h"
+#include "unity_fixture.h"
+
+/* Driver includes */
+#include "aws_hal_perf_cntr.h"
+
+
+TEST_GROUP( Full_HAL_PERF_CNTR );
+
+/*-----------------------------------------------------------*/
+
+TEST_SETUP( Full_HAL_PERF_CNTR )
+{
+}
+
+/*-----------------------------------------------------------*/
+
+TEST_TEAR_DOWN( Full_HAL_PERF_CNTR )
+{
+}
+
+/*-----------------------------------------------------------*/
+
+TEST_GROUP_RUNNER( Full_HAL_PERF_CNTR )
+{
+    RUN_TEST_CASE( Full_HAL_PERF_CNTR, perf_counter_happy_path );
+}
+
+/*-----------------------------------------------------------*/
+
+TEST( Full_HAL_PERF_CNTR, perf_counter_happy_path )
+{
+    uint64_t ullCounterValue1 = 0;
+    uint64_t ullCounterValue2 = 0;
+    uint32_t ulCounterFreq = 0;
+
+    aws_hal_perfcounter_open();
+    ullCounterValue1 = aws_hal_perfcounter_get_value();
+    ulCounterFreq = aws_hal_perfcounter_get_frequency_hz();
+    ullCounterValue2 = aws_hal_perfcounter_get_value();
+    aws_hal_perfcounter_close();
+
+    TEST_ASSERT_MESSAGE( ullCounterValue2 > ullCounterValue1, "Performance counter value should grow upwards.");
+    TEST_ASSERT_MESSAGE( ulCounterFreq > 0, "Performance counter value should be at least larger than 0.")
+}

--- a/tests/common/test_runner/aws_test_runner.c
+++ b/tests/common/test_runner/aws_test_runner.c
@@ -155,6 +155,11 @@ static void RunTests( void )
         extern void vStartOTAUpdateDemoTask( void );
         vStartOTAUpdateDemoTask();
     #endif
+
+    #if ( testrunnerFULL_HAL_PERF_CNTR == 1 )
+        RUN_TEST_GROUP( Full_HAL_PERF_CNTR );
+    #endif
+
 }
 /*-----------------------------------------------------------*/
 

--- a/tests/st/stm32l475_discovery/ac6/.cproject
+++ b/tests/st/stm32l475_discovery/ac6/.cproject
@@ -14,7 +14,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="elf" artifactName="aws_tests" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="fr.ac6.managedbuild.config.gnu.cross.exe.debug.887144602" name="Debug" parent="fr.ac6.managedbuild.config.gnu.cross.exe.debug" postannouncebuildStep="Generating binary and Printing size information:" postbuildStep="arm-none-eabi-objcopy -O ihex &quot;${BuildArtifactFileBaseName}.elf&quot; &quot;${BuildArtifactFileBaseName}.hex&quot; &amp;&amp; arm-none-eabi-size &quot;${BuildArtifactFileName}&quot;">
+				<configuration artifactExtension="elf" artifactName="aws_tests" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="fr.ac6.managedbuild.config.gnu.cross.exe.debug.887144602" name="Debug" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="fr.ac6.managedbuild.config.gnu.cross.exe.debug" postannouncebuildStep="Generating binary and Printing size information:" postbuildStep="arm-none-eabi-objcopy -O ihex &quot;${BuildArtifactFileBaseName}.elf&quot; &quot;${BuildArtifactFileBaseName}.hex&quot; &amp;&amp; arm-none-eabi-size &quot;${BuildArtifactFileName}&quot;">
 					<folderInfo id="fr.ac6.managedbuild.config.gnu.cross.exe.debug.887144602." name="/" resourcePath="">
 						<toolChain id="fr.ac6.managedbuild.toolchain.gnu.cross.exe.debug.999539370" name="Ac6 STM32 MCU GCC" superClass="fr.ac6.managedbuild.toolchain.gnu.cross.exe.debug">
 							<option id="fr.ac6.managedbuild.option.gnu.cross.prefix.22516938" name="Prefix" superClass="fr.ac6.managedbuild.option.gnu.cross.prefix" useByScannerDiscovery="false" value="arm-none-eabi-" valueType="string"/>
@@ -32,9 +32,10 @@
 							<tool command="gcc" id="fr.ac6.managedbuild.tool.gnu.cross.c.compiler.684170490" name="MCU GCC Compiler" superClass="fr.ac6.managedbuild.tool.gnu.cross.c.compiler">
 								<option defaultValue="gnu.c.optimization.level.none" id="fr.ac6.managedbuild.gnu.c.compiler.option.optimization.level.226248843" name="Optimization Level" superClass="fr.ac6.managedbuild.gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="fr.ac6.managedbuild.gnu.c.optimization.level.none" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.debugging.level.722772844" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.include.paths.1847441575" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1847441575" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../../../../lib/FreeRTOS-Plus-POSIX/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../../../../lib/FreeRTOS-Plus-POSIX/include/portable/st/stm32l475_discovery&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../../../..//lib/hal/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/config_files}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/application_code}&quot;"/>
@@ -61,7 +62,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lib/third_party/mcu_vendor/st/stm32l475_discovery/BSP/Components/vl53l0x}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lib/third_party/mcu_vendor/st/stm32l475_discovery/BSP/Components/es_wifi}&quot;"/>
 								</option>
-								<option id="gnu.c.compiler.option.preprocessor.def.symbols.1779062689" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1779062689" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
 									<listOptionValue builtIn="false" value="STM32L475xx"/>
 									<listOptionValue builtIn="false" value="MQTTCLIENT_PLATFORM_HEADER=MQTTCMSIS.h"/>

--- a/tests/st/stm32l475_discovery/ac6/.project
+++ b/tests/st/stm32l475_discovery/ac6/.project
@@ -61,6 +61,11 @@
 			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
+			<name>application_code/common_tests/commonio</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
 			<name>application_code/common_tests/crypto</name>
 			<type>2</type>
 			<locationURI>AWS_IOT_MCU_ROOT/tests/common/crypto</locationURI>
@@ -103,7 +108,7 @@
 		<link>
 			<name>application_code/common_tests/posix</name>
 			<type>2</type>
-			<location>AWS_IOT_MCU_ROOT/tests/common/posix</location>
+			<locationURI>AWS_IOT_MCU_ROOT/tests/common/posix</locationURI>
 		</link>
 		<link>
 			<name>application_code/common_tests/secure_sockets</name>
@@ -156,6 +161,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/lib/greengrass</locationURI>
 		</link>
 		<link>
+			<name>lib/aws/hal</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
 			<name>lib/aws/include</name>
 			<type>2</type>
 			<locationURI>AWS_IOT_MCU_ROOT/lib/include</locationURI>
@@ -169,6 +179,11 @@
 			<name>lib/aws/pkcs11</name>
 			<type>2</type>
 			<locationURI>AWS_IOT_MCU_ROOT/lib/pkcs11/portable/st/stm32l475_discovery</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/portable</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
 			<name>lib/aws/secure_sockets</name>
@@ -226,6 +241,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/lib/third_party/unity/extras/fixture/src</locationURI>
 		</link>
 		<link>
+			<name>application_code/common_tests/commonio/aws_test_hal_perf_cntr.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/tests/common/commonio/aws_test_hal_perf_cntr.c</locationURI>
+		</link>
+		<link>
 			<name>application_code/common_tests/greengrass/aws_test_greengrass_discovery.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/tests/common/greengrass/aws_test_greengrass_discovery.c</locationURI>
@@ -258,12 +278,32 @@
 		<link>
 			<name>lib/aws/FreeRTOS-Plus-POSIX/source</name>
 			<type>2</type>
-			<location>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/source</location>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/source</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/hal/include</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/hal/portable</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/include/aws_hal_perf_cntr.h</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/hal/include/aws_hal_perf_cntr.h</locationURI>
 		</link>
 		<link>
 			<name>lib/aws/pkcs11/aws_pkcs11_mbedtls.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/lib/pkcs11/mbedtls/aws_pkcs11_mbedtls.c</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/portable/st</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
 			<name>lib/third_party/mbedtls/include</name>
@@ -283,22 +323,42 @@
 		<link>
 			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX.h</name>
 			<type>1</type>
-			<location>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX.h</location>
-		</link>
-		<link>
-			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_portable.h</name>
-			<type>1</type>
-			<location>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/portable/st/stm32l475_discovery/FreeRTOS_POSIX_portable.h</location>
-		</link>
-		<link>
-			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_portable_default.h</name>
-			<type>1</type>
-			<location>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h</location>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX.h</locationURI>
 		</link>
 		<link>
 			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h</name>
 			<type>1</type>
-			<location>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h</location>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_portable.h</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/portable/st/stm32l475_discovery/FreeRTOS_POSIX_portable.h</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_portable_default.h</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/hal/include/aws_hal_perf_cntr.h</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/hal/include/aws_hal_perf_cntr.h</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/hal/portable/st</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/portable/st/aws_hal_perf_cntr.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/hal/portable/st/aws_hal_perf_cntr.c</locationURI>
+		</link>
+		<link>
+			<name>lib/aws/hal/portable/st/aws_hal_perf_cntr.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/lib/hal/portable/st/aws_hal_perf_cntr.c</locationURI>
 		</link>
 	</linkedResources>
 	<filteredResources>

--- a/tests/st/stm32l475_discovery/common/application_code/st_code/stm32l4xx_hal_conf.h
+++ b/tests/st/stm32l475_discovery/common/application_code/st_code/stm32l4xx_hal_conf.h
@@ -209,6 +209,9 @@
   */
 /* #define USE_FULL_ASSERT    1 */
 
+/* ######################## FreeRTOS Additional ############################ */
+#define USE_HAL_TIM_REGISTER_CALLBACKS    1U
+
 /* Includes ------------------------------------------------------------------*/
 /**
   * @brief Include module's header file 

--- a/tests/st/stm32l475_discovery/common/config_files/FreeRTOSConfig.h
+++ b/tests/st/stm32l475_discovery/common/config_files/FreeRTOSConfig.h
@@ -72,6 +72,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configOVERRIDE_DEFAULT_TICK_CONFIGURATION    1
 #define configRECORD_STACK_HIGH_ADDRESS              1
 #define configUSE_POSIX_ERRNO                        1
+#define configUSE_HAL_PERF_COUNTER                   1
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES                        0
@@ -122,6 +123,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configMAX_SYSCALL_INTERRUPT_PRIORITY \
     ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+/* Performance counter frequency in Hz. */
+#define configHAL_PERF_COUNTER_FREQ                     ( 10000000 )    // 10MHz
+
+/* Performance counter interrupt priority.
+ * Do not disable performance counter interrupt in critical section. */
+#define configHAL_PERF_COUNTER_INTERRUPT_PRIORITY       ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY - 1 )
 
 /* Normal assert() semantics without relying on the provision of an assert.h
  * header file. */

--- a/tests/st/stm32l475_discovery/common/config_files/aws_test_runner_config.h
+++ b/tests/st/stm32l475_discovery/common/config_files/aws_test_runner_config.h
@@ -52,4 +52,6 @@
 #define testrunnerFULL_TLS_ENABLED                 0
 #define testrunnerFULL_POSIX_ENABLED               0
 
+#define testrunnerFULL_HAL_PERF_CNTR               1
+
 #endif /* AWS_TEST_RUNNER_CONFIG_H */


### PR DESCRIPTION
Implementation of HAL performance counter APIs for STM32 discovery. 

Description
-----------
This PR is purely "device driver", which includes configuration for HW peripheral timer, IRQ, compilation, and etc. I would like to get code structure and generic steps reviewed. 

Known todos:
- FreeRTOSConfig.h, when configUSE_HAL_PERF_COUNTER is set to 0, perf counter APIs and memory allocation should be completely switched off.
- Code formatting. My debugging env is on MacOS && Eclipse, I need to format everything with our uncrustify cfg. 

Things you may find interesting -- the way perf counter resolution is configured:
In FreeRTOSConfig.h, user seems to be able to define whatever counter resolution they want with ```configHAL_PERF_COUNTER_FREQ```. However, to minimize the need for kernel to server counter overflow IRQ, timer period is always set to the maximum it allows. (for 32-bit counter, 0xffffffff) And period absolute duration is adjusted with clock prescaler, which only takes integer. 

e.g.1 APB1 bus frequency max is 80MHz, and our test project use 80MHz as APB1 frequency. When user sets ```configHAL_PERF_COUNTER_FREQ = 50MHz```, ```prescaler = (uint32_t) 80Mhz/50Mhz = 1```. In this case, timer source clock is still 80MHz, and  ```aws_hal_perfcounter_get_frequency_hz()``` returns 80MHz.

e.g.2 ```configHAL_PERF_COUNTER_FREQ = 40MHz```, ```prescaler = 2```. So, ```aws_hal_perfcounter_get_frequency_hz()``` returns 40MHz.

See more in code comment.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.