### PR TITLE
fix: pthread_mutex_unlock update owner atomically

### DIFF
--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
@@ -297,6 +297,10 @@ int pthread_mutex_unlock( pthread_mutex_t * mutex )
 
     if( iStatus == 0 )
     {
+        /* Suspend the sheduler so that
+         * mutex is unlocked AND owner is updated atomically */
+        vTaskSuspendAll();
+
         /* Call the correct FreeRTOS mutex unlock function based on mutex type. */
         if( pxMutex->xAttr.iType == PTHREAD_MUTEX_RECURSIVE )
         {
@@ -310,6 +314,9 @@ int pthread_mutex_unlock( pthread_mutex_t * mutex )
         /* Update the owner of the mutex. A recursive mutex may still have an
          * owner, so it should be updated with xSemaphoreGetMutexHolder. */
         pxMutex->xTaskOwner = xSemaphoreGetMutexHolder( ( SemaphoreHandle_t ) &pxMutex->xMutex );
+
+        /* Resume the scheduler */
+        ( void ) xTaskResumeAll();
     }
 
     return iStatus;


### PR DESCRIPTION
Added critical section protection to update owner and unlock atomically

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
