### PR TITLE
Fix: Fixing instabilities due to UART

### DIFF
--- a/demos/nordic/nrf52840-dk/common/config_files/sdk_config.h
+++ b/demos/nordic/nrf52840-dk/common/config_files/sdk_config.h
@@ -7347,7 +7347,7 @@
 // <i> Log data is buffered and can be processed in idle.
 
 #ifndef NRF_LOG_DEFERRED
-#define NRF_LOG_DEFERRED 1
+#define NRF_LOG_DEFERRED 0
 #endif
 
 // <q> NRF_LOG_FILTERS_ENABLED  - Enable dynamic filtering of logs.
@@ -12146,7 +12146,7 @@
 
 // <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
 #ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
-#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 180
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 247 
 #endif
 
 // <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.


### PR DESCRIPTION
Fix: ble reliability fix

Description
-----------
 ble reliability fix.
UART interrupt was getting preempted cause system instabilities

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
