### PR TITLE
fix: Add printing of FS security alert count to the main.c of the TI CC3220SF

### DIFF
--- a/demos/ti/cc3220_launchpad/common/application_code/main.c
+++ b/demos/ti/cc3220_launchpad/common/application_code/main.c
@@ -88,7 +88,7 @@ const AppVersion32_t xAppFirmwareVersion =
 void vApplicationDaemonTaskStartupHook( void );
 static void prvWifiConnect( void );
 static CK_RV prvProvisionRootCA( void );
-
+static void prvShowTiCc3220SecurityAlertCounts( void );
 
 /**
  * @brief Performs board and logging initializations, then starts the OS.
@@ -171,6 +171,12 @@ void vApplicationDaemonTaskStartupHook( void )
     if( SYSTEM_Init() == pdPASS )
     {
         prvWifiConnect();
+
+        /* Show the possible security alerts that will affect re-flashing the device. 
+         * When the number of security alerts reaches the threshold, the device file system is locked and 
+         * the device cannot be automatically flashed, but must be reprogrammed with uniflash. This routine is placed 
+         * here for debugging purposes. */
+        prvShowTiCc3220SecurityAlertCounts();
 
         DEMO_RUNNER_RunDemos();
     }
@@ -385,3 +391,24 @@ void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief In the Texas Instruments CC3220(SF) device, we retrieve the number of security alerts and the threshold.
+ */
+static void prvShowTiCc3220SecurityAlertCounts( void )
+{
+    int32_t lResult;
+    SlFsControlGetStorageInfoResponse_t xStorageResponseInfo;
+
+    lResult = sl_FsCtl( ( SlFsCtl_e ) SL_FS_CTL_GET_STORAGE_INFO, 0, NULL, NULL, 0, ( _u8 * ) &xStorageResponseInfo, sizeof( SlFsControlGetStorageInfoResponse_t ), NULL );
+
+    if( lResult == 0 )
+    {
+        configPRINTF( ( "Security alert threshold = %d\r\n", xStorageResponseInfo.FilesUsage.NumOfAlertsThreshold ) );
+        configPRINTF( ( "Current number of alerts = %d\r\n", xStorageResponseInfo.FilesUsage.NumOfAlerts ) );
+    }
+    else
+    {
+        configPRINTF( ( "sl_FsCtl failed with error code: %d\r\n", lResult ) );
+    }
+}

--- a/tests/common/ota/aws_test_ota_pal.c
+++ b/tests/common/ota/aws_test_ota_pal.c
@@ -78,28 +78,6 @@ static uint8_t ucDummyData[] =
 static OTA_FileContext_t xOtaFile;
 
 #ifdef CC3220sf
-
-    /**
-     * @brief In the Texas Instruments CC3220(SF) device, we retrieve the number of security alerts and the threshold.
-     */
-    static void prvShowTiCc3220SecurityAlertCounts()
-    {
-        int32_t lResult;
-        SlFsControlGetStorageInfoResponse_t xStorageResponseInfo;
-
-        lResult = sl_FsCtl( ( SlFsCtl_e ) SL_FS_CTL_GET_STORAGE_INFO, 0, NULL, NULL, 0, ( _u8 * ) &xStorageResponseInfo, sizeof( SlFsControlGetStorageInfoResponse_t ), NULL );
-
-        if( lResult == 0 )
-        {
-            configPRINTF( ( "Security alert threshold = %d\r\n", xStorageResponseInfo.FilesUsage.NumOfAlertsThreshold ) );
-            configPRINTF( ( "Current number of alerts = %d\r\n", xStorageResponseInfo.FilesUsage.NumOfAlerts ) );
-        }
-        else
-        {
-            configPRINTF( ( "sl_FsCtl failed with error code: %d\r\n", lResult ) );
-        }
-    }
-
     /**
      * @brief In the Texas Instruments CC3220(SF) device, we need to restore mcuflashimage.bin to factory following tests
      * that increase the number of security alerts.

--- a/tests/common/ota/aws_test_ota_pal.c
+++ b/tests/common/ota/aws_test_ota_pal.c
@@ -79,9 +79,9 @@ static OTA_FileContext_t xOtaFile;
 
 #ifdef CC3220sf
 
-/**
- * @brief In the Texas Instruments CC3220(SF) device, we retrieve the number of security alerts and the threshold.
- */
+    /**
+     * @brief In the Texas Instruments CC3220(SF) device, we retrieve the number of security alerts and the threshold.
+     */
     static void prvShowTiCc3220SecurityAlertCounts()
     {
         int32_t lResult;
@@ -100,10 +100,10 @@ static OTA_FileContext_t xOtaFile;
         }
     }
 
-/**
- * @brief In the Texas Instruments CC3220(SF) device, we need to restore mcuflashimage.bin to factory following tests
- * that increase the number of security alerts.
- */
+    /**
+     * @brief In the Texas Instruments CC3220(SF) device, we need to restore mcuflashimage.bin to factory following tests
+     * that increase the number of security alerts.
+     */
     static void prvResetTiCc3220ToFactoryImage()
     {
         int32_t lResult, lRetVal, lExtendedError;


### PR DESCRIPTION
* This is to help with debugging possible security alerts caused by testing that are not cleared. 
* Through experimentation the alert count would print only when the routine is placed after the WiFi connection is complete.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
