### PR TITLE
docs: Add OTA image download partition information to prvPAL_CreateFileForRx().

### DIFF
--- a/lib/include/private/aws_ota_pal.h
+++ b/lib/include/private/aws_ota_pal.h
@@ -64,6 +64,9 @@ OTA_Err_t prvPAL_Abort( OTA_FileContext_t * const C );
  * 
  * @note Opens the file indicated in the OTA file context in the MCU file system.
  * 
+ * @note The previous image may be present in the designated image download partition or file, so the partition or file
+ * must be completely erased or overwritten in this routine.
+ * 
  * @note The input OTA_FileContext_t C is checked for NULL by the OTA agent before this
  * function is called. 
  * The device file path is a required field in the OTA job document, so C->pacFilepath is 


### PR DESCRIPTION
* Specify that the entire flash partition designated for OTA image download must be completely erased in prvPAL_CreateFileForRx().

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [n/a] I have tested my changes. No regression in existing tests.
- [n/a] My code is Linted.
