### PR TITLE
Updates to the Quick Start script given documention feedback

### DIFF
--- a/tools/aws_config_quick_start/README.md
+++ b/tools/aws_config_quick_start/README.md
@@ -5,7 +5,7 @@ and the configuring the files `aws_clientcredential.h` and `aws_cliencredential_
 Make sure you have `aws cli` configured on your machine with access_key, secret_key and region.
 
 Open the file `configure.json` and fill in the following details:
-* afr_source_dir : The path of the amazon-freertos directory. By default, this is set to the amazon-freertos directory this tool is located (../..).
+* afr_source_dir : The path of the amazon-freertos directory. By default, this is set to the top level of this repo (../..).
 * thing_name : Name of the thing you want to create
 * wifi_ssid : The SSID of the wifi you want to use.
 * wifi_password : The password of your wifi.

--- a/tools/aws_config_quick_start/README.md
+++ b/tools/aws_config_quick_start/README.md
@@ -5,7 +5,7 @@ and the configuring the files `aws_clientcredential.h` and `aws_cliencredential_
 Make sure you have `aws cli` configured on your machine with access_key, secret_key and region.
 
 Open the file `configure.json` and fill in the following details:
-* afr_source_dir : The absolute path of the amazon-freertos directory.
+* afr_source_dir : The path of the amazon-freertos directory. By default, this is set to the amazon-freertos directory this tool is located (../..).
 * thing_name : Name of the thing you want to create
 * wifi_ssid : The SSID of the wifi you want to use.
 * wifi_password : The password of your wifi.

--- a/tools/aws_config_quick_start/SetupAWS.py
+++ b/tools/aws_config_quick_start/SetupAWS.py
@@ -73,7 +73,7 @@ def update_credential_file():
     with open('configure.json') as file:
         json_text = json.load(file)
 
-    afr_source_dir = json_text['afr_source_dir']
+    afr_source_dir = os.path.expanduser(json_text['afr_source_dir'])
     thing_name = json_text['thing_name']
     wifi_ssid = json_text['wifi_ssid']
     wifi_passwd = json_text['wifi_password']
@@ -139,7 +139,7 @@ def cleanup_creds():
     with open('configure.json') as file:
         json_text = json.load(file)
 
-    afr_source_dir = json_text['afr_source_dir']
+    afr_source_dir = os.path.expanduser(json_text['afr_source_dir'])
     # Cleanup modified 'aws_clientcredential.h' file
     misc.cleanup_client_credential_file(afr_source_dir)
 

--- a/tools/aws_config_quick_start/configure.json
+++ b/tools/aws_config_quick_start/configure.json
@@ -1,5 +1,5 @@
 {
-    "afr_source_dir":"$afr_source_dir",
+    "afr_source_dir":"../..",
     "thing_name":"$thing_name",
     "wifi_ssid":"$wifi_ssid",
     "wifi_password":"$wifi_password",


### PR DESCRIPTION
- For ease of use add the relative path to afr_source_dir in configure.json.
- Add support for the ~ relative home path in Unix systems. 

Tested ../.., ~, and absolute paths in Linux and Windows.

----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [n/a] My code is Linted.
