### PR TITLE
fix: Update variable exception in the OTA E2E tests.

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_before_signing.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_before_signing.py
@@ -60,7 +60,7 @@ class OtaTestCorruptImageBeforeSigning( OtaTestCase ):
         )
         if self._otaAwsAgent._stageParams:
             # Create a job.
-            jobId = self._otaAwsAgent.createOtaUpdate(
+            otaUpdateId = self._otaAwsAgent.createOtaUpdate(
                 deploymentFiles = [
                     {
                         'fileName': self._otaConfig['device_firmware_file_name'],

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_untrusted_certificate.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_untrusted_certificate.py
@@ -63,7 +63,7 @@ class OtaTestUntrustedCertificate( OtaTestCase ):
         )
         # Create a job.
         if self._otaAwsAgent._stageParams:
-            jobId = self._otaAwsAgent.createOtaUpdate(
+            otaUpdateId = self._otaAwsAgent.createOtaUpdate(
                 deploymentFiles = [
                     {
                         'fileName': os.path.basename(self._otaConfig['ota_firmware_file_path']),


### PR DESCRIPTION
* "jobId" variable name was changes for accuracy and was missed in some files.
* This exception manifested only during testing in non-production AWS development stages for the tests OtaTestUntrustedCertificate and OtaTestCorruptImageBeforeSigning.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests. http://34.216.37.221/job/afr_test_ota_e2e_custom/4/
- [n/a] My code is Linted.
