### PR TITLE
Exit the OTA E2E tests for build failures and AWS initialization errors

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case.py
@@ -93,12 +93,13 @@ class OtaTestCase( object ):
         """Run this OTA test case.
         """
         print('---------- Running '+ self._boardConfig['name'] + ' : ' + self._name + ' ----------')
-        # Run the implemented setup.
-        self.setup()
 
         # Run the implemented runTest function
         logAppendage = ''
         try:
+            # Run the implemented setup.
+            self.setup()
+            # Run the actual test.
             testResult = self.run()
         except Exception:
             logAppendage = traceback.format_exc()

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_main.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_main.py
@@ -27,7 +27,6 @@ import os
 import json
 import sys
 import argparse
-import traceback
 from threading import Thread
 from functools import reduce
 from operator import add
@@ -199,17 +198,13 @@ def otaTestMain():
         if boardConfig['exclude']:
             continue
         boardToResults[boardConfig['name']] = []
-        try:
-            if args.separateThreads == True:
-                threads.append(Thread(
-                    target=getBoardOtaTestResult, \
-                    args=(boardConfig, stageParams, boardToResults[boardConfig['name']])
-                ))
-            else:
-                getBoardOtaTestResult(boardConfig, stageParams, boardToResults[boardConfig['name']])
-        except:
-            print(traceback.format_exc())
-            sys.exit(-1)
+        if args.separateThreads == True:
+            threads.append(Thread(
+                target=getBoardOtaTestResult, \
+                args=(boardConfig, stageParams, boardToResults[boardConfig['name']])
+            ))
+        else:
+            getBoardOtaTestResult(boardConfig, stageParams, boardToResults[boardConfig['name']])
         
     for i in range(len(threads)):
         threads[i].start()

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_main.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_main.py
@@ -27,6 +27,7 @@ import os
 import json
 import sys
 import argparse
+import traceback
 from threading import Thread
 from functools import reduce
 from operator import add
@@ -198,13 +199,17 @@ def otaTestMain():
         if boardConfig['exclude']:
             continue
         boardToResults[boardConfig['name']] = []
-        if args.separateThreads == True:
-            threads.append(Thread(
-                target=getBoardOtaTestResult, \
-                args=(boardConfig, stageParams, boardToResults[boardConfig['name']])
-            ))               
-        else:
-            getBoardOtaTestResult(boardConfig, stageParams, boardToResults[boardConfig['name']])
+        try:
+            if args.separateThreads == True:
+                threads.append(Thread(
+                    target=getBoardOtaTestResult, \
+                    args=(boardConfig, stageParams, boardToResults[boardConfig['name']])
+                ))
+            else:
+                getBoardOtaTestResult(boardConfig, stageParams, boardToResults[boardConfig['name']])
+        except:
+            print(traceback.format_exc())
+            sys.exit(-1)
         
     for i in range(len(threads)):
         threads[i].start()

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -24,6 +24,7 @@ http://www.FreeRTOS.org
 
 """
 import os
+import traceback
 from .aws_flash_serial_comm import FlashSerialComm
 from .aws_ota_project import OtaAfrProject
 from .aws_ota_aws_agent import OtaAwsAgent
@@ -56,8 +57,6 @@ class OtaTestRunner:
         self._boardConfig = boardConfig
         self._stageParams = stageParams
         self._otaConfig = boardConfig['ota_config']
-        
-        # Initialize all objects needed by test cases.
         self._flashComm = FlashSerialComm(boardConfig['flash_config'], boardConfig['flash_config']['output'], self._otaConfig['device_firmware_file_name'])
         self._otaProject = OtaAfrProject(os.path.join(boardConfig['afr_root'], boardConfig['demos_or_tests']), boardConfig['vendor_board_path'], boardConfig['build_config'])
         self._otaAwsAgent = OtaAwsAgent(self._boardConfig['name'], self._otaConfig['aws_ota_update_role_arn'], self._otaConfig['aws_s3_bucket_name'], stageParams, True)

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -57,9 +57,10 @@ class OtaTestRunner:
         self._boardConfig = boardConfig
         self._stageParams = stageParams
         self._otaConfig = boardConfig['ota_config']
-        self._flashComm = FlashSerialComm(boardConfig['flash_config'], boardConfig['flash_config']['output'], self._otaConfig['device_firmware_file_name'])
         self._otaProject = OtaAfrProject(os.path.join(boardConfig['afr_root'], boardConfig['demos_or_tests']), boardConfig['vendor_board_path'], boardConfig['build_config'])
         self._otaAwsAgent = OtaAwsAgent(self._boardConfig['name'], self._otaConfig['aws_ota_update_role_arn'], self._otaConfig['aws_s3_bucket_name'], stageParams, True)
+        # FlashSerialComm opens a thread. If there is an exception in OtaAwsAgent we want to exit the program, so this is initialized last.
+        self._flashComm = FlashSerialComm(boardConfig['flash_config'], boardConfig['flash_config']['output'], self._otaConfig['device_firmware_file_name'])
 
         # Get the test cases from the board's ota config.
         self._otaTestCases = self.__getOtaTestCases(self._otaConfig)


### PR DESCRIPTION
When the program did not exit, this hogged the test machine indefinitely. 

When there was an exception in initializing AWS resources or the initial project build for a test case fails, then the program would not exit. This is because FlashSerialComm opened a separate thread that was still running. I have moved the initialization of the serial port reading thread last. I moved the test case setup, that may build a project, to a try catch block noting the exception as a failure. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests. http://34.216.37.221/job/ota_e2e_cust/7/console
- [ ] My code is Linted.
