### PR TITLE
Fix: Numeric comparison flag

### DIFF
--- a/demos/common/ble/aws_ble_numericComparison.c
+++ b/demos/common/ble/aws_ble_numericComparison.c
@@ -71,8 +71,7 @@ void NumericComparisonInit(void)
 	#if( bleconfigENABLE_NUMERIC_COMPARISON == 1 )
     /* Create a queue that will pass in the code to the UART task and wait validation from the user. */
     xNumericComparisonQueue = xQueueCreate( 1, sizeof( BLEPassKeyConfirm_t ) );
-	#endif
-
     xTaskCreate(userInputTask, "InputTask", 2048, NULL, 0, NULL);
+    #endif
 
 }


### PR DESCRIPTION
Fix Numeric comparison flag

Description
-----------
Fix a bug, when numeric comparison was disabled, it would cause a crash

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
