### PR TITLE
prvCheckOptions refactoring

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -1272,8 +1272,8 @@ static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pp
 	{
 		/* All other options have a length field, so that we easily
 		can skip past them. */
-		unsigned char len = ( *ppucPtr )[ 1 ];
-		if( ( len < 2 ) || ( len > xRemainingOptionsBytes ) )
+		unsigned char ucLen = ( *ppucPtr )[ 1 ];
+		if( ( ucLen < 2 ) || ( ucLen > xRemainingOptionsBytes ) )
 		{
 			/* If the length field is too small or too big, the options are
 			 * malformed, don't process them further.
@@ -1289,19 +1289,19 @@ static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pp
 			 */
 			if( ( *ppucPtr )[0] == TCP_OPT_SACK_A )
 			{
-				len -= 2;
+				ucLen -= 2;
 				( *ppucPtr ) += 2;
 
-				while( len >= 8 )
+				while( ucLen >= 8 )
 				{
-					prvSkipPastRemainingOptions( ppucPtr, ppxSocket, &len );
+					prvSkipPastRemainingOptions( ppucPtr, ppxSocket, &ucLen );
 				}
-				/* len should be 0 by now. */
+				/* ucLen should be 0 by now. */
 			}
 		}
 		#endif	/* ipconfigUSE_TCP_WIN == 1 */
 
-		( *ppucPtr ) += len;
+		( *ppucPtr ) += ucLen;
 	}
 	return xRet;
 }

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -1182,168 +1182,171 @@ BaseType_t should_continue_loop;
 
 static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pucPtr, const unsigned char ** const pucLast, FreeRTOS_Socket_t ** const pxSocket, TCPWindow_t ** const pxTCPWindow)
 {
-		UBaseType_t uxNewMSS;
-		UBaseType_t xRemainingOptionsBytes = ( *pucLast ) - ( *pucPtr );
+	UBaseType_t uxNewMSS;
+	UBaseType_t xRemainingOptionsBytes = ( *pucLast ) - ( *pucPtr );
 
-		if( ( *pucPtr )[ 0 ] == TCP_OPT_END )
-		{
-			/* End of options. */
-			return pdFALSE;
-		}
-		if( ( *pucPtr )[ 0 ] == TCP_OPT_NOOP)
-		{
-			/* NOP option, inserted to make the length a multiple of 4. */
-			( *pucPtr )++;
-			return pdTRUE;
-		}
-
-		/* Any other well-formed option must be at least two bytes: the option
-		type byte followed by a length byte. */
-		if( xRemainingOptionsBytes < 2 )
-		{
-			return pdFALSE;
-		}
-#if( ipconfigUSE_TCP_WIN != 0 )
-		else if( ( *pucPtr )[ 0 ] == TCP_OPT_WSOPT )
-		{
-			/* Confirm that the option fits in the remaining buffer space. */
-			if( ( xRemainingOptionsBytes < TCP_OPT_WSOPT_LEN ) || ( ( *pucPtr )[ 1 ] != TCP_OPT_WSOPT_LEN ) )
-			{
-				return pdFALSE;
-			}
-
-			( *pxSocket )->u.xTCP.ucPeerWinScaleFactor = ( *pucPtr )[ 2 ];
-			( *pxSocket )->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
-			( *pucPtr ) += TCP_OPT_WSOPT_LEN;
-		}
-#endif	/* ipconfigUSE_TCP_WIN */
-		else if( ( *pucPtr )[ 0 ] == TCP_OPT_MSS )
-		{
-			/* Confirm that the option fits in the remaining buffer space. */
-			if( ( xRemainingOptionsBytes < TCP_OPT_MSS_LEN )|| ( ( *pucPtr )[ 1 ] != TCP_OPT_MSS_LEN ) )
-			{
-				return pdFALSE;
-			}
-
-			/* An MSS option with the correct option length.  FreeRTOS_htons()
-			is not needed here because usChar2u16() already returns a host
-			endian number. */
-			uxNewMSS = usChar2u16( ( *pucPtr ) + 2 );
-
-			if( ( *pxSocket )->u.xTCP.usInitMSS != uxNewMSS )
-			{
-				/* Perform a basic check on the the new MSS. */
-				if( uxNewMSS == 0 )
-				{
-					return pdFALSE;
-				}
-
-				FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", ( *pxSocket )->u.xTCP.usInitMSS, uxNewMSS ) );
-			}
-
-			if( ( *pxSocket )->u.xTCP.usInitMSS > uxNewMSS )
-			{
-				/* our MSS was bigger than the MSS of the other party: adapt it. */
-				( *pxSocket )->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
-				if( ( ( *pxTCPWindow ) != NULL ) && ( ( *pxSocket )->u.xTCP.usCurMSS > uxNewMSS ) )
-				{
-					/* The peer advertises a smaller MSS than this socket was
-					using.  Use that as well. */
-					FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", ( *pxSocket )->u.xTCP.usCurMSS, uxNewMSS ) );
-					( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-				}
-				( *pxTCPWindow )->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( ( *pxTCPWindow )->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
-				( *pxTCPWindow )->usMSSInit = ( uint16_t ) uxNewMSS;
-				( *pxTCPWindow )->usMSS = ( uint16_t ) uxNewMSS;
-				( *pxSocket )->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-				( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-			}
-
-			#if( ipconfigUSE_TCP_WIN != 1 )
-				/* Without scaled windows, MSS is the only interesting option. */
-				return pdFALSE;
-			#else
-				/* Or else we continue to check another option: selective ACK. */
-				( *pucPtr ) += TCP_OPT_MSS_LEN;
-			#endif	/* ipconfigUSE_TCP_WIN != 1 */
-		}
-		else
-		{
-			/* All other options have a length field, so that we easily
-			can skip past them. */
-			unsigned char len = ( *pucPtr )[ 1 ];
-			if( ( len < 2 ) || ( len > xRemainingOptionsBytes ) )
-			{
-				/* If the length field is too small or too big, the options are malformed.
-				Don't process them further. */
-				return pdFALSE;
-			}
-
-			#if( ipconfigUSE_TCP_WIN == 1 )
-			{
-				/* Selective ACK: the peer has received a packet but it is missing earlier
-				packets.  At least this packet does not need retransmission anymore
-				ulTCPWindowTxSack( ) takes care of this administration. */
-				if( ( *pucPtr )[0] == TCP_OPT_SACK_A )
-				{
-					len -= 2;
-					( *pucPtr ) += 2;
-
-					while( len >= 8 )
-					{
-						prvSkipPastRemainingOptions( pucPtr, pxSocket, &len );
-					}
-					/* len should be 0 by now. */
-				}
-			}
-			#endif	/* ipconfigUSE_TCP_WIN == 1 */
-
-			( *pucPtr ) += len;
-		}
+	if( ( *pucPtr )[ 0 ] == TCP_OPT_END )
+	{
+		/* End of options. */
+		return pdFALSE;
+	}
+	if( ( *pucPtr )[ 0 ] == TCP_OPT_NOOP)
+	{
+		/* NOP option, inserted to make the length a multiple of 4. */
+		( *pucPtr )++;
 		return pdTRUE;
 	}
+
+	/* Any other well-formed option must be at least two bytes: the option
+	type byte followed by a length byte. */
+	if( xRemainingOptionsBytes < 2 )
+	{
+		return pdFALSE;
+	}
+#if( ipconfigUSE_TCP_WIN != 0 )
+	else if( ( *pucPtr )[ 0 ] == TCP_OPT_WSOPT )
+	{
+		/* Confirm that the option fits in the remaining buffer space. */
+		if( ( xRemainingOptionsBytes < TCP_OPT_WSOPT_LEN ) || ( ( *pucPtr )[ 1 ] != TCP_OPT_WSOPT_LEN ) )
+		{
+			return pdFALSE;
+		}
+
+		( *pxSocket )->u.xTCP.ucPeerWinScaleFactor = ( *pucPtr )[ 2 ];
+		( *pxSocket )->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
+		( *pucPtr ) += TCP_OPT_WSOPT_LEN;
+	}
+#endif	/* ipconfigUSE_TCP_WIN */
+	else if( ( *pucPtr )[ 0 ] == TCP_OPT_MSS )
+	{
+		/* Confirm that the option fits in the remaining buffer space. */
+		if( ( xRemainingOptionsBytes < TCP_OPT_MSS_LEN )|| ( ( *pucPtr )[ 1 ] != TCP_OPT_MSS_LEN ) )
+		{
+			return pdFALSE;
+		}
+
+		/* An MSS option with the correct option length.  FreeRTOS_htons()
+		is not needed here because usChar2u16() already returns a host
+		endian number. */
+		uxNewMSS = usChar2u16( ( *pucPtr ) + 2 );
+
+		if( ( *pxSocket )->u.xTCP.usInitMSS != uxNewMSS )
+		{
+			/* Perform a basic check on the the new MSS. */
+			if( uxNewMSS == 0 )
+			{
+				return pdFALSE;
+			}
+
+			FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", ( *pxSocket )->u.xTCP.usInitMSS, uxNewMSS ) );
+		}
+
+		if( ( *pxSocket )->u.xTCP.usInitMSS > uxNewMSS )
+		{
+			/* our MSS was bigger than the MSS of the other party: adapt it. */
+			( *pxSocket )->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
+			if( ( ( *pxTCPWindow ) != NULL ) && ( ( *pxSocket )->u.xTCP.usCurMSS > uxNewMSS ) )
+			{
+				/* The peer advertises a smaller MSS than this socket was
+				using.  Use that as well. */
+				FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", ( *pxSocket )->u.xTCP.usCurMSS, uxNewMSS ) );
+				( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+			}
+			( *pxTCPWindow )->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( ( *pxTCPWindow )->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
+			( *pxTCPWindow )->usMSSInit = ( uint16_t ) uxNewMSS;
+			( *pxTCPWindow )->usMSS = ( uint16_t ) uxNewMSS;
+			( *pxSocket )->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
+			( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+		}
+
+		#if( ipconfigUSE_TCP_WIN != 1 )
+			/* Without scaled windows, MSS is the only interesting option. */
+			return pdFALSE;
+		#else
+			/* Or else we continue to check another option: selective ACK. */
+			( *pucPtr ) += TCP_OPT_MSS_LEN;
+		#endif	/* ipconfigUSE_TCP_WIN != 1 */
+	}
+	else
+	{
+		/* All other options have a length field, so that we easily
+		can skip past them. */
+		unsigned char len = ( *pucPtr )[ 1 ];
+		if( ( len < 2 ) || ( len > xRemainingOptionsBytes ) )
+		{
+			/* If the length field is too small or too big, the options are
+			 * malformed, don't process them further.
+			 */
+			return pdFALSE;
+		}
+
+		#if( ipconfigUSE_TCP_WIN == 1 )
+		{
+			/* Selective ACK: the peer has received a packet but it is missing
+			 * earlier packets. At least this packet does not need retransmission
+			 * anymore. ulTCPWindowTxSack( ) takes care of this administration.
+			 */
+			if( ( *pucPtr )[0] == TCP_OPT_SACK_A )
+			{
+				len -= 2;
+				( *pucPtr ) += 2;
+
+				while( len >= 8 )
+				{
+					prvSkipPastRemainingOptions( pucPtr, pxSocket, &len );
+				}
+				/* len should be 0 by now. */
+			}
+		}
+		#endif	/* ipconfigUSE_TCP_WIN == 1 */
+
+		( *pucPtr ) += len;
+	}
+	return pdTRUE;
+}
 
 /*-----------------------------------------------------------*/
 
 static void prvSkipPastRemainingOptions( const unsigned char ** const pucPtr, FreeRTOS_Socket_t ** const pxSocket, unsigned char * const pucLen )
 {
-					uint32_t ulFirst = ulChar2u32( ( *pucPtr ) );
-					uint32_t ulLast  = ulChar2u32( ( *pucPtr ) + 4 );
-					uint32_t ulCount = ulTCPWindowTxSack( &( *pxSocket )->u.xTCP.xTCPWindow, ulFirst, ulLast );
-						/* ulTCPWindowTxSack( ) returns the number of bytes which have been acked
-						starting from the head position.
-						Advance the tail pointer in txStream. */
-						if( ( ( *pxSocket )->u.xTCP.txStream  != NULL ) && ( ulCount > 0 ) )
-						{
-							/* Just advancing the tail index, 'ulCount' bytes have been confirmed. */
-							uxStreamBufferGet( ( *pxSocket )->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
-							( *pxSocket )->xEventBits |= eSOCKET_SEND;
+uint32_t ulFirst = ulChar2u32( ( *pucPtr ) );
+uint32_t ulLast  = ulChar2u32( ( *pucPtr ) + 4 );
+uint32_t ulCount = ulTCPWindowTxSack( &( *pxSocket )->u.xTCP.xTCPWindow, ulFirst, ulLast );
+	/* ulTCPWindowTxSack( ) returns the number of bytes which have been acked
+	 * starting from the head position.  Advance the tail pointer in txStream.
+	 */
+	if( ( ( *pxSocket )->u.xTCP.txStream  != NULL ) && ( ulCount > 0 ) )
+	{
+		/* Just advancing the tail index, 'ulCount' bytes have been confirmed. */
+		uxStreamBufferGet( ( *pxSocket )->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
+		( *pxSocket )->xEventBits |= eSOCKET_SEND;
 
-							#if ipconfigSUPPORT_SELECT_FUNCTION == 1
-							{
-								if( ( *pxSocket )->xSelectBits & eSELECT_WRITE )
-								{
-									/* The field 'xEventBits' is used to store regular socket events (at most 8),
-									as well as 'select events', which will be left-shifted */
-									( *pxSocket )->xEventBits |= ( eSELECT_WRITE << SOCKET_EVENT_BIT_COUNT );
-								}
-							}
-							#endif
+		#if ipconfigSUPPORT_SELECT_FUNCTION == 1
+		{
+			if( ( *pxSocket )->xSelectBits & eSELECT_WRITE )
+			{
+				/* The field 'xEventBits' is used to store regular socket events
+				 * (at most 8), as well as 'select events', which will be left-shifted.
+				 */
+				( *pxSocket )->xEventBits |= ( eSELECT_WRITE << SOCKET_EVENT_BIT_COUNT );
+			}
+		}
+		#endif
 
-							/* In case the socket owner has installed an OnSent handler,
-							call it now. */
-							#if( ipconfigUSE_CALLBACKS == 1 )
-							{
-								if( ipconfigIS_VALID_PROG_ADDRESS( ( *pxSocket )->u.xTCP.pxHandleSent ) )
-								{
-									( *pxSocket )->u.xTCP.pxHandleSent( (Socket_t *)( *pxSocket ), ulCount );
-								}
-							}
-							#endif /* ipconfigUSE_CALLBACKS == 1  */
-						}
-						( *pucPtr ) += 8;
-						( *pucLen ) -= 8;
-					}
+		/* In case the socket owner has installed an OnSent handler, call it now.
+		 */
+		#if( ipconfigUSE_CALLBACKS == 1 )
+		{
+			if( ipconfigIS_VALID_PROG_ADDRESS( ( *pxSocket )->u.xTCP.pxHandleSent ) )
+			{
+				( *pxSocket )->u.xTCP.pxHandleSent( (Socket_t *)( *pxSocket ), ulCount );
+			}
+		}
+		#endif /* ipconfigUSE_CALLBACKS == 1  */
+	}
+	( *pucPtr ) += 8;
+	( *pucLen ) -= 8;
+}
 
 /*-----------------------------------------------------------*/
 

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -228,6 +228,13 @@ static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t *pxSocket );
 static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer );
 
 /*
+ * Identify and deal with a single TCP header option, advancing the pointer to
+ * the header. This function returns pdTRUE or pdFALSE depending on whether the
+ * caller should continue to parse more header options or break the loop.
+ */
+static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pucPtr, const unsigned char ** const pucLast, UBaseType_t *uxNewMSS, FreeRTOS_Socket_t ** const pxSocket, TCPWindow_t ** const pxTCPWindow);
+
+/*
  * Set the initial properties in the options fields, like the preferred
  * value of MSS and whether SACK allowed.  Will be transmitted in the state
  * 'eCONNECT_SYN'.
@@ -1141,6 +1148,7 @@ const unsigned char *pucPtr;
 const unsigned char *pucLast;
 TCPWindow_t *pxTCPWindow;
 UBaseType_t uxNewMSS;
+BaseType_t should_continue_loop;
 
 	pxTCPPacket = ( TCPPacket_t * ) ( pxNetworkBuffer->pucEthernetBuffer );
 	pxTCPHeader = &pxTCPPacket->xTCPHeader;
@@ -1158,102 +1166,111 @@ UBaseType_t uxNewMSS;
 
 	/* The comparison with pucLast is only necessary in case the option data are
 	corrupted, we don't like to run into invalid memory and crash. */
-	while( pucPtr < pucLast )
+	should_continue_loop = pdTRUE;
+	while( ( pucPtr < pucLast ) && ( should_continue_loop == pdTRUE ) )
 	{
-		UBaseType_t xRemainingOptionsBytes = pucLast - pucPtr;
+		should_continue_loop = prvSingleStepTCPHeaderOptions( &pucPtr, &pucLast, &uxNewMSS, &pxSocket, &pxTCPWindow );
+	}
+}
 
-		if( pucPtr[ 0 ] == TCP_OPT_END )
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pucPtr, const unsigned char ** const pucLast, UBaseType_t *uxNewMSS, FreeRTOS_Socket_t ** const pxSocket, TCPWindow_t ** const pxTCPWindow)
+{
+		UBaseType_t xRemainingOptionsBytes = ( *pucLast ) - ( *pucPtr );
+
+		if( ( *pucPtr )[ 0 ] == TCP_OPT_END )
 		{
 			/* End of options. */
-			break;
+			return pdFALSE;
 		}
-		if( pucPtr[ 0 ] == TCP_OPT_NOOP)
+		if( ( *pucPtr )[ 0 ] == TCP_OPT_NOOP)
 		{
 			/* NOP option, inserted to make the length a multiple of 4. */
-			pucPtr++;
-			continue;
+			( *pucPtr )++;
+			return pdTRUE;
 		}
 
 		/* Any other well-formed option must be at least two bytes: the option
 		type byte followed by a length byte. */
 		if( xRemainingOptionsBytes < 2 )
 		{
-			break;
+			return pdFALSE;
 		}
 #if( ipconfigUSE_TCP_WIN != 0 )
-		else if( pucPtr[ 0 ] == TCP_OPT_WSOPT )
+		else if( ( *pucPtr )[ 0 ] == TCP_OPT_WSOPT )
 		{
 			/* Confirm that the option fits in the remaining buffer space. */
-			if( ( xRemainingOptionsBytes < TCP_OPT_WSOPT_LEN ) || ( pucPtr[ 1 ] != TCP_OPT_WSOPT_LEN ) )
+			if( ( xRemainingOptionsBytes < TCP_OPT_WSOPT_LEN ) || ( ( *pucPtr )[ 1 ] != TCP_OPT_WSOPT_LEN ) )
 			{
-				break;
+				return pdFALSE;
 			}
 
-			pxSocket->u.xTCP.ucPeerWinScaleFactor = pucPtr[ 2 ];
-			pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
-			pucPtr += TCP_OPT_WSOPT_LEN;
+			( *pxSocket )->u.xTCP.ucPeerWinScaleFactor = ( *pucPtr )[ 2 ];
+			( *pxSocket )->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
+			( *pucPtr ) += TCP_OPT_WSOPT_LEN;
 		}
 #endif	/* ipconfigUSE_TCP_WIN */
-		else if( pucPtr[ 0 ] == TCP_OPT_MSS )
+		else if( ( *pucPtr )[ 0 ] == TCP_OPT_MSS )
 		{
 			/* Confirm that the option fits in the remaining buffer space. */
-			if( ( xRemainingOptionsBytes < TCP_OPT_MSS_LEN )|| ( pucPtr[ 1 ] != TCP_OPT_MSS_LEN ) )
+			if( ( xRemainingOptionsBytes < TCP_OPT_MSS_LEN )|| ( ( *pucPtr )[ 1 ] != TCP_OPT_MSS_LEN ) )
 			{
-				break;
+				return pdFALSE;
 			}
 
 			/* An MSS option with the correct option length.  FreeRTOS_htons()
 			is not needed here because usChar2u16() already returns a host
 			endian number. */
-			uxNewMSS = usChar2u16( pucPtr + 2 );
+			( *uxNewMSS ) = usChar2u16( ( *pucPtr ) + 2 );
 
-			if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
+			if( ( *pxSocket )->u.xTCP.usInitMSS != ( *uxNewMSS ) )
 			{
 				/* Perform a basic check on the the new MSS. */
-				if( uxNewMSS == 0 )
+				if( ( *uxNewMSS ) == 0 )
 				{
-					break;
+					return pdFALSE;
 				}
 
-				FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
+				FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", ( *pxSocket )->u.xTCP.usInitMSS, ( *uxNewMSS ) ) );
 			}
 
-			if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
+			if( ( *pxSocket )->u.xTCP.usInitMSS > ( *uxNewMSS ) )
 			{
 				/* our MSS was bigger than the MSS of the other party: adapt it. */
-				pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
-				if( ( pxTCPWindow != NULL ) && ( pxSocket->u.xTCP.usCurMSS > uxNewMSS ) )
+				( *pxSocket )->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
+				if( ( ( *pxTCPWindow ) != NULL ) && ( ( *pxSocket )->u.xTCP.usCurMSS > ( *uxNewMSS ) ) )
 				{
 					/* The peer advertises a smaller MSS than this socket was
 					using.  Use that as well. */
-					FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
-					pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+					FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", ( *pxSocket )->u.xTCP.usCurMSS, ( *uxNewMSS ) ) );
+					( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) ( *uxNewMSS );
 				}
-				pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
-				pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
-				pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
-				pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-				pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+				( *pxTCPWindow )->xSize.ulRxWindowLength = ( ( uint32_t ) ( *uxNewMSS ) ) * ( ( *pxTCPWindow )->xSize.ulRxWindowLength / ( ( uint32_t ) ( *uxNewMSS ) ) );
+				( *pxTCPWindow )->usMSSInit = ( uint16_t ) ( *uxNewMSS );
+				( *pxTCPWindow )->usMSS = ( uint16_t ) ( *uxNewMSS );
+				( *pxSocket )->u.xTCP.usInitMSS = ( uint16_t ) ( *uxNewMSS );
+				( *pxSocket )->u.xTCP.usCurMSS = ( uint16_t ) ( *uxNewMSS );
 			}
 
 			#if( ipconfigUSE_TCP_WIN != 1 )
 				/* Without scaled windows, MSS is the only interesting option. */
-				break;
+				return pdFALSE;
 			#else
 				/* Or else we continue to check another option: selective ACK. */
-				pucPtr += TCP_OPT_MSS_LEN;
+				( *pucPtr ) += TCP_OPT_MSS_LEN;
 			#endif	/* ipconfigUSE_TCP_WIN != 1 */
 		}
 		else
 		{
 			/* All other options have a length field, so that we easily
 			can skip past them. */
-			unsigned char len = pucPtr[ 1 ];
+			unsigned char len = ( *pucPtr )[ 1 ];
 			if( ( len < 2 ) || ( len > xRemainingOptionsBytes ) )
 			{
 				/* If the length field is too small or too big, the options are malformed.
 				Don't process them further. */
-				break;
+				return pdFALSE;
 			}
 
 			#if( ipconfigUSE_TCP_WIN == 1 )
@@ -1261,32 +1278,32 @@ UBaseType_t uxNewMSS;
 				/* Selective ACK: the peer has received a packet but it is missing earlier
 				packets.  At least this packet does not need retransmission anymore
 				ulTCPWindowTxSack( ) takes care of this administration. */
-				if( pucPtr[0] == TCP_OPT_SACK_A )
+				if( ( *pucPtr )[0] == TCP_OPT_SACK_A )
 				{
 					len -= 2;
-					pucPtr += 2;
+					( *pucPtr ) += 2;
 
 					while( len >= 8 )
 					{
-					uint32_t ulFirst = ulChar2u32( pucPtr );
-					uint32_t ulLast  = ulChar2u32( pucPtr + 4 );
-					uint32_t ulCount = ulTCPWindowTxSack( &pxSocket->u.xTCP.xTCPWindow, ulFirst, ulLast );
+					uint32_t ulFirst = ulChar2u32( ( *pucPtr ) );
+					uint32_t ulLast  = ulChar2u32( ( *pucPtr ) + 4 );
+					uint32_t ulCount = ulTCPWindowTxSack( &( *pxSocket )->u.xTCP.xTCPWindow, ulFirst, ulLast );
 						/* ulTCPWindowTxSack( ) returns the number of bytes which have been acked
 						starting from the head position.
 						Advance the tail pointer in txStream. */
-						if( ( pxSocket->u.xTCP.txStream  != NULL ) && ( ulCount > 0 ) )
+						if( ( ( *pxSocket )->u.xTCP.txStream  != NULL ) && ( ulCount > 0 ) )
 						{
 							/* Just advancing the tail index, 'ulCount' bytes have been confirmed. */
-							uxStreamBufferGet( pxSocket->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
-							pxSocket->xEventBits |= eSOCKET_SEND;
+							uxStreamBufferGet( ( *pxSocket )->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
+							( *pxSocket )->xEventBits |= eSOCKET_SEND;
 
 							#if ipconfigSUPPORT_SELECT_FUNCTION == 1
 							{
-								if( pxSocket->xSelectBits & eSELECT_WRITE )
+								if( ( *pxSocket )->xSelectBits & eSELECT_WRITE )
 								{
 									/* The field 'xEventBits' is used to store regular socket events (at most 8),
 									as well as 'select events', which will be left-shifted */
-									pxSocket->xEventBits |= ( eSELECT_WRITE << SOCKET_EVENT_BIT_COUNT );
+									( *pxSocket )->xEventBits |= ( eSELECT_WRITE << SOCKET_EVENT_BIT_COUNT );
 								}
 							}
 							#endif
@@ -1295,14 +1312,14 @@ UBaseType_t uxNewMSS;
 							call it now. */
 							#if( ipconfigUSE_CALLBACKS == 1 )
 							{
-								if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleSent ) )
+								if( ipconfigIS_VALID_PROG_ADDRESS( ( *pxSocket )->u.xTCP.pxHandleSent ) )
 								{
-									pxSocket->u.xTCP.pxHandleSent( (Socket_t *)pxSocket, ulCount );
+									( *pxSocket )->u.xTCP.pxHandleSent( (Socket_t *)( *pxSocket ), ulCount );
 								}
 							}
 							#endif /* ipconfigUSE_CALLBACKS == 1  */
 						}
-						pucPtr += 8;
+						( *pucPtr ) += 8;
 						len -= 8;
 					}
 					/* len should be 0 by now. */
@@ -1310,10 +1327,11 @@ UBaseType_t uxNewMSS;
 			}
 			#endif	/* ipconfigUSE_TCP_WIN == 1 */
 
-			pucPtr += len;
+			( *pucPtr ) += len;
 		}
+		return pdTRUE;
 	}
-}
+
 /*-----------------------------------------------------------*/
 
 #if( ipconfigUSE_TCP_WIN != 0 )

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -1185,6 +1185,7 @@ static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pp
 	UBaseType_t uxNewMSS;
 	UBaseType_t xRemainingOptionsBytes = ( *ppucLast ) - ( *ppucPtr );
 	BaseType_t xRet = pdTrue;
+	unsigned char ucLen;
 
 	if( ( *ppucPtr )[ 0 ] == TCP_OPT_END )
 	{
@@ -1272,7 +1273,7 @@ static BaseType_t prvSingleStepTCPHeaderOptions( const unsigned char ** const pp
 	{
 		/* All other options have a length field, so that we easily
 		can skip past them. */
-		unsigned char ucLen = ( *ppucPtr )[ 1 ];
+		ucLen = ( *ppucPtr )[ 1 ];
 		if( ( ucLen < 2 ) || ( ucLen > xRemainingOptionsBytes ) )
 		{
 			/* If the length field is too small or too big, the options are


### PR DESCRIPTION
Description
-----------
Prior to these commits, the function `prvCheckOptions` was rather long and contained two nested loops that were difficult to follow. This PR pulls each of those loops out into separate functions, `prvCheckOptions_innerLoop` and `prvCheckOptions_outerLoop`. The variables manipulated by those loops are passed in by const reference.

This makes the code easier to follow, and is in preparation for a commit introducing automated proofs of code correctness for the two loops and the overall function.

Much of this PR was originally contributed by Mark R. Tuttle.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
  - Switched on `testrunnerFULL_TCP_ENABLED` and ran in Windows Simulator, all tests passed
- [ ] My code is Linted.
  - No. I ran uncrustify and it changed the entire file, so I decided to keep consistency with the existing code. Let me know if anything needs tidying :)
