### PR TITLE
Protect PKCS Sign/Verify keys during multithreaded use

### DIFF
--- a/demos/common/devmode_key_provisioning/aws_dev_mode_key_provisioning.c
+++ b/demos/common/devmode_key_provisioning/aws_dev_mode_key_provisioning.c
@@ -220,11 +220,11 @@ CK_RV xProvisionCertificate( CK_SESSION_HANDLE xSession,
                              uint8_t * pucCertificate,
                              size_t xCertificateLength,
                              uint8_t * pucLabel,
-                             CK_OBJECT_HANDLE_PTR xObjectHandle )
+                             CK_OBJECT_HANDLE_PTR pxObjectHandle )
 {
     PKCS11_CertificateTemplate_t xCertificateTemplate;
     CK_OBJECT_CLASS xCertificateClass = CKO_CERTIFICATE;
-    CK_FUNCTION_LIST_PTR xFunctionList;
+    CK_FUNCTION_LIST_PTR pxFunctionList;
     CK_RV xResult;
     uint8_t * pucDerObject = NULL;
     int32_t lConversionReturn = 0;
@@ -242,7 +242,7 @@ CK_RV xProvisionCertificate( CK_SESSION_HANDLE xSession,
     xCertificateTemplate.xLabel.pValue = ( CK_VOID_PTR ) pucLabel;
     xCertificateTemplate.xLabel.ulValueLen = sizeof( pucLabel );
 
-    xResult = C_GetFunctionList( &xFunctionList );
+    xResult = C_GetFunctionList( &pxFunctionList );
 
     if( xResult == CKR_OK )
     {
@@ -270,16 +270,25 @@ CK_RV xProvisionCertificate( CK_SESSION_HANDLE xSession,
             xCertificateTemplate.xValue.pValue = pucDerObject;
             xCertificateTemplate.xValue.ulValueLen = xDerLen;
         }
+        else
+        {
+            configPRINTF( ( "ERROR: Failed to provision certificate %d \r\n", lConversionReturn ) );
+        }
 
         /* Create an object using the encoded client certificate. */
         if( CKR_OK == xResult )
         {
-            configPRINTF( ( "Write code signing certificate...\r\n" ) );
+            configPRINTF( ( "Write certificate...\r\n" ) );
 
-            xResult = xFunctionList->C_CreateObject( xSession,
-                                                     ( CK_ATTRIBUTE_PTR ) &xCertificateTemplate,
-                                                     sizeof( xCertificateTemplate ) / sizeof( CK_ATTRIBUTE ),
-                                                     xObjectHandle );
+            xResult = pxFunctionList->C_CreateObject( xSession,
+                                                      ( CK_ATTRIBUTE_PTR ) &xCertificateTemplate,
+                                                      sizeof( xCertificateTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                                      pxObjectHandle );
+        }
+
+        if( xResult != CKR_OK )
+        {
+            configPRINTF( ( "ERROR: Failed to provision certificate %d \r\n", xResult ) );
         }
 
         if( pucDerObject != NULL )
@@ -299,7 +308,7 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
     CK_RV xResult;
     CK_OBJECT_CLASS xPrivateKeyClass = CKO_PRIVATE_KEY;
     CK_KEY_TYPE xPrivateKeyType = ( CK_KEY_TYPE ) pxParams->ulClientPrivateKeyType;
-    CK_FUNCTION_LIST_PTR xFunctionList;
+    CK_FUNCTION_LIST_PTR pxFunctionList;
     CK_OBJECT_HANDLE xObject = 0;
     uint8_t * pucDerObject = NULL;
     int32_t lConversionReturn = 0;
@@ -307,7 +316,7 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
 
     PKCS11_KeyTemplate_t xPrivateKeyTemplate;
 
-    xResult = C_GetFunctionList( &xFunctionList );
+    xResult = C_GetFunctionList( &pxFunctionList );
 
     /* Initialize the device private key template. */
     xPrivateKeyTemplate.xObjectClass.type = CKA_CLASS;
@@ -345,6 +354,11 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
                                                     xPrivateKeyTemplate.xValue.ulValueLen,
                                                     pucDerObject,
                                                     &xDerLen );
+
+            if( lConversionReturn != 0 )
+            {
+                configPRINTF( ( "ERROR: Failed to parse private key %d \r\n", lConversionReturn ) );
+            }
         }
         else
         {
@@ -362,10 +376,10 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
         {
             configPRINTF( ( "Write device private key...\r\n" ) );
 
-            xResult = xFunctionList->C_CreateObject( xSession,
-                                                     ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
-                                                     sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
-                                                     &xObject );
+            xResult = pxFunctionList->C_CreateObject( xSession,
+                                                      ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
+                                                      sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                                      &xObject );
         }
 
         if( pucDerObject != NULL )
@@ -374,8 +388,10 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
         }
     }
 
-    configPRINTF( ( "Key provisioning done...\r\n" ) );
-
+    if( xResult != CKR_OK )
+    {
+        configPRINTF( ( "ERROR: Failed to provision private key %d \r\n", xResult ) );
+    }
 
     return xResult;
 }
@@ -385,12 +401,12 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
 void vAlternateKeyProvisioning( ProvisioningParams_t * xParams )
 {
     CK_RV xResult = CKR_OK;
-    CK_FUNCTION_LIST_PTR xFunctionList = NULL;
+    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
     CK_SLOT_ID xSlotId = 0;
     CK_SESSION_HANDLE xSession = 0;
 
     /* Initialize the PKCS Module */
-    xResult = xInitializePkcsSession( &xFunctionList,
+    xResult = xInitializePkcsSession( &pxFunctionList,
                                       &xSlotId,
                                       &xSession );
 
@@ -399,7 +415,7 @@ void vAlternateKeyProvisioning( ProvisioningParams_t * xParams )
         xResult = xProvisionDevice( xSession, xParams );
     }
 
-    xFunctionList->C_CloseSession( xSession );
+    pxFunctionList->C_CloseSession( xSession );
 }
 /*-----------------------------------------------------------*/
 

--- a/lib/pkcs11/mbedtls/aws_pkcs11_mbedtls.c
+++ b/lib/pkcs11/mbedtls/aws_pkcs11_mbedtls.c
@@ -90,7 +90,9 @@ typedef struct P11Session
     CK_BBOOL xFindObjectComplete;
     uint8_t * xFindObjectLabel;
     uint8_t xFindObjectLabelLength;
+    SemaphoreHandle_t xVerifyMutex; /* Protects the verification key from being modified while in use. */
     mbedtls_pk_context xVerifyKey;
+    SemaphoreHandle_t xSignMutex;   /* Protects the signing key from being modified while in use. */
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
 } P11Session_t, * P11SessionPtr_t;
@@ -518,15 +520,28 @@ CK_DEFINE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID xSlotID,
         {
             xResult = CKR_HOST_MEMORY;
         }
-    }
 
-    /*
-     * Zero out the session structure.
-     */
+        /*
+         * Zero out the session structure.
+         */
+        if( CKR_OK == xResult )
+        {
+            memset( pxSessionObj, 0, sizeof( P11Session_t ) );
+        }
 
-    if( CKR_OK == xResult )
-    {
-        memset( pxSessionObj, 0, sizeof( P11Session_t ) );
+        pxSessionObj->xSignMutex = xSemaphoreCreateMutex();
+
+        if( NULL == pxSessionObj->xSignMutex )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        pxSessionObj->xVerifyMutex = xSemaphoreCreateMutex();
+
+        if( NULL == pxSessionObj->xVerifyMutex )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
     }
 
     if( CKR_OK == xResult )
@@ -581,10 +596,20 @@ CK_DEFINE_FUNCTION( CK_RV, C_CloseSession )( CK_SESSION_HANDLE xSession )
             mbedtls_pk_free( &pxSession->xSignKey );
         }
 
+        if( NULL != pxSession->xSignMutex )
+        {
+            vSemaphoreDelete( pxSession->xSignMutex );
+        }
+
         /* Free the public key context if it exists. */
         if( NULL != pxSession->xVerifyKey.pk_ctx )
         {
             mbedtls_pk_free( &pxSession->xVerifyKey );
+        }
+
+        if( NULL != pxSession->xVerifyMutex )
+        {
+            vSemaphoreDelete( pxSession->xVerifyMutex );
         }
 
         if( NULL != &pxSession->xSHA256Context )
@@ -1219,21 +1244,37 @@ CK_DEFINE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE xSession,
 
         if( xResult == CKR_OK )
         {
-            mbedtls_pk_init( &pxSession->xSignKey );
-
-            if( 0 == mbedtls_pk_parse_key( &pxSession->xSignKey, keyData, ulKeyDataLength, NULL, 0 ) )
+            if( pdTRUE == xSemaphoreTake( pxSession->xSignMutex, portMAX_DELAY ) )
             {
-                /* TODO: Check the mechanism.  Note: Currently, mechanism is being set to CKM_SHA256, rather than
-                 * CKM_RSA_PKCS
-                 * CKM_SHA256_RSA_PKCS
-                 * CKM_ECDSA
-                 * Calling function does not know whether key is RSA or ECDSA.
-                 * xKeyType = mbedtls_pk_get_type( &pxSession->xSignKey );
-                 */
+                /* Free the private key context if it exists.
+                * TODO: Check if the key is the same as was used previously. */
+                if ( NULL != pxSession->xSignKey.pk_ctx )
+                {
+                    mbedtls_pk_free( &pxSession->xSignKey );
+                }
+
+                mbedtls_pk_init( &pxSession->xSignKey );
+
+                if( 0 == mbedtls_pk_parse_key( &pxSession->xSignKey, keyData, ulKeyDataLength, NULL, 0 ) )
+                {
+                    /* TODO: Check the mechanism.  Note: Currently, mechanism is being set to CKM_SHA256, rather than
+                     * CKM_RSA_PKCS
+                     * CKM_SHA256_RSA_PKCS
+                     * CKM_ECDSA
+                     * Calling function does not know whether key is RSA or ECDSA.
+                     * xKeyType = mbedtls_pk_get_type( &pxSession->xSignKey );
+                     */
+                }
+                else
+                {
+                    xResult = CKR_KEY_HANDLE_INVALID;
+                }
+
+                xSemaphoreGive( pxSession->xSignMutex );
             }
             else
             {
-                xResult = CKR_KEY_HANDLE_INVALID;
+                xResult = CKR_CANT_LOCK;
             }
         }
 
@@ -1285,18 +1326,27 @@ CK_DEFINE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE xSession,
 
             if( CKR_OK == xResult )
             {
-                BaseType_t x = mbedtls_pk_sign( &pxSessionObj->xSignKey,
-                                                MBEDTLS_MD_SHA256,
-                                                pucData,
-                                                ulDataLen,
-                                                pucSignature,
-                                                ( size_t * ) pulSignatureLen,
-                                                mbedtls_ctr_drbg_random,
-                                                &xP11Context.xMbedDrbgCtx );
-
-                if( x != CKR_OK )
+                if( pdTRUE == xSemaphoreTake( pxSessionObj->xSignMutex, portMAX_DELAY ) )
                 {
-                    xResult = CKR_FUNCTION_FAILED;
+                    BaseType_t x = mbedtls_pk_sign( &pxSessionObj->xSignKey,
+                                                    MBEDTLS_MD_SHA256,
+                                                    pucData,
+                                                    ulDataLen,
+                                                    pucSignature,
+                                                    ( size_t * ) pulSignatureLen,
+                                                    mbedtls_ctr_drbg_random,
+                                                    &xP11Context.xMbedDrbgCtx );
+
+                    if( x != CKR_OK )
+                    {
+                        xResult = CKR_FUNCTION_FAILED;
+                    }
+
+                    xSemaphoreGive( pxSessionObj->xSignMutex );
+                }
+                else
+                {
+                    xResult = CKR_CANT_LOCK;
                 }
             }
         }
@@ -1341,14 +1391,30 @@ CK_DEFINE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE xSession,
 
     if( xResult == CKR_OK )
     {
-        mbedtls_pk_init( &pxSession->xVerifyKey );
-
-        if( 0 != mbedtls_pk_parse_public_key( &pxSession->xVerifyKey, keyData, ulKeyDataLength ) )
+        if( pdTRUE == xSemaphoreTake( pxSession->xVerifyMutex, portMAX_DELAY ) )
         {
-            if( 0 != mbedtls_pk_parse_key( &pxSession->xVerifyKey, keyData, ulKeyDataLength, NULL, 0 ) )
+            /* Free the public key context if it exists.
+            * TODO: Check if the key is the same as used by last verify operation. */
+            if ( NULL != pxSession->xVerifyKey.pk_ctx )
             {
-                xResult = CKR_KEY_HANDLE_INVALID;
+                mbedtls_pk_free( &pxSession->xVerifyKey );
             }
+
+            mbedtls_pk_init( &pxSession->xVerifyKey );
+
+            if( 0 != mbedtls_pk_parse_public_key( &pxSession->xVerifyKey, keyData, ulKeyDataLength ) )
+            {
+                if( 0 != mbedtls_pk_parse_key( &pxSession->xVerifyKey, keyData, ulKeyDataLength, NULL, 0 ) )
+                {
+                    xResult = CKR_KEY_HANDLE_INVALID;
+                }
+            }
+
+            xSemaphoreGive( pxSession->xVerifyMutex );
+        }
+        else
+        {
+            xResult = CKR_CANT_LOCK;
         }
 
         PKCS11_PAL_GetObjectValueCleanup( keyData, ulKeyDataLength );
@@ -1382,18 +1448,27 @@ CK_DEFINE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE xSession,
     {
         pxSessionObj = prvSessionPointerFromHandle( xSession ); /*lint !e9072 It's OK to have different parameter name. */
 
-        /* Verify the signature. If a public key is present, use it. */
-        if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
+        if( pdTRUE == xSemaphoreTake( pxSessionObj->xVerifyMutex, portMAX_DELAY ) )
         {
-            if( 0 != mbedtls_pk_verify( &pxSessionObj->xVerifyKey,
-                                        MBEDTLS_MD_SHA256,
-                                        pucData,
-                                        ulDataLen,
-                                        pucSignature,
-                                        ulSignatureLen ) )
+            /* Verify the signature. If a public key is present, use it. */
+            if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
             {
-                xResult = CKR_SIGNATURE_INVALID;
+                if( 0 != mbedtls_pk_verify( &pxSessionObj->xVerifyKey,
+                                            MBEDTLS_MD_SHA256,
+                                            pucData,
+                                            ulDataLen,
+                                            pucSignature,
+                                            ulSignatureLen ) )
+                {
+                    xResult = CKR_SIGNATURE_INVALID;
+                }
             }
+
+            xSemaphoreGive( pxSessionObj->xVerifyMutex );
+        }
+        else
+        {
+            xResult = CKR_CANT_LOCK;
         }
 
         /* TODO: Deleted else. */


### PR DESCRIPTION
Resolves issue #262

<!--- Title -->

Description
-----------
Tested by running WinSim TCP, TLS, PKCS tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
