### PR TITLE
Make vLoggingPrint scheduler-safe

### DIFF
--- a/demos/pc/windows/common/application_code/aws_demo_logging.c
+++ b/demos/pc/windows/common/application_code/aws_demo_logging.c
@@ -347,6 +347,7 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
 			xLength2 = snprintf(
 	            cPrintString + xLength,
 				dlMAX_PRINT_STRING_LENGTH - xLength,
+				"%s",
 				pcFormat );
 		}
 

--- a/demos/pc/windows/common/application_code/aws_demo_logging.c
+++ b/demos/pc/windows/common/application_code/aws_demo_logging.c
@@ -118,7 +118,7 @@ static void prvCreatePrintSocket( void * pvParameter1,
  * A Windows thread will finally call printf() and fflush().
  */
 
-static int prvLoggingPrintf( BaseType_t xFormatted, const char *pcFormat, va_list xArgs );
+static void prvLoggingPrintf( BaseType_t xFormatted, const char *pcFormat, va_list xArgs );
 
 /*-----------------------------------------------------------*/
 
@@ -293,7 +293,7 @@ void vLoggingPrint( const char * pcFormat )
 }
 /*-----------------------------------------------------------*/
 
-static int prvLoggingPrintf( BaseType_t xFormatted,
+static void prvLoggingPrintf( BaseType_t xFormatted,
 							 const char *pcFormat,
 							 va_list xArgs )
 {

--- a/demos/pc/windows/common/application_code/aws_demo_logging.c
+++ b/demos/pc/windows/common/application_code/aws_demo_logging.c
@@ -113,6 +113,13 @@ static DWORD WINAPI prvWin32LoggingThread( void * pvParam );
 static void prvCreatePrintSocket( void * pvParameter1,
                                   uint32_t ulParameter2 );
 
+/*
+ * Write a messages to stdout, either with or without a time-stamp.
+ * A Windows thread will finally call printf() and fflush().
+ */
+
+static int prvLoggingPrintf( BaseType_t xFormatted, const char *pcFormat, va_list xArgs );
+
 /*-----------------------------------------------------------*/
 
 /* Windows event used to wake the Win32 thread which performs any logging that
@@ -273,12 +280,28 @@ static void prvCreatePrintSocket( void * pvParameter1,
 void vLoggingPrintf( const char * pcFormat,
                      ... )
 {
+	va_list xArgs;
+	va_start( xArgs, pcFormat );
+	prvLoggingPrintf( pdTRUE, pcFormat, xArgs );
+	va_end( xArgs );
+}
+/*-----------------------------------------------------------*/
+
+void vLoggingPrint( const char * pcFormat )
+{
+	prvLoggingPrintf( pdFALSE, pcFormat, NULL );
+}
+/*-----------------------------------------------------------*/
+
+static int prvLoggingPrintf( BaseType_t xFormatted,
+							 const char *pcFormat,
+							 va_list xArgs )
+{
     char cPrintString[ dlMAX_PRINT_STRING_LENGTH ];
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, xLength2, rc;
     static BaseType_t xMessageNumber = 0;
-    va_list args;
     uint32_t ulIPAddress;
     const char * pcTaskName;
     const char * pcNoTask = "None";
@@ -289,9 +312,6 @@ void vLoggingPrintf( const char * pcFormat,
         ( xDiskFileLoggingUsed != pdFALSE ) ||
         ( xUDPLoggingUsed != pdFALSE ) )
     {
-        /* There are a variable number of parameters. */
-        va_start( args, pcFormat );
-
         /* Additional info to place at the start of the log. */
         if( xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED )
         {
@@ -302,7 +322,7 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
-        if( strcmp( pcFormat, "\n" ) != 0 )
+        if( ( strcmp( pcFormat, "\n" ) != 0 ) && ( xFormatted != pdFALSE ) )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,
@@ -314,12 +334,21 @@ void vLoggingPrintf( const char * pcFormat,
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
         }
-
-        xLength2 = vsnprintf(
-            cPrintString + xLength,
-            dlMAX_PRINT_STRING_LENGTH - xLength,
-            pcFormat,
-            args );
+		if( xArgs != NULL )
+		{
+			xLength2 = vsnprintf(
+	            cPrintString + xLength,
+				dlMAX_PRINT_STRING_LENGTH - xLength,
+				pcFormat,
+				xArgs );
+		}
+		else
+		{
+			xLength2 = snprintf(
+	            cPrintString + xLength,
+				dlMAX_PRINT_STRING_LENGTH - xLength,
+				pcFormat );
+		}
 
         if( xLength2 < 0 )
         {
@@ -329,7 +358,6 @@ void vLoggingPrintf( const char * pcFormat,
         }
 
         xLength += xLength2;
-        va_end( args );
 
         /* For ease of viewing, copy the string into another buffer, converting
          * IP addresses to dot notation on the way. */
@@ -463,13 +491,6 @@ void vLoggingPrintf( const char * pcFormat,
             }
         }
     }
-}
-/*-----------------------------------------------------------*/
-
-void vLoggingPrint( const char * pcMessage )
-{
-    printf( "%s", pcMessage );
-    fflush(stdout);
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/pc/windows/common/application_code/aws_demo_logging.h
+++ b/demos/pc/windows/common/application_code/aws_demo_logging.h
@@ -41,4 +41,13 @@ void vLoggingInit( BaseType_t xLogToStdout,
                    uint32_t ulRemoteIPAddress,
                    uint16_t usRemotePort );
 
+/* Write logging to stdout, to be called by FreeRTOS tasks only.
+Each line will be preceded by the name of the task and a time-stamp. */
+void vLoggingPrintf( const char * pcFormat,
+                     ... );
+
+/* Write logging to stdout, to be called by FreeRTOS tasks only.
+No stamps will be printed, just the bare message. */
+void vLoggingPrint( const char * pcFormat );
+
 #endif /* AWS_DEMO_LOGGING_H */


### PR DESCRIPTION
<!--- Title -->

Make vLoggingPrint compatible with FreeRTOS tasks.
-----------
<!--- Describe your changes in detail -->

For a detailed description of the problem, see [issue 124](https://github.com/aws/amazon-freertos/issues/214)

With this patch, both `vLoggingPrint` and `vLoggingPrintf` can be used from a FreeRTOS task.
The latter will mostly be used in the Windows self-test application.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
