### PR TITLE
AWS WiFi Test Stability Upates + NXP LPC54018 AWS WiFi port updates

### DIFF
--- a/lib/wifi/portable/nxp/lpc54018iotmodule/aws_wifi.c
+++ b/lib/wifi/portable/nxp/lpc54018iotmodule/aws_wifi.c
@@ -369,7 +369,7 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
     const TickType_t connect_timeout = pdMS_TO_TICKS( 30000UL );
     const TickType_t dhcp_timeout = pdMS_TO_TICKS( 20000UL );
     uint32_t tmp_ip4_addr = 0, tmp_ip4_mask = 0, tmp_ip4_gw = 0;
-    static uint8_t ucDhcpSuccessful = 0;
+    uint8_t ucDhcpSuccessful = 0;
 
     /* Check initialization */
     if (!g_wifi_is_on)

--- a/lib/wifi/portable/nxp/lpc54018iotmodule/aws_wifi.c
+++ b/lib/wifi/portable/nxp/lpc54018iotmodule/aws_wifi.c
@@ -306,9 +306,9 @@ WIFIReturnCode_t WIFI_On( void )
 {
     A_STATUS result;
 
-    /* Prevent re-initialization */
+    /* Prevent re-initialization. WiFi is aleady on this is successful. */
     if (g_wifi_is_on)
-        return eWiFiFailure;
+        return eWiFiSuccess;
 
     /* Initialize Wi-Fi shield */
     result = (A_STATUS)WIFISHIELD_Init();
@@ -369,6 +369,7 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
     const TickType_t connect_timeout = pdMS_TO_TICKS( 30000UL );
     const TickType_t dhcp_timeout = pdMS_TO_TICKS( 20000UL );
     uint32_t tmp_ip4_addr = 0, tmp_ip4_mask = 0, tmp_ip4_gw = 0;
+    static uint8_t ucDhcpSuccessful = 0;
 
     /* Check initialization */
     if (!g_wifi_is_on)
@@ -469,13 +470,13 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
             }
 
             g_expected_event = expected_event_connect;
-            /* Commit settings to Wi-Fi module */
+            /* Commit settings to Wi-Fi module. Calling this function starts the connection process. */
             if (A_OK != qcom_commit(g_devid))
             {
                 break;
             }
 
-            /* Wait for callback, that is invoked from 'driver_task' context */
+            /* Wait for callback, that is invoked from 'driver_task' context. This callback sets g_connected to connected (1) or disconnected (0). */
             if (pdTRUE != xSemaphoreTake(g_connect_semaph, connect_timeout))
             {
                 break;
@@ -519,9 +520,14 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
             {
                 break;
             }
+            /* Otherwise after all is said and done the DHCP request is successful. */
+            else
+            {
+                ucDhcpSuccessful = 1;
+            }
 
-            /* Everything is OK */
-            status = g_connected ? eWiFiSuccess : eWiFiFailure;
+            /* Everything is OK. We connected to the AP and got an IP address with DHCP. */
+            status = ( g_connected && ucDhcpSuccessful ) ? eWiFiSuccess : eWiFiFailure;
         } while (0);
 
         /* Release semaphore */

--- a/tests/common/wifi/aws_test_wifi.c
+++ b/tests/common/wifi/aws_test_wifi.c
@@ -50,12 +50,12 @@
 /* Testing configurations defintions. */
 
 /* The number of times to retry a WiFi Connect if it fails. */
-#define testwifiCONNECTION_RETRY_TIMES      3
+#define testwifiCONNECTION_RETRY_TIMES    3
 /* The initial delay between connection attempts that multiplies with each attempt. */
-#define testwifiCONNECTION_RETRY_DELAY      250
+#define testwifiCONNECTION_RETRY_DELAY    250
 
 /* The number of times to loop in the WiFiConnectionLoop test. */
-#define testwifiCONNECTION_LOOP_TIMES    3
+#define testwifiCONNECTION_LOOP_TIMES     3
 
 /* The delay in ms between connection and disconnection. This can be configured
  * in aws_test_wifi_config.h for your specific platform. */
@@ -118,14 +118,15 @@
 #endif
 
 /* String for round-trip testing. */
-#define testwifiROUND_TRIP_TEST_STRING                  "abcd"
+#define testwifiROUND_TRIP_TEST_STRING                    "abcd"
 /* Arbitrary max length for the round trip string. */
-#define testwifiROUND_TRIP_TEST_STRING_MAX_LENGTH       32
+#define testwifiROUND_TRIP_TEST_STRING_MAX_LENGTH         32
 /* The amount of times to retry the socket connect in the round trip test. */
-#define testwifiROUND_TRIP_TEST_RETRY_CONNECTION_TIMES  6
-/* The delay in milliseconds that is multiplied during exponential retires of the socket 
+#define testwifiROUND_TRIP_TEST_RETRY_CONNECTION_TIMES    6
+
+/* The delay in milliseconds that is multiplied during exponential retires of the socket
  * connection in the round trip test. This is to prevent network congestion. */
-#define testwifiROUND_TRIP_TEST_RETRY_DELAY_MS          150
+#define testwifiROUND_TRIP_TEST_RETRY_DELAY_MS            150
 
 /* Socket receive and send timeouts for the loopback test. These can be
  * configured in aws_test_wifi_config.h*/
@@ -178,7 +179,7 @@ typedef struct
 {
     uint16_t usTaskId;
     WIFIReturnCode_t xWiFiStatus;
-    char cStatusMsg[100];        /* A status message associated with the WiFi return code. This is needed until there are more error return codes. */
+    char cStatusMsg[ 100 ]; /* A status message associated with the WiFi return code. This is needed until there are more error return codes. */
     TaskHandle_t xTaskHandle;
 } testwifiTaskParams_t;
 
@@ -388,7 +389,7 @@ static BaseType_t prvRoundTripTest( void )
         xEchoServerSockaddr.ucSocketDomain = SOCKETS_AF_INET;
 
         RETRY_EXPONENTIAL( xSocketResult = SOCKETS_Connect( xSocket, &xEchoServerSockaddr,
-                                           sizeof( xEchoServerSockaddr ) ),
+                                                            sizeof( xEchoServerSockaddr ) ),
                            SOCKETS_ERROR_NONE,
                            ulInitialRetryPeriodMs,
                            xMaxRetries );
@@ -2244,7 +2245,7 @@ static void prvConnectionTask( void * pvParameters )
      * complete. */
     pxTaskParams = ( testwifiTaskParams_t * ) ( pvParameters );
     pxTaskParams->xWiFiStatus = eWiFiFailure;
-    memset(pxTaskParams->cStatusMsg, 0, sizeof(pxTaskParams->cStatusMsg));
+    memset( pxTaskParams->cStatusMsg, 0, sizeof( pxTaskParams->cStatusMsg ) );
 
     for( ulIndex = 0; ulIndex < testwifiCONNECTION_LOOP_TIMES; ulIndex++ )
     {
@@ -2253,12 +2254,12 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xWiFiConnectStatus != eWiFiSuccess )
         {
-            snprintf( pxTaskParams->cStatusMsg,  
-                     sizeof( pxTaskParams->cStatusMsg ),
-                     "Task %d failed to connect to the AP %s with error code %d.\r\n",
-                     pxTaskParams->usTaskId, 
-                     xTestNetworkParams.pcSSID,
-                     xWiFiConnectStatus );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d failed to connect to the AP %s with error code %d.\r\n",
+                      pxTaskParams->usTaskId,
+                      xTestNetworkParams.pcSSID,
+                      xWiFiConnectStatus );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
@@ -2272,7 +2273,7 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xWiFiConnectStatus != eWiFiSuccess )
         {
-            snprintf( pxTaskParams->cStatusMsg, 
+            snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
                       "Task %d failed to connect to the AP %s with error code %d.\r\n",
                       pxTaskParams->usTaskId, xClientNetworkParams.pcSSID,
@@ -2286,20 +2287,20 @@ static void prvConnectionTask( void * pvParameters )
 
         /* Wait for the other tasks to finish connecting. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
-            xEventGroupSync(
-                xTaskConnectDisconnectSyncEventGroupHandle,
-                ( 0x1
-                    << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
-                testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
-                                                  * task. */
-                testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
+            ( xEventGroupSync(
+                  xTaskConnectDisconnectSyncEventGroupHandle,
+                  ( 0x1
+                      << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
+                  testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
+                                                    * task. */
+                  testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK ) )
         {
-            snprintf( pxTaskParams->cStatusMsg, 
+            snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
                       "Task %d timeout waiting for the other task to finish "
                       "connection.\r\n",
-                      pxTaskParams->usTaskId);
-                    
+                      pxTaskParams->usTaskId );
+
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
@@ -2324,22 +2325,22 @@ static void prvConnectionTask( void * pvParameters )
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
                       "Task %d failed the round-trip test after connect.\r\n",
-                      pxTaskParams->usTaskId);
+                      pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
         /* Wait for the other tasks before moving on to disconnecting. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
-            xEventGroupSync(
-                xTaskConnectDisconnectSyncEventGroupHandle, /* The event group used
-                                                             * for the rendezvous.
-                                                             */
-                ( 0x1
-                    << pxTaskParams->usTaskId ),            /* Set our task ID when we are done. */
-                testwifiTASK_FINISH_MASK,                   /* Wait for both our task and the other
-                                                             * task. */
-                testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
+            ( xEventGroupSync(
+                  xTaskConnectDisconnectSyncEventGroupHandle, /* The event group used
+                                                               * for the rendezvous.
+                                                               */
+                  ( 0x1
+                      << pxTaskParams->usTaskId ),            /* Set our task ID when we are done. */
+                  testwifiTASK_FINISH_MASK,                   /* Wait for both our task and the other
+                                                               * task. */
+                  testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK ) )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
@@ -2368,13 +2369,13 @@ static void prvConnectionTask( void * pvParameters )
 
         /* Wait for the other tasks. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
-            xEventGroupSync(
-                xTaskConnectDisconnectSyncEventGroupHandle,
-                ( 0x1
-                    << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
-                testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
-                                                  * task. */
-                testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
+            ( xEventGroupSync(
+                  xTaskConnectDisconnectSyncEventGroupHandle,
+                  ( 0x1
+                      << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
+                  testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
+                                                    * task. */
+                  testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK ) )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
@@ -2415,13 +2416,13 @@ static void prvConnectionTask( void * pvParameters )
 
         /* Wait for the other tasks. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
-            xEventGroupSync(
-                xTaskConnectDisconnectSyncEventGroupHandle,
-                ( 0x1
-                    << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
-                testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
-                                                  * task. */
-                testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
+            ( xEventGroupSync(
+                  xTaskConnectDisconnectSyncEventGroupHandle,
+                  ( 0x1
+                      << pxTaskParams->usTaskId ), /* Set our task ID when we are done. */
+                  testwifiTASK_FINISH_MASK,        /* Wait for both our task and the other
+                                                    * task. */
+                  testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK ) )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
@@ -2443,7 +2444,7 @@ static void prvConnectionTask( void * pvParameters )
     if( xTaskFinishEventGroupHandle != NULL )
     {
         xEventGroupSetBits( xTaskFinishEventGroupHandle,
-                        ( 1 << pxTaskParams->usTaskId ) );
+                            ( 1 << pxTaskParams->usTaskId ) );
     }
 
     vTaskDelete( NULL ); /* Delete this task. */

--- a/tests/common/wifi/aws_test_wifi.c
+++ b/tests/common/wifi/aws_test_wifi.c
@@ -49,6 +49,11 @@
 
 /* Testing configurations defintions. */
 
+/* The number of times to retry a WiFi Connect if it fails. */
+#define testwifiCONNECTION_RETRY_TIMES      3
+/* The initial delay between connection attempts that multiplies with each attempt. */
+#define testwifiCONNECTION_RETRY_DELAY      250
+
 /* The number of times to loop in the WiFiConnectionLoop test. */
 #define testwifiCONNECTION_LOOP_TIMES    3
 
@@ -113,9 +118,14 @@
 #endif
 
 /* String for round-trip testing. */
-#define testwifiROUND_TRIP_TEST_STRING               "abcd"
+#define testwifiROUND_TRIP_TEST_STRING                  "abcd"
 /* Arbitrary max length for the round trip string. */
-#define testwifiROUND_TRIP_TEST_STRING_MAX_LENGTH    32
+#define testwifiROUND_TRIP_TEST_STRING_MAX_LENGTH       32
+/* The amount of times to retry the socket connect in the round trip test. */
+#define testwifiROUND_TRIP_TEST_RETRY_CONNECTION_TIMES  6
+/* The delay in milliseconds that is multiplied during exponential retires of the socket 
+ * connection in the round trip test. This is to prevent network congestion. */
+#define testwifiROUND_TRIP_TEST_RETRY_DELAY_MS          150
 
 /* Socket receive and send timeouts for the loopback test. These can be
  * configured in aws_test_wifi_config.h*/
@@ -168,6 +178,7 @@ typedef struct
 {
     uint16_t usTaskId;
     WIFIReturnCode_t xWiFiStatus;
+    char cStatusMsg[100];        /* A status message associated with the WiFi return code. This is needed until there are more error return codes. */
     TaskHandle_t xTaskHandle;
 } testwifiTaskParams_t;
 
@@ -276,10 +287,13 @@ static BaseType_t prvConnectAPTest( void )
     WIFIReturnCode_t xWiFiStatus;
     WIFINetworkParams_t xNetworkParams = { 0 };
     BaseType_t xResult = pdPASS;
+    uint32_t ulInitialRetryPeriodMs = testwifiCONNECTION_RETRY_DELAY;
+    BaseType_t xMaxRetries = testwifiCONNECTION_RETRY_TIMES;
 
     prvSetClientNetworkParameters( &xNetworkParams );
 
-    xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
+    RETRY_EXPONENTIAL( xWiFiStatus = WIFI_ConnectAP( &xNetworkParams ),
+                       eWiFiSuccess, ulInitialRetryPeriodMs, xMaxRetries );
 
     if( eWiFiSuccess != xWiFiStatus )
     {
@@ -323,6 +337,8 @@ static BaseType_t prvRoundTripTest( void )
         pdMS_TO_TICKS( testwifiLOOPBACK_TEST_SOCKETS_RECEIVE_TIMEOUT );
     TickType_t xTxTimeOut =
         pdMS_TO_TICKS( testwifiLOOPBACK_TEST_SOCKETS_SEND_TIMEOUT );
+    uint32_t ulInitialRetryPeriodMs = testwifiROUND_TRIP_TEST_RETRY_DELAY_MS;
+    BaseType_t xMaxRetries = testwifiROUND_TRIP_TEST_RETRY_CONNECTION_TIMES;
 
     configPRINTF(
         ( "%s:%d %s\r\n", __FILENAME__, __LINE__, "Starting round trip test." ) );
@@ -371,8 +387,11 @@ static BaseType_t prvRoundTripTest( void )
         xEchoServerSockaddr.ucLength = sizeof( SocketsSockaddr_t );
         xEchoServerSockaddr.ucSocketDomain = SOCKETS_AF_INET;
 
-        xSocketResult = SOCKETS_Connect( xSocket, &xEchoServerSockaddr,
-                                         sizeof( xEchoServerSockaddr ) );
+        RETRY_EXPONENTIAL( xSocketResult = SOCKETS_Connect( xSocket, &xEchoServerSockaddr,
+                                           sizeof( xEchoServerSockaddr ) ),
+                           SOCKETS_ERROR_NONE,
+                           ulInitialRetryPeriodMs,
+                           xMaxRetries );
 
         if( xSocketResult != SOCKETS_ERROR_NONE )
         {
@@ -2225,6 +2244,7 @@ static void prvConnectionTask( void * pvParameters )
      * complete. */
     pxTaskParams = ( testwifiTaskParams_t * ) ( pvParameters );
     pxTaskParams->xWiFiStatus = eWiFiFailure;
+    memset(pxTaskParams->cStatusMsg, 0, sizeof(pxTaskParams->cStatusMsg));
 
     for( ulIndex = 0; ulIndex < testwifiCONNECTION_LOOP_TIMES; ulIndex++ )
     {
@@ -2233,10 +2253,13 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xWiFiConnectStatus != eWiFiSuccess )
         {
-            configPRINTF(
-                ( "Task %d failed to connect to the AP %s with error code %d.\r\n",
-                  pxTaskParams->usTaskId, xTestNetworkParams.pcSSID,
-                  xWiFiConnectStatus ) );
+            snprintf( pxTaskParams->cStatusMsg,  
+                     sizeof( pxTaskParams->cStatusMsg ),
+                     "Task %d failed to connect to the AP %s with error code %d.\r\n",
+                     pxTaskParams->usTaskId, 
+                     xTestNetworkParams.pcSSID,
+                     xWiFiConnectStatus );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2249,10 +2272,12 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xWiFiConnectStatus != eWiFiSuccess )
         {
-            configPRINTF(
-                ( "Task %d failed to connect to the AP %s with error code %d.\r\n",
-                  pxTaskParams->usTaskId, xClientNetworkParams.pcSSID,
-                  xWiFiConnectStatus ) );
+            snprintf( pxTaskParams->cStatusMsg, 
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d failed to connect to the AP %s with error code %d.\r\n",
+                      pxTaskParams->usTaskId, xClientNetworkParams.pcSSID,
+                      xWiFiConnectStatus );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2269,10 +2294,13 @@ static void prvConnectionTask( void * pvParameters )
                                                   * task. */
                 testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
         {
-            configPRINTF(
-                ( "Task %d timeout waiting for the other task to finish "
-                  "connection.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg, 
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d timeout waiting for the other task to finish "
+                      "connection.\r\n",
+                      pxTaskParams->usTaskId);
+                    
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2293,8 +2321,11 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xRoundTripResults == pdFALSE )
         {
-            configPRINTF( ( "Task %d failed the round-trip test after connect.\r\n",
-                            pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d failed the round-trip test after connect.\r\n",
+                      pxTaskParams->usTaskId);
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2310,10 +2341,12 @@ static void prvConnectionTask( void * pvParameters )
                                                              * task. */
                 testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
         {
-            configPRINTF(
-                ( "Task %d timeout waiting for the other task to finish round-trip "
-                  "test after connect.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d timeout waiting for the other task to finish round-trip "
+                      "test after connect.\r\n",
+                      pxTaskParams->usTaskId );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2343,10 +2376,12 @@ static void prvConnectionTask( void * pvParameters )
                                                   * task. */
                 testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
         {
-            configPRINTF(
-                ( "Task %d timeout waiting for the other task to finish "
-                  "disconnection.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d timeout waiting for the other task to finish "
+                      "disconnection.\r\n",
+                      pxTaskParams->usTaskId );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2355,10 +2390,12 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xIsConnected == pdTRUE )
         {
-            configPRINTF(
-                ( "Task %d returned eWiFiSuccess from WIFI_Disconnect(), but is not "
-                  "disconnected.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d returned eWiFiSuccess from WIFI_Disconnect(), but is not "
+                      "disconnected.\r\n",
+                      pxTaskParams->usTaskId );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2367,10 +2404,12 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xRoundTripResults == pdPASS )
         {
-            configPRINTF(
-                ( "Task %d completed the round-trip test after supposedly "
-                  "disconnecting.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d completed the round-trip test after supposedly "
+                      "disconnecting.\r\n",
+                      pxTaskParams->usTaskId );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
 
@@ -2384,10 +2423,12 @@ static void prvConnectionTask( void * pvParameters )
                                                   * task. */
                 testwifiTASK_SYNC_TIMEOUT ) != testwifiTASK_FINISH_MASK )
         {
-            configPRINTF(
-                ( "Task %d timeout waiting for the other task to finish the round "
-                  "trip after disconnect.\r\n",
-                  pxTaskParams->usTaskId ) );
+            snprintf( pxTaskParams->cStatusMsg,
+                      sizeof( pxTaskParams->cStatusMsg ),
+                      "Task %d timeout waiting for the other task to finish the round "
+                      "trip after disconnect.\r\n",
+                      pxTaskParams->usTaskId );
+            configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
     }

--- a/tests/nxp/lpc54018iotmodule/common/application_code/main.c
+++ b/tests/nxp/lpc54018iotmodule/common/application_code/main.c
@@ -252,7 +252,7 @@ static void prvWifiConnect(void)
     xWifiStatus = WIFI_On();
     if (xWifiStatus == eWiFiSuccess)
     {
-        configPRINTF(("Wi-Fi module initialized. Connecting to AP...\r\n"));
+        configPRINTF(("Wi-Fi module initialized. Connecting to AP %s...\r\n", xNetworkParams.pcSSID));
     }
     else
     {
@@ -279,7 +279,7 @@ static void prvWifiConnect(void)
     }
     else
     {
-        configPRINTF(("Wi-Fi failed to connect to AP.\r\n"));
+        configPRINTF(("Wi-Fi failed to connect to AP %s.\r\n", xNetworkParams.pcSSID));
 
         /* Delay to allow the lower priority logging task to print the above status. */
         vTaskDelay(pdMS_TO_TICKS(mainLOGGING_WIFI_STATUS_DELAY));


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Updated the WiFi tests to put the status message in the task parameters for the multi-task test.
Updated the WiFi tests to retry the socket connection in the round trip test.
Updated the NXP WiFi port to return success when it was already successfully initialized and to fail the WiFi connection if the DHCP fails.

http://34.216.37.221/job/afr_test_custom/715/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
