### PR TITLE
 Fix FreeRTOS_setsockopt()

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
@@ -1481,8 +1481,17 @@ FreeRTOS_Socket_t *pxSocket;
 					}
 
 					pxProps = ( ( WinProperties_t * ) pvOptionValue );
-					FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ), sizeof( pxProps->lTxBufSize ) );
-					FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ), sizeof( pxProps->lRxBufSize ) );
+
+					if ( FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ), sizeof( pxProps->lTxBufSize ) ) != 0 )
+					{
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+
+					if ( FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ), sizeof( pxProps->lRxBufSize ) ) != 0 )
+					{
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+
 					#if( ipconfigUSE_TCP_WIN == 1 )
 					{
 						pxSocket->u.xTCP.uxRxWinSize = ( uint32_t )pxProps->lRxWinSize;	/* Fixed value: size of the TCP reception window */


### PR DESCRIPTION
Description
-----------
bug fix to "ARG FV Finding: FreeRTOS_setsockopt() returns wrong error codes".
ticket number: E039512548

Please check with current on-call for status update. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests. 
- [ ] My code is Linted.