### PR TITLE
Changed GATT and GAPP service and event lists to the linked containers

### DIFF
--- a/lib/include/aws_ble.h
+++ b/lib/include/aws_ble.h
@@ -37,6 +37,7 @@
 #include "bt_hal_gatt_server.h"
 #include "bt_hal_gatt_types.h"
 #include "aws_doubly_linked_list.h"
+#include "iot_linear_containers.h"
 
 /**
  * @brief Structure containing all advertisement parameters.
@@ -78,7 +79,8 @@ typedef struct
  */
 typedef struct
 {
-    Link_t xConnectionList;
+    IotLink_t xConnectionList;
+
     BLEConnectionParam_t xConnectionParams; /**< Connection parameters. */
     uint16_t usConnId;                      /**< Connection Id. */
     BTBdaddr_t pxRemoteBdAddr;              /**< Remote device address. */
@@ -612,7 +614,7 @@ BTStatus_t BLE_SendResponse( BLEEventResponse_t * pxResp,
  * @param[out] pxConnectionList Returns the head of the connection list.
  * @return Returns eBTStatusSuccess on successful call.
  */
-BTStatus_t BLE_GetConnectionInfoList( Link_t ** ppxConnectionInfoList );
+BTStatus_t BLE_GetConnectionInfoList( IotLink_t ** ppxConnectionInfoList );
 
 /**
  * @brief Get connection info for a specific connection ID.

--- a/lib/include/iot_linear_containers.h
+++ b/lib/include/iot_linear_containers.h
@@ -27,11 +27,6 @@
 #ifndef _IOT_LINEAR_CONTAINERS_H_
 #define _IOT_LINEAR_CONTAINERS_H_
 
-/* Build using a config header, if provided. */
-#ifdef AWS_IOT_CONFIG_FILE
-    #include AWS_IOT_CONFIG_FILE
-#endif
-
 /* Standard includes. */
 #include <stdbool.h>
 #include <stddef.h>

--- a/lib/include/iot_metrics.h
+++ b/lib/include/iot_metrics.h
@@ -29,6 +29,11 @@
 #define _IOT_METRICS_H_
 
 #include <stdint.h>
+
+#ifdef AWS_IOT_CONFIG_FILE
+    #include AWS_IOT_CONFIG_FILE
+#endif
+
 #include "iot_linear_containers.h"
 
 /**

--- a/lib/include/private/aws_ble_internals.h
+++ b/lib/include/private/aws_ble_internals.h
@@ -32,6 +32,7 @@
 #define _AWS_BLE_INTERNALS_H_
 
 #include "aws_doubly_linked_list.h"
+#include "iot_linear_containers.h"
 
 /* Place holder for saving Char descriptors into memory. */
 typedef struct {
@@ -55,7 +56,7 @@ typedef struct {
 /* End of place holder. */
 
 typedef struct{
-	Link_t xServiceList;
+	IotLink_t xServiceList;
 	BLEAttribute_t * pxAttributesPtr;
 	BLEService_t * pxService;
 	uint16_t usStartHandle;
@@ -80,7 +81,7 @@ typedef struct
 }BLEInternalEventsCallbacks_t;
 
 typedef struct{
-	Link_t xEventList;
+	IotLink_t xEventList;
 	BLEEventsCallbacks_t xSubscribedEventCb;
 }BLESubscrEventListElement_t;
 
@@ -91,9 +92,12 @@ typedef struct{
 	/*  @TODO pending indication response with a global only works for one simultaneous connection */
 	uint16_t usHandlePendingIndicationResponse;
 	uint8_t ucServerIf;
-	Link_t xServiceListHead;
-	Link_t xConnectionListHead;
-	Link_t xSubscrEventListHead[eNbEvents];    /**< Any task can subscribe to events in that array, several callback can subscribe to the same event */
+
+    IotListDouble_t xServiceListHead;
+	IotListDouble_t xConnectionListHead;
+	
+	IotListDouble_t xSubscrEventListHead[eNbEvents];    /**< Any task can subscribe to events in that array, several callback can subscribe to the same event */
+	
 	uint16_t usHandlePendingPrepareWrite;
 	BLEInternalEventsCallbacks_t pxBLEEventsCallbacks;
 	BTInterface_t * pxBTInterface;


### PR DESCRIPTION
Changed GATT and GAPP service and event lists to the linked containers

Description
-----------
The containers in aws_ble_gatt.c and aws_ble_gap.c were using aws_doubly_linked_list.h
This change switches these containers over to the new iot_linear_containers.h 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
