### PR TITLE
implement old defender library interfaces, including demo and tests

### DIFF
--- a/demos/common/defender/aws_iot_demo_defender_v1.c
+++ b/demos/common/defender/aws_iot_demo_defender_v1.c
@@ -1,0 +1,209 @@
+/*
+ * Amazon FreeRTOS Device Defender Demo V1.4.5
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+ /* Standard includes. */
+#include "stdio.h"
+#include "string.h"
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "message_buffer.h"
+#include "task.h"
+
+/* Defender includes. */
+#include "aws_defender.h"
+
+/* Demo for device defender */
+static void prvDefenderDemo(void *);
+
+/* Logs the metrics init status */
+static void prvLogInitStatus(DefenderErr_t eStartStatus);
+
+/* Logs the status returned from PeriodSet */
+static void prvLogPeriodStatus(DefenderErr_t eStartStatus);
+
+/* Logs the result from starting Device Defender */
+static void prvLogStartStatus(DefenderErr_t eStartStatus);
+
+/* Monitors the report status */
+static void prvMonitorReportStatus(void);
+
+/* Logs the report status */
+static void prvLogReportStatus(DefenderReportStatus_t eStartStatus);
+
+void vStartDeviceDefenderDemo(void)
+{
+    configSTACK_DEPTH_TYPE const xStackDepth = configMINIMAL_STACK_SIZE;
+
+    (void)xTaskCreate(prvDefenderDemo,
+        "Defender Demo",
+        xStackDepth,
+        NULL,
+        tskIDLE_PRIORITY,
+        NULL);
+}
+
+static void prvDefenderDemo(void * param)
+{
+    DefenderMetric_t xMetricsList[1];
+    int32_t lReportPeriodSec = 300;
+    DefenderErr_t eInitStatus;
+    DefenderErr_t ePeriodStatus;
+    DefenderErr_t eStartStatus;
+
+    xMetricsList[0] = xDefenderTCPConnections;
+
+    /* Silence warning about unused param */
+    (void)param;
+
+    eInitStatus = DEFENDER_MetricsInit(xMetricsList);
+    prvLogInitStatus(eInitStatus);
+
+    ePeriodStatus = DEFENDER_ReportPeriodSet(lReportPeriodSec);
+    prvLogPeriodStatus(ePeriodStatus);
+
+    eStartStatus = DEFENDER_Start();
+    prvLogStartStatus(eStartStatus);
+
+    prvMonitorReportStatus();
+    configPRINTF(("----Device Defender Demo Complete----.\r\n"));
+    vTaskDelete(NULL);
+}
+
+static void prvLogInitStatus(DefenderErr_t eInitStatus)
+{
+    switch (eInitStatus)
+    {
+    case eDefenderErrSuccess:
+        configPRINTF(("Defender metrics were initialized.\r\n"));
+        break;
+
+    case eDefenderErrTooManyMetrics:
+        configPRINTF(("Too many metrics were provided.\r\n"));
+        break;
+
+    default:
+        configPRINTF(("Unexpected init status: %d.\r\n", eInitStatus));
+        break;
+    }
+}
+
+static void prvLogPeriodStatus(DefenderErr_t ePeriodStatus)
+{
+    switch (ePeriodStatus)
+    {
+    case eDefenderErrSuccess:
+        configPRINTF(("Defender period was set.\r\n"));
+        break;
+
+    case eDefenderErrPeriodTooShort:
+        configPRINTF(("Report period was too short (less than 300 sec).\r\n"));
+        break;
+
+    default:
+        configPRINTF(("Unexpected period status: %d.\r\n", ePeriodStatus));
+        break;
+    }
+}
+
+static void prvLogStartStatus(DefenderErr_t eStartStatus)
+{
+    switch (eStartStatus)
+    {
+    case eDefenderErrSuccess:
+        configPRINTF(("Defender was started.\r\n"));
+        break;
+
+    case eDefenderErrFailedToCreateTask:
+        configPRINTF(("Defender task could not be created.\r\n"));
+        break;
+
+    case eDefenderErrAlreadyStarted:
+        configPRINTF(("Defender task was started outside of the demo.\r\n"));
+        break;
+
+    default:
+        configPRINTF(("Unexpected start status: %d.\r\n", eStartStatus));
+        break;
+    }
+}
+
+static void prvMonitorReportStatus(void)
+{
+    /* Defender is started.  No further action is required by the calling
+     * aplication.  However the application can query the report status as
+     * demonstrated below. */
+    int32_t lTaskDelayPeriodMs = 11;
+    DefenderReportStatus_t eReportStatus = DEFENDER_ReportStatusGet();
+
+    while (eDefenderRepInit == eReportStatus)
+    {
+        /* The first report is sent on start.  Subsequent reports are sent
+         * periodically */
+         /* Wait for agent to send the first report */
+        eReportStatus = DEFENDER_ReportStatusGet();
+        vTaskDelay(pdMS_TO_TICKS(lTaskDelayPeriodMs));
+    }
+
+    /* First report has been sent.  Will wait for a short period to give the
+     * service a chance to respond. */
+    vTaskDelay(pdMS_TO_TICKS(10000));
+
+    eReportStatus = DEFENDER_ReportStatusGet();
+    prvLogReportStatus(eReportStatus);
+}
+
+static void prvLogReportStatus(DefenderReportStatus_t eReportStatus)
+{
+    switch (eReportStatus)
+    {
+    case eDefenderRepSuccess:
+        configPRINTF(("Device Defender Acknowledged the report.\r\n"));
+        break;
+
+    case eDefenderRepInit:
+        configPRINTF(("Metrics report has not yet been sent.\r\n"));
+        break;
+
+    case eDefenderRepRejected:
+        configPRINTF(("Device defender service received and rejected the "
+            "metrics report.\r\n"));
+        break;
+
+    case eDefenderRepNoAck:
+        configPRINTF(("Device defender servie did not acknowledge the metrics "
+            "within the expected time.\r\n"));
+        break;
+
+    case eDefenderRepNotSent:
+        configPRINTF(("The metrics report was not sent.\r\n"));
+        break;
+
+    default:
+        configPRINTF(("Unexpected report status: %d.\r\n", eReportStatus));
+        break;
+    }
+}

--- a/demos/pc/windows/visual_studio/aws_demos.vcxproj
+++ b/demos/pc/windows/visual_studio/aws_demos.vcxproj
@@ -97,6 +97,7 @@
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c" />
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_collector.c" />
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_mqtt.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_v1.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_clock.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_mqueue.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_pthread.c" />
@@ -244,7 +245,9 @@
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_defender_posix.c" />
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_metrics_posix.c" />
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_mqtt_posix.c" />
+    <ClCompile Include="..\..\..\..\lib\utils\taskpool\aws_iot_taskpool.c" />
     <ClCompile Include="..\..\..\common\defender\aws_iot_demo_defender.c" />
+    <ClCompile Include="..\..\..\common\defender\aws_iot_demo_defender_v1.c" />
     <ClCompile Include="..\..\..\common\demo_runner\aws_demo_runner.c" />
     <ClCompile Include="..\..\..\common\devmode_key_provisioning\aws_dev_mode_key_provisioning.c" />
     <ClCompile Include="..\..\..\common\greengrass_connectivity\aws_greengrass_discovery_demo.c" />
@@ -278,12 +281,14 @@
     <ClInclude Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\include\FreeRTOS_POSIX_internal.h" />
     <ClInclude Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\include\portable\FreeRTOS_POSIX_portable_default.h" />
     <ClInclude Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\include\portable\pc\windows\FreeRTOS_POSIX_portable.h" />
+    <ClInclude Include="..\..\..\..\lib\include\aws_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_json_utils.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_logging_setup.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_mqtt.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_serializer.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_shadow.h" />
+    <ClInclude Include="..\..\..\..\lib\include\aws_iot_taskpool.h" />
     <ClInclude Include="..\..\..\..\lib\include\FreeRTOS_POSIX\errno.h" />
     <ClInclude Include="..\..\..\..\lib\include\FreeRTOS_POSIX\fcntl.h" />
     <ClInclude Include="..\..\..\..\lib\include\FreeRTOS_POSIX\mqueue.h" />

--- a/demos/pc/windows/visual_studio/aws_demos.vcxproj.filters
+++ b/demos/pc/windows/visual_studio/aws_demos.vcxproj.filters
@@ -148,6 +148,9 @@
     <Filter Include="lib\aws\metrics">
       <UniqueIdentifier>{b1d77a3f-e396-4722-94c6-2301cc8b3f37}</UniqueIdentifier>
     </Filter>
+    <Filter Include="lib\aws\utils\taskpool">
+      <UniqueIdentifier>{28b6177e-d0ab-47e7-820a-eaf1b6b7b0fb}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\lib\crypto\aws_crypto.c">
@@ -677,6 +680,15 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c">
       <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_v1.c">
+      <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\utils\taskpool\aws_iot_taskpool.c">
+      <Filter>lib\aws\utils\taskpool</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\defender\aws_iot_demo_defender_v1.c">
+      <Filter>application_code\common_demos\source</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1297,6 +1309,12 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\lib\include\private\aws_secure_sockets_wrapper_metrics.h">
       <Filter>lib\aws\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\lib\include\aws_defender.h">
+      <Filter>lib\aws\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\lib\include\aws_iot_taskpool.h">
+      <Filter>lib\aws\include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/lib/defender/aws_iot_defender_collector.c
+++ b/lib/defender/aws_iot_defender_collector.c
@@ -80,6 +80,11 @@ static _metrics_t _metrics = { 0 };
 /* Define a "snapshot" global array of metrics flag. */
 static uint32_t _metricsFlagSnapshot[ _DEFENDER_METRICS_GROUP_COUNT ];
 
+/* Report id integer. */
+uint64_t _AwsIotDefenderReportId = 0;
+
+/*---------------------- Helper Functions -------------------------*/
+
 static void copyMetricsFlag();
 
 static AwsIotDefenderEventType_t getLatestMetricsData();
@@ -92,14 +97,6 @@ static void tcpConnectionsCallback( void * param1,
 static void _serialize();
 
 static void _serializeTcpConnections( AwsIotSerializerEncoderObject_t * pMetricsObject );
-
-/**
- * Attempt to serialize metrics report with given data buffer.
- */
-
-/*static bool _serialize( AwsIotSerializerEncoderObject_t * pEncoderObject,
- *                      uint8_t * pDataBuffer,
- *                      size_t dataSize );*/
 
 /*-----------------------------------------------------------*/
 
@@ -151,6 +148,9 @@ AwsIotDefenderEventType_t AwsIotDefenderInternal_CreateReport()
 
     if( !eventError )
     {
+        /* Generate report id based on current time. */
+        _AwsIotDefenderReportId = AwsIotClock_GetTimeMs();
+
         /* Dry-run serialization to calculate the required size. */
         _serialize();
 
@@ -248,7 +248,7 @@ static void _serialize()
     /* Append key-value pair of "report_Id" which uses clock time. */
     serializerError = _AwsIotDefenderEncoder.appendKeyValue( &headerMap,
                                                              _REPORTID_TAG,
-                                                             AwsIotSerializer_ScalarSignedInt( AwsIotClock_GetTimeMs() ) );
+                                                             AwsIotSerializer_ScalarSignedInt( _AwsIotDefenderReportId ) );
     assertNoError( serializerError );
 
     /* Append key-value pair of "version". */

--- a/lib/defender/aws_iot_defender_v1.c
+++ b/lib/defender/aws_iot_defender_v1.c
@@ -1,0 +1,262 @@
+/*
+ * Amazon FreeRTOS Device Defender Agent V1.0.2
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* Old and new defender includes. */
+#include "aws_iot_defender.h"
+#include "aws_defender.h"
+
+#include "aws_clientcredential.h"
+
+extern uint64_t _AwsIotDefenderReportId;
+
+/* Defender agent's status, initialized with eDefenderRepInit. */
+static DefenderReportStatus_t _status = eDefenderRepInit;
+
+/*-----------------------------------------------------------*/
+
+void _defenderCallback( void * param1,
+                        AwsIotDefenderCallbackInfo_t * const pCallbackInfo )
+{
+    ( void ) param1;
+
+    switch( pCallbackInfo->eventType )
+    {
+        /* Metrics is accepted. */
+        case AWS_IOT_DEFENDER_METRICS_ACCEPTED:
+            _status = eDefenderRepSuccess;
+            break;
+
+        /* Metrics is rejected. */
+        case AWS_IOT_DEFENDER_METRICS_REJECTED:
+            _status = eDefenderRepRejected;
+            break;
+
+        /* Metrics failed to be sent. */
+        default:
+            _status = eDefenderRepNotSent;
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static DefenderErr_t _toDefenderErr( AwsIotDefenderError_t error )
+{
+    DefenderErr_t oldError = eDefenderErrSuccess;
+
+    switch( error )
+    {
+        case AWS_IOT_DEFENDER_SUCCESS:
+            oldError = eDefenderErrSuccess;
+            break;
+
+        case AWS_IOT_DEFENDER_ALREADY_STARTED:
+            oldError = eDefenderErrAlreadyStarted;
+            break;
+
+        case AWS_IOT_DEFENDER_PERIOD_TOO_SHORT:
+            oldError = eDefenderErrPeriodTooShort;
+            break;
+
+        default:
+            oldError = eDefenderErrOther;
+    }
+
+    return oldError;
+}
+
+/*-----------------------------------------------------------*/
+
+DefenderErr_t DEFENDER_MetricsInitFunc( DefenderMetric_t * pxMetricsList,
+                                        int32_t lMetricsLength )
+{
+    uint32_t flag = 0;
+
+    size_t i = 0, metricsLength = ( size_t ) lMetricsLength;
+
+    for( ; i < metricsLength; i++ )
+    {
+        switch( pxMetricsList[ i ] )
+        {
+            case xDefenderTCPConnections:
+                flag |= AWS_IOT_DEFENDER_METRICS_TCP_CONNECTIONS_ESTABLISHED_TOTAL;
+                break;
+
+            default:
+                ;
+        }
+    }
+
+    return _toDefenderErr( AwsIotDefender_SetMetrics( AWS_IOT_DEFENDER_METRICS_TCP_CONNECTIONS, flag ) );
+}
+
+
+/*-----------------------------------------------------------*/
+
+DefenderErr_t DEFENDER_ReportPeriodSet( uint32_t ulPeriodSec )
+{
+    return _toDefenderErr( AwsIotDefender_SetPeriod( ( uint64_t ) ulPeriodSec ) );
+}
+
+
+/*-----------------------------------------------------------*/
+
+DefenderErr_t DEFENDER_ConnectionTimeoutSet( uint32_t ulTimeoutMs )
+{
+    ( void ) ulTimeoutMs;
+
+    /* Not set anthing. This function is just for backward compatibility. */
+    return eDefenderErrSuccess;
+}
+
+
+/*-----------------------------------------------------------*/
+
+DefenderErr_t DEFENDER_Start( void )
+{
+    /* Register an internal callback. */
+    const AwsIotDefenderCallback_t callback = { .function = _defenderCallback, .param1 = NULL };
+
+    /* Use compile-time network information. */
+    AwsIotDefenderStartInfo_t startInfo =
+    {
+        .tlsInfo         = AWS_IOT_NETWORK_TLS_INFO_INITIALIZER,
+        .pAwsIotEndpoint = clientcredentialMQTT_BROKER_ENDPOINT,
+        .port            = clientcredentialMQTT_BROKER_PORT,
+        .pThingName      = clientcredentialIOT_THING_NAME,
+        .thingNameLength = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME ),
+        .callback        = callback
+    };
+
+    /* Use the default root CA provided with Amazon FreeRTOS. */
+    startInfo.tlsInfo.pRootCa = NULL;
+    startInfo.tlsInfo.rootCaLength = 0;
+
+    /* Set client credentials. */
+    startInfo.tlsInfo.pClientCert = clientcredentialCLIENT_CERTIFICATE_PEM;
+    startInfo.tlsInfo.clientCertLength = ( size_t ) clientcredentialCLIENT_CERTIFICATE_LENGTH;
+    startInfo.tlsInfo.pPrivateKey = clientcredentialCLIENT_PRIVATE_KEY_PEM;
+    startInfo.tlsInfo.privateKeyLength = ( size_t ) clientcredentialCLIENT_PRIVATE_KEY_LENGTH;
+
+    /* If not connecting over port 443, disable ALPN. */
+    if( clientcredentialMQTT_BROKER_PORT != 443 )
+    {
+        startInfo.tlsInfo.pAlpnProtos = NULL;
+    }
+
+    /* Invoke defender start API. */
+    return _toDefenderErr( AwsIotDefender_Start( &startInfo ) );
+}
+
+/*-----------------------------------------------------------*/
+
+DefenderErr_t DEFENDER_Stop( void )
+{
+    AwsIotDefender_Stop();
+
+    /* No failure cases. */
+    return eDefenderErrSuccess;
+}
+
+/*-----------------------------------------------------------*/
+
+DefenderReportStatus_t DEFENDER_ReportStatusGet( void )
+{
+    return _status;
+}
+
+/*-----------------------------------------------------------*/
+
+int32_t GetLastReportId( void )
+{
+    return ( int32_t ) _AwsIotDefenderReportId;
+}
+
+/*-----------------------------------------------------------*/
+
+char const * DEFENDER_ErrAsString( DefenderErr_t eErrNum )
+{
+    switch( eErrNum )
+    {
+        case eDefenderErrSuccess:
+
+            return "eDefenderErrSuccess";
+
+        case eDefenderErrTooManyMetrics:
+
+            return "eDefenderErrTooManyMetrics";
+
+        case eDefenderErrPeriodTooShort:
+
+            return "eDefenderErrPeriodTooShort";
+
+        case eDefenderErrFailedToCreateTask:
+
+            return "eDefenderErrFailedToCreateTask";
+
+        case eDefenderErrAlreadyStarted:
+
+            return "eDefenderErrAlreadyStarted";
+
+        case eDefenderErrNotStarted:
+
+            return "eDefenderErrNotStarted";
+
+        case eDefenderErrOther:
+
+            return "eDefenderErrOther";
+    }
+
+    return "Invalid value";
+}
+
+/*-----------------------------------------------------------*/
+
+char const * DEFENDER_ReportStatusAsString( DefenderReportStatus_t eStatusNum )
+{
+    switch( eStatusNum )
+    {
+        case eDefenderRepSuccess:
+
+            return "eDefenderRepSuccess";
+
+        case eDefenderRepInit:
+
+            return "eDefenderRepInit";
+
+        case eDefenderRepRejected:
+
+            return "eDefenderRepRejected";
+
+        case eDefenderRepNoAck:
+
+            return "eDefenderRepNoAck";
+
+        case eDefenderRepNotSent:
+
+            return "eDefenderRepNotSent";
+    }
+
+    return "Invalid value";
+}

--- a/lib/include/aws_defender.h
+++ b/lib/include/aws_defender.h
@@ -1,0 +1,165 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+#ifndef AWS_DEFENDER_H
+#define AWS_DEFENDER_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * @brief Metrics enums.
+ * @see DEFENDER_MetricsInit
+ */
+typedef enum
+{
+    xDefenderTCPConnections
+} DefenderMetric_t;
+
+/** Status returned from public functions */
+typedef enum
+{
+    /** Function was successful */
+    eDefenderErrSuccess = 0,
+
+    /** More metrics were provided than are available for use and/or storage.
+     * Double check that the metrics list is correct. */
+    eDefenderErrTooManyMetrics,
+
+    /** Request reporting period was too short.  The period should not be less
+     * than 300 seconds. */
+    eDefenderErrPeriodTooShort,
+
+    /** A task could not be created, and therefore the device defender agent
+     * failed to start. */
+    eDefenderErrFailedToCreateTask,
+
+    /** The agent is already running.  The function that emitted this error
+     * cannot be called while the agent is running (e.g. DEFENDER_Start) */
+    eDefenderErrAlreadyStarted,
+
+    /** The agent is not running.  The function that emitted this error cannot
+     * be called when the agent is not running (e.g. DEFENDER_Stop) */
+    eDefenderErrNotStarted,
+
+    /** An otherwise unspecified error has occurred.   */
+    eDefenderErrOther,
+} DefenderErr_t;
+
+/** Indicates the status of the last report sent */
+typedef enum
+{
+    /** Last report was successfully sent and acknowledged */
+    eDefenderRepSuccess = 0,
+
+    /** Device defender has been started but no report has been sent */
+    eDefenderRepInit,
+
+    /** Last report was rejected */
+    eDefenderRepRejected,
+
+    /** Last report was not acknowledged */
+    eDefenderRepNoAck,
+
+    /** Last report failed to send, likely due to a connectivity issue */
+    eDefenderRepNotSent,
+} DefenderReportStatus_t;
+
+/** Maximum number of reportable metrics */
+#define DEFENDER_MAX_METRICS_COUNT    ( 1 )
+
+/**
+ * @param pxMetricsList List of the metrics to put in the report
+ * @return DefenderErr_t
+ */
+#define DEFENDER_MetricsInit( pxMetricsList ) \
+    DEFENDER_MetricsInitFunc(                 \
+        pxMetricsList, sizeof( pxMetricsList ) / sizeof( DefenderMetric_t ) )
+
+/**
+ * @note Prefer using DEFENDER_MetricsInit where possible.
+ * @brief Initializes the metrics list
+ * @return DefenderErr_t
+ */
+DefenderErr_t DEFENDER_MetricsInitFunc( DefenderMetric_t * pxMetricsList,
+                                        int32_t lMetricsLength );
+
+/**
+ * @brief Set the reporting period in seconds
+ *
+ * Device defender provides metric reports on an interval.  If the device is
+ * awake, and the interval has elapsed, the device will report the metrics.
+ *
+ * @param  periodSec Reporting period in seconds
+ * @return DefenderErr_t
+ */
+DefenderErr_t DEFENDER_ReportPeriodSet( uint32_t ulPeriodSec );
+
+/**
+ * @brief      Set the timeout period for various connection actions
+ *
+ * @param[in]  ulTimeoutMs  The timeout in milliseconds
+ *
+ * @return     DefenderErr_t
+ */
+DefenderErr_t DEFENDER_ConnectionTimeoutSet( uint32_t ulTimeoutMs );
+
+/**
+ * @brief Starts the defender agent
+ * @return DefenderErr_t
+ */
+DefenderErr_t DEFENDER_Start( void );
+
+/**
+ * @brief Stops the defender agent
+ * @return DefenderErr_t
+ */
+DefenderErr_t DEFENDER_Stop( void );
+
+/**
+ * @return Status of most recent report
+ * @return DefenderReportStatus_t
+ */
+DefenderReportStatus_t DEFENDER_ReportStatusGet( void );
+
+/**
+ * @brief Returns the last Report ID used.
+ */
+int32_t GetLastReportId( void );
+
+/**
+ * @brief Returns the name of the given enum value
+ *
+ * @return Pointer to a string literal
+ */
+char const * DEFENDER_ErrAsString( DefenderErr_t /*eErrNum*/ );
+
+/**
+ * @brief Returns the name of the given enum value
+ *
+ * @return Pointer to a string literal
+ */
+char const * DEFENDER_ReportStatusAsString( DefenderReportStatus_t /*eStatusNum*/ );
+
+#endif /* end of include guard: AWS_DEFENDER_H */

--- a/tests/common/defender/aws_iot_tests_defender_api_v1.c
+++ b/tests/common/defender/aws_iot_tests_defender_api_v1.c
@@ -1,0 +1,591 @@
+/*
+ * Amazon FreeRTOS Device Defender Agent V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include "FreeRTOS.h"
+
+#include "projdefs.h"
+#include "task.h"
+
+#include "aws_cbor.h"
+#include "aws_cbor_print.h"
+#include "aws_cbor_types.h"
+#include "aws_clientcredential.h"
+#include "aws_defender.h"
+#include "aws_mqtt_agent.h"
+#include "unity_fixture.h"
+
+static bool xReportAccepted;
+static bool xReportRejected;
+
+TEST_GROUP( Full_DEFENDER_OLD );
+
+TEST_SETUP( Full_DEFENDER_OLD )
+{
+    /* Delay to allow the MQTT logs to flush */
+    vTaskDelay( pdMS_TO_TICKS( 500 ) );
+    xReportAccepted = false;
+    xReportRejected = false;
+}
+
+TEST_TEAR_DOWN( Full_DEFENDER_OLD )
+{
+    /* Delay to allow the MQTT logs to flush */
+    ( void ) DEFENDER_Stop();
+    vTaskDelay( pdMS_TO_TICKS( 500 ) );
+}
+
+TEST_GROUP_RUNNER( Full_DEFENDER_OLD )
+{
+    /* These test should not require any network connectivity */
+    RUN_TEST_CASE( Full_DEFENDER_OLD, Start_should_return_err_if_already_started );
+    RUN_TEST_CASE( Full_DEFENDER_OLD, Start_should_return_success );
+    RUN_TEST_CASE( Full_DEFENDER_OLD, Stop_should_return_success_when_started );
+
+    /* These tests check the connectivity and responses from the service */
+    RUN_TEST_CASE( Full_DEFENDER_OLD, report_to_echo_server );
+    RUN_TEST_CASE( Full_DEFENDER_OLD, endpoint_accepts_cbor_example_report );
+    RUN_TEST_CASE( Full_DEFENDER_OLD, endpoint_accepts_json_example_report );
+
+    /* This tests that the agent successfully reports to the service */
+    RUN_TEST_CASE( Full_DEFENDER_OLD, endpoint_accepts_report_from_agent );
+}
+
+/*----------------------------------------------------------------------------*/
+
+TEST( Full_DEFENDER_OLD, Start_should_return_err_if_already_started )
+{
+    ( void ) DEFENDER_Start();
+    DefenderErr_t eErr = DEFENDER_Start();
+    TEST_ASSERT_EQUAL( eDefenderErrAlreadyStarted, eErr );
+}
+
+TEST( Full_DEFENDER_OLD, Start_should_return_success )
+{
+    DefenderErr_t eErr = DEFENDER_Start();
+
+    TEST_ASSERT_EQUAL( eDefenderErrSuccess, eErr );
+}
+
+TEST( Full_DEFENDER_OLD, Stop_should_return_success_when_started )
+{
+    ( void ) DEFENDER_Start();
+    DefenderErr_t eErr = DEFENDER_Stop();
+    TEST_ASSERT_EQUAL( eDefenderErrSuccess, eErr );
+}
+
+/*----------------------------------------------------------------------------*/
+
+static bool xEchoTriggered;
+
+static CBORHandle_t prvCreateDummyReport( void );
+static MQTTAgentHandle_t prvMqttAgentNew( void );
+static void prvMqttAgentConnectToEcho( MQTTAgentHandle_t );
+static void prvSubscribeToEcho( MQTTAgentHandle_t );
+static MQTTBool_t prvEchoCallback( void * pvPublishCallbackContext,
+                                   MQTTPublishData_t const * pxPublishData );
+static void prvReportPublishToEcho( MQTTAgentHandle_t,
+                                    CBORHandle_t );
+
+TEST( Full_DEFENDER_OLD, report_to_echo_server )
+{
+    CBORHandle_t xDefenderReport = prvCreateDummyReport();
+    MQTTAgentHandle_t xDefenderMqttAgent = prvMqttAgentNew();
+
+    prvMqttAgentConnectToEcho( xDefenderMqttAgent );
+    prvSubscribeToEcho( xDefenderMqttAgent );
+    prvReportPublishToEcho( xDefenderMqttAgent, xDefenderReport );
+
+    /* Wait for 1 second while we  */
+    vTaskDelay( pdMS_TO_TICKS( 10000 ) );
+    TEST_ASSERT_TRUE_MESSAGE( xEchoTriggered,
+                              "Expected the echo to trigger the callback" )
+
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    ( void ) MQTT_AGENT_Disconnect( xDefenderMqttAgent, xTimeout );
+    ( void ) MQTT_AGENT_Delete( xDefenderMqttAgent );
+    CBOR_Delete( &xDefenderReport );
+}
+
+/*-----------------------------------------------------------*/
+
+static CBORHandle_t prvCreateDummyReport( void )
+{
+    /* Create example report */
+    CBORHandle_t xDefenderReport = CBOR_New( 0 );
+
+    TEST_ASSERT_NOT_NULL_MESSAGE( xDefenderReport,
+                                  "Failed to create new pcReport" );
+    CBORHandle_t xHeader = CBOR_New( 0 );
+
+    if( NULL == xHeader )
+    {
+        CBOR_Delete( &xDefenderReport );
+        TEST_FAIL_MESSAGE( "Failed to create new xHeader" );
+    }
+    else
+    {
+        /* Using configRAND32 instead of ipconfigRAND32 */
+        /* Including xHeader with ipconfigRAND32 causes redefinition errors */
+        /* Cryptographically secure rand is not important here */
+        uint32_t ulReportId = configRAND32() && ( 0x3FFFFFFF );
+        CBOR_AppendKeyWithInt( xHeader, "report_id", ulReportId );
+        CBOR_AppendKeyWithString( xHeader, "version", "1.0" );
+        CBOR_AppendKeyWithMap( xDefenderReport, "header", xHeader );
+    }
+
+    CBOR_Delete( &xHeader );
+
+    CBORHandle_t xMetrics = CBOR_New( 0 );
+    {
+        CBORHandle_t xTcpPorts = CBOR_New( 0 );
+        {
+            CBOR_AppendKeyWithInt( xTcpPorts, "total", 0 );
+            CBOR_AppendKeyWithMap( xMetrics, "listening_tcp_ports", xTcpPorts );
+        }
+        CBOR_Delete( &xTcpPorts );
+
+        CBORHandle_t xUdpPorts = CBOR_New( 0 );
+        {
+            CBOR_AppendKeyWithInt( xUdpPorts, "total", 0 );
+            CBOR_AppendKeyWithMap( xMetrics, "listening_udp_ports", xUdpPorts );
+        }
+        CBOR_Delete( &xUdpPorts );
+
+        CBORHandle_t xTcpConnections = CBOR_New( 0 );
+        {
+            CBORHandle_t xEstConnections = CBOR_New( 0 );
+            {
+                CBOR_AppendKeyWithInt( xEstConnections, "total", 2 );
+                CBOR_AppendKeyWithMap( xTcpConnections,
+                                       "established_connections",
+                                       xEstConnections );
+            }
+            CBOR_AppendKeyWithMap( xMetrics, "tcp_connections",
+                                   xTcpConnections );
+        }
+        CBOR_Delete( &xTcpConnections );
+
+        CBOR_AppendKeyWithMap( xDefenderReport, "metrics", xMetrics );
+    }
+    CBOR_Delete( &xMetrics );
+    cborError_t eErr = CBOR_CheckError( xDefenderReport );
+
+    if( eErr )
+    {
+        CBOR_Delete( &xDefenderReport );
+        TEST_ASSERT_EQUAL_MESSAGE( eCborErrNoError, eErr,
+                                   "Failed to create pcReport" );
+    }
+
+    return xDefenderReport;
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTAgentHandle_t prvMqttAgentNew( void )
+{
+    MQTTAgentHandle_t xNewMqttAgent = 0;
+    MQTTAgentReturnCode_t eCreateResult = MQTT_AGENT_Create( &xNewMqttAgent );
+
+    TEST_ASSERT_EQUAL_MESSAGE( eMQTTAgentSuccess, eCreateResult,
+                               "Failed to create agent" );
+
+    return xNewMqttAgent;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvMqttAgentConnectToEcho( MQTTAgentHandle_t pxMQTTAgent )
+{
+    MQTTAgentConnectParams_t xDefenderConParams =
+    {
+        .pcURL              = clientcredentialMQTT_BROKER_ENDPOINT,
+        .xFlags             = mqttagentREQUIRE_TLS,
+        .xURLIsIPAddress    = pdFALSE,
+        .usPort             = clientcredentialMQTT_BROKER_PORT,
+        .pucClientId        = ( const uint8_t * ) clientcredentialIOT_THING_NAME,
+        .usClientIdLength   = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME ),
+        .xSecuredConnection = pdTRUE,
+        .pvUserData         = NULL,
+        .pxCallback         = NULL,
+        .pcCertificate      = NULL,
+        .ulCertificateSize  = 0,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eConnectResult =
+        MQTT_AGENT_Connect( pxMQTTAgent, &xDefenderConParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eConnectResult,
+                         "Failed to connect agent to echo broker" );
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvSubscribeToEcho( MQTTAgentHandle_t pxMQTTAgent )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "freertos/tests/echo";
+    MQTTAgentSubscribeParams_t xSubscriptionParams =
+    {
+        .pucTopic                 = pucTopic,
+        .usTopicLength            = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS                     = eMQTTQoS0,
+        .pvPublishCallbackContext = NULL,
+        .pxPublishCallback        = prvEchoCallback,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eSubscriptionResult =
+        MQTT_AGENT_Subscribe( pxMQTTAgent, &xSubscriptionParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eSubscriptionResult,
+                         "Failed to subscribe to pucTopic" );
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTBool_t prvEchoCallback( void * pvPublishCallbackContext,
+                                   MQTTPublishData_t const * pxPublishData )
+{
+    xEchoTriggered = true;
+
+    return eMQTTFalse;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvReportPublishToEcho( MQTTAgentHandle_t pxMQTTAgent,
+                                    CBORHandle_t xReport )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "freertos/tests/echo";
+
+    MQTTAgentPublishParams_t xPubRecParams =
+    {
+        .pucTopic      = pucTopic,
+        .usTopicLength = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS          = eMQTTQoS0,
+        .pvData        = xReport->pxBufferStart,
+        .ulDataLength  = xReport->pxMapEnd - xReport->pxBufferStart,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 1000 );
+    MQTTAgentReturnCode_t ePublishResult =
+        MQTT_AGENT_Publish( pxMQTTAgent, &xPubRecParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == ePublishResult,
+                         "Failed to publish to pucTopic" );
+}
+
+/*----------------------------------------------------------------------------*/
+
+static char const * const pcDefenderTestEndpoint =
+    clientcredentialMQTT_BROKER_ENDPOINT;
+/* "data.gamma.us-east-1.iot.amazonaws.com"; */
+
+static MQTTBool_t testRejectCallback( void * pvPublishCallbackContext,
+                                      MQTTPublishData_t const * pxPublishData );
+
+static MQTTBool_t testAcceptCallback( void * pvPublishCallbackContext,
+                                      MQTTPublishData_t const * pxPublishData );
+
+static void MqttAgentConnectToDevDef( MQTTAgentHandle_t );
+static void SubscribeToAcceptCbor( MQTTAgentHandle_t );
+static void SubscribeToRejectCbor( MQTTAgentHandle_t );
+static void PublishCborToDevDef( MQTTAgentHandle_t,
+                                 CBORHandle_t );
+
+TEST( Full_DEFENDER_OLD, endpoint_accepts_cbor_example_report )
+{
+    CBORHandle_t xDefenderReport = prvCreateDummyReport();
+    MQTTAgentHandle_t xDefenderMqttAgent = prvMqttAgentNew();
+
+    MqttAgentConnectToDevDef( xDefenderMqttAgent );
+    SubscribeToAcceptCbor( xDefenderMqttAgent );
+    SubscribeToRejectCbor( xDefenderMqttAgent );
+    PublishCborToDevDef( xDefenderMqttAgent, xDefenderReport );
+
+    /* Wait for 1 second for the response to come back from the service */
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    vTaskDelay( pdMS_TO_TICKS( xTimeout ) );
+
+    /* Clean up resources before checking test assertions */
+    ( void ) MQTT_AGENT_Disconnect( xDefenderMqttAgent, xTimeout );
+    ( void ) MQTT_AGENT_Delete( xDefenderMqttAgent );
+    CBOR_Delete( &xDefenderReport );
+
+    TEST_ASSERT_FALSE_MESSAGE( xReportRejected, "Metrics pcReport was rejected." )
+    TEST_ASSERT_TRUE_MESSAGE( xReportAccepted,
+                              "Expected the pcReport to be accepted." )
+}
+
+/*-----------------------------------------------------------*/
+
+static void MqttAgentConnectToDevDef( MQTTAgentHandle_t pxMQTTAgent )
+{
+    MQTTAgentConnectParams_t xDefenderConParams =
+    {
+        .pcURL              = pcDefenderTestEndpoint,
+        .xFlags             = mqttagentREQUIRE_TLS,
+        .xURLIsIPAddress    = pdFALSE,
+        .usPort             = clientcredentialMQTT_BROKER_PORT,
+        .pucClientId        = ( const uint8_t * ) clientcredentialIOT_THING_NAME,
+        .usClientIdLength   = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME ),
+        .xSecuredConnection = pdTRUE,
+        .pvUserData         = NULL,
+        .pxCallback         = NULL,
+        .pcCertificate      = NULL,
+        .ulCertificateSize  = 0,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eConnectResult =
+        MQTT_AGENT_Connect( pxMQTTAgent, &xDefenderConParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eConnectResult,
+                         "Failed to connect agent to broker" );
+}
+
+/*-----------------------------------------------------------*/
+
+static void SubscribeToAcceptCbor( MQTTAgentHandle_t pxMQTTAgent )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/" clientcredentialIOT_THING_NAME
+                         "/defender/metrics/cbor/accepted";
+    MQTTAgentSubscribeParams_t xSubscriptionParams =
+    {
+        .pucTopic                 = pucTopic,
+        .usTopicLength            = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS                     = eMQTTQoS0,
+        .pvPublishCallbackContext = NULL,
+        .pxPublishCallback        = testAcceptCallback,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eSubscriptionResult =
+        MQTT_AGENT_Subscribe( pxMQTTAgent, &xSubscriptionParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eSubscriptionResult,
+                         "Failed to subscribe to pucTopic" );
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTBool_t testAcceptCallback( void * pvPublishCallbackContext,
+                                      MQTTPublishData_t const * pxPublishData )
+{
+    xReportAccepted = true;
+
+    return eMQTTFalse;
+}
+
+/*-----------------------------------------------------------*/
+
+static void SubscribeToRejectCbor( MQTTAgentHandle_t pxMQTTAgent )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/" clientcredentialIOT_THING_NAME
+                         "/defender/metrics/cbor/rejected";
+    MQTTAgentSubscribeParams_t xSubscriptionParams =
+    {
+        .pucTopic                 = pucTopic,
+        .usTopicLength            = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS                     = eMQTTQoS0,
+        .pvPublishCallbackContext = NULL,
+        .pxPublishCallback        = testRejectCallback,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eSubscriptionResult =
+        MQTT_AGENT_Subscribe( pxMQTTAgent, &xSubscriptionParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eSubscriptionResult,
+                         "Failed to subscribe to pucTopic" );
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTBool_t testRejectCallback( void * pvPublishCallbackContext,
+                                      MQTTPublishData_t const * pxPublishData )
+{
+    xReportRejected = true;
+
+    return eMQTTFalse;
+}
+
+/*-----------------------------------------------------------*/
+
+static void PublishCborToDevDef( MQTTAgentHandle_t pxMQTTAgent,
+                                 CBORHandle_t xReport )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/"
+                         clientcredentialIOT_THING_NAME
+                         "/defender/metrics/cbor";
+    uint8_t const * pucBuffer = xReport->pxBufferStart;
+    int lBufLen = xReport->pxMapEnd - xReport->pxBufferStart + 1;
+
+    MQTTAgentPublishParams_t xPubRecParams =
+    {
+        .pucTopic      = pucTopic,
+        .usTopicLength = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS          = eMQTTQoS0,
+        .pvData        = pucBuffer,
+        .ulDataLength  = lBufLen,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+
+    MQTTAgentReturnCode_t ePublishResult =
+        MQTT_AGENT_Publish( pxMQTTAgent, &xPubRecParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == ePublishResult,
+                         "Failed to publish to pucTopic" );
+}
+
+/*----------------------------------------------------------------------------*/
+
+static void SubscribeToAcceptJson( MQTTAgentHandle_t );
+static void SubscribeToRejectJson( MQTTAgentHandle_t );
+static void PublishJsonToDevDef( MQTTAgentHandle_t,
+                                 char const * );
+
+TEST( Full_DEFENDER_OLD, endpoint_accepts_json_example_report )
+{
+    CBORHandle_t xDefenderReport = prvCreateDummyReport();
+    char * pcJSONReport = CBOR_AsString( xDefenderReport );
+
+    CBOR_Delete( &xDefenderReport );
+
+    MQTTAgentHandle_t xDefenderMqttAgent = prvMqttAgentNew();
+    MqttAgentConnectToDevDef( xDefenderMqttAgent );
+    SubscribeToAcceptJson( xDefenderMqttAgent );
+    SubscribeToRejectJson( xDefenderMqttAgent );
+    PublishJsonToDevDef( xDefenderMqttAgent, pcJSONReport );
+    vPortFree( pcJSONReport );
+
+    /* Wait for the service to respond */
+    vTaskDelay( pdMS_TO_TICKS( 10000 ) );
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+
+    ( void ) MQTT_AGENT_Disconnect( xDefenderMqttAgent, xTimeout );
+    ( void ) MQTT_AGENT_Delete( xDefenderMqttAgent );
+
+    TEST_ASSERT_FALSE_MESSAGE( xReportRejected,
+                               "JSON Metrics pcReport was rejected." )
+    TEST_ASSERT_TRUE_MESSAGE( xReportAccepted,
+                              "Expected the JSON pcReport to be accepted." )
+}
+
+/*-----------------------------------------------------------*/
+
+static void SubscribeToAcceptJson( MQTTAgentHandle_t pxMQTTAgent )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/" clientcredentialIOT_THING_NAME
+                         "/defender/metrics/json/accepted";
+    MQTTAgentSubscribeParams_t xSubscriptionParams =
+    {
+        .pucTopic                 = pucTopic,
+        .usTopicLength            = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS                     = eMQTTQoS0,
+        .pvPublishCallbackContext = NULL,
+        .pxPublishCallback        = testAcceptCallback,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eSubscriptionResult =
+        MQTT_AGENT_Subscribe( pxMQTTAgent, &xSubscriptionParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eSubscriptionResult,
+                         "Failed to subscribe to pucTopic" );
+}
+
+/*-----------------------------------------------------------*/
+
+static void SubscribeToRejectJson( MQTTAgentHandle_t pxMQTTAgent )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/" clientcredentialIOT_THING_NAME
+                         "/defender/metrics/json/rejected";
+    MQTTAgentSubscribeParams_t xSubscriptionParams =
+    {
+        .pucTopic                 = pucTopic,
+        .usTopicLength            = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS                     = eMQTTQoS0,
+        .pvPublishCallbackContext = NULL,
+        .pxPublishCallback        = testRejectCallback,
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t eSubscriptionResult =
+        MQTT_AGENT_Subscribe( pxMQTTAgent, &xSubscriptionParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == eSubscriptionResult,
+                         "Failed to subscribe to pucTopic" );
+}
+
+/*-----------------------------------------------------------*/
+
+static void PublishJsonToDevDef( MQTTAgentHandle_t pxMQTTAgent,
+                                 char const * pcReport )
+{
+    uint8_t * pucTopic = ( uint8_t * ) "$aws/things/"
+                         clientcredentialIOT_THING_NAME
+                         "/defender/metrics/json";
+
+    MQTTAgentPublishParams_t xPubRecParams =
+    {
+        .pucTopic      = pucTopic,
+        .usTopicLength = ( uint16_t ) strlen( ( char * ) pucTopic ),
+        .xQoS          = eMQTTQoS0,
+        .pvData        = pcReport,
+        .ulDataLength  = ( uint16_t ) strlen( pcReport ),
+    };
+    TickType_t const xTimeout = pdMS_TO_TICKS( 10000 );
+    MQTTAgentReturnCode_t ePublishResult =
+        MQTT_AGENT_Publish( pxMQTTAgent, &xPubRecParams, xTimeout );
+
+    TEST_ASSERT_MESSAGE( eMQTTAgentSuccess == ePublishResult,
+                         "Failed to publish JSON pcReport to pucTopic" );
+}
+
+/*----------------------------------------------------------------------------*/
+
+TEST( Full_DEFENDER_OLD, endpoint_accepts_report_from_agent )
+{
+    int32_t const lMaxStrLen = 128;
+    char cFailStr[ 128 ] = { 0 };
+
+    DefenderMetric_t xMetricsList[] =
+    {
+        xDefenderTCPConnections,
+    };
+
+    ( void ) DEFENDER_MetricsInit( xMetricsList );
+
+    int32_t lReportPeriodSec = 20;
+    ( void ) DEFENDER_ReportPeriodSet( lReportPeriodSec );
+
+    DEFENDER_Start();
+
+    sleep( 5 );
+
+    DEFENDER_Stop();
+
+    DefenderReportStatus_t eReportStatus = DEFENDER_ReportStatusGet();
+
+    ( void ) snprintf( cFailStr, lMaxStrLen, "Metrics pcReport ID: %d",
+                       ( int ) GetLastReportId() );
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(
+        DEFENDER_ReportStatusAsString( eDefenderRepSuccess ),
+        DEFENDER_ReportStatusAsString( eReportStatus ), cFailStr );
+}

--- a/tests/common/include/aws_iot_config_common.h
+++ b/tests/common/include/aws_iot_config_common.h
@@ -209,4 +209,8 @@
 #define AWS_IOT_DEFENDER_FORMAT          AWS_IOT_DEFENDER_FORMAT_CBOR
 #define AWS_IOT_DEFENDER_USE_LONG_TAG    ( 1 )
 
+/* Task pool configuration. */
+#define AWS_IOT_TASKPOOL_THREADS_STACK_SIZE ( 5 * configMINIMAL_STACK_SIZE )
+#define AWS_IOT_TASKPOOL_THREADS_PRIORITY ( 6 )
+
 #endif /* ifndef _AWS_IOT_CONFIG_COMMON_H_ */

--- a/tests/common/test_runner/aws_test_runner.c
+++ b/tests/common/test_runner/aws_test_runner.c
@@ -170,6 +170,7 @@ static void RunTests( void )
 
     #if ( testrunnerFULL_DEFENDER_ENABLED == 1 )
         RUN_TEST_GROUP( Full_DEFENDER );
+        RUN_TEST_GROUP( Full_DEFENDER_OLD );
     #endif
 
     #if ( testrunnerFULL_POSIX_ENABLED == 1 )

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj
@@ -92,10 +92,12 @@
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_mem.h" />
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_string.h" />
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_types.h" />
+    <ClInclude Include="..\..\..\..\lib\include\aws_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_json_utils.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_logging_setup.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_serializer.h" />
+    <ClInclude Include="..\..\..\..\lib\include\aws_iot_taskpool.h" />
     <ClInclude Include="..\..\..\..\lib\include\iot_metrics.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_mqtt.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_shadow.h" />
@@ -303,6 +305,7 @@
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c" />
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_collector.c" />
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_mqtt.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_v1.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_clock.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_mqueue.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_pthread.c" />
@@ -453,9 +456,11 @@
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_metrics_posix.c" />
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_mqtt_posix.c" />
     <ClCompile Include="..\..\..\..\lib\utils\platform\static_memory\aws_iot_static_memory_shadow_posix.c" />
+    <ClCompile Include="..\..\..\..\lib\utils\taskpool\aws_iot_taskpool.c" />
     <ClCompile Include="..\..\..\common\cbor\aws_test_cbor.c" />
     <ClCompile Include="..\..\..\common\crypto\aws_test_crypto.c" />
     <ClCompile Include="..\..\..\common\defender\aws_iot_tests_defender_api.c" />
+    <ClCompile Include="..\..\..\common\defender\aws_iot_tests_defender_api_v1.c" />
     <ClCompile Include="..\..\..\common\framework\aws_test_framework.c" />
     <ClCompile Include="..\..\..\common\freertos_tcp\aws_test_freertos_tcp.c" />
     <ClCompile Include="..\..\..\common\greengrass\aws_test_greengrass_discovery.c" />

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
@@ -220,6 +220,9 @@
     <Filter Include="lib\aws\metrics">
       <UniqueIdentifier>{b454a175-6acd-4b03-8418-ab8368543cc9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="lib\aws\utils\taskpool">
+      <UniqueIdentifier>{49e54a6e-02ff-4c70-9bc5-5db01510871a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\lib\third_party\unity\extras\fixture\src\unity_fixture.h">
@@ -820,6 +823,12 @@
       <Filter>lib\aws\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_serializer.h">
+      <Filter>lib\aws\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\lib\include\aws_defender.h">
+      <Filter>lib\aws\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\lib\include\aws_iot_taskpool.h">
       <Filter>lib\aws\include</Filter>
     </ClInclude>
   </ItemGroup>
@@ -1435,6 +1444,15 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c">
       <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_v1.c">
+      <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\defender\aws_iot_tests_defender_api_v1.c">
+      <Filter>application_code\common_tests\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\utils\taskpool\aws_iot_taskpool.c">
+      <Filter>lib\aws\utils\taskpool</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
implement old defender library interfaces, including demo and tests. Only support one metrics: TCP connections count

Changes from original defender library:
- DefenderMetric_t is defined as enum, instead of pointer to internal metrics structure
- DEFENDER_ConnectionTimeoutSet function will do nothing but return success
- remove irrelevant tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
