### PR TITLE
Why: TLS_Send does not handle the error condition when space is not available on disk.

### DIFF
--- a/lib/tls/aws_tls.c
+++ b/lib/tls/aws_tls.c
@@ -280,9 +280,9 @@ static int prvPrivateKeySigningCallback( void * pvContext,
                                          size_t xHashLen,
                                          unsigned char * pucSig,
                                          size_t * pxSigLen,
-                                         int ( *piRng )( void *,
-                                                         unsigned char *,
-                                                         size_t ), /*lint !e955 This parameter is unused. */
+                                         int ( * piRng )( void *,
+                                                          unsigned char *,
+                                                          size_t ), /*lint !e955 This parameter is unused. */
                                          void * pvRng )
 {
     BaseType_t xResult = 0;
@@ -825,11 +825,12 @@ BaseType_t TLS_Send( void * pvContext,
                 /* Sent data, so update the tally and keep looping. */
                 xWritten += ( size_t ) xResult;
             }
-            else if( 0 == xResult )
+            else if( ( 0 == xResult ) || ( -pdFREERTOS_ERRNO_ENOSPC == xResult ) )
             {
-                /* No data sent (and no error). The secure sockets
+                /* No data sent. The secure sockets
                  * API supports non-blocking send, so stop the loop but don't
                  * flag an error. */
+                xResult = 0;
                 break;
             }
             else if( MBEDTLS_ERR_SSL_WANT_WRITE != xResult )


### PR DESCRIPTION
TLS_Send does not handle the error condition when space is not available on disk.

Related Issues: https://github.com/aws/amazon-freertos/issues/275

Description
-----------
mbedtls_write sends back pdFREERTOS_ERRNO_ENOSPC when the send buffer is full.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.