### PR TITLE
Update shadow error message in response to issue #304

### DIFF
--- a/lib/shadow/aws_shadow.c
+++ b/lib/shadow/aws_shadow.c
@@ -1242,8 +1242,8 @@ static ShadowReturnCode_t prvShadowOperation( ShadowOperationCallParams_t * pxPa
                 if( xSemaphoreTake( pxShadowClient->xCallbackSemaphore,
                                     xTimeOutData.xTicksRemaining ) != pdPASS )
                 {
-                    Shadow_debug_printf( ( "[Shadow %d] Timeout waiting on"
-                                           " %s accepted/rejected.\r\n",
+                    Shadow_debug_printf( ( "[Shadow %d] Error while waiting for"
+                                           " %s accepted/rejected callback.\r\n",
                                            pxParams->xShadowClientID,
                                            pxParams->pcOperationName ) );
                     xReturn = eShadowTimeout;

--- a/lib/shadow/aws_shadow_json.c
+++ b/lib/shadow/aws_shadow_json.c
@@ -193,8 +193,8 @@ static int16_t prvParseJSON( const char * const pcDoc,
                                       shadowconfigJSON_JSMN_TOKENS );
 
     /* Report errors in JSON parsing. */
-    if ( sReturn == JSMN_ERROR_NOMEM ) {
-      Shadow_json_debug_printf( ( "[Shadow JSON]: Error parsing JSON (document length %d): Not enough tokens allocated for JSMN, ran out of memory.\r\n", ulDocLength ) );
+    if ( sReturn < 0 ) {
+      Shadow_json_debug_printf( ( "[Shadow JSON]: Error parsing JSON: JSMN error code %d\r\n", sReturn ) );
     }
 
     return sReturn;

--- a/lib/shadow/aws_shadow_json.c
+++ b/lib/shadow/aws_shadow_json.c
@@ -48,6 +48,12 @@
 #define shadowJSON_ERROR_MESSAGE    "message"
 #define shadowJSON_CLIENT_TOKEN     "clientToken"
 
+#if shadowconfigENABLE_DEBUG_LOGS == 1
+    #define Shadow_json_debug_printf( X )    configPRINTF( X )
+#else
+    #define Shadow_json_debug_printf( X )
+#endif
+
 /**
  * @brief Given a JSON key, get its value. Does not work on arrays or objects.  Returns
  * length of value and sets ppcValue to the start of the value.  Returns 0 on
@@ -185,6 +191,11 @@ static int16_t prvParseJSON( const char * const pcDoc,
                                       ulDocLength,
                                       pxJSMNTokens,
                                       shadowconfigJSON_JSMN_TOKENS );
+
+    /* Report errors in JSON parsing. */
+    if ( sReturn == JSMN_ERROR_NOMEM ) {
+      Shadow_json_debug_printf( ( "[Shadow JSON]: Error parsing JSON (document length %d): Not enough tokens allocated for JSMN, ran out of memory.\r\n", ulDocLength ) );
+    }
 
     return sReturn;
 }


### PR DESCRIPTION
Our Shadow client has an error message which reports a 'timeout' in reference to trying to acquire a semaphore handle. But that sounds a lot like a network timeout in the context of MQTT applications; we could be a bit clearer.

Description
-----------
Update the error message to clarify that the application appears to have encountered an error in the callback method which the application was waiting on, inferred from the fact that its callback never released its semaphore.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.
