### PR TITLE
Add support for Wireshark TLS packet decryption to aws_tls.c

### DIFF
--- a/lib/tls/aws_tls.c
+++ b/lib/tls/aws_tls.c
@@ -54,7 +54,8 @@
 
 #ifdef MBEDTLS_DEBUG_C
     /* Support for writing to SSLKEYLOGFILE for Wireshark TLS decryption. */
-    typedef struct {
+    typedef struct
+    {
         FILE * xKeyLogFile;
         int lInClientRandom : 1;
         int lInMasterSecret : 1;
@@ -284,7 +285,7 @@ static int prvPrivateKeySigningCallback( void * pvContext,
                                          size_t xHashLen,
                                          unsigned char * pucSig,
                                          size_t * pxSigLen,
-                                         int ( *piRng )( void *, unsigned char *, size_t ), /*lint !e955 This parameter is unused. */
+                                         int ( * piRng )( void *, unsigned char *, size_t ), /*lint !e955 This parameter is unused. */
                                          void * pvRng )
 {
     BaseType_t xResult = 0;
@@ -523,58 +524,76 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
 
 #ifdef MBEDTLS_DEBUG_C
     /* Write to SSLKEYLOGFILE or stderr to support Wireshark TLS packet decryption. */
-    void vKeyLogDebugCallback( void *ctx, int level,
-                                const char *file, int line,
-                                const char *str )
+    void vKeyLogDebugCallback( void * ctx,
+                               int level,
+                               const char * file,
+                               int line,
+                               const char * str )
     {
-        TLSKeyLogDebugContext_t *xKeyLogDebugContext = (TLSKeyLogDebugContext_t *) ctx;
+        TLSKeyLogDebugContext_t * xKeyLogDebugContext = ( TLSKeyLogDebugContext_t * ) ctx;
 
-        ((void) level); ((void) file); ((void) line);
+        ( ( void ) level );
+        ( ( void ) file );
+        ( ( void ) line );
 
-        if (strstr(str, "dumping 'client hello, random bytes' (32 bytes)")) {
+        if( strstr( str, "dumping 'client hello, random bytes' (32 bytes)" ) )
+        {
             xKeyLogDebugContext->lInClientRandom = 1;
             xKeyLogDebugContext->lHexdumpLinesToProces = 2;
-            fputs("CLIENT_RANDOM ", xKeyLogDebugContext->xKeyLogFile);
+            fputs( "CLIENT_RANDOM ", xKeyLogDebugContext->xKeyLogFile );
             return;
-        } else if (strstr(str, "dumping 'master secret' (48 bytes)")) {
+        }
+        else if( strstr( str, "dumping 'master secret' (48 bytes)" ) )
+        {
             xKeyLogDebugContext->lInMasterSecret = 1;
             xKeyLogDebugContext->lHexdumpLinesToProces = 3;
-            fputc(' ', xKeyLogDebugContext->xKeyLogFile);
+            fputc( ' ', xKeyLogDebugContext->xKeyLogFile );
             return;
-        } else if ((!xKeyLogDebugContext->lInClientRandom && !xKeyLogDebugContext->lInMasterSecret) ||
-                xKeyLogDebugContext->lHexdumpLinesToProces == 0) {
+        }
+        else if( ( !xKeyLogDebugContext->lInClientRandom && !xKeyLogDebugContext->lInMasterSecret ) ||
+                 ( xKeyLogDebugContext->lHexdumpLinesToProces == 0 ) )
+        {
             return;
         }
 
         /* Parse "0000:  64 df 18 71 ca 4a 4b e4 63 87 2a ef 5f 29 ca ff  ..." */
-        str = strstr(str, ":  ");
-        if (!str || strlen(str) < 3 + 3*16) {
-            goto reset;         /* not the expected hex buffer */
+        str = strstr( str, ":  " );
+
+        if( !str || ( strlen( str ) < 3 + 3 * 16 ) )
+        {
+            goto reset; /* not the expected hex buffer */
         }
-        str += 3;               /* skip over ":  " */
+
+        str += 3; /* skip over ":  " */
 
         /* Process sequences of "hh " */
-        for (int i = 0; i < 3 * 16; i += 3) {
-            char c1 = str[i], c2 = str[i + 1], c3 = str[i + 2];
-            if ((('0' <= c1 && c1 <= '9') || ('a' <= c1 && c1 <= 'f')) &&
-                (('0' <= c2 && c2 <= '9') || ('a' <= c2 && c2 <= 'f')) &&
-                c3 == ' ') {
-                fputc(c1, xKeyLogDebugContext->xKeyLogFile);
-                fputc(c2, xKeyLogDebugContext->xKeyLogFile);
-            } else {
-                goto reset;     /* unexpected non-hex char */
+        for( int i = 0; i < 3 * 16; i += 3 )
+        {
+            char c1 = str[ i ], c2 = str[ i + 1 ], c3 = str[ i + 2 ];
+
+            if( ( ( ( '0' <= c1 ) && ( c1 <= '9' ) ) || ( ( 'a' <= c1 ) && ( c1 <= 'f' ) ) ) &&
+                ( ( ( '0' <= c2 ) && ( c2 <= '9' ) ) || ( ( 'a' <= c2 ) && ( c2 <= 'f' ) ) ) &&
+                ( c3 == ' ' ) )
+            {
+                fputc( c1, xKeyLogDebugContext->xKeyLogFile );
+                fputc( c2, xKeyLogDebugContext->xKeyLogFile );
+            }
+            else
+            {
+                goto reset; /* unexpected non-hex char */
             }
         }
 
-        if (--xKeyLogDebugContext->lHexdumpLinesToProces != 0 || !xKeyLogDebugContext->lInMasterSecret) {
-            return;             /* line is not yet finished. */
+        if( ( --xKeyLogDebugContext->lHexdumpLinesToProces != 0 ) || !xKeyLogDebugContext->lInMasterSecret )
+        {
+            return; /* line is not yet finished. */
         }
 
-    reset:
+reset:
         xKeyLogDebugContext->lHexdumpLinesToProces = 0;
         xKeyLogDebugContext->lInClientRandom = xKeyLogDebugContext->lInMasterSecret = 0;
-        fputc('\n', xKeyLogDebugContext->xKeyLogFile);   /* finish key log line */
-        fflush(xKeyLogDebugContext->xKeyLogFile);
+        fputc( '\n', xKeyLogDebugContext->xKeyLogFile ); /* finish key log line */
+        fflush( xKeyLogDebugContext->xKeyLogFile );
     }
 
 #endif /* ifdef MBEDTLS_DEBUG_C */
@@ -692,7 +711,8 @@ BaseType_t TLS_Connect( void * pvContext )
             xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
                                               ( const unsigned char * ) tlsATS1_ROOT_CERTIFICATE_PEM,
                                               tlsATS1_ROOT_CERTIFICATE_LENGTH );
-            if ( 0 == xResult )
+
+            if( 0 == xResult )
             {
                 xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
                                                   ( const unsigned char * ) tlsSTARFIELD_ROOT_CERTIFICATE_PEM,
@@ -751,31 +771,37 @@ BaseType_t TLS_Connect( void * pvContext )
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );
         mbedtls_debug_set_threshold( tlsDEBUG_VERBOSE );
+
         /* Wireshark debugging support on the Windows Simulator.
          * When https://github.com/ARMmbed/mbedtls/issues/1504 is implemented consider
-         * deleting this code. To give proper credit, this code is adapted from: 
+         * deleting this code. To give proper credit, this code is adapted from:
          * https://github.com/Lekensteyn/mbedtls/commit/68aea15. */
         #ifdef WIN32
             {
                 /* On windows an environment variable value has a maximum size
-                 * of 32,627 characters, including the null-terminating character. */ 
-                char cKeyLogFileName[32767];
+                 * of 32,627 characters, including the null-terminating character. */
+                char cKeyLogFileName[ 32767 ];
                 unsigned int ulReturnValue = GetEnvironmentVariable(
                     "SSLKEYLOGFILE",
                     cKeyLogFileName,
-                    sizeof(cKeyLogFileName));
-                if (ulReturnValue > 0) {
-                    pxCtx->xKeyLogDebugCtx.xKeyLogFile = fopen(cKeyLogFileName, "a");
-                } else {
+                    sizeof( cKeyLogFileName ) );
+
+                if( ulReturnValue > 0 )
+                {
+                    pxCtx->xKeyLogDebugCtx.xKeyLogFile = fopen( cKeyLogFileName, "a" );
+                }
+                else
+                {
                     pxCtx->xKeyLogDebugCtx.xKeyLogFile = stderr;
                 }
             }
 
-            if (pxCtx->xKeyLogDebugCtx.xKeyLogFile) {
+            if( pxCtx->xKeyLogDebugCtx.xKeyLogFile )
+            {
                 mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, vKeyLogDebugCallback, &pxCtx->xKeyLogDebugCtx );
             }
-        #endif
-    #endif
+        #endif /* ifdef WIN32 */
+    #endif /* ifdef MBEDTLS_DEBUG_C */
 
     if( 0 == xResult )
     {


### PR DESCRIPTION
This change supports writing the CLIENT_RANDOM symmetric session keys to SSLKEYLOGFILE.
SSLKEYLOGFILE is supported by Chrome, Firefox, and Openssl. This file allows Wireshark to decrypt TLS traffic. 
You can find instructions on how to enable this feature on Windows here: https://jimshaver.net/2015/02/11/decrypting-tls-browser-traffic-with-wireshark-the-easy-way/

This feature is enabled only when MBEDTLS_DEBUG_C is enabled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
