### PR TITLE
Update Windows Simulator to use AWS Logging Task Dynamic Buffers.

### DIFF
--- a/demos/pc/windows/common/application_code/main.c
+++ b/demos/pc/windows/common/application_code/main.c
@@ -50,7 +50,7 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_DHCP.h"
-#include "aws_demo_logging.h"
+#include "aws_logging_task.h"
 #include "aws_system_init.h"
 #include "aws_demo_runner.h"
 #include "aws_application_version.h"
@@ -68,6 +68,10 @@ const AppVersion32_t xAppFirmwareVersion = {
  * using DHCP. */
 #define mainHOST_NAME           "RTOSDemo"
 #define mainDEVICE_NICK_NAME    "windows_demo"
+
+/* Logging thread parameters. */
+#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
 
 /*-----------------------------------------------------------*/
 
@@ -264,24 +268,16 @@ void vApplicationMallocFailedHook()
 
 static void prvMiscInitialisation( void )
 {
-    uint32_t ulLoggingIPAddress;
-
     /* Initialise the trace recorder and create the label used to post user
      * events to the trace recording on each tick interrupt. */
     vTraceEnable( TRC_START );
 
     /* Initialise the logging library. */
-    ulLoggingIPAddress = FreeRTOS_inet_addr_quick(
-        configECHO_SERVER_ADDR0,
-        configECHO_SERVER_ADDR1,
-        configECHO_SERVER_ADDR2,
-        configECHO_SERVER_ADDR3 );
-    vLoggingInit(
-        xLogToStdout,
-        xLogToFile,
-        xLogToUDP,
-        ulLoggingIPAddress,
-        configPRINT_PORT );
+    /* Start logging task. */
+    xLoggingTaskInitialize(
+        mainLOGGING_TASK_STACK_SIZE,
+        tskIDLE_PRIORITY,
+        mainLOGGING_MESSAGE_QUEUE_LENGTH);
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/pc/windows/common/config_files/FreeRTOSConfig.h
+++ b/demos/pc/windows/common/config_files/FreeRTOSConfig.h
@@ -132,6 +132,18 @@ extern void vLoggingPrintf( const char * pcFormat,
                             ... );
 #define configPRINTF( X )    vLoggingPrintf X
 
+/* Map the logging task's printf to the board specific output function. */
+#define configPRINT_STRING( x )    printf( x );
+
+
+/* Sets the length of the buffers into which logging messages are written - so
+ * also defines the maximum length of each log message. */
+#define configLOGGING_MAX_MESSAGE_LENGTH            1028
+
+ /* Set to 1 to prepend each log message with a message number, the task name,
+  * and a time stamp. */
+#define configLOGGING_INCLUDE_TIME_AND_TASK_NAME    1
+
 /* Application specific definitions follow. **********************************/
 
 /* If configINCLUDE_DEMO_DEBUG_STATS is set to one, then a few basic IP trace

--- a/demos/pc/windows/visual_studio/aws_demos.vcxproj
+++ b/demos/pc/windows/visual_studio/aws_demos.vcxproj
@@ -221,6 +221,7 @@
     <ClCompile Include="..\..\..\common\demo_runner\aws_demo_runner.c" />
     <ClCompile Include="..\..\..\common\devmode_key_provisioning\aws_dev_mode_key_provisioning.c" />
     <ClCompile Include="..\..\..\common\greengrass_connectivity\aws_greengrass_discovery_demo.c" />
+    <ClCompile Include="..\..\..\common\logging\aws_logging_task_dynamic_buffers.c" />
     <ClCompile Include="..\..\..\common\mqtt\aws_hello_world.c" />
     <ClCompile Include="..\..\..\common\mqtt\aws_subscribe_publish_loop.c" />
     <ClCompile Include="..\..\..\common\ota\aws_ota_update_demo.c" />
@@ -228,7 +229,6 @@
     <ClCompile Include="..\..\..\common\tcp\aws_simple_tcp_echo_server.c" />
     <ClCompile Include="..\..\..\common\tcp\aws_tcp_echo_client_separate_tasks.c" />
     <ClCompile Include="..\..\..\common\tcp\aws_tcp_echo_client_single_task.c" />
-    <ClCompile Include="..\common\application_code\aws_demo_logging.c" />
     <ClCompile Include="..\common\application_code\aws_entropy_hardware_poll.c" />
     <ClCompile Include="..\common\application_code\aws_run-time-stats-utils.c" />
     <ClCompile Include="..\common\application_code\main.c" />
@@ -406,7 +406,6 @@
     <ClInclude Include="..\..\..\common\include\aws_simple_tcp_echo_server.h" />
     <ClInclude Include="..\..\..\common\include\aws_subscribe_publish_loop.h" />
     <ClInclude Include="..\..\..\common\include\aws_tcp_echo_client_single_tasks.h" />
-    <ClInclude Include="..\common\application_code\aws_demo_logging.h" />
     <ClInclude Include="..\common\application_code\stdbool.h" />
     <ClInclude Include="..\common\application_code\unistd.h" />
     <ClInclude Include="..\common\config_files\aws_bufferpool_config.h" />

--- a/demos/pc/windows/visual_studio/aws_demos.vcxproj.filters
+++ b/demos/pc/windows/visual_studio/aws_demos.vcxproj.filters
@@ -441,9 +441,6 @@
     <ClCompile Include="..\..\..\common\mqtt\aws_subscribe_publish_loop.c">
       <Filter>application_code\common_demos\source</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\application_code\aws_demo_logging.c">
-      <Filter>application_code</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\application_code\aws_entropy_hardware_poll.c">
       <Filter>application_code</Filter>
     </ClCompile>
@@ -566,6 +563,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\lib\third_party\mbedtls\library\platform_util.c">
       <Filter>lib\third_party\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\logging\aws_logging_task_dynamic_buffers.c">
+      <Filter>application_code\common_demos\source</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -868,9 +868,6 @@
     </ClInclude>
     <ClInclude Include="..\..\..\common\include\aws_tcp_echo_client_single_tasks.h">
       <Filter>application_code\common_demos\include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\common\application_code\aws_demo_logging.h">
-      <Filter>application_code</Filter>
     </ClInclude>
     <ClInclude Include="..\common\application_code\stdbool.h">
       <Filter>application_code</Filter>

--- a/tests/pc/windows/common/application_code/main.c
+++ b/tests/pc/windows/common/application_code/main.c
@@ -45,7 +45,7 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_DHCP.h"
-#include "aws_demo_logging.h"
+#include "aws_logging_task.h"
 #include "aws_system_init.h"
 
 #include "aws_dev_mode_key_provisioning.h"
@@ -62,6 +62,11 @@
 
 #define TEST_RUNNER_TASK_STACK_SIZE    10000
 #define FIRST_EXCEPTION_HANDLER        1
+
+/* Logging thread parameters. */
+#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
+
 /* Windows-NT VectoredHandler callback function. */
 static LONG CALLBACK prvExceptionHandler( _In_ PEXCEPTION_POINTERS ExceptionInfo );
 jmp_buf xMark; /* Address for long jump to jump to. */
@@ -137,13 +142,12 @@ int main( void )
 
     vTraceEnable( TRC_START );
 
-    /* Initialize logging for libraries that depend on it. */
-    vLoggingInit(
-        pdTRUE,
-        pdFALSE,
-        pdFALSE,
-        0,
-        0 );
+    /* Initialise the logging library. */
+    /* Start logging task. */
+    xLoggingTaskInitialize(
+        mainLOGGING_TASK_STACK_SIZE,
+        tskIDLE_PRIORITY,
+        mainLOGGING_MESSAGE_QUEUE_LENGTH);
 
     /* Initialize the network interface.
      *

--- a/tests/pc/windows/common/config_files/FreeRTOSConfig.h
+++ b/tests/pc/windows/common/config_files/FreeRTOSConfig.h
@@ -139,6 +139,17 @@ void vLoggingPrintf( char const * pcFormat,
 extern void vLoggingPrint( const char * pcMessage );
 #define configPRINT( X )    vLoggingPrint( X )
 
+/* Map the logging task's printf to the board specific output function. */
+#define configPRINT_STRING( x )    printf( x );
+
+/* Sets the length of the buffers into which logging messages are written - so
+ * also defines the maximum length of each log message. */
+#define configLOGGING_MAX_MESSAGE_LENGTH            1028
+
+ /* Set to 1 to prepend each log message with a message number, the task name,
+  * and a time stamp. */
+#define configLOGGING_INCLUDE_TIME_AND_TASK_NAME    1
+
 /* Application specific definitions follow. **********************************/
 
 /* If configINCLUDE_DEMO_DEBUG_STATS is set to one, then a few basic IP trace

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj
@@ -282,8 +282,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\demos\common\devmode_key_provisioning\aws_dev_mode_key_provisioning.c" />
+    <ClCompile Include="..\..\..\..\demos\common\logging\aws_logging_task_dynamic_buffers.c" />
     <ClCompile Include="..\..\..\..\demos\common\ota\aws_ota_update_demo.c" />
-    <ClCompile Include="..\..\..\..\demos\pc\windows\common\application_code\aws_demo_logging.c" />
     <ClCompile Include="..\..\..\..\demos\pc\windows\common\application_code\aws_entropy_hardware_poll.c" />
     <ClCompile Include="..\..\..\..\lib\bufferpool\aws_bufferpool_static_thread_safe.c" />
     <ClCompile Include="..\..\..\..\lib\cbor\src\aws_cbor.c" />

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
@@ -193,6 +193,9 @@
     <Filter Include="application_code\common_tests\memory_leak">
       <UniqueIdentifier>{5131d122-df24-4aef-9924-853498fadda5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="application_code\common_tests\logging">
+      <UniqueIdentifier>{2063179e-d128-4e96-8c6a-fa91144372d4}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\lib\third_party\unity\extras\fixture\src\unity_fixture.h">
@@ -1097,9 +1100,6 @@
     <ClCompile Include="..\common\application_code\main.c">
       <Filter>application_code</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\demos\pc\windows\common\application_code\aws_demo_logging.c">
-      <Filter>application_code</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\lib\FreeRTOS\portable\MSVC-MingW\port.c">
       <Filter>lib\aws\FreeRTOS\portable\MSVC-Ming</Filter>
     </ClCompile>
@@ -1318,6 +1318,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\lib\third_party\mbedtls\library\platform_util.c">
       <Filter>lib\third_party\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\demos\common\logging\aws_logging_task_dynamic_buffers.c">
+      <Filter>application_code\common_tests\logging</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Windows Simulator is updated to use the same logging task as the rest of the platforms for consistency. 
aws_logging_task_dynamic_buffers.c also facilitates printing a large variable sized buffer easier.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
