### PR TITLE
fix: Fix uninitialized variable in TCP tests

### DIFF
--- a/tests/common/secure_sockets/aws_test_tcp.c
+++ b/tests/common/secure_sockets/aws_test_tcp.c
@@ -1892,6 +1892,9 @@ static void prvConnect_InvalidAddressLength( Server_t xConn,
     {
         if( xConn == eNonsecure )
         {
+            xEchoServerAddress.ucLength = ( uint8_t ) sizeof( SocketsSockaddr_t );
+            xEchoServerAddress.ucSocketDomain = ( uint8_t ) SOCKETS_AF_INET;
+
             /* Populate the non-secure echo server address. */
             xEchoServerAddress.ulAddress = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                     tcptestECHO_SERVER_ADDR1,

--- a/tests/common/secure_sockets/aws_test_tcp.c
+++ b/tests/common/secure_sockets/aws_test_tcp.c
@@ -1955,7 +1955,7 @@ TEST( Full_TCP, AFQP_SOCKETS_Connect_InvalidAddressLength )
     /* AddressLength 0. */
     prvConnect_InvalidAddressLength( eNonsecure, 0 );
 
-    /* AddressLength 1000. */
+    /* AddressLength 100. */
     prvConnect_InvalidAddressLength( eNonsecure, 100 );
 
     tcptestPRINTF( ( "%s complete.\r\n", __FUNCTION__ ) );
@@ -1969,7 +1969,7 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_Connect_InvalidAddressLength )
     /* AddressLength 0. */
     prvConnect_InvalidAddressLength( eSecure, 0 );
 
-    /* AddressLength 1000. */
+    /* AddressLength 100. */
     prvConnect_InvalidAddressLength( eSecure, 100 );
 
     tcptestPRINTF( ( "%s complete.\r\n", __FUNCTION__ ) );

--- a/tests/common/secure_sockets/aws_test_tcp.c
+++ b/tests/common/secure_sockets/aws_test_tcp.c
@@ -1956,7 +1956,7 @@ TEST( Full_TCP, AFQP_SOCKETS_Connect_InvalidAddressLength )
     prvConnect_InvalidAddressLength( eNonsecure, 0 );
 
     /* AddressLength 1000. */
-    prvConnect_InvalidAddressLength( eNonsecure, 1000 );
+    prvConnect_InvalidAddressLength( eNonsecure, 100 );
 
     tcptestPRINTF( ( "%s complete.\r\n", __FUNCTION__ ) );
 }
@@ -1970,7 +1970,7 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_Connect_InvalidAddressLength )
     prvConnect_InvalidAddressLength( eSecure, 0 );
 
     /* AddressLength 1000. */
-    prvConnect_InvalidAddressLength( eSecure, 1000 );
+    prvConnect_InvalidAddressLength( eSecure, 100 );
 
     tcptestPRINTF( ( "%s complete.\r\n", __FUNCTION__ ) );
 }

--- a/tests/common/secure_sockets/aws_test_tcp.c
+++ b/tests/common/secure_sockets/aws_test_tcp.c
@@ -1890,11 +1890,11 @@ static void prvConnect_InvalidAddressLength( Server_t xConn,
 
     if( TEST_PROTECT() )
     {
+        xEchoServerAddress.ucLength = ( uint8_t ) ulAddressLength;
+        xEchoServerAddress.ucSocketDomain = ( uint8_t ) SOCKETS_AF_INET;
+
         if( xConn == eNonsecure )
         {
-            xEchoServerAddress.ucLength = ( uint8_t ) sizeof( SocketsSockaddr_t );
-            xEchoServerAddress.ucSocketDomain = ( uint8_t ) SOCKETS_AF_INET;
-
             /* Populate the non-secure echo server address. */
             xEchoServerAddress.ulAddress = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                     tcptestECHO_SERVER_ADDR1,


### PR DESCRIPTION

Description
-----------
xEhoServerAddress was created on stack and some of the member variables
were not initialized. As a result those variables would end up having
garbage values - this did not create any problem because we did not use
those member variables. This commit initializes those member variables
to correct values.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
