### PR TITLE
Fix: Scheduler does not start on dsPIC processors

### DIFF
--- a/lib/FreeRTOS/portable/MPLAB/PIC24_dsPIC/port.c
+++ b/lib/FreeRTOS/portable/MPLAB/PIC24_dsPIC/port.c
@@ -108,7 +108,7 @@ UBaseType_t uxCriticalNesting = 0xef;
 							"POP.D	W0						\n"																\
 							"POP	SR						  " );
 		#endif /* __HAS_EDS__ */
-#endif /* MPLAB_PIC24_PORT */
+#endif /* defined( __PIC24E__ ) || defined ( __PIC24F__ ) || defined( __PIC24FK__ ) || defined( __PIC24H__ ) */
 
 #if defined( __dsPIC30F__ ) || defined( __dsPIC33F__ )
 
@@ -142,7 +142,7 @@ UBaseType_t uxCriticalNesting = 0xef;
 						"POP.D	W0						\n"																\
 						"POP	SR						  " );
 
-#endif /* MPLAB_DSPIC_PORT */
+#endif /* defined( __dsPIC30F__ ) || defined( __dsPIC33F__ ) */
 
 #ifndef portRESTORE_CONTEXT
 	#error Unrecognised device selected
@@ -184,7 +184,7 @@ const StackType_t xInitialStack[] =
 	0xabac, /* TBLPAG */
 
 	/* dsPIC specific registers. */
-	#ifdef MPLAB_DSPIC_PORT
+	#if defined( __dsPIC30F__ ) || defined( __dsPIC33F__ )
 		0x0202, /* ACCAL */
 		0x0303, /* ACCAH */
 		0x0404, /* ACCAU */
@@ -196,7 +196,7 @@ const StackType_t xInitialStack[] =
 		0x1010, /* DOSTARTH */
 		0x1110, /* DOENDL */
 		0x1212, /* DOENDH */
-	#endif
+	#endif /* defined( __dsPIC30F__ ) || defined( __dsPIC33F__ ) */
 };
 
 	/* Setup the stack as if a yield had occurred.


### PR DESCRIPTION
<!--- Title -->
Fix: PIC24_dsPIC/port.c used deprecated definition
Description
-----------
<!--- Describe your changes in detail -->
In lib/FreeRTOS/portable/MPLAB/PIC24_dsPIC/port.c deprecated definition `MPLAB_DSPIC_PORT` was used to determine if extra dsPIC specific registers values should be present in `xInitialStack` array but `portRESTORE_CONTEXT()` macro used another condition to determine what registers should be poped from stack which caused wrong number of register actually poped from stack. At this point, after 
returning from function which called `portRESTORE_CONTEXT()` wrong program counter was restored and program behavior become unpredictable.

`MPLAB_DSPIC_PORT` was changed to condition used for deciding what `portRESTORE_CONTEXT()` macro definition should be used. Also comment line after corresponding `#endif`s was updated

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
