### PR TITLE
Delete the serial thread first in the test cleanup.

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -143,5 +143,17 @@ class OtaTestRunner:
     def __cleanup(self):
         """Free resources used by the OTA agent and the flash serial object.
         """
-        self._otaAwsAgent.cleanup()
-        self._flashComm.cleanup()
+        # We will want to close the serial flash thread first so that there are no outstanding threads
+        # in case cleaning AWS Resources causes exceptions.
+        try:
+            self._flashComm.cleanup()
+        except:
+            # We still want to clean up AWS resources if the serial thread fails to cleanup. So just
+            # print the exception here.
+            print(e)
+
+        try:
+            self._otaAwsAgent.cleanup()
+        except Exception as e:
+            print(e)
+            raise


### PR DESCRIPTION
* Print exceptions that occur when cleaning up AWS resources.
We are deleting the serial thread first, so that when exceptions occur in cleaning up the AWS resources the program exits because there are no outstanding threads.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [n/a] My code is Linted.
