### PR TITLE
Add the 'off_t' POSIX type and ensure that 'sys/types.h' is included in 'unistd.h' so that the 'useconds_t' type is known to be known.

### DIFF
--- a/lib/include/FreeRTOS_POSIX/sys/types.h
+++ b/lib/include/FreeRTOS_POSIX/sys/types.h
@@ -153,7 +153,7 @@ typedef void                * pthread_barrierattr_t;
  * @brief Used for file sizes.
  */
 #if !defined( posixconfigUSING_FILESYSTEM ) || ( posixconfigUSING_FILESYSTEM == 1 )
-    typedef int64_t         off_t;
+    typedef long int        off_t;
     // POSIX Macro definitions required for file seeking.
     #define SEEK_SET (0)
     #define SEEK_CUR (1)

--- a/lib/include/FreeRTOS_POSIX/sys/types.h
+++ b/lib/include/FreeRTOS_POSIX/sys/types.h
@@ -154,10 +154,6 @@ typedef void                * pthread_barrierattr_t;
  */
 #if !defined( posixconfigUSING_FILESYSTEM ) || ( posixconfigUSING_FILESYSTEM == 1 )
     typedef long int        off_t;
-    // POSIX Macro definitions required for file seeking.
-    #define SEEK_SET (0)
-    #define SEEK_CUR (1)
-    #define SEEK_END (2)
 #endif
 
 #endif /* ifndef _FREERTOS_POSIX_TYPES_H_ */

--- a/lib/include/FreeRTOS_POSIX/sys/types.h
+++ b/lib/include/FreeRTOS_POSIX/sys/types.h
@@ -152,7 +152,7 @@ typedef void                * pthread_barrierattr_t;
 /**
  * @brief Used for file sizes.
  */
-#if !defined( posixconfigUSING_FILESYSTEM ) || ( posixconfigUSING_FILESYSTEM == 1 )
+#if !defined( posixconfigENABLE_OFF_T ) || ( posixconfigENABLE_OFF_T == 1 )
     typedef long int        off_t;
 #endif
 

--- a/lib/include/FreeRTOS_POSIX/sys/types.h
+++ b/lib/include/FreeRTOS_POSIX/sys/types.h
@@ -149,4 +149,15 @@ typedef void                * pthread_barrierattr_t;
     typedef unsigned long   useconds_t;
 #endif
 
+/**
+ * @brief Used for file sizes.
+ */
+#if !defined( posixconfigUSING_FILESYSTEM ) || ( posixconfigUSING_FILESYSTEM == 1 )
+    typedef int64_t         off_t;
+    // POSIX Macro definitions required for file seeking.
+    #define SEEK_SET (0)
+    #define SEEK_CUR (1)
+    #define SEEK_END (2)
+#endif
+
 #endif /* ifndef _FREERTOS_POSIX_TYPES_H_ */

--- a/lib/include/FreeRTOS_POSIX/unistd.h
+++ b/lib/include/FreeRTOS_POSIX/unistd.h
@@ -33,6 +33,8 @@
 #ifndef _FREERTOS_POSIX_UNISTD_H_
 #define _FREERTOS_POSIX_UNISTD_H_
 
+#include "sys/types.h"
+
 /**
  * @brief Suspend execution for an interval of time.
  *

--- a/lib/include/FreeRTOS_POSIX/unistd.h
+++ b/lib/include/FreeRTOS_POSIX/unistd.h
@@ -33,7 +33,7 @@
 #ifndef _FREERTOS_POSIX_UNISTD_H_
 #define _FREERTOS_POSIX_UNISTD_H_
 
-#include "sys/types.h"
+#include "FreeRTOS_POSIX/sys/types.h"
 
 /**
  * @brief Suspend execution for an interval of time.


### PR DESCRIPTION
I ran into a couple of small issues building FreeRTOS+POSIX into a project, and these changes seemed to fix them.

Description
-----------

* Add the 'off_t' file size/offset type, set to what looks like the POSIX standard of a long int.
* Add a 'sys/types.h' include to the 'unistd.h' header file to make sure that the 'useconds_t' type is defined.

I'm not sure if this is actually part of the POSIX standard, or just how POSIX says that the 'off_t' type should be dealt with in systems which implement it. But this seems like a fairly minor change, and it also seems good to avoid compile-time 'libc'-related errors where we can. See resources such as:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
