### PR TITLE
Include C runtime header for snprintf.

### DIFF
--- a/lib/greengrass/aws_greengrass_discovery.c
+++ b/lib/greengrass/aws_greengrass_discovery.c
@@ -50,6 +50,7 @@
 /* Standard includes. */
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 /**
  * @brief Discovery: Strings for JSON file parsing.


### PR DESCRIPTION
Include the C runtime header for snprintf (stdio.h).