### PR TITLE
aws_tcp_echo_client_single_task.c : a time-out is not fatal

### DIFF
--- a/demos/common/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/common/tcp/aws_tcp_echo_client_single_task.c
@@ -307,7 +307,7 @@ static void prvEchoClientTask( void * pvParameters )
                 /* If an error occurred it will be latched in xReceivedBytes,
                  * otherwise xReceived bytes will be just that - the number of
                  * bytes received from the echo server. */
-                if( xReceivedBytes > 0 )
+                if( xReceivedBytes == xTransmitted )
                 {
                     /* Compare the transmitted string to the received string. */
                     configASSERT( strncmp( pcReceivedString, pcTransmittedString, xTransmitted ) == 0 );
@@ -334,6 +334,11 @@ static void prvEchoClientTask( void * pvParameters )
                 }
                 else
                 {
+                    /* The received length did not match the transmitted
+                     * length. */
+                    ulTxRxFailures[ xInstance ]++;
+                    configPRINTF( ( "ERROR: xTransmitted %d xReceivedBytes %d \r\n",
+						(int)xTransmitted, (int)xReceivedBytes ) );
                     /* Timed out without receiving anything? */
                     break;
                 }

--- a/demos/common/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/common/tcp/aws_tcp_echo_client_single_task.c
@@ -338,7 +338,7 @@ static void prvEchoClientTask( void * pvParameters )
                      * length. */
                     ulTxRxFailures[ xInstance ]++;
                     configPRINTF( ( "ERROR: xTransmitted %d xReceivedBytes %d \r\n",
-						(int)xTransmitted, (int)xReceivedBytes ) );
+                                    (int)xTransmitted, (int)xReceivedBytes ) );
                     /* Timed out without receiving anything? */
                     break;
                 }


### PR DESCRIPTION
aws_tcp_echo_client_single_task.c : a time-out is not fatal

Description
-----------
When the reception of data times out, and at least 1 byte has been received, an ASSERT will be thrown because the contents does not match.
When the number of bytes received is less than expected, it would be nicer to just consider this as a failure. The link may have failed, the remote party is too slow, etc.

Only when the expected number of bytes was received, but the received string does not match, this should be a fatal error ( calling `configASSERT()` ).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
