### PR TITLE
Report the correct WIN size

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
+++ b/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
@@ -577,7 +577,6 @@ BaseType_t xIPIsNetworkTaskReady( void );
 			FOnConnected_t pxHandleConnected;	/* Actually type: typedef void (* FOnConnected_t) (Socket_t xSocket, BaseType_t ulConnected ); */
 		#endif /* ipconfigUSE_CALLBACKS */
 		uint32_t ulWindowSize;		/* Current Window size advertised by peer */
-		uint32_t ulRxCurWinSize;	/* Constantly changing: this is the current size available for data reception */
 		size_t uxRxWinSize;	/* Fixed value: size of the TCP reception window */
 		size_t uxTxWinSize;	/* Fixed value: size of the TCP transmit window */
 

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -678,7 +678,7 @@ static void prvTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescri
 TCPPacket_t * pxTCPPacket;
 IPHeader_t *pxIPHeader;
 EthernetHeader_t *pxEthernetHeader;
-uint32_t ulFrontSpace, ulSpace, ulSourceAddress, ulWinSize, ulOutstanding;
+uint32_t ulFrontSpace, ulSpace, ulSourceAddress, ulWinSize;
 TCPWindow_t *pxTCPWindow;
 NetworkBufferDescriptor_t xTempBuffer;
 /* For sending, a pseudo network buffer will be used, as explained above. */
@@ -738,16 +738,7 @@ NetworkBufferDescriptor_t xTempBuffer;
 			}
 
 			/* Take the minimum of the RX buffer space and the RX window size. */
-			ulOutstanding = pxTCPWindow->rx.ulHighestSequenceNumber - pxTCPWindow->rx.ulCurrentSequenceNumber;
-			if( pxTCPWindow->xSize.ulRxWindowLength >= ulOutstanding )
-			{
-				ulSpace = pxTCPWindow->xSize.ulRxWindowLength - ulOutstanding;
-				ulSpace = FreeRTOS_min_uint32( ulSpace, ulFrontSpace );
-			}
-			else
-			{
-				ulSpace = 0ul;
-			}
+			ulSpace = FreeRTOS_min_uint32( pxTCPWindow->xSize.ulRxWindowLength, ulFrontSpace );
 
 			if( ( pxSocket->u.xTCP.bits.bLowWater != pdFALSE_UNSIGNED ) || ( pxSocket->u.xTCP.bits.bRxStopped != pdFALSE_UNSIGNED ) )
 			{


### PR DESCRIPTION
Report the correct WIN size

Description
-----------
A FreeRTOS+TCP user Wolfgang Schur, reported that under some rare circumstances, the reported value of WIN ( the available space in the TCP r4ecption window) is not correct.
In fact, it would be a bit behind: the last read from a socket would not be taken into account, so the reported WIN size sometimes wat too small.

The WIN size would be stored in the TCP socket field called `ulRxCurWinSize`.

In this patch, the field `ulRxCurWinSize` will be removed, and WIN will be calculated at the moment it must be send to the peer.

Under certain circumstances, this patch will make the communication a bit more efficient.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
