### PR TITLE
Convert errors in TLS wrapper to negative error codes

### DIFF
--- a/lib/include/aws_tls.h
+++ b/lib/include/aws_tls.h
@@ -32,6 +32,20 @@
 #endif
 
 /**
+ * @defgroup TlsErrors TLS Error Codes
+ * @brief Error codes returned by the TLS API.
+ *
+ * Note that TLS API may also propagate port-specific
+ * error codes, or codes from mbedTLS.
+ */
+/**@{ */
+#define TLS_ERROR_HANDSHAKE_FAILED    ( -2001 )   /*!< Error in handshake. */
+#define TLS_ERROR_RNG                 ( -2002 )   /*!< Error in RNG. */
+#define TLS_ERROR_SIGN                ( -2003 )   /*!< Error in sign operation. */
+
+/**@} */
+
+/**
  * @brief Defines callback type for receiving bytes from the network.
  *
  * @param[in] pvCallerContext Opaque context handle provided by caller.

--- a/lib/pkcs11/portable/pc/windows/aws_pkcs11_pal.c
+++ b/lib/pkcs11/portable/pc/windows/aws_pkcs11_pal.c
@@ -296,7 +296,7 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
         /* Open the file. */
         hFile = CreateFileA( pcFileName,
                              GENERIC_READ,
-                             0,
+                             FILE_SHARE_READ,
                              NULL,
                              OPEN_EXISTING,
                              FILE_ATTRIBUTE_NORMAL,

--- a/lib/tls/aws_tls.c
+++ b/lib/tls/aws_tls.c
@@ -180,7 +180,7 @@ static int prvGenerateRandomBytes( void * pvCtx,
                                    size_t xRandomLength )
 {
     TLSContext_t * pxCtx = ( TLSContext_t * ) pvCtx; /*lint !e9087 !e9079 Allow casting void* to other types. */
-    CK_RV xResult;
+    BaseType_t xResult;
 
     xResult = pxCtx->xP11FunctionList->C_GenerateRandom( pxCtx->xP11Session, pucRandom, xRandomLength );
 
@@ -280,7 +280,7 @@ static int prvPrivateKeySigningCallback( void * pvContext,
                                          size_t xHashLen,
                                          unsigned char * pucSig,
                                          size_t * pxSigLen,
-                                         int ( * piRng )( void *,
+                                         int ( *piRng )( void *,
                                                          unsigned char *,
                                                          size_t ), /*lint !e955 This parameter is unused. */
                                          void * pvRng )

--- a/tests/common/secure_sockets/aws_test_tcp.c
+++ b/tests/common/secure_sockets/aws_test_tcp.c
@@ -1538,7 +1538,7 @@ static void prvTestSOCKETS_Recv_ByteByByte( Server_t xConn )
     }
 
     /* Close this socket before looping back to create another. */
-    TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Failed received\r\n" );
+    TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Failed received" );
     xResult = prvShutdownHelper( xSocket );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket failed to shutdown" );
 


### PR DESCRIPTION
TLS library states that it returns negative error codes, but PKCS #11
library returns positive error codes.  Some positive PKCS #11 error codes
were propogated out of TLS, breaking API contract and occasionally causing
error code to be interpreted as number of bytes sent or received.

This commit also fixes a threading bug in the Windows PKCS #11 PAL layer
when reading files, and cleans up formatting on an error print statement in
the sockets tests.

<!--- Title -->

Description
-----------
Ran TLS & Sockets tests on WinSIm for testing.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
