### PR TITLE
Fix some issues in quick start script under Windows

### DIFF
--- a/tools/aws_config_quick_start/SetupAWS.py
+++ b/tools/aws_config_quick_start/SetupAWS.py
@@ -122,11 +122,18 @@ def delete_prereq():
     cert_id =  cert_id_file.read()
     cert_obj = certs.Certificate(cert_id)
     cert_obj.delete()
+    cert_id_file.close()
+    cert_id_file_path = os.path.abspath(cert_id_filename)
+    os.chmod(cert_id_file_path, 0o666)
     os.remove(cert_id_filename)
 
     # Delete cert_pem file and private_key_pem file
     cert_pem_filename = thing_name + '_cert_pem_file'
     private_key_pem_filename = thing_name + '_private_key_pem_file'
+    cert_pem_file_path = os.path.abspath(cert_pem_filename)
+    private_key_pem_file_path = os.path.abspath(private_key_pem_filename)
+    os.chmod(cert_pem_file_path, 0o666)
+    os.chmod(private_key_pem_file_path, 0o666)
     os.remove(cert_pem_filename)
     os.remove(private_key_pem_filename)
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- We cannot delete read-only file under Windows, need to change permission first.
- cert_id_file is open without being closed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~My code is Linted.~~
