### PR TITLE
Fix a compiler warning / potential error from an int/int32_t mismatch

### DIFF
--- a/lib/include/iot_linear_containers.h
+++ b/lib/include/iot_linear_containers.h
@@ -432,7 +432,7 @@ static inline void IotListDouble_InsertAfter( IotLink_t * const pElement,
 /* @[declare_linear_containers_list_double_insertsorted] */
 static inline void IotListDouble_InsertSorted( IotListDouble_t * const pList,
                                                IotLink_t * const pLink,
-                                               int ( *compare )( const IotLink_t * const, const IotLink_t * const ) )
+                                               int32_t ( *compare )( const IotLink_t * const, const IotLink_t * const ) )
 /* @[declare_linear_containers_list_double_insertsorted] */
 {
     /* This function must not be called with NULL parameters. */


### PR DESCRIPTION
Fix a potential build error caused by int type mismatch.

Description
-----------
Depending on how strict the compiler flags are, this can cause a build failure because the `IotListDouble_InsertSorted` function is called with an int*(...) for its last argument instead of an int32_t*(...) in the taskpool source files.

Another option would be to make the `_timerEventCompare(...)` method in `lib/common/iot_taskpool.c` return an int instead of an int32_t. But the method is marked as static, so it is unlikely to be used outside of the library file and the extra specificity shouldn't cause issues for users who choose to use generic 'int' types in their application code.

I also did not observe any issues with calls to `IotListDouble_InsertSorted` in other places with different int types.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
