### PR TITLE
fix: Use accessor macro to access list member

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_WIN.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_WIN.c
@@ -292,7 +292,7 @@ void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem
 	pxWhere->pxPrevious = pxNewListItem;
 
 	/* Remember which list the item is in. */
-	pxNewListItem->pvContainer = ( void * ) pxList; /* If this line fails to build then ensure configENABLE_BACKWARD_COMPATIBILITY is set to 1 in FreeRTOSConfig.h. */
+	listLIST_ITEM_CONTAINER( pxNewListItem ) = ( void * ) pxList;
 
 	( pxList->uxNumberOfItems )++;
 }


### PR DESCRIPTION
Description
-----------

FreeRTOS_TCP_WIN.c accessed the container member of the list item
directly instead of using the provided accessor macro for the same. The
container variable name was changed from pvContainer to pxContainer
which resulted in build failure. To ensure backward compatibility,
pxContainer was replaced with pvContainer using preprocessor if
configENABLE_BACKWARD_COMPATIBILITY was set to 1.

This commit removes the direct access and replaces it with the provided
accessor macro. As a result, it is no longer needed to set
configENABLE_BACKWARD_COMPATIBILITY to 1.

Fix issue: https://github.com/aws/amazon-freertos/issues/366

Testing
----------
- Generated the preprocessed file and examined manually for both configENABLE_BACKWARD_COMPATIBILITY = 1 and configENABLE_BACKWARD_COMPATIBILITY  = 0.
- Tested MQTT Hello World on Windows Simulator.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
