### PR TITLE
FreeRTOS_DHCP.c 'ucFirstOptionByte' was counted twice in earlier rele…

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
@@ -926,7 +926,8 @@ size_t xOptionsLength = sizeof( ucDHCPRequestOptions );
 	FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( xDHCPData.ulOfferedIPAddress ) ) );
 	iptraceSENDING_DHCP_REQUEST();
 
-	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+	/* 'ucFirstOptionByte' was counted twice in earlier releases, subtract 1 byte. */
+	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength - 1 ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
 	{
 		/* The packet was not successfully queued for sending and must be
 		returned to the stack. */
@@ -954,7 +955,8 @@ size_t xOptionsLength = sizeof( ucDHCPDiscoverOptions );
 	FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
 	iptraceSENDING_DHCP_DISCOVER();
 
-	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+	/* 'ucFirstOptionByte' was counted twice in earlier releases, subtract 1 byte. */
+	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength - 1 ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
 	{
 		/* The packet was not successfully queued for sending and must be
 		returned to the stack. */

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
@@ -926,7 +926,7 @@ size_t xOptionsLength = sizeof( ucDHCPRequestOptions );
 	FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( xDHCPData.ulOfferedIPAddress ) ) );
 	iptraceSENDING_DHCP_REQUEST();
 
-	/* 'ucFirstOptionByte' was counted twice in earlier releases, subtract 1 byte. */
+	/* 'ucFirstOptionByte' is part of DHCP message struct, so subtract one byte. */
 	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength - 1 ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
 	{
 		/* The packet was not successfully queued for sending and must be
@@ -955,7 +955,7 @@ size_t xOptionsLength = sizeof( ucDHCPDiscoverOptions );
 	FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
 	iptraceSENDING_DHCP_DISCOVER();
 
-	/* 'ucFirstOptionByte' was counted twice in earlier releases, subtract 1 byte. */
+	/* 'ucFirstOptionByte' is part of DHCP message struct, so subtract one byte. */
 	if( FreeRTOS_sendto( xDHCPData.xDHCPSocket, pucUDPPayloadBuffer, ( sizeof( DHCPMessage_t ) + xOptionsLength - 1 ), FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
 	{
 		/* The packet was not successfully queued for sending and must be


### PR DESCRIPTION
FreeRTOS_DHCP.c 'ucFirstOptionByte' was counted twice in earlier releases, subtract 1 byte to send the correct amount of bytes.

Description
-----------
The outgoing DHCP packets were always one byte too long. 
I described that in the FreeRTOS forum: [FreeRTOS plus TCP DHCP problem](https://sourceforge.net/p/freertos/discussion/382005/thread/54ab111544/?limit=250#4d23)

The first option byte was counted twice.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
