### PR TITLE
fix: Fix warning portHAS_STACK_OVERFLOW_CHECKING not defined

### DIFF
--- a/lib/include/FreeRTOS.h
+++ b/lib/include/FreeRTOS.h
@@ -766,10 +766,6 @@ extern "C" {
 	#define portALLOCATE_SECURE_CONTEXT( ulSecureStackSize )
 #endif
 
-#ifndef portHAS_STACK_OVERFLOW_CHECKING
-	#define portHAS_STACK_OVERFLOW_CHECKING 0
-#endif
-
 #ifndef configUSE_TIME_SLICING
 	#define configUSE_TIME_SLICING 1
 #endif

--- a/lib/include/private/portable.h
+++ b/lib/include/private/portable.h
@@ -84,6 +84,10 @@ must be set in the compiler's include path. */
 	#define portNUM_CONFIGURABLE_REGIONS 1
 #endif
 
+#ifndef portHAS_STACK_OVERFLOW_CHECKING
+	#define portHAS_STACK_OVERFLOW_CHECKING 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Description
-----------
portHAS_STACK_OVERFLOW_CHECKING was getting defined too late before
being used in portable.h for the platforms that do not have stack
overflow checking registers. This commit ensures that it is defined
before it is used.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
