### PR TITLE
fix: Fix duplicate defined FreeRTOS hooks in Microchip.

### DIFF
--- a/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
+++ b/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
@@ -36,7 +36,6 @@
         </logicalFolder>
       </logicalFolder>
       <logicalFolder name="f2" displayName="microchip_code" projectFiles="true">
-        <itemPath>../common/application_code/microchip_code/rtos_hooks.c</itemPath>
         <itemPath>../common/application_code/microchip_code/system_config.h</itemPath>
         <itemPath>../common/application_code/microchip_code/system_definitions.h</itemPath>
         <itemPath>../common/application_code/microchip_code/system_exceptions.c</itemPath>


### PR DESCRIPTION
* Took rtos_hooks.c out of compilation in the demo project. This is already done in the test project.

This is the first fix for support of XC32 v2.15. Updating Harmony to v2.06 and the subsequent auto-generated system configuration files will be in a separate PR.

Requesting a review from all engineers involved in the original investigation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
