### PR TITLE
Make TCP low-water/high-water limits configurable with a socket option

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_Sockets.h
+++ b/lib/FreeRTOS-Plus-TCP/include/FreeRTOS_Sockets.h
@@ -130,6 +130,7 @@ FreeRTOS_setsockopt(). */
 	#define FREERTOS_SO_WAKEUP_CALLBACK	( 17 )
 #endif
 
+#define FREERTOS_SO_SET_LOW_HIGH_WATER	( 18 )
 
 #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET 	( 0x80 )  /* For internal use only, but also part of an 8-bit bitwise value. */
 #define FREERTOS_FRAGMENTED_PACKET				( 0x40 )  /* For internal use only, but also part of an 8-bit bitwise value. */
@@ -154,6 +155,12 @@ typedef struct xWIN_PROPS {
 	int32_t lRxBufSize;	/* Unit: bytes */
 	int32_t lRxWinSize;	/* Unit: MSS */
 } WinProperties_t;
+
+typedef struct xLOW_HIGH_WATER {
+	/* Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option */
+	size_t uxLittleSpace;	/* Send a STOP when buffer space drops below X bytes */
+	size_t uxEnoughSpace;	/* Send a GO when buffer space grows above X bytes */
+} LowHighWater_t;
 
 /* For compatibility with the expected Berkeley sockets naming. */
 #define socklen_t uint32_t

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
@@ -1428,6 +1428,23 @@ FreeRTOS_Socket_t *pxSocket;
 				break;
 			#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
 
+			case FREERTOS_SO_SET_LOW_HIGH_WATER:
+				{
+					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+					{
+						/* It is not allowed to access 'pxSocket->u.xTCP'. */
+						FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: wrong socket type\n" ) );
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+					LowHighWater_t *pxLowHighWater = ( LowHighWater_t * ) pvOptionValue;
+					/* Send a STOP when buffer space drops below 'uxLittleSpace' bytes. */
+					pxSocket->u.xTCP.uxLittleSpace = pxLowHighWater->uxLittleSpace;
+					/* Send a GO when buffer space grows above 'uxEnoughSpace' bytes. */
+					pxSocket->u.xTCP.uxEnoughSpace = pxLowHighWater->uxEnoughSpace;
+					xReturn = 0;
+				}
+				break;
+
 			case FREERTOS_SO_SNDBUF:	/* Set the size of the send buffer, in units of MSS (TCP only) */
 			case FREERTOS_SO_RCVBUF:	/* Set the size of the receive buffer, in units of MSS (TCP only) */
 				{


### PR DESCRIPTION
<!--- Title -->

Make TCP low-water/high-water limits configurable with a socket option

Description
-----------
When receiving data on a TCP socket, there is a mechanism that controls the flow: when the reception stream buffer gets filled for more than 80%, a WIN update will be sent to the peer.
When the buffer drops below 20%, again a WIN update will be sent in order to resume transmission.

These 20/80 limits have been hard-coded up until now.

This patch allows to control the 2 limits per socket. It adds a new socket option:

`#define FREERTOS_SO_SET_LOW_HIGH_WATER	( 18 )`

and it should be called with a (pointer to a) parameter of this type:

`typedef struct xLOW_HIGH_WATER {`
`	/* Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option */`
`	size_t uxLittleSpace;	/* Send a STOP when buffer space drops below X bytes */`
`	size_t uxEnoughSpace;	/* Send a GO when buffer space grows above X bytes */`
`} LowHighWater_t;`

Note that the two variables express as a number of bytes, not a percentage.

As this is an expert option, the supplied values are not being checked on their validity.

When the socket option is not used, the defaults of 20/80 will still be applied.

Most users won't need this option, but some have found it quiet useful.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
