### PR TITLE
fix: Remove the warning of unused variable xTaskStatus

### DIFF
--- a/demos/common/mqtt/aws_subscribe_publish_loop.c
+++ b/demos/common/mqtt/aws_subscribe_publish_loop.c
@@ -596,7 +596,6 @@ static void prvSubscribePublishDemo( MQTTAgentHandle_t xMQTTClientHandle,
 {
     BaseType_t xResult;
     MQTTAgentConnectParams_t xConnectParams;
-    TaskStatus_t xTaskStatus;
     SubpubUserData_t xUserData;
 
     /* Create the event group used to synchronize tasks and callback functions.
@@ -659,6 +658,7 @@ static void prvSubscribePublishDemo( MQTTAgentHandle_t xMQTTClientHandle,
     {
         #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
             {
+                TaskStatus_t xTaskStatus;
                 /* Report on space efficiency of this demo task. */
                 vTaskGetInfo( NULL, &xTaskStatus, pdTRUE, eInvalid );
                 configPRINTF( ( "Heap low-water mark %u, Stack high-water mark %u.\r\n",


### PR DESCRIPTION
There was a warning generated on System Workbench of -Wunused-variable.
The reason being it falls under the preprocessor block of INCLUDE_uxTaskGetStackHighWaterMark.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
