### PR TITLE
Created abstraction layer for HW button push

### DIFF
--- a/demos/common/combined/aws_iot_combined_demo.c
+++ b/demos/common/combined/aws_iot_combined_demo.c
@@ -70,8 +70,13 @@
 
 /* 
  * Push button HW platform.
+ *
+ * Include the aws_hw_button.h if turning BLE on/off by pushing a button on the hw
+ * is part of the demo. If enabling this capability please make sure the hardware
+ * specific code to push a button exists. See the aws_hw_button.h file for 
+ * further details.
  */
-#include "aws_hw_button.h"
+/*#include "aws_hw_button.h" */
 
 /**
  * @brief Transport types supported for MQTT Echo demo.

--- a/demos/common/include/aws_hw_button.h
+++ b/demos/common/include/aws_hw_button.h
@@ -1,0 +1,55 @@
+/*
+ * Amazon FreeRTOS Combined Demo V1.0.0
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/**
+ * @file aws_hw_button.h
+ * @brief AWS abstration of a physical push button on a particular version of HW
+ *
+ * Modify this file to include files to HW that is specific to a demo, then create the files 
+ * specific for a that version of hw. 
+ *
+ * This example is for ESP32 Wrover Kit
+ *     ~/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/esp_wrover_sw3_button.c
+ */
+#ifndef _HW_BUTTON_H_
+#define _HW_BUTTON_H_
+
+/**
+ * @brief Init HW for push button detection.
+ * Only call this function once.
+ */
+extern void buttonInit( void );
+
+/**
+ * @brief Determine if button was pushed.
+ */
+extern bool buttonWasPushed( void );
+
+#define HW_BUTTON      
+
+#endif /* _HW_BUTTON_H_ */
+
+

--- a/demos/common/include/aws_hw_button.h
+++ b/demos/common/include/aws_hw_button.h
@@ -28,10 +28,10 @@
  * @file aws_hw_button.h
  * @brief AWS abstration of a physical push button on a particular version of HW
  *
- * Modify this file to include files to HW that is specific to a demo, then create the files 
- * specific for a that version of hw. 
+ * Make sure that files for your specific hardware support the buttonInit() and 
+ * buttonWasPushed().
  *
- * This example is for ESP32 Wrover Kit
+ * An example for ESP32 Wrover Kit
  *     ~/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/esp_wrover_sw3_button.c
  */
 #ifndef _HW_BUTTON_H_

--- a/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/esp_wrover_sw3_button.c
+++ b/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/esp_wrover_sw3_button.c
@@ -1,0 +1,115 @@
+/*
+ * Amazon FreeRTOS Combined Demo V1.0.0
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/**
+ * @file esp_wrover_sw3_button.c
+ * @brief Espressif ESP32 Rover KIT hardware specific routines to detect button push
+ *
+ * These routines should be called from an application task wanting to monitor
+ * the SW3 or boot button on the ESP32 Rover Kit HW being pushed. This only 
+ * applies to this specific version of hw. In order to duplicate this functionaliy
+ * on other HW from Espressif or another vendor one must create similar routines specific
+ * to the HW on which Amazon FreeRTOS runs.
+ *
+ * Expected use/operation of this code:
+ *      buttonInit() is called once at the beginning of the task. 
+ *      buttonWasPushed() is called repeatedly within a while loop.
+ *
+ */
+
+/* POSIX and Platform layer includes. */
+#include "platform/iot_clock.h"
+#include "FreeRTOS_POSIX/time.h"
+
+#include "driver/gpio.h"
+
+/**
+ * @brief Time button must be pushed down before release
+ */
+#define demoBUTTON_DELAY ( 1000 )
+
+/**
+ * @brief IO pin for push button.
+ */
+#define GPIO_INPUT_IO_0                          ( 4 )
+
+void buttonInit( void )
+{
+    /* Enable GPIO 0 so that we can read the state */
+    gpio_config_t io_conf;
+
+    io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
+    /*bit mask of the pins, use GPIO0 here */
+    io_conf.pin_bit_mask = ( 1 << GPIO_INPUT_IO_0 );
+    /*set as input mode */
+    io_conf.mode = GPIO_MODE_INPUT;
+    /*enable pull-up mode */
+    io_conf.pull_up_en = 1;
+    gpio_config( &io_conf );
+}
+
+
+/*-----------------------------------------------------------*/
+
+bool buttonWasPushed( void )
+{
+    int numSecsToWait = 5;
+    bool pushed = false;
+    bool released = false;
+    TickType_t buttonDelay = pdMS_TO_TICKS( demoBUTTON_DELAY );
+
+    while( numSecsToWait-- )
+    {
+        if( gpio_get_level( GPIO_NUM_0 ) == 0 )
+        {
+            /*   IotLogInfo("buttonWasPushed: button pushed\n"); */
+            pushed = true;
+            break;
+        }
+
+        vTaskDelay( buttonDelay );
+    }
+
+    if( pushed )
+    {
+        numSecsToWait = 20;
+
+        while( numSecsToWait-- )
+        {
+            if( gpio_get_level( GPIO_NUM_0 ) == 1 )
+            {
+                /* IotLogInfo("buttonWasPushed: button released\n"); */
+                released = true;
+                break;
+            }
+
+            vTaskDelay( buttonDelay );
+        }
+    }
+
+    return released;
+}
+


### PR DESCRIPTION
<!--- Title -->

Created abstraction layer for HW button push.

-----------
<!--- Describe your changes in detail -->

Abstracts HW specific information as a generic push button in the aws_iot_combined_demo.c file. Provides a clean template for mapping the abstract HW push button functions into different versions of HW.

Modified the ~/demos/common/combined/aws_iot_combined.c that turns on/off BLE file by removing all the HW specific information. No w BLE on/off code is only called if HW_BUTTON is defined. Now makes calls to generic functions:
   buttonInit()
   buttonWasPushed()

Added header file in ~/demos/common/include/aws_hw_button.h with:
   #define HW_BUTTON
   declarations for buttonInit() and buttonWasPushed()

Added .c file ~/demos/espressif/esp32_devkitc_esp_wrover_kit/common/ application_code/esp_wrover_sw3_button.c with definitions for buttonInit()
and buttonWasPushed() and HW specific defines.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [Y ] I have tested my changes. No regression in existing tests.
- [ N] My code is Linted.
