### PR TITLE
fix: pcap_freecode() was in the wrong spot.

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/lib/FreeRTOS-Plus-TCP/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -386,10 +386,10 @@ uint32_t ulNetMask;
 		if( pcap_setfilter( pxOpenedInterfaceHandle, &xFilterCode ) < 0 )
 		{
 			printf( "\nAn error occurred setting the packet filter.\n" );
-			/* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct 
-			parameter.pcap_freecode() will free that memory. */
-			pcap_freecode( &xFilterCode );
 		}
+		/* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct 
+		parameter.pcap_freecode() will free that memory. */
+		pcap_freecode( &xFilterCode );
 	}
 
 	/* Create the buffers used to pass packets between the FreeRTOS simulator


### PR DESCRIPTION
* I accidentally placed it within the if() of pcap_setfilter(). 
* pcap_freecode() needs to be called anytime pcap_compile succeeds.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
