### PR TITLE
docs: Fix spelling of priority in comments

### DIFF
--- a/lib/FreeRTOS/portable/GCC/ARM_CM0/port.c
+++ b/lib/FreeRTOS/portable/GCC/ARM_CM0/port.c
@@ -175,7 +175,7 @@ void vPortStartFirstTask( void )
  */
 BaseType_t xPortStartScheduler( void )
 {
-	/* Make PendSV, CallSV and SysTick the same priroity as the kernel. */
+	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
 	*(portNVIC_SYSPRI2) |= portNVIC_PENDSV_PRI;
 	*(portNVIC_SYSPRI2) |= portNVIC_SYSTICK_PRI;
 

--- a/lib/FreeRTOS/portable/RVDS/ARM_CM0/port.c
+++ b/lib/FreeRTOS/portable/RVDS/ARM_CM0/port.c
@@ -157,7 +157,7 @@ __asm void prvPortStartFirstTask( void )
  */
 BaseType_t xPortStartScheduler( void )
 {
-	/* Make PendSV, CallSV and SysTick the same priroity as the kernel. */
+	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
 	*(portNVIC_SYSPRI2) |= portNVIC_PENDSV_PRI;
 	*(portNVIC_SYSPRI2) |= portNVIC_SYSTICK_PRI;
 


### PR DESCRIPTION
Description
-----------
Fix spelling of priority in comments. This was pointed out in the PR: https://github.com/aws/amazon-freertos/pull/320

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
