### PR TITLE
docs: Fix README.md style for Windows Simulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The following MCU boards are supported for Amazon FreeRTOS:
 11. **Cypress CYW43907** - [Cypress CYW943907AEVAL1F Evaluation Kit](https://www.cypress.com/documentation/development-kitsboards/cyw943907aeval1f-evaluation-kit)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_43.html)
     * IDE: [WICED Studio](https://community.cypress.com/community/wiced-wifi)
-12. **Windows Simulator**
-To evaluate Amazon FreeRTOS without using MCU-based hardware, you can use the Windows Simulator.
-* Requirements: Microsoft Windows 7 or newer, with at least a dual core and a hard-wired Ethernet connection
-* [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_windows.html)
-* IDE: [Visual Studio Community Edition](https://www.visualstudio.com/downloads/)
+12. **Windows Simulator** - To evaluate Amazon FreeRTOS without using MCU-based hardware, you can use the Windows Simulator.
+    * Requirements: Microsoft Windows 7 or newer, with at least a dual core and a hard-wired Ethernet connection
+    * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_windows.html)
+    * IDE: [Visual Studio Community Edition](https://www.visualstudio.com/downloads/)


### PR DESCRIPTION
The Windows Simulator sections is inconsistently styled from the other platform's sections and looks weird in the browser rendering. 
This pull request fixes that styling.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
