### PR TITLE
fix: Fix link failure with latest XC32 compiler on Microchip

### DIFF
--- a/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
+++ b/demos/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
@@ -1888,6 +1888,7 @@
         <property key="symbol-stripping" value=""/>
         <property key="trace-symbols" value=""/>
         <property key="warn-section-align" value="false"/>
+        <appendMe value="--allow-multiple-definition"/>
       </C32-LD>
       <C32CPP>
         <property key="additional-warnings" value="false"/>

--- a/tests/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
+++ b/tests/microchip/curiosity_pic32mzef/mplab/nbproject/configurations.xml
@@ -1984,6 +1984,7 @@
         <property key="symbol-stripping" value=""/>
         <property key="trace-symbols" value=""/>
         <property key="warn-section-align" value="false"/>
+        <appendMe value="--allow-multiple-definition"/>
       </C32-LD>
       <C32CPP>
         <property key="additional-warnings" value="false"/>


### PR DESCRIPTION
Description
-----------
The latest XC32 compiler (version 2.15) does not allow multiple
definitions while the previous versions allowed it. As a result, using
the latest compiler results in linker errors. We should remove
multiple definitions but allowing explicitly for now to fix the
build failure with the latest compiler.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
