### PR TITLE
Remove Windows SDK version from VS projects.

### DIFF
--- a/demos/pc/windows/visual_studio/aws_demos.vcxproj
+++ b/demos/pc/windows/visual_studio/aws_demos.vcxproj
@@ -9,7 +9,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
     <ProjectName>aws_demos</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj
@@ -16,7 +16,6 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>aws_IoT_MCU_Full_Tests</RootNamespace>
     <ProjectName>aws_tests</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Description
-----------
Removes Visual Studio Windows SDK versions from project files.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
