### PR TITLE
POSIX compliance fix.

### DIFF
--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_clock.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_clock.c
@@ -63,11 +63,8 @@ int clock_getcpuclockid( pid_t pid,
     ( void ) pid;
     ( void ) clock_id;
 
-    /* This function is currently unsupported. It will always return -1 and
-     * set errno to EPERM. */
-    errno = EPERM;
-
-    return -1;
+    /* This function is currently unsupported. It will always return EPERM. */
+    return EPERM;
 }
 
 /*-----------------------------------------------------------*/
@@ -103,14 +100,6 @@ int clock_gettime( clockid_t clock_id,
 
     /* Silence warnings about unused parameters. */
     ( void ) clock_id;
-
-    /* Check tp. */
-    if( tp == NULL )
-    {
-        /* POSIX does not specify this function setting errno for invalid
-         * parameters, so just set the return value. */
-        iStatus = -1;
-    }
 
     if( iStatus == 0 )
     {

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_clock.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_clock.c
@@ -91,7 +91,6 @@ int clock_gettime( clockid_t clock_id,
                    struct timespec * tp )
 {
     TimeOut_t xCurrentTime = { 0 };
-    int iStatus = 0;
 
     /* Intermediate variable used to convert TimeOut_t to struct timespec.
      * Also used to detect overflow issues. It must be unsigned because the
@@ -101,24 +100,21 @@ int clock_gettime( clockid_t clock_id,
     /* Silence warnings about unused parameters. */
     ( void ) clock_id;
 
-    if( iStatus == 0 )
-    {
-        /* Get the current tick count and overflow count. vTaskSetTimeOutState()
-         * is used to get these values because they are both static in tasks.c. */
-        vTaskSetTimeOutState( &xCurrentTime );
+    /* Get the current tick count and overflow count. vTaskSetTimeOutState()
+     * is used to get these values because they are both static in tasks.c. */
+    vTaskSetTimeOutState( &xCurrentTime );
 
-        /* Adjust the tick count for the number of times a TickType_t has overflowed.
-         * portMAX_DELAY should be the maximum value of a TickType_t. */
-        ullTickCount = ( uint64_t ) ( xCurrentTime.xOverflowCount ) << ( sizeof( TickType_t ) * 8 );
+    /* Adjust the tick count for the number of times a TickType_t has overflowed.
+     * portMAX_DELAY should be the maximum value of a TickType_t. */
+    ullTickCount = ( uint64_t ) ( xCurrentTime.xOverflowCount ) << ( sizeof( TickType_t ) * 8 );
 
-        /* Add the current tick count. */
-        ullTickCount += xCurrentTime.xTimeOnEntering;
+    /* Add the current tick count. */
+    ullTickCount += xCurrentTime.xTimeOnEntering;
 
-        /* Convert ullTickCount to timespec. */
-        UTILS_NanosecondsToTimespec( ( int64_t ) ullTickCount * NANOSECONDS_PER_TICK, tp );
-    }
+    /* Convert ullTickCount to timespec. */
+    UTILS_NanosecondsToTimespec( ( int64_t ) ullTickCount * NANOSECONDS_PER_TICK, tp );
 
-    return iStatus;
+    return 0;
 }
 
 /*-----------------------------------------------------------*/

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_mqueue.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_mqueue.c
@@ -525,7 +525,7 @@ mqd_t mq_open( const char * name,
     /* Check attributes, if given. */
     if( xMessageQueue == NULL )
     {
-        if( ( attr != NULL ) && ( ( attr->mq_maxmsg < 0 ) || ( attr->mq_msgsize < 0 ) ) )
+        if ((oflag & O_CREAT) && (attr != NULL) && ((attr->mq_maxmsg <= 0) || (attr->mq_msgsize <= 0)))
         {
             /* Invalid mq_attr.mq_maxmsg or mq_attr.mq_msgsize. */
             errno = EINVAL;
@@ -840,7 +840,7 @@ int mq_unlink( const char * name )
     if( prvValidateQueueName( name, &xNameSize ) == pdFALSE )
     {
         /* Error with mq name. */
-        errno = ENAMETOOLONG;
+        errno = EINVAL;
         iStatus = -1;
     }
 

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
@@ -134,14 +134,7 @@ static void prvRunThread( void * pxArg )
 
 int pthread_attr_destroy( pthread_attr_t * attr )
 {
-    int iStatus = 0;
-
-    if( attr == NULL )
-    {
-        iStatus = EINVAL;
-    }
-
-    return iStatus;
+    return 0;
 }
 
 /*-----------------------------------------------------------*/
@@ -191,21 +184,10 @@ int pthread_attr_getstacksize( const pthread_attr_t * attr,
 
 int pthread_attr_init( pthread_attr_t * attr )
 {
-    int iStatus = 0;
-
-    /* Check if the attribute is NULL. */
-    if( attr == NULL )
-    {
-        iStatus = EINVAL;
-    }
-
     /* Copy the default values into the new thread attributes object. */
-    if( iStatus == 0 )
-    {
-        *( ( pthread_attr_internal_t * ) ( attr ) ) = xDefaultThreadAttributes;
-    }
+    *( ( pthread_attr_internal_t * ) ( attr ) ) = xDefaultThreadAttributes;
 
-    return iStatus;
+    return 0;
 }
 
 /*-----------------------------------------------------------*/
@@ -400,15 +382,7 @@ int pthread_getschedparam( pthread_t thread,
 int pthread_equal( pthread_t t1,
                    pthread_t t2 )
 {
-    int iStatus = 0;
-
-    /* Compare the thread IDs. */
-    if( ( t1 != NULL ) && ( t2 != NULL ) )
-    {
-        iStatus = ( t1 == t2 );
-    }
-
-    return iStatus;
+    return t1 == t2;
 }
 
 /*-----------------------------------------------------------*/

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
@@ -341,21 +341,9 @@ int pthread_mutexattr_gettype( const pthread_mutexattr_t * attr,
 
 int pthread_mutexattr_init( pthread_mutexattr_t * attr )
 {
-    int iStatus = 0;
+    *( ( pthread_mutexattr_internal_t * ) ( attr ) ) = xDefaultMutexAttributes;
 
-    if( attr == NULL )
-    {
-        /* Invalid Attribute. */
-        iStatus = EINVAL;
-    }
-
-    /* Set the mutex attributes to default values. */
-    if( iStatus == 0 )
-    {
-        *( ( pthread_mutexattr_internal_t * ) ( attr ) ) = xDefaultMutexAttributes;
-    }
-
-    return iStatus;
+    return 0;
 }
 
 /*-----------------------------------------------------------*/

--- a/lib/include/FreeRTOS_POSIX/pthread.h
+++ b/lib/include/FreeRTOS_POSIX/pthread.h
@@ -138,7 +138,6 @@ int pthread_attr_getstacksize( const pthread_attr_t * attr,
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_attr_init.html
  *
  * @retval 0 - Upon successful completion.
- * @retval ENOMEM - Insufficient memory exists to initialize the thread attributes object.
  * 
  * @note Currently, only stack size, sched_param, and detach state attributes
  * are supported. Also see pthread_attr_get*() and pthread_attr_set*().
@@ -460,7 +459,6 @@ int pthread_mutexattr_gettype( const pthread_mutexattr_t * attr,
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutexattr_init.html
  *
  * @retval 0 - Upon successful completion.
- * @retval ENOMEM - Insufficient memory exists to initialize the mutex attributes object.
  *
  * @note Currently, only the type attribute is supported. Also see pthread_mutexattr_settype() 
  *       and pthread_mutexattr_gettype().

--- a/tests/common/posix/aws_test_posix_mqueue.c
+++ b/tests/common/posix/aws_test_posix_mqueue.c
@@ -343,7 +343,7 @@ TEST( Full_POSIX_MQUEUE, mq_unlink_invalid_params )
     /* Try to unlink a message queue whose name is longer than NAME_MAX. */
     iStatus = mq_unlink( pcNameBuffer );
     TEST_ASSERT_EQUAL_INT( -1, iStatus );
-    TEST_ASSERT_EQUAL_INT( ENAMETOOLONG, errno );
+    TEST_ASSERT_EQUAL_INT( EINVAL, errno );
 
     /* Try to unlink a queue that doesn't exist. */
     iStatus = mq_unlink( posixtestMQ_DEFAULT_NAME );


### PR DESCRIPTION
POSIX compliance fix.

Description
-----------
This PR comes from staging repo feature/ble-beta branch commit SHA 4b4d61db72079236e307e9fcf48873f581575118.
This PR passes winsim test project, POSIX test suite. 

FreeRTOS_POSIX_clock.c -- clock_getcpuclockid(), Open Group "Upon successful completion, clock_getcpuclockid() shall return zero; otherwise, an error number shall be returned to indicate the error."

FreeRTOS_POSIX_clock.c -- clock_gettime(), Open Group does not require this branch, and returning -1 without errno set is confusing. Thus taking out tp null check.

FreeRTOS_POSIX_mqueue.c -- mq_open(), Open Group "[EINVAL]
O_CREAT was specified in oflag, the value of attr is not NULL, and either mq_maxmsg or mq_msgsize was less than or equal to zero." Additional args -- mode and attr are only required when O_CREAT.

FreeRTOS_POSIX_mqueue.c -- mq_unlink(). To be consistent in our own implementation, if prvValidateQueueName() fails, lets always return EINVAL. Refer to mq_open().

FreeRTOS_POSIX_pthread.c -- pthread_attr_destroy(), Open Group does not require null check, and also to be consistent in our own implementation, remove null check.

FreeRTOS_POSIX_pthread.c -- pthread_attr_init(), Open Group does not require null check.

FreeRTOS_POSIX_pthread.c -- pthread_equal(), if one of the thread was null, this function would tell you threads are equal, which is a false statement.

FreeRTOS_POSIX_pthread_mutex.c -- pthread_mutexattr_init(), Open Group does not requrie EINVAL, and also to be consistent within our own implementation.


test update -- Expected return value update. 

API doc update -- We removed memory allocation inside a couple of APIs. Thus, error value "memory not available" will never be returned from these APIs. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.