### PR TITLE
fix platform types afr and project file

### DIFF
--- a/lib/include/platform/iot_platform_types_afr.h
+++ b/lib/include/platform/iot_platform_types_afr.h
@@ -27,6 +27,7 @@
 #ifndef _IOT_PLATFORM_TYPES_POSIX_H_
 #define _IOT_PLATFORM_TYPES_POSIX_H_
 
+#include <stdbool.h>
 #include "timers.h"
 
 

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj
@@ -313,6 +313,9 @@
     <ClCompile Include="..\..\..\..\lib\common\static_memory\iot_static_memory_mqtt.c" />
     <ClCompile Include="..\..\..\..\lib\common\static_memory\iot_static_memory_taskpool.c" />
     <ClCompile Include="..\..\..\..\lib\crypto\aws_crypto.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_collector.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_mqtt.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_clock.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_mqueue.c" />
     <ClCompile Include="..\..\..\..\lib\FreeRTOS-Plus-POSIX\source\FreeRTOS_POSIX_pthread.c" />
@@ -457,9 +460,9 @@
     <ClCompile Include="..\..\..\..\lib\third_party\tracealyzer_recorder\trcSnapshotRecorder.c" />
     <ClCompile Include="..\..\..\..\lib\tls\aws_tls.c" />
     <ClCompile Include="..\..\..\..\lib\utils\aws_system_init.c" />
-    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_clock_posix.c" />
+    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_clock_afr.c" />
     <ClCompile Include="..\..\..\..\lib\utils\platform\iot_network_afr.c" />
-    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_threads_posix.c" />
+    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_threads_afr.c" />
     <ClCompile Include="..\..\..\common\cbor\aws_test_cbor.c" />
     <ClCompile Include="..\..\..\common\crypto\aws_test_crypto.c" />
     <ClCompile Include="..\..\..\common\framework\aws_test_framework.c" />

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
@@ -214,6 +214,9 @@
     <Filter Include="application_code\common_tests\serializer">
       <UniqueIdentifier>{067a1587-18d8-413e-a931-59262c0e8c5f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="lib\aws\defender">
+      <UniqueIdentifier>{08e19228-c970-4d8c-933c-ebe94a403c77}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\lib\third_party\unity\extras\fixture\src\unity_fixture.h">
@@ -1398,13 +1401,7 @@
     <ClCompile Include="..\..\..\..\lib\mqtt\iot_mqtt_validate.c">
       <Filter>lib\aws\mqtt</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_clock_posix.c">
-      <Filter>lib\aws\utils\platform</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\lib\utils\platform\iot_network_afr.c">
-      <Filter>lib\aws\utils\platform</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_threads_posix.c">
       <Filter>lib\aws\utils\platform</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\common\mqtt\unit\iot_tests_mqtt_api.c">
@@ -1440,6 +1437,22 @@
     </ClCompile>
     <ClCompile Include="..\..\..\common\serializer\aws_test_serializer_json.c">
       <Filter>application_code\common_tests\serializer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\ota\aws_iot_ota_agent.c" />
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_api.c">
+      <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_collector.c">
+      <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\defender\aws_iot_defender_mqtt.c">
+      <Filter>lib\aws\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_clock_afr.c">
+      <Filter>lib\aws\utils\platform</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\lib\utils\platform\iot_threads_afr.c">
+      <Filter>lib\aws\utils\platform</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Windows Tests cannot be built:
- add stdbool.h to iot_platform_types_afr.h
- fix project file

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
