### PR TITLE
Atomic & POSIX with atomic.

### DIFF
--- a/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h
+++ b/lib/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h
@@ -45,9 +45,10 @@
 #endif
 
 #if posixconfigENABLE_PTHREAD_MUTEX_T == 1
-    /**
-     * @brief Mutex.
-     */
+
+/**
+ * @brief Mutex.
+ */
     typedef struct pthread_mutex_internal
     {
         BaseType_t xIsInitialized;          /**< Set to pdTRUE if this mutex is initialized, pdFALSE otherwise. */
@@ -56,70 +57,73 @@
         pthread_mutexattr_internal_t xAttr; /**< Mutex attributes. */
     } pthread_mutex_internal_t;
 
-    /**
-     * @brief Compile-time initializer of pthread_mutex_internal_t.
-     */
+/**
+ * @brief Compile-time initializer of pthread_mutex_internal_t.
+ */
     #define FREERTOS_POSIX_MUTEX_INITIALIZER \
-        ( ( ( pthread_mutex_internal_t )     \
-        {                                    \
-            .xIsInitialized = pdFALSE,       \
-            .xMutex = { { 0 } },             \
-            .xTaskOwner = NULL,              \
-            .xAttr = { .iType = 0 }          \
-        }                                    \
-          )                                  \
-        )
-#endif
+    ( ( ( pthread_mutex_internal_t )         \
+    {                                        \
+        .xIsInitialized = pdFALSE,           \
+        .xMutex = { { 0 } },                 \
+        .xTaskOwner = NULL,                  \
+        .xAttr = { .iType = 0 }              \
+    }                                        \
+        )                                    \
+    )
+#endif /* if posixconfigENABLE_PTHREAD_MUTEX_T == 1 */
 
 #if posixconfigENABLE_PTHREAD_COND_T == 1
-    /**
-     * @brief Condition variable.
-     */
+
+/**
+ * @brief Condition variable.
+ */
     typedef struct pthread_cond_internal
     {
         BaseType_t xIsInitialized;            /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
-        StaticSemaphore_t xCondMutex;         /**< Prevents concurrent accesses to iWaitingThreads. */
         StaticSemaphore_t xCondWaitSemaphore; /**< Threads block on this semaphore in pthread_cond_wait. */
-        int iWaitingThreads;                  /**< The number of threads currently waiting on this condition variable. */
+        unsigned iWaitingThreads;                  /**< The number of threads currently waiting on this condition variable. */
     } pthread_cond_internal_t;
 
-    /**
-     * @brief Compile-time initializer of pthread_cond_internal_t.
-     */
-    #define FREERTOS_POSIX_COND_INITIALIZER \
-        ( ( ( pthread_cond_internal_t )     \
-        {                                   \
-            .xIsInitialized = pdFALSE,      \
-            .xCondMutex = { { 0 } },        \
-            .xCondWaitSemaphore = { { 0 } },\
-            .iWaitingThreads = 0            \
-        }                                   \
-          )                                 \
-        )
-#endif
+/**
+ * @brief Compile-time initializer of pthread_cond_internal_t.
+ */
+
+        #define FREERTOS_POSIX_COND_INITIALIZER \
+    ( ( ( pthread_cond_internal_t )             \
+    {                                           \
+        .xIsInitialized = pdFALSE,              \
+        .xCondWaitSemaphore = { { 0 } },        \
+        .iWaitingThreads = 0                    \
+    }                                           \
+        )                                       \
+    )
+
+#endif /* if posixconfigENABLE_PTHREAD_COND_T == 1 */
 
 #if posixconfigENABLE_SEM_T == 1
-    /**
-     * @brief Semaphore type.
-     */
+
+/**
+ * @brief Semaphore type.
+ */
     typedef struct
     {
-        StaticSemaphore_t xSemaphore; /**< FreeRTOS semaphore. */
+        StaticSemaphore_t xSemaphore;   /**< FreeRTOS semaphore. */
+        int value;                      /**< POSIX semaphore count. */
     } sem_internal_t;
-#endif
+#endif /* if posixconfigENABLE_SEM_T == 1 */
 
 #if posixconfigENABLE_PTHREAD_BARRIER_T == 1
-    /**
-     * @brief Barrier object.
-     */
+
+/**
+ * @brief Barrier object.
+ */
     typedef struct pthread_barrier_internal
     {
         unsigned uThreadCount;                   /**< Current number of threads that have entered barrier. */
         unsigned uThreshold;                     /**< The count argument of pthread_barrier_init. */
-        StaticSemaphore_t xThreadCountMutex;     /**< Guards access to uThreadCount. */
         StaticSemaphore_t xThreadCountSemaphore; /**< Prevents more than uThreshold threads from exiting pthread_barrier_wait at once. */
         StaticEventGroup_t xBarrierEventGroup;   /**< FreeRTOS event group that blocks to wait on threads entering barrier. */
     } pthread_barrier_internal_t;
-#endif
+#endif /* if posixconfigENABLE_PTHREAD_BARRIER_T == 1 */
 
 #endif /* _FREERTOS_POSIX_INTERNAL_H_ */

--- a/lib/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h
+++ b/lib/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h
@@ -75,7 +75,7 @@
     #define NAME_MAX             64                                               /**< Maximum number of bytes in a filename (not including terminating null). */
 #endif
 #ifndef SEM_VALUE_MAX
-    #define SEM_VALUE_MAX        0xFFFFU                                          /**< Maximum value of a sem_t. */
+    #define SEM_VALUE_MAX        0x7FFFU                                          /**< Maximum value of a sem_t. */
 #endif
 /**@} */
 

--- a/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
+++ b/lib/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
@@ -37,6 +37,8 @@
 #include "FreeRTOS_POSIX/pthread.h"
 #include "FreeRTOS_POSIX/utils.h"
 
+#include "atomic.h"
+
 /**
  * @brief Initialize a PTHREAD_COND_INITIALIZER cond.
  *
@@ -67,7 +69,6 @@ static void prvInitializeStaticCond( pthread_cond_internal_t * pxCond )
             /* Set the members of the cond. The semaphore create calls will never fail
              * when their arguments aren't NULL. */
             pxCond->xIsInitialized = pdTRUE;
-            ( void ) xSemaphoreCreateMutexStatic( &pxCond->xCondMutex );
             ( void ) xSemaphoreCreateCountingStatic( INT_MAX, 0U, &pxCond->xCondWaitSemaphore );
             pxCond->iWaitingThreads = 0;
         }
@@ -87,21 +88,28 @@ int pthread_cond_broadcast( pthread_cond_t * cond )
     /* If the cond is uninitialized, perform initialization. */
     prvInitializeStaticCond( pxCond );
 
-    /* Lock xCondMutex to protect access to iWaitingThreads.
-     * This call will never fail because it blocks forever. */
-    ( void ) xSemaphoreTake( ( SemaphoreHandle_t ) &pxCond->xCondMutex, portMAX_DELAY );
+    /* Local copy of number of threads waiting. */
+    unsigned iLocalWaitingThreads = pxCond->iWaitingThreads;
 
-    /* Unblock all threads waiting on this condition variable. */
-    for( i = 0; i < pxCond->iWaitingThreads; i++ )
+    /* Test local copy of threads waiting is larger than zero. */
+    while( iLocalWaitingThreads > 0 )
     {
-        ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondWaitSemaphore );
+        /* Test-and-set. Atomically check whether the copy in memory has changed.
+         * And, if not set the copy of threads waiting in memory to zero. */
+        if( ATOMIC_COMPARE_AND_SWAP_SUCCESS == Atomic_CompareAndSwap_u32( ( uint32_t * ) &pxCond->iWaitingThreads, 0, ( uint32_t ) iLocalWaitingThreads ) )
+        {
+            /* Unblock all. */
+            for( i = 0; i < iLocalWaitingThreads; i++ )
+            {
+                ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondWaitSemaphore );
+            }
+        }
+        else
+        {
+            /* Local copy is out dated. Reload, and retry. */
+            iLocalWaitingThreads = pxCond->iWaitingThreads;
+        }
     }
-
-    /* All threads were unblocked, set waiting threads to 0. */
-    pxCond->iWaitingThreads = 0;
-
-    /* Release xCondMutex. */
-    ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondMutex );
 
     return 0;
 }
@@ -113,7 +121,6 @@ int pthread_cond_destroy( pthread_cond_t * cond )
     pthread_cond_internal_t * pxCond = ( pthread_cond_internal_t * ) ( cond );
 
     /* Free all resources in use by the cond. */
-    vSemaphoreDelete( ( SemaphoreHandle_t ) &pxCond->xCondMutex );
     vSemaphoreDelete( ( SemaphoreHandle_t ) &pxCond->xCondWaitSemaphore );
 
     return 0;
@@ -140,7 +147,7 @@ int pthread_cond_init( pthread_cond_t * cond,
         /* Set the members of the cond. The semaphore create calls will never fail
          * when their arguments aren't NULL. */
         pxCond->xIsInitialized = pdTRUE;
-        ( void ) xSemaphoreCreateMutexStatic( &pxCond->xCondMutex );
+
         ( void ) xSemaphoreCreateCountingStatic( INT_MAX, 0U, &pxCond->xCondWaitSemaphore );
         pxCond->iWaitingThreads = 0;
     }
@@ -157,25 +164,27 @@ int pthread_cond_signal( pthread_cond_t * cond )
     /* If the cond is uninitialized, perform initialization. */
     prvInitializeStaticCond( pxCond );
 
-    /* Check that at least one thread is waiting for a signal. */
-    if( pxCond->iWaitingThreads > 0 )
-    {
-        /* Lock xCondMutex to protect access to iWaitingThreads.
-         * This call will never fail because it blocks forever. */
-        ( void ) xSemaphoreTake( ( SemaphoreHandle_t ) &pxCond->xCondMutex, portMAX_DELAY );
+    /* Local copy of number of threads waiting. */
+    unsigned iLocalWaitingThreads = pxCond->iWaitingThreads;
 
-        /* Check again that at least one thread is waiting for a signal after
-         * taking xCondMutex. If so, unblock it. */
-        if( pxCond->iWaitingThreads > 0 )
+    /* Test local copy of threads waiting is larger than zero. */
+    while( iLocalWaitingThreads > 0 )
+    {
+        /* Test-and-set. Atomically check whether the copy in memory has changed.
+         * And, if not decrease the copy of threads waiting in memory. */
+        if( ATOMIC_COMPARE_AND_SWAP_SUCCESS == Atomic_CompareAndSwap_u32( ( uint32_t * ) &pxCond->iWaitingThreads, ( uint32_t ) iLocalWaitingThreads - 1, ( uint32_t ) iLocalWaitingThreads ) )
         {
+            /* Unblock one. */
             ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondWaitSemaphore );
 
-            /* Decrease the number of waiting threads. */
-            pxCond->iWaitingThreads--;
+            /* Signal one succeeded. Break. */
+            break;
         }
-
-        /* Release xCondMutex. */
-        ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondMutex );
+        else
+        {
+            /* Local copy is out dated. Reload, and retry. */
+            iLocalWaitingThreads = pxCond->iWaitingThreads;
+        }
     }
 
     return 0;
@@ -214,9 +223,7 @@ int pthread_cond_timedwait( pthread_cond_t * cond,
      * unlock mutex. */
     if( iStatus == 0 )
     {
-        ( void ) xSemaphoreTake( ( SemaphoreHandle_t ) &pxCond->xCondMutex, portMAX_DELAY );
-        pxCond->iWaitingThreads++;
-        ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondMutex );
+        ( void ) Atomic_Increment_u32( ( uint32_t * ) &pxCond->iWaitingThreads );
 
         iStatus = pthread_mutex_unlock( mutex );
     }
@@ -236,9 +243,7 @@ int pthread_cond_timedwait( pthread_cond_t * cond,
             iStatus = ETIMEDOUT;
             ( void ) pthread_mutex_lock( mutex );
 
-            ( void ) xSemaphoreTake( ( SemaphoreHandle_t ) &pxCond->xCondMutex, portMAX_DELAY );
-            pxCond->iWaitingThreads--;
-            ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxCond->xCondMutex );
+            ( void ) Atomic_Decrement_u32( ( uint32_t * ) &pxCond->iWaitingThreads );
         }
     }
 

--- a/lib/common/iot_taskpool.c
+++ b/lib/common/iot_taskpool.c
@@ -58,7 +58,7 @@
 /**
  * @brief Maximum semaphore value for wait operations.
  */
-#define TASKPOOL_MAX_SEM_VALUE              0xFFFF
+#define TASKPOOL_MAX_SEM_VALUE              0x7FFFU
 
 /**
  * @brief Reschedule delay in milliseconds for deferred jobs.

--- a/lib/include/atomic.h
+++ b/lib/include/atomic.h
@@ -1,0 +1,541 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file atomic.h
+ * @brief FreeRTOS atomic operation support.
+ *
+ * Two implementations of atomic are given in this header file:
+ * 1. Disabling interrupt globally.
+ * 2. ISA native atomic support.
+ * The former is available to all ports (compiler-architecture combination),
+ * while the latter is only available to ports compiling with GCC (version at
+ * least 4.7.0), which also have ISA atomic support.
+ *
+ * User can select which implementation to use by:
+ * setting/clearing configUSE_ATOMIC_INSTRUCTION in FreeRTOSConfig.h.
+ * Define AND set configUSE_ATOMIC_INSTRUCTION to 1 for ISA native atomic support.
+ * Undefine OR clear configUSE_ATOMIC_INSTRUCTION for disabling global interrupt
+ * implementation.
+ *
+ * @see GCC Built-in Functions for Memory Model Aware Atomic Operations
+ *      https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
+ */
+
+#ifndef ATOMIC_H
+#define ATOMIC_H
+
+#ifndef INC_FREERTOS_H
+    #error "include FreeRTOS.h must appear in source files before include atomic.h"
+#endif
+
+/* Standard includes. */
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    /* Needed for __atomic_compare_exchange() weak=false. */
+    #include <stdbool.h>
+
+    /* This branch is for GCC compiler and GCC compiler only. */
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE  inline __attribute__((always_inline))
+    #endif
+
+#else
+
+    /* Port specific definitions -- entering/exiting critical section.
+     * Refer template -- ./lib/FreeRTOS/portable/Compiler/Arch/portmacro.h
+     *
+     * Every call to ATOMIC_EXIT_CRITICAL() must be closely paired with
+     * ATOMIC_ENTER_CRITICAL().
+     */
+    #if defined( portSET_INTERRUPT_MASK_FROM_ISR )
+
+        /* Nested interrupt scheme is supported in this port. */
+        #define ATOMIC_ENTER_CRITICAL()     \
+            UBaseType_t uxCriticalSectionType = portSET_INTERRUPT_MASK_FROM_ISR()
+
+        #define ATOMIC_EXIT_CRITICAL()      \
+            portCLEAR_INTERRUPT_MASK_FROM_ISR( uxCriticalSectionType )
+
+    #else
+
+        /* Nested interrupt scheme is NOT supported in this port. */
+        #define ATOMIC_ENTER_CRITICAL()     portENTER_CRITICAL()
+        #define ATOMIC_EXIT_CRITICAL()      portEXIT_CRITICAL()
+
+    #endif /* portSET_INTERRUPT_MASK_FROM_ISR() */
+
+    /* Port specific definition -- "always inline". 
+     * Inline is compiler specific, and may not always get inlined depending on your optimization level. 
+     * Also, inline is considerred as performance optimization for atomic. 
+     * Thus, if portFORCE_INLINE is not provided by portmacro.h, instead of resulting error,
+     * simply define it. 
+     */
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE 
+    #endif
+
+#endif /* configUSE_GCC_BUILTIN_ATOMICS */
+
+#define ATOMIC_COMPARE_AND_SWAP_SUCCESS     0x1U        /**< Compare and swap succeeded, swapped. */
+#define ATOMIC_COMPARE_AND_SWAP_FAILURE     0x0U        /**< Compare and swap failed, did not swap. */
+
+/*----------------------------- Swap && CAS ------------------------------*/
+
+/**
+ * Atomic compare-and-swap
+ *
+ * @brief Performs an atomic compare-and-swap operation on the specified values.
+ *
+ * @param[in, out] pDestination  Pointer to memory location from where value is
+ *                               to be loaded and checked.
+ * @param[in] ulExchange         If condition meets, write this value to memory.
+ * @param[in] ulComparand        Swap condition.
+ *
+ * @return Unsigned integer of value 1 or 0. 1 for swapped, 0 for not swapped.
+ *
+ * @note This function only swaps *pDestination with ulExchange, if previous
+ *       *pDestination value equals ulComparand.
+ */
+static portFORCE_INLINE uint32_t Atomic_CompareAndSwap_u32(
+        uint32_t volatile * pDestination,
+        uint32_t ulExchange,
+        uint32_t ulComparand )
+{
+
+    uint32_t ulReturnValue = ATOMIC_COMPARE_AND_SWAP_FAILURE;
+
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    if ( __atomic_compare_exchange( pDestination,
+                                    &ulComparand,
+                                    &ulExchange,
+                                    false,
+                                    __ATOMIC_SEQ_CST,
+                                    __ATOMIC_SEQ_CST ) )
+    {
+        ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+    }
+
+#else
+
+    ATOMIC_ENTER_CRITICAL();
+
+    if ( *pDestination == ulComparand )
+    {
+        *pDestination = ulExchange;
+        ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+    }
+
+    ATOMIC_EXIT_CRITICAL();
+
+#endif
+
+    return ulReturnValue;
+
+}
+
+/**
+ * Atomic swap (pointers)
+ *
+ * @brief Atomically sets the address pointed to by *ppDestination to the value
+ *        of *pExchange.
+ *
+ * @param[in, out] ppDestination  Pointer to memory location from where a pointer
+ *                                value is to be loaded and written back to.
+ * @param[in] pExchange           Pointer value to be written to *ppDestination.
+ *
+ * @return The initial value of *ppDestination.
+ */
+static portFORCE_INLINE void * Atomic_SwapPointers_p32(
+        void * volatile * ppDestination,
+        void * pExchange )
+{
+    void * pReturnValue;
+
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    __atomic_exchange( ppDestination, &pExchange, &pReturnValue, __ATOMIC_SEQ_CST );
+
+#else
+
+    ATOMIC_ENTER_CRITICAL();
+
+    pReturnValue = *ppDestination;
+
+    *ppDestination = pExchange;
+
+    ATOMIC_EXIT_CRITICAL();
+
+#endif
+
+    return pReturnValue;
+}
+
+/**
+ * Atomic compare-and-swap (pointers)
+ *
+ * @brief Performs an atomic compare-and-swap operation on the specified pointer
+ *        values.
+ *
+ * @param[in, out] ppDestination  Pointer to memory location from where a pointer
+ *                                value is to be loaded and checked.
+ * @param[in] pExchange           If condition meets, write this value to memory.
+ * @param[in] pComparand          Swap condition.
+ *
+ * @return Unsigned integer of value 1 or 0. 1 for swapped, 0 for not swapped.
+ *
+ * @note This function only swaps *ppDestination with pExchange, if previous
+ *       *ppDestination value equals pComparand.
+ */
+static portFORCE_INLINE uint32_t Atomic_CompareAndSwapPointers_p32(
+        void * volatile * ppDestination,
+        void * pExchange, void * pComparand )
+{
+    uint32_t ulReturnValue = ATOMIC_COMPARE_AND_SWAP_FAILURE;
+
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+    if ( __atomic_compare_exchange( ppDestination,
+                                    &pComparand,
+                                    &pExchange,
+                                    false,
+                                    __ATOMIC_SEQ_CST,
+                                    __ATOMIC_SEQ_CST ) )
+    {
+        ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+    }
+
+#else
+
+    ATOMIC_ENTER_CRITICAL();
+
+    if ( *ppDestination == pComparand )
+    {
+        *ppDestination = pExchange;
+        ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+    }
+
+    ATOMIC_EXIT_CRITICAL();
+
+#endif
+
+    return ulReturnValue;
+}
+
+
+/*----------------------------- Arithmetic ------------------------------*/
+
+/**
+ * Atomic add
+ *
+ * @brief Atomically adds count to the value of the specified pointer points to.
+ *
+ * @param[in,out] pAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ * @param[in] ulCount      Value to be added to *pAddend.
+ *
+ * @return previous *pAddend value.
+ */
+static portFORCE_INLINE uint32_t Atomic_Add_u32(
+        uint32_t volatile * pAddend,
+        uint32_t ulCount )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_add(pAddend, ulCount, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pAddend;
+
+    *pAddend += ulCount;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic subtract
+ *
+ * @brief Atomically subtracts count from the value of the specified pointer
+ *        pointers to.
+ *
+ * @param[in,out] pAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ * @param[in] ulCount      Value to be subtract from *pAddend.
+ *
+ * @return previous *pAddend value.
+ */
+static portFORCE_INLINE uint32_t Atomic_Subtract_u32(
+        uint32_t volatile * pAddend,
+        uint32_t ulCount )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_sub(pAddend, ulCount, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pAddend;
+
+    *pAddend -= ulCount;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic increment
+ *
+ * @brief Atomically increments the value of the specified pointer points to.
+ *
+ * @param[in,out] pAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ *
+ * @return *pAddend value before increment.
+ */
+static portFORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAddend )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_add(pAddend, 1, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pAddend;
+
+    *pAddend += 1;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic decrement
+ *
+ * @brief Atomically decrements the value of the specified pointer points to
+ *
+ * @param[in,out] pAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ *
+ * @return *pAddend value before decrement.
+ */
+static portFORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pAddend )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_sub(pAddend, 1, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pAddend;
+
+    *pAddend -= 1;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/*----------------------------- Bitwise Logical ------------------------------*/
+
+/**
+ * Atomic OR
+ *
+ * @brief Performs an atomic OR operation on the specified values.
+ *
+ * @param [in, out] pDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be ORed with *pDestination.
+ *
+ * @return The original value of *pDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_OR_u32(
+        uint32_t volatile * pDestination,
+        uint32_t ulValue )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_or(pDestination, ulValue, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pDestination;
+
+    *pDestination |= ulValue;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic AND
+ *
+ * @brief Performs an atomic AND operation on the specified values.
+ *
+ * @param [in, out] pDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be ANDed with *pDestination.
+ *
+ * @return The original value of *pDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_AND_u32(
+        uint32_t volatile * pDestination,
+        uint32_t ulValue )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_and(pDestination, ulValue, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pDestination;
+
+    *pDestination &= ulValue;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic NAND
+ *
+ * @brief Performs an atomic NAND operation on the specified values.
+ *
+ * @param [in, out] pDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be NANDed with *pDestination.
+ *
+ * @return The original value of *pDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_NAND_u32(
+        uint32_t volatile * pDestination,
+        uint32_t ulValue )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_nand(pDestination, ulValue, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pDestination;
+
+    *pDestination = ~(ulCurrent & ulValue);
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+/**
+ * Atomic XOR
+ *
+ * @brief Performs an atomic XOR operation on the specified values.
+ *
+ * @param [in, out] pDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be XORed with *pDestination.
+ *
+ * @return The original value of *pDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_XOR_u32(
+        uint32_t volatile * pDestination,
+        uint32_t ulValue )
+{
+#if defined ( configUSE_GCC_BUILTIN_ATOMICS ) && ( configUSE_GCC_BUILTIN_ATOMICS == 1 )
+
+    return __atomic_fetch_xor(pDestination, ulValue, __ATOMIC_SEQ_CST);
+
+#else
+
+    uint32_t ulCurrent;
+
+    ATOMIC_ENTER_CRITICAL();
+
+    ulCurrent = *pDestination;
+
+    *pDestination ^= ulValue;
+
+    ATOMIC_EXIT_CRITICAL();
+
+    return ulCurrent;
+
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATOMIC_H */

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj
@@ -93,6 +93,7 @@
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_mem.h" />
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_string.h" />
     <ClInclude Include="..\..\..\..\lib\cbor\src\aws_cbor_types.h" />
+    <ClInclude Include="..\..\..\..\lib\include\atomic.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\aws_iot_defender.h" />
     <ClInclude Include="..\..\..\..\lib\include\iot_common.h" />

--- a/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
+++ b/tests/pc/windows/visual_studio/aws_tests.vcxproj.filters
@@ -840,6 +840,9 @@
     <ClInclude Include="..\..\..\..\lib\include\platform\iot_metrics.h">
       <Filter>lib\aws\include\platform</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\lib\include\atomic.h">
+      <Filter>lib\aws\include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\lib\third_party\unity\extras\fixture\src\unity_fixture.c">


### PR DESCRIPTION
Atomic & POSIX with atomic.

Description
-----------
- ```atomic.h``` header. 
   post previous review:
(1) added macro ```ATOMIC_COMPARE_AND_SWAP_SUCCESS```/```ATOMIC_COMPARE_AND_SWAP_FAILURE```.
(2) CAS API returns type uint32_t, which indicates swapped or not, instead of previous value. 
(3) if ```portmacro.h``` does not provide compiler specific force inline, don't inline. 
- POSIX barrier, pthread mutex condition, and semaphore are updated. (```pthread_cond_broadcast()``` and ```pthread_cond_signal()``` would be fun to review, CAS is involved. To see which mutexes are removed, ```FreeRTOS_POSIX_internal.h```)
- POSIX semaphore maximum allowed value got updated, since POSIX requires sem value to be int, and atomic is using uint32_t.
- Task pool maximum allowed semaphore value also got updated due to above.
- windows port test project and project filter.

### !!!Note for reviewers!!!
- Before rebasing with most recent feature/ble-beta branch, this commit was built on WinSim port and passed POSIX test suite and memory leak test. Though our tests don't do much.
- <del>WinSim port test project currently doesn't built after rebase. I will create another PR to fix.</del> 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.