### PR TITLE
define/undefine metrics macro to all secure sockets implementations

### DIFF
--- a/lib/secure_sockets/portable/infineon/xmc4800_iotkit/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/infineon/xmc4800_iotkit/aws_secure_sockets.c
@@ -33,6 +33,10 @@
  * @brief WiFi and Secure Socket interface implementation.
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
@@ -49,6 +53,8 @@
 
 /* WiFi configuration includes. */
 #include "aws_wifi_config.h"
+
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /**
  * @brief A Flag to indicate whether or not a socket is

--- a/lib/secure_sockets/portable/lwip/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/lwip/aws_secure_sockets.c
@@ -29,6 +29,10 @@
  * @brief WiFi and Secure Socket interface implementation.
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
 /* Socket and WiFi interface includes. */
 #include "aws_secure_sockets.h"
 
@@ -45,6 +49,8 @@
 #include "task.h"
 
 #include <stdbool.h>
+
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /*-----------------------------------------------------------*/
 

--- a/lib/secure_sockets/portable/nxp/lpc54018iotmodule/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/nxp/lpc54018iotmodule/aws_secure_sockets.c
@@ -27,6 +27,9 @@
  * Copyright (C) NXP 2017.
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -43,6 +46,7 @@
 #include "custom_stack_offload.h"
 #include "atheros_stack_offload.h"
 
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /**
  * @brief Flag indicating that socket send operations are not permitted.

--- a/lib/secure_sockets/portable/st/stm32l475_discovery/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/st/stm32l475_discovery/aws_secure_sockets.c
@@ -29,6 +29,10 @@
  * @brief WiFi and Secure Socket interface implementation for ST board.
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
@@ -51,6 +55,8 @@
 /* Credentials includes. */
 #include "aws_clientcredential.h"
 #include "aws_default_root_certificates.h"
+
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /**
  * @brief A Flag to indicate whether or not a socket is

--- a/lib/secure_sockets/portable/ti/cc3220_launchpad/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/ti/cc3220_launchpad/aws_secure_sockets.c
@@ -23,6 +23,10 @@
  * http://www.FreeRTOS.org
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
 /* Standard includes. */
 #include <stdint.h>
 #include <stdio.h>
@@ -43,7 +47,7 @@
 #include "aws_clientcredential.h"
 #include "aws_default_root_certificates.h"
 
-
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 #define SOCKETS_PRINT( X )               vLoggingPrintf X
 

--- a/lib/secure_sockets/portable/vendor/board/aws_secure_sockets.c
+++ b/lib/secure_sockets/portable/vendor/board/aws_secure_sockets.c
@@ -28,8 +28,14 @@
  * @brief WiFi and Secure Socket interface implementation.
  */
 
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in aws_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
 /* Socket and WiFi interface includes. */
 #include "aws_secure_sockets.h"
+
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- define/undefine _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE, so that the implementation of aws_secure_sockets refer to the normal socket functions

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
