### PR TITLE
Fix multithreaded subscription test on Nordic

### DIFF
--- a/lib/utils/platform/iot_threads_afr.c
+++ b/lib/utils/platform/iot_threads_afr.c
@@ -326,7 +326,7 @@ bool IotSemaphore_TimedWait( IotSemaphore_t * pSemaphore,
 
     /* Take the semaphore using the FreeRTOS API. Cast the calculation to 64 bit to avoid overflows*/
     if( xSemaphoreTake( ( SemaphoreHandle_t ) &internalSemaphore->xSemaphore,
-                        ( uint64_t ) timeoutMs * configTICK_RATE_HZ / 1000 ) != pdTRUE )
+                        pdMS_TO_TICKS( timeoutMs ) ) != pdTRUE )
     {
         /* Only warn if timeout > 0 */
         if( timeoutMs > 0 )

--- a/tests/nordic/nrf52840-dk/common/config_files/FreeRTOSConfig.h
+++ b/tests/nordic/nrf52840-dk/common/config_files/FreeRTOSConfig.h
@@ -65,7 +65,7 @@
 #define configTICK_RATE_HZ                                                        100
 #define configMAX_PRIORITIES                                                      ( 15 )
 #define configMINIMAL_STACK_SIZE                                                  ( 600 )
-#define configTOTAL_HEAP_SIZE                                                     ( 160000 )
+#define configTOTAL_HEAP_SIZE                                                     ( 175000 )
 #define configMAX_TASK_NAME_LEN                                                   ( 15 )
 #define configUSE_16_BIT_TICKS                                                    0
 #define configIDLE_SHOULD_YIELD                                                   1

--- a/tests/nordic/nrf52840-dk/common/config_files/iot_test_config.h
+++ b/tests/nordic/nrf52840-dk/common/config_files/iot_test_config.h
@@ -29,10 +29,10 @@
 
 /* Uncomment one of these definitions to override the log level configuration for
  * a specific library. */
-#define IOT_LOG_LEVEL_PLATFORM               IOT_LOG_INFO
-#define IOT_LOG_LEVEL_NETWORK                IOT_LOG_INFO
-#define IOT_LOG_LEVEL_MQTT                   IOT_LOG_INFO
-#define AWS_IOT_LOG_LEVEL_SHADOW             IOT_LOG_INFO
+#define IOT_LOG_LEVEL_PLATFORM               IOT_LOG_NONE
+#define IOT_LOG_LEVEL_NETWORK                IOT_LOG_NONE
+#define IOT_LOG_LEVEL_MQTT                   IOT_LOG_NONE
+#define AWS_IOT_LOG_LEVEL_SHADOW             IOT_LOG_NONE
 
 extern bool IotBleMqtt_InitSerialize( void );
 extern void IotBleMqtt_CleanupSerialize( void );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix MQTT "multithreaded subscription" test on Nordic.  Was running out of memory when creating threads.  Increased FreeRTOS heap size on Nordic by 15KB.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
