### PR TITLE
init metrics library in socket init when enabled

### DIFF
--- a/lib/common/iot_common.c
+++ b/lib/common/iot_common.c
@@ -30,9 +30,6 @@
 /* Task pool include. */
 #include "iot_taskpool.h"
 
-/* Metrics include. */
-#include "platform/iot_metrics.h"
-
 /* Static memory include (if dynamic memory allocation is disabled). */
 #include "private/iot_static_memory.h"
 
@@ -56,11 +53,6 @@ bool IotCommon_Init( void )
     _IOT_FUNCTION_ENTRY( bool, true );
     IotTaskPoolError_t taskPoolStatus = IOT_TASKPOOL_SUCCESS;
     IotTaskPoolInfo_t taskPoolInfo = IOT_TASKPOOL_INFO_INITIALIZER_LARGE;
-
-    if (status == true)
-    {
-        status = IotMetrics_Init();
-    }
 
     /* Initialize static memory if dynamic memory allocation is disabled. */
     #if IOT_STATIC_MEMORY_ONLY == 1

--- a/lib/include/private/aws_secure_sockets_wrapper_metrics.h
+++ b/lib/include/private/aws_secure_sockets_wrapper_metrics.h
@@ -38,6 +38,7 @@
 /* This macro is included in aws_secure_socket.c and aws_secure_socket_wrapper_metrics.c.
  * It will prevent the redefine in those source files. */
     #ifndef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+        #define SOCKETS_Init        Sockets_MetricsInit
         #define SOCKETS_Connect     Sockets_MetricsConnect
         #define SOCKETS_Shutdown    Sockets_MetricsShutdown
     #endif

--- a/lib/secure_sockets/aws_secure_sockets_wrapper_metrics.c
+++ b/lib/secure_sockets/aws_secure_sockets_wrapper_metrics.c
@@ -49,6 +49,20 @@
 
 /*-----------------------------------------------------------*/
 
+    BaseType_t Sockets_MetricsInit( void )
+    {
+        BaseType_t result = SOCKETS_Init();
+
+        if( result == pdTRUE )
+        {
+            result = IotMetrics_Init() ? pdTRUE : pdFALSE;
+        }
+
+        return result;
+    }
+
+/*-----------------------------------------------------------*/
+
     int32_t Sockets_MetricsConnect( Socket_t xSocket,
                                     SocketsSockaddr_t * pxAddress,
                                     Socklen_t xAddressLength )

--- a/lib/utils/aws_system_init.c
+++ b/lib/utils/aws_system_init.c
@@ -27,9 +27,8 @@
 
 #include "FreeRTOS.h"
 #include "aws_system_init.h"
+#include "aws_secure_sockets.h"
 
-/* Library code. */
-extern BaseType_t SOCKETS_Init( void );
 
 /*-----------------------------------------------------------*/
 

--- a/tests/pc/windows/common/config_files/iot_test_config.h
+++ b/tests/pc/windows/common/config_files/iot_test_config.h
@@ -28,9 +28,6 @@
 /* Library logging configuration. */
 #define IOT_LOG_LEVEL_GLOBAL    IOT_LOG_NONE
 
-/* Enable socket metrics for defender tests. */
-#define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED
-
 /* Include the default configuration file at the bottom of this file. */
 #include "iot_config_common.h"
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- remove metrics from IotCommon_Init
- map socket init to socket-metrics-init when metrics is enabled
- update aws_system_init.c to include aws_secure_socket header instead of linking extern function

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
