### PR TITLE
Check for EWOULDBLOCK on timeout

### DIFF
--- a/demos/common/include/iot_config_common.h
+++ b/demos/common/include/iot_config_common.h
@@ -34,7 +34,7 @@
 #define IOT_SDK_VERSION    "4.0.0"
 
 /* Standard library function overrides. */
-#define IotLogging_Puts( str )                 configPRINTF( ( "%s\n", str ) )
+#define IotLogging_Puts( str )                 configPRINTF( ( "%s\r\n", str ) )
 #define IotContainers_Assert( expression )     configASSERT( expression )
 #define IotMqtt_Assert( expression )           configASSERT( expression )
 

--- a/lib/utils/platform/iot_network_afr.c
+++ b/lib/utils/platform/iot_network_afr.c
@@ -130,14 +130,19 @@ static void _networkReceiveTask( void * pArgument )
                                          &( pNetworkConnection->bufferedByte ),
                                          1,
                                          0 );
-        } while( socketStatus == 0 );
 
-        connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
+            /* On a timeout, check if the connection was closed. */
+            if( socketStatus == 0 )
+            {
+                connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
 
-        if( ( connectionFlags & _FLAG_SHUTDOWN ) == _FLAG_SHUTDOWN )
-        {
-            socketStatus = SOCKETS_ECLOSED;
-        }
+                if( ( connectionFlags & _FLAG_SHUTDOWN ) == _FLAG_SHUTDOWN )
+                {
+                    socketStatus = SOCKETS_ECLOSED;
+                }
+            }
+        /* Check for timeout. Some ports return 0, some return EWOULDBLOCK. */
+        } while( ( socketStatus == 0 ) || ( socketStatus == SOCKETS_EWOULDBLOCK ) );
 
         if( socketStatus <= 0 )
         {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Secure sockets is inconsistent and returns either 0 or `EWOULDBLOCK` on timeout, depending on the port.  Change the network layer to check for both values.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
