### PR TITLE
fix: ESP WIFI_GetMac returning wrong mac.

### DIFF
--- a/lib/wifi/portable/espressif/esp32_devkitc_esp_wrover_kit/aws_wifi.c
+++ b/lib/wifi/portable/espressif/esp32_devkitc_esp_wrover_kit/aws_wifi.c
@@ -591,7 +591,23 @@ WIFIReturnCode_t WIFI_GetMAC( uint8_t * pucMac )
     /* Try to acquire the semaphore. */
     if( xSemaphoreTake( xWiFiSem, xSemaphoreWaitTicks ) == pdTRUE )
     {
-        esp_err_t ret = esp_wifi_get_mac(WIFI_MODE_STA, pucMac);
+        wifi_mode_t mode;
+        esp_err_t ret = esp_wifi_get_mode(&mode);
+        if( ret == ESP_OK )
+        {
+            if( mode == WIFI_MODE_STA )
+            {
+                ret = esp_wifi_get_mac(WIFI_IF_STA, pucMac);
+            }
+            else if( mode == WIFI_MODE_AP )
+            {
+                ret = esp_wifi_get_mac(WIFI_IF_AP, pucMac);
+            }
+            else
+            {
+                ret = ESP_ERR_INVALID_ARG;
+            }
+        }
         xRetVal = (ret == ESP_OK) ? eWiFiSuccess : eWiFiFailure;
         /* Return the semaphore. */
         xSemaphoreGive( xWiFiSem );


### PR DESCRIPTION
ESP WIFI_GetMac was calling esp_wifi_get_mac with wrong argument.

# Related Issues:
https://github.com/aws/amazon-freertos/issues/452



<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
