### PR TITLE
Fixing syntax error ( Issue#482 )

### DIFF
--- a/demos/common/network_manager/aws_iot_network_manager.c
+++ b/demos/common/network_manager/aws_iot_network_manager.c
@@ -355,11 +355,11 @@ static bool _wifiConnectAccessPoint( void )
     bool ret = true;
     static const WIFINetworkParams_t network =
     {
-        .pcSSID           = clientcredentialWIFI_SSID;
-        .ucSSIDLength     = sizeof(clientcredentialWIFI_SSID);
-        .pcPassword       = clientcredentialWIFI_PASSWORD;
-        .ucPasswordLength = sizeof(clientcredentialWIFI_PASSWORD);
-        .xSecurity        = clientcredentialWIFI_SECURITY;
+        .pcSSID           = clientcredentialWIFI_SSID,
+        .ucSSIDLength     = sizeof(clientcredentialWIFI_SSID),
+        .pcPassword       = clientcredentialWIFI_PASSWORD,
+        .ucPasswordLength = sizeof(clientcredentialWIFI_PASSWORD),
+        .xSecurity        = clientcredentialWIFI_SECURITY
     };
 
     /* Setup parameters. */


### PR DESCRIPTION
Fixing syntax error in network manager

Description
-----------
Fixing syntax error in network manager with WIFI provisioning disabled.
Tested with all the configurations.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
