### PR TITLE
tools: Fix when we enable s3 bucket versioning.

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_aws_agent.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_aws_agent.py
@@ -725,11 +725,12 @@ class AWSS3Bucket:
                         'LocationConstraint': boto3.session.Session().region_name
                     }
                 )
+            self._s3_client.BucketVersioning(self.s3_name).enable();
+            
         # If the bucket exists we want to make sure it is in the right region for the AWS development stage.
         if response and self._stageParams:
             if response['ResponseMetadata']['HTTPHeaders']['x-amz-bucket-region'] != 'us-east-1':
                 raise Exception('ERROR: Please delete S3 bucket {} because it is in region {}, and rerun this script. This script does not delete the bucket because after deleting the bucket it takes 1+ hours for a bucket of the same name of be made again.'.format(self.s3_name, response['ResponseMetadata']['HTTPHeaders']['x-amz-bucket-region']))
-        self._s3_client.BucketVersioning(self.s3_name).enable();
 
     def upload_file(self, file_path, file_name):
         self._s3_client.Bucket(self.s3_name).upload_file(file_path, file_name)


### PR DESCRIPTION
* The versioning enabling should happen when we create a bucket.
  It was happening for every initialization previously and causing a potentional
  for conflicting operations.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
