### PR TITLE
fix: Cypress build error on IDE

### DIFF
--- a/lib/pkcs11/portable/cypress/CYW943907AEVAL1F/hw_poll.c
+++ b/lib/pkcs11/portable/cypress/CYW943907AEVAL1F/hw_poll.c
@@ -42,6 +42,9 @@
  * truly random in nature.
  */
 
+/* Amazon FreeRTOS Includes. */
+#include "FreeRTOS.h"
+
 /* C runtime includes. */
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/pkcs11/portable/cypress/CYW954907AEVAL1F/hw_poll.c
+++ b/lib/pkcs11/portable/cypress/CYW954907AEVAL1F/hw_poll.c
@@ -42,6 +42,9 @@
  * truly random in nature.
  */
 
+/* Amazon FreeRTOS Includes. */
+#include "FreeRTOS.h"
+
 /* C runtime includes. */
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
The file hw_poll.c complains of unknown type for uint32_t.
Included FreeRTOS.h to fix the error.

- [x ] I have tested my changes. No regression in existing tests.