### PR TITLE
docs: fix OTA pal readme file by removing line that OTA is beta.

### DIFF
--- a/lib/ota/portable/README.md
+++ b/lib/ota/portable/README.md
@@ -1,7 +1,7 @@
 ## Porting
 In order to support Amazon FreeRTOS Over-the-Air Updates (OTA) on your microcontroller, it is necessary to implement the Portable Application Layer (PAL). This subdirectory consists of silicon vendor names that have successfully completed and tested at least one PAL. The PAL interface is defined in lib\include\private\aws_ota_pal.h (relative to the top of the repo).
 
-PAL interface documentation is in https://docs.aws.amazon.com/freertos/latest/userguide/porting-ota-pal.html. However, please note that OTA is still in beta, so the definitive PAL interface reference is the header file. 
+PAL interface documentation is in https://docs.aws.amazon.com/freertos/latest/userguide/porting-ota-pal.html.
 
 ## Unit Testing for an OTA PAL
 


### PR DESCRIPTION

<!--- Title -->
Fix the Readme file in OTA pal.

Description
-----------
<!--- Describe your changes in detail -->
The readme file in OTA pal was still having a statement that OTA is in beta. This changes removes that line in readme as OTA is in GA.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
