### PR TITLE
Move wifi provisioning to taskpool

### DIFF
--- a/demos/common/demo_runner/iot_demo_afr.c
+++ b/demos/common/demo_runner/iot_demo_afr.c
@@ -107,7 +107,6 @@ static void _onNetworkStateChangeCallback( uint32_t network,
                 credentials.pAlpnProtos = NULL;
             }
 
-            IotLogInfo("OnConnected: %d", network);
             pDemoContext->networkConnectedCallback(awsIotMqttMode,
                                                    clientcredentialIOT_THING_NAME,
                                                    &serverInfo,
@@ -121,7 +120,6 @@ static void _onNetworkStateChangeCallback( uint32_t network,
         pDemoContext->connectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
         if( pDemoContext->networkDisconnectedCallback != NULL )
         {
-            IotLogInfo("OnDisconnected: %d", network);
             pNetworkInterface = AwsIotNetworkManager_GetNetworkInterface(network);
             pDemoContext->networkDisconnectedCallback(pNetworkInterface);
         }
@@ -137,8 +135,6 @@ static void _onNetworkStateChangeCallback( uint32_t network,
             {
                 credentials.pAlpnProtos = NULL;
             }
-
-            IotLogInfo("OnConnected: %d", networkAvailable);
 
             pDemoContext->networkConnectedCallback( awsIotMqttMode,
                                                    clientcredentialIOT_THING_NAME,
@@ -193,7 +189,7 @@ static int _initializeDemo( demoContext_t* pContext )
     /* Enable all the transport type networks used by the demo application. */
     if(status == EXIT_SUCCESS)
     {
-        if( AwsIotNetworkManager_EnableNetwork( pContext->networkTypes ) != pContext->networkTypes )
+        if( AwsIotNetworkManager_EnableNetwork( configENABLED_NETWORKS ) != configENABLED_NETWORKS )
         {
             IotLogError("Failed to enable all the networks required by the demo application.");
             status = EXIT_FAILURE;

--- a/lib/bluetooth_low_energy/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/lib/bluetooth_low_energy/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -615,26 +615,33 @@ static bool _handleListNetworkRequest( uint8_t * pData,
         memset( &wifiProvisioning.listNetworkRequest, 0x00, sizeof( IotBleListNetworkRequest_t ) );
         status = _deserializeListNetworkRequest( pData, length, &wifiProvisioning.listNetworkRequest );
 
-        taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                      _listNetworkTask,
-                                                      NULL,
-                                                      &pJob );
-        if (taskStatus == IOT_TASKPOOL_SUCCESS)
+        if( status == true )
         {
-            taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
-            if (taskStatus != IOT_TASKPOOL_SUCCESS)
+
+            taskStatus = IotTaskPool_CreateRecyclableJob(IOT_SYSTEM_TASKPOOL,
+                                                         _listNetworkTask,
+                                                         NULL,
+                                                         &pJob);
+            if (taskStatus == IOT_TASKPOOL_SUCCESS)
             {
-                configPRINTF(( "Failed to schedule taskpool job for list network request \r\n" ));
-                IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, pJob );
-                xSemaphoreGive( wifiProvisioning.lock );
+                taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
+                if (taskStatus != IOT_TASKPOOL_SUCCESS)
+                {
+                    configPRINTF(("Failed to schedule taskpool job for list network request \r\n"));
+                    IotTaskPool_RecycleJob(IOT_SYSTEM_TASKPOOL, pJob);
+                    status = false;
+                }
+            }
+            else
+            {
+                configPRINTF(("Failed to allocate taskpool job for list network request \r\n"));
                 status = false;
             }
         }
-        else
+
+        if( status == false )
         {
-            configPRINTF(( "Failed to allocate taskpool job for list network request \r\n" ));
             xSemaphoreGive( wifiProvisioning.lock );
-            status = false;
         }
     }
     else
@@ -835,26 +842,34 @@ static bool _handleSaveNetworkRequest( uint8_t * pData,
         memset( &wifiProvisioning.addNetworkRequest, 0x00, sizeof( IotBleAddNetworkRequest_t ) );
         status = _deserializeAddNetworkRequest( pData, length, &wifiProvisioning.addNetworkRequest );
 
-        taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                      _addNetworkTask,
-                                                      NULL,
-                                                      &pJob );
-        if (taskStatus == IOT_TASKPOOL_SUCCESS)
+        if (status == true)
         {
-            taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
-            if (taskStatus != IOT_TASKPOOL_SUCCESS)
+            taskStatus = IotTaskPool_CreateRecyclableJob(IOT_SYSTEM_TASKPOOL,
+                                                         _addNetworkTask,
+                                                         NULL,
+                                                         &pJob);
+            if (taskStatus == IOT_TASKPOOL_SUCCESS)
             {
-                configPRINTF(( "Failed to schedule taskpool job for add network request \r\n" ));
-                IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, pJob );
-                xSemaphoreGive( wifiProvisioning.lock );
+                taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
+                if (taskStatus != IOT_TASKPOOL_SUCCESS)
+                {
+                    configPRINTF(("Failed to schedule taskpool job for add network request \r\n"));
+                    IotTaskPool_RecycleJob(IOT_SYSTEM_TASKPOOL, pJob);
+                    xSemaphoreGive(wifiProvisioning.lock);
+                    status = false;
+                }
+            }
+            else
+            {
+                configPRINTF(("Failed to allocate taskpool job for add network request \r\n"));
                 status = false;
             }
         }
-        else
+
+        if( status == false )
         {
-            configPRINTF(( "Failed to allocate taskpool job for add network request \r\n" ));
-            xSemaphoreGive( wifiProvisioning.lock );
-            status = false;
+            xSemaphoreGive(wifiProvisioning.lock);
+
         }
     }
     else
@@ -953,26 +968,33 @@ static bool _handleEditNetworkRequest( uint8_t * pData,
         memset( &wifiProvisioning.editNetworkRequest, 0x00, sizeof( IotBleEditNetworkRequest_t ) );
         status = _deserializeEditNetworkRequest( pData, length, &wifiProvisioning.editNetworkRequest );
 
-        taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                      _editNetworkTask,
-                                                      NULL,
-                                                      &pJob );
-        if (taskStatus == IOT_TASKPOOL_SUCCESS)
+        if( status == true )
         {
-            taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
-            if (taskStatus != IOT_TASKPOOL_SUCCESS)
+
+            taskStatus = IotTaskPool_CreateRecyclableJob(IOT_SYSTEM_TASKPOOL,
+                                                         _editNetworkTask,
+                                                         NULL,
+                                                         &pJob);
+            if (taskStatus == IOT_TASKPOOL_SUCCESS)
             {
-                configPRINTF(( "Failed to schedule taskpool job for edit network request \r\n" ));
-                IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, pJob );
-                xSemaphoreGive( wifiProvisioning.lock );
-                status = false;
+                taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
+                if (taskStatus != IOT_TASKPOOL_SUCCESS)
+                {
+                    configPRINTF(("Failed to schedule taskpool job for edit network request \r\n"));
+                    IotTaskPool_RecycleJob(IOT_SYSTEM_TASKPOOL, pJob);
+                    status = false;
+                }
             }
         }
         else
         {
-            configPRINTF(( "Failed to allocate taskpool job for edit network request \r\n" ));
-            xSemaphoreGive( wifiProvisioning.lock );
+            configPRINTF(( "Failed to allocate taskpool job for edit network request \r\n" )); 
             status = false;
+        }
+
+        if( status == false )
+        {
+            xSemaphoreGive(wifiProvisioning.lock);
         }
     }
     else
@@ -1045,26 +1067,33 @@ static bool _handleDeleteNetworkRequest( uint8_t * pData,
         memset( &wifiProvisioning.deleteNetworkRequest, 0x00, sizeof( IotBleDeleteNetworkRequest_t ) );
         status = _deserializeDeleteNetworkRequest( pData, length, &wifiProvisioning.deleteNetworkRequest );
 
-        taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                      _deleteNetworkTask,
-                                                      NULL,
-                                                      &pJob );
-        if (taskStatus == IOT_TASKPOOL_SUCCESS)
+        if (status == true)
         {
-            taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
-            if (taskStatus != IOT_TASKPOOL_SUCCESS)
+
+            taskStatus = IotTaskPool_CreateRecyclableJob(IOT_SYSTEM_TASKPOOL,
+                                                         _deleteNetworkTask,
+                                                         NULL,
+                                                         &pJob);
+            if (taskStatus == IOT_TASKPOOL_SUCCESS)
             {
-                configPRINTF(( "Failed to schedule taskpool job for delete network request \r\n" ));
-                IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, pJob );
-                xSemaphoreGive( wifiProvisioning.lock );
+                taskStatus = IotTaskPool_Schedule(IOT_SYSTEM_TASKPOOL, pJob, 0);
+                if (taskStatus != IOT_TASKPOOL_SUCCESS)
+                {
+                    configPRINTF(("Failed to schedule taskpool job for delete network request \r\n"));
+                    IotTaskPool_RecycleJob(IOT_SYSTEM_TASKPOOL, pJob);
+                    status = false;
+                }
+            }
+            else
+            {
+                configPRINTF(("Failed to allocate taskpool job for delete network request \r\n"));
                 status = false;
             }
         }
-        else
+
+        if( status == false )
         {
-            configPRINTF(( "Failed to allocate taskpool job for delete network request \r\n" ));
-            xSemaphoreGive( wifiProvisioning.lock );
-            status = false;
+            xSemaphoreGive(wifiProvisioning.lock);
         }
     }
     else
@@ -1230,7 +1259,7 @@ void _sendStatusResponse( IotBleWifiProvAttributes_t characteristic,
                           WIFIReturnCode_t status )
 {
     uint8_t * pBuffer = NULL;
-    size_t mesgLen;
+    size_t mesgLen = 0;
     IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
 
     ret = _serializeStatusResponse( status, NULL, &mesgLen );
@@ -1568,7 +1597,6 @@ void _listNetworkTask( struct IotTaskPool * pTaskPool, struct IotTaskPoolJob * p
     memset( scanNetworks, 0x00, sizeof( WIFIScanResult_t ) * IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS );
     
     status = WIFI_Scan( scanNetworks, wifiProvisioning.listNetworkRequest.maxNetworks );
-    configPRINTF(( "Scan completed with result %d \r\n", status ));
 
     if( status == eWiFiSuccess )
     {
@@ -1608,7 +1636,7 @@ static void _addNetworkTask( struct IotTaskPool * pTaskPool, struct IotTaskPoolJ
         }
         else
         {
-            configPRINTF(("Failed to add a new network, max networks limit (%d) reached.", IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS));
+            configPRINTF(("Failed to add a new network, max networks limit (%d) reached.\r\n", IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS));
             ret = eWiFiFailure;
         }
     }

--- a/lib/bluetooth_low_energy/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/lib/bluetooth_low_energy/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -416,7 +416,7 @@ void _characteristicCallback( IotBleAttributeEvent_t * pEventParam )
 
     resp.pAttrData = &attrData;
 
-    if( pEventParam->xEventType == eBLEWrite )
+     if( pEventParam->xEventType == eBLEWrite )
     {
         pWriteParam = pEventParam->pParamWrite;
         wifiProvisioning.BLEConnId = pWriteParam->connId;
@@ -566,10 +566,9 @@ static bool _deserializeListNetworkRequest( uint8_t * pData,
         {
             if( ( value.value.signedInt <= 0 ) || ( value.value.signedInt > IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ) )
             {
-                configPRINTF( ( "WARN: Max Networks (%d) exceeds configured Max networks (%d). Caping max networks to %d\n",
-                                value.value.signedInt,
-                                IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS,
-                                IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ) );
+                configPRINTF( ( "WARN: Networks %d exceeds configured value, truncating to  %d max network\n",
+                                (uint16_t)value.value.signedInt,
+                                IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS) );
                 pListNetworkRequest->maxNetworks = IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS;
             }
             else

--- a/lib/include/iot_ble_wifi_provisioning.h
+++ b/lib/include/iot_ble_wifi_provisioning.h
@@ -62,10 +62,6 @@
 #define IOT_BLE_WIFI_PROV_CLIENT_CHAR_CFG_UUID        ( 0x2902 )                                                                            /**< @brief Client configuration. */
 /* @[define_ble_constants_wifi_provisioning] */
 
-/**
- * @brief Maximum number of WiFi networks that can be provisioned
- */
-#define IOT_BLE_WIFI_PROV_MAX_SAVED_NETWORKS    ( 8 )
 
 /**
  * @ingroup ble_datatypes_enums

--- a/lib/include/iot_ble_wifi_provisioning.h
+++ b/lib/include/iot_ble_wifi_provisioning.h
@@ -178,6 +178,12 @@ typedef struct IotBleWifiProvService
     uint16_t numNetworks;            /**< The number of networks. */
     int16_t connectedIdx;            /**< The index of the network that is connected. */
     bool init;                       /**< A flag to indicate if the service has been initialized. */
+
+    IotBleListNetworkRequest_t   listNetworkRequest;
+    IotBleAddNetworkRequest_t    addNetworkRequest;
+    IotBleEditNetworkRequest_t   editNetworkRequest;
+    IotBleDeleteNetworkRequest_t deleteNetworkRequest;
+
 } IotBleWifiProvService_t;
 
 /**

--- a/lib/include/private/iot_ble_config_defaults.h
+++ b/lib/include/private/iot_ble_config_defaults.h
@@ -186,7 +186,7 @@
  * A higher number will consume more stack space. The size increase in multiple of sizeof(WIFIScanResult_t).
  */
 #ifndef IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS
-    #define IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS                  ( 50 )
+    #define IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS                  ( 10 )
 #endif
 
 

--- a/lib/include/private/iot_ble_config_defaults.h
+++ b/lib/include/private/iot_ble_config_defaults.h
@@ -181,12 +181,22 @@
 #endif
 
 /**
- * @brief Controls the number of network that can be discovered for WIFI provisionning
+ * @brief Controls the number of network that can be discovered for WIFI provisionning.
  *
- * A higher number will consume more stack space. The size increase in multiple of sizeof(WIFIScanResult_t)
+ * A higher number will consume more stack space. The size increase in multiple of sizeof(WIFIScanResult_t).
  */
-#ifndef IOT_BLE_MAX_NETWORK
-    #define IOT_BLE_MAX_NETWORK                  ( 50 )
+#ifndef IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS
+    #define IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS                  ( 50 )
+#endif
+
+
+ /* @brief Controls the number of network that can be saved using WIFI provisionning.
+ *
+ * The number should be set according to amount of flash space available on the device.
+ * The size increase in multiple of sizeof(WIFINetworkProfile_t).
+ */
+#ifndef IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS
+    #define IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS               ( 8 )
 #endif
 
 /**


### PR DESCRIPTION
Use task pool for WiFi-Provisioning 

Description
-----------
Use task pool to avoid dynamic task creation.
Change names of variables/config.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
