### PR TITLE
[Issue #486] Avoid Clearing STARTED_BIT in WIFI_Scan()

### DIFF
--- a/lib/wifi/portable/espressif/esp32_devkitc_esp_wrover_kit/aws_wifi.c
+++ b/lib/wifi/portable/espressif/esp32_devkitc_esp_wrover_kit/aws_wifi.c
@@ -494,7 +494,7 @@ WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
     		}
 
     		// Wait for wifi started event
-    		xEventGroupWaitBits(wifi_event_group, STARTED_BIT, pdTRUE, pdFALSE, portMAX_DELAY);
+		xEventGroupWaitBits(wifi_event_group, STARTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
     	}
 
         if ( wifi_conn_state == false && wifi_auth_failure == true )

--- a/tests/common/include/iot_ble_wifi_prov_test_access_define.h
+++ b/tests/common/include/iot_ble_wifi_prov_test_access_define.h
@@ -94,7 +94,7 @@ WIFIReturnCode_t test_ConnectSavedNetwork( uint16_t index )
 BaseType_t test_GetConnectedNetwork( WIFINetworkProfile_t * pNetwork )
 {
     BaseType_t ret = pdFALSE;
-    if( _getSavedNetwork( WifiProvService.connectedIdx, pNetwork ) == eWiFiSuccess )
+    if( _getSavedNetwork( wifiProvisioning.connectedIdx, pNetwork ) == eWiFiSuccess )
     {
     	ret = pdTRUE;
     }

--- a/tests/common/wifi_provisioning/aws_test_wifi_provisioning.c
+++ b/tests/common/wifi_provisioning/aws_test_wifi_provisioning.c
@@ -534,7 +534,7 @@ static void prvGetTestWIFINetwork( WIFINetworkProfile_t *pxNetwork, uint16_t usI
 
 static void prvRemoveSavedNetworks( void )
 {
-	uint16_t usNumNetworks = IOT_BLE_WIFI_PROV_MAX_SAVED_NETWORKS;
+	uint16_t usNumNetworks = IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS;
 	WIFIReturnCode_t xRet;
 	WIFINetworkProfile_t xProfile;
 


### PR DESCRIPTION
Avoid Clearing STARTED_BIT in WIFI_Scan() API 

Description
-----------
STARTED_BIT should not be cleared from event group after WiFi driver has started successfully. This causes other APIs to block on the started bit.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
