### PR TITLE
fix: DNS cache processing

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.c
@@ -1348,7 +1348,7 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 		{
 			if( xDNSCache[ x ].pcName[ 0 ] == 0 )
 			{
-				break;
+				continue;
 			}
 
 			if( 0 == strcmp( xDNSCache[ x ].pcName, pcName ) )


### PR DESCRIPTION
prvProcessDNSCache() stops the search when pcName[0] is zero
pcName[0] is set to zero when cache entry is invalidated.

https://github.com/aws/amazon-freertos/issues/471

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
