### PR TITLE
Fix: receive/received

### DIFF
--- a/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/espressif_code/ethernet/include/esp_eth.h
+++ b/demos/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/espressif_code/ethernet/include/esp_eth.h
@@ -245,7 +245,7 @@ static inline esp_err_t esp_eth_smi_wait_set(uint32_t reg_num, uint16_t value_ma
  *
  * @note  buf can not be null,and it is tcpip input buf.
  *
- * @param[in] buf: start address of recevie packet data.
+ * @param[in] buf: start address of received packet data.
  *
  */
 void esp_eth_free_rx_buf(void *buf);

--- a/lib/third_party/mcu_vendor/espressif/esp-idf/components/esp32/include/rom/uart.h
+++ b/lib/third_party/mcu_vendor/espressif/esp-idf/components/esp32/include/rom/uart.h
@@ -306,7 +306,7 @@ char uart_rx_one_char_block(void);
 STATUS UartRxString(uint8_t *pString, uint8_t MaxStrlen);
 
 /**
-  * @brief Process uart recevied information in the interrupt handler.
+  * @brief Process uart received information in the interrupt handler.
   *        Please do not call this function in SDK.
   *
   * @param  void *para : the message receive buffer.

--- a/lib/third_party/mcu_vendor/espressif/esp-idf/components/esp32/spiram_psram.c
+++ b/lib/third_party/mcu_vendor/espressif/esp-idf/components/esp32/spiram_psram.c
@@ -125,8 +125,8 @@ typedef struct {
     uint16_t addrBitLen;         /*!< Address byte length*/
     uint32_t *txData;            /*!< Point to send data buffer*/
     uint16_t txDataBitLen;       /*!< Send data byte length.*/
-    uint32_t *rxData;            /*!< Point to recevie data buffer*/
-    uint16_t rxDataBitLen;       /*!< Recevie Data byte length.*/
+    uint32_t *rxData;            /*!< Point to receive data buffer*/
+    uint16_t rxDataBitLen;       /*!< Receive Data byte length.*/
     uint32_t dummyBitLen;
 } psram_cmd_t;
 

--- a/lib/third_party/mcu_vendor/mediatek/mt7697hx-dev-kit/driver/chip/inc/hal_irrx.h
+++ b/lib/third_party/mcu_vendor/mediatek/mt7697hx-dev-kit/driver/chip/inc/hal_irrx.h
@@ -207,7 +207,7 @@ typedef void (*hal_irrx_callback_t)(hal_irrx_event_t event, void  *user_data);
 
 /** @brief RC5 code. The structure member bits specifies the valid bits in code[2]. */
 typedef struct {
-    uint8_t     bits;  /**<  RC5 recevied bits number. */
+    uint8_t     bits;  /**<  RC5 received bits number. */
     uint32_t    code[2];   /**<  RC5 received data code. */
 } hal_irrx_rc5_code_t;
 

--- a/lib/third_party/mcu_vendor/nxp/LPC54018/middleware/wifi_qca/common_src/stack_common/common_stack_offload.h
+++ b/lib/third_party/mcu_vendor/nxp/LPC54018/middleware/wifi_qca/common_src/stack_common/common_stack_offload.h
@@ -168,7 +168,7 @@ typedef struct ath_socket_context
     int32_t result; // API return value
     void *sock_context; // Pointer to custom socket context
     void *pReq; // Used to hold wmi netbuf to be freed from the user thread
-    uint8_t *data; // Generic pointer to data recevied from target
+    uint8_t *data; // Generic pointer to data received from target
     uint8_t domain; // IPv4/v6
     uint8_t type; // TCP vs UDP
     uint16_t remaining_bytes;

--- a/lib/third_party/mcu_vendor/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/net/wifi/sl_socket.h
+++ b/lib/third_party/mcu_vendor/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/net/wifi/sl_socket.h
@@ -421,7 +421,7 @@ typedef struct SlFdSet_t  /* The select socket array manager */
 
 typedef struct
 {
-    _u8   Rate;               /* Recevied Rate  */
+    _u8   Rate;               /* Received Rate  */
     _u8   Channel;            /* The received channel*/
     _i8   Rssi;               /* The computed RSSI value in db of current frame */
     _u8   Padding;            /* pad to align to 32 bits */

--- a/lib/third_party/mcu_vendor/xilinx/aws_bsp/ps7_cortexa9_0/include/xemacps_bd.h
+++ b/lib/third_party/mcu_vendor/xilinx/aws_bsp/ps7_cortexa9_0/include/xemacps_bd.h
@@ -193,7 +193,7 @@ typedef u32 XEmacPs_Bd[XEMACPS_BD_NUM_WORDS];
  * @param  BdPtr is the BD pointer to operate on
  * @param  Addr  is the value to write to BD's status field.
  *
- * @note : Due to some bits are mixed within recevie BD's address field,
+ * @note : Due to some bits are mixed within receive BD's address field,
  *         read-modify-write is performed.
  *
  * C-style signature:

--- a/lib/third_party/mcu_vendor/xilinx/aws_bsp/ps7_cortexa9_0/libsrc/emacps_v3_7/src/xemacps_bd.h
+++ b/lib/third_party/mcu_vendor/xilinx/aws_bsp/ps7_cortexa9_0/libsrc/emacps_v3_7/src/xemacps_bd.h
@@ -193,7 +193,7 @@ typedef u32 XEmacPs_Bd[XEMACPS_BD_NUM_WORDS];
  * @param  BdPtr is the BD pointer to operate on
  * @param  Addr  is the value to write to BD's status field.
  *
- * @note : Due to some bits are mixed within recevie BD's address field,
+ * @note : Due to some bits are mixed within receive BD's address field,
  *         read-modify-write is performed.
  *
  * C-style signature:

--- a/tests/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/espressif_code/ethernet/include/esp_eth.h
+++ b/tests/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/espressif_code/ethernet/include/esp_eth.h
@@ -245,7 +245,7 @@ static inline esp_err_t esp_eth_smi_wait_set(uint32_t reg_num, uint16_t value_ma
  *
  * @note  buf can not be null,and it is tcpip input buf.
  *
- * @param[in] buf: start address of recevie packet data.
+ * @param[in] buf: start address of receive packet data.
  *
  */
 void esp_eth_free_rx_buf(void *buf);


### PR DESCRIPTION
Fix receive/received in comments

Description
-----------
Replace wrong versions of 'receive/received' with good ones.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
