### PR TITLE
Fix/ble stack init

### DIFF
--- a/tests/common/test_runner/iot_tests_network.c
+++ b/tests/common/test_runner/iot_tests_network.c
@@ -32,6 +32,7 @@
 #include "private/iot_error.h"
 #include "stdbool.h"
 
+extern bool bleStackInit(void);
 static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 static bool bleEnabled = false;
 /*-----------------------------------------------------------*/
@@ -200,7 +201,10 @@ void IotTestNetwork_SelectNetworkType( uint16_t networkType )
             	if( bleEnabled == false)
             	{
             		bleEnabled = true;
-            		_BLEEnable();
+            		if( bleStackInit() == true)
+            		{
+            			_BLEEnable();
+            		}
             	}
                 break;
         #endif

--- a/tests/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/main.c
+++ b/tests/espressif/esp32_devkitc_esp_wrover_kit/common/application_code/main.c
@@ -115,9 +115,6 @@ static const uint8_t ucDNSServerAddress[ 4 ] =
     configDNS_SERVER_ADDR3
 };
 
-/* Initializes bluetooth */
-static esp_err_t prvBLEStackInit( void );
-
 /**
  * @brief Application task startup hook for applications using Wi-Fi. If you are not
  * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
@@ -160,24 +157,21 @@ int app_main( void )
 
     if( SYSTEM_Init() == pdPASS )
     {
-        if( prvBLEStackInit() == eBTStatusSuccess )
-        {
-            /* Connect to the wifi before running the tests. */
-            prvWifiConnect();
+		/* Connect to the wifi before running the tests. */
+		prvWifiConnect();
 
-            /* A simple example to demonstrate key and certificate provisioning in
-            * microcontroller flash using PKCS#11 interface. This should be replaced
-            * by production ready key provisioning mechanism. */
-            vDevModeKeyProvisioning();
+		/* A simple example to demonstrate key and certificate provisioning in
+		* microcontroller flash using PKCS#11 interface. This should be replaced
+		* by production ready key provisioning mechanism. */
+		vDevModeKeyProvisioning();
 
-            /* Create the task to run unit tests. */
-            xTaskCreate( TEST_RUNNER_RunTests_task,
-                    "RunTests_task",
-                    mainTEST_RUNNER_TASK_STACK_SIZE,
-                    NULL,
-                    tskIDLE_PRIORITY + 5,
-                    NULL );
-        }
+		/* Create the task to run unit tests. */
+		xTaskCreate( TEST_RUNNER_RunTests_task,
+				"RunTests_task",
+				mainTEST_RUNNER_TASK_STACK_SIZE,
+				NULL,
+				tskIDLE_PRIORITY + 5,
+				NULL );
     }
 
     /* Start the scheduler.  Initialization that requires the OS to be running,
@@ -418,16 +412,12 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     }
 }
 
-static esp_err_t prvBLEStackInit( void )
+bool bleStackInit( void )
 {
     /* Initialize BLE */
+	bool status =false;
     esp_err_t xRet = ESP_OK;
     esp_bt_controller_config_t xBtCfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-
-/* ESP32 doesn't have enough memory to maintain 2 secure connection + BLE in this environment.
-* We disable BLE when not used in test to free up memory.
-*/
-#if ( (testrunnerFULL_BLE_ENABLED == 1) ||(testrunnerFULL_BLE_END_TO_END_TEST_ENABLED == 1) )
 
     ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_CLASSIC_BT ) );
 
@@ -455,11 +445,11 @@ static esp_err_t prvBLEStackInit( void )
     {
         xRet = esp_bluedroid_enable();
     }
-#else
-    ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_CLASSIC_BT ) );
-    ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_BLE ) );
-#endif
 
-    return xRet;
+    if(xRet == ESP_OK)
+    {
+    	status = true;
+    }
 
+    return status;
 }

--- a/tests/nordic/nrf52840-dk/common/application_code/main.c
+++ b/tests/nordic/nrf52840-dk/common/application_code/main.c
@@ -332,6 +332,13 @@ static void prvMiscInitialization( void )
 }
 /*-----------------------------------------------------------*/
 
+bool bleStackInit()
+{
+   /* No initialization to do on Nordic. It starts up with the softdevice task. */
+   return true;
+}
+
+
 /**
  * @brief Application runtime entry point.
  */


### PR DESCRIPTION
BLE stack init

Description
-----------
BLE stack init was done in the main. Initialization was disabled for every tests but BLE.
This however conflict with our test infrastructure that does not generate the #define relative to each test.

The BLE stack is now initialized inside the network selection.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
