### PR TITLE
Fix new loop unwinding issue in CBMC proof of ParseDSNReply

### DIFF
--- a/tools/cbmc/proofs/ParseDNSReply/Makefile.json
+++ b/tools/cbmc/proofs/ParseDNSReply/Makefile.json
@@ -43,7 +43,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset {PARSELOOP0}:{PARSELOOP0_UNWIND},{PARSELOOP1}:{PARSELOOP1_UNWIND}"
+    "--unwindset {PARSELOOP0}:{PARSELOOP0_UNWIND},{PARSELOOP1}:{PARSELOOP1_UNWIND},prvProcessDNSCache.0:5"
   ],
 
   "OBJS":

--- a/tools/cbmc/proofs/ParseDNSReply/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ParseDNSReply/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: 	'=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;prvParseDNSReply.0:6,prvParseDNSReply.1:12,prvProcessDNSCache.0:5='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;prvParseDNSReply.0:6,prvParseDNSReply.1:12,prvProcessDNSCache.0:5='
 goto: ParseDNSReply.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ParseDNSReply/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ParseDNSReply/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--object-bits;7;--unwind;0;--unwindset;prvParseDNSReply.0:6,prvParseDNSReply.1:12;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: 	'=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;prvParseDNSReply.0:6,prvParseDNSReply.1:12,prvProcessDNSCache.0:5='
 goto: ParseDNSReply.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/make-common-makefile.py
+++ b/tools/cbmc/proofs/make-common-makefile.py
@@ -195,7 +195,7 @@ def write_cbmcbatchyaml_target(opsys, _makefile):
 # Build configuration file to run cbmc under cbmc-batch in CI
 
 define encode_options
-	'=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+'=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
 endef
 
 cbmc-batch.yaml: Makefile ../Makefile.common

--- a/tools/cbmc/proofs/make-common-makefile.py
+++ b/tools/cbmc/proofs/make-common-makefile.py
@@ -189,12 +189,35 @@ def write_makefile(opsys, template, defines, makefile):
                     line = patch_compile_output(opsys, line, key, value)
             makefile.write(line)
 
+def write_cbmcbatchyaml_target(opsys, _makefile):
+    target = """
+################################################################
+# Build configuration file to run cbmc under cbmc-batch in CI
+
+define encode_options
+	'=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+endef
+
+cbmc-batch.yaml: Makefile ../Makefile.common
+	@echo "Building $@"
+	@$(RM) $@
+	@echo "jobos: ubuntu16" >> $@
+	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS))" >> $@
+	@echo "goto: $(ENTRY).goto" >> $@
+	@echo "expected: SUCCESSFUL" >> $@
+
+################################################################
+"""
+    if opsys != "windows":
+        _makefile.write(target)
+
 def makefile_from_template(opsys, template, defines, makefile="Makefile"):
     with open(makefile, "w") as _makefile:
         write_define(opsys, "FREERTOS", defines, _makefile)
         write_define(opsys, "PROOFS", defines, _makefile)
         write_common_defines(opsys, defines, _makefile)
         write_makefile(opsys, template, defines, _makefile)
+        write_cbmcbatchyaml_target(opsys, _makefile)
 
 ################################################################
 # Main


### PR DESCRIPTION
Fix new loop unwinding issue in CBMC proof of ParseDSNReply

Description
-----------
The function prvProcessDNSCache includes a loop that needs to be unwound for the CBMC proof to be sound.  This pull request unwinds the loop 5 times which is sufficient for the proof to succeed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
