### PR TITLE
add CMakefile for nxp and fix build problems

### DIFF
--- a/modules/libraries/3rdparty/CMakeLists.txt
+++ b/modules/libraries/3rdparty/CMakeLists.txt
@@ -52,7 +52,6 @@ afr_glob_files(tinycbor_src DIRECTORY "${AFR_3RDPARTY_DIR}/tinycbor" RECURSE)
 target_sources(
     3rdparty::tinycbor INTERFACE
     ${tinycbor_src}
-    "${AFR_3RDPARTY_DIR}/tinycbor/LICENSE"
 )
 target_include_directories(
     3rdparty::tinycbor INTERFACE

--- a/modules/libraries/standard/serializer/CMakeLists.txt
+++ b/modules/libraries/standard/serializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-afr_module()
+afr_module(OPTIONAL)
 
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")

--- a/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
+++ b/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
@@ -1,0 +1,318 @@
+set(lpc54018_dir "${AFR_VENDORS_DIR}/nxp/LPC54018")
+set(lpc54018iotmodule_dir "${AFR_VENDORS_DIR}/nxp/boards/lpc54018iotmodule")
+
+set(lpc54018_ports_dir "${lpc54018iotmodule_dir}/ports")
+set(lpc54018_demos_common_dir "${lpc54018iotmodule_dir}/aws_demos/common")
+set(lpc54018_tests_common_dir "${lpc54018iotmodule_dir}/aws_tests/common")
+
+if(AFR_IS_TESTING)
+    set(lpc54018_app_dir "${lpc54018_tests_common_dir}")
+else()
+    set(lpc54018_app_dir "${lpc54018_demos_common_dir}")
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+
+afr_set_board_metadata(ID "NXP-LPC54018-IoT-Module")
+afr_set_board_metadata(DISPLAY_NAME "LPC54018 IoT Module")
+afr_set_board_metadata(DESCRIPTION "Development kit for ARM® Cortex®-M4 based LPC54018 MCU")
+afr_set_board_metadata(VENDOR_NAME "NXP")
+afr_set_board_metadata(FAMILY_NAME "LPC5401x_54S0xx")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(DATA_RAM_MEMORY "360KB")
+afr_set_board_metadata(PROGRAM_MEMORY "128MB")
+afr_set_board_metadata(SUPPORTED_IDE "IAREmbeddedWorkbench;MCUXpresso")
+afr_set_board_metadata(IDE_IAREmbeddedWorkbench_NAME "IAR Embedded Workbench")
+afr_set_board_metadata(IDE_IAREmbeddedWorkbench_COMPILER "IAR")
+afr_set_board_metadata(IDE_IAREmbeddedWorkbench_RECOMMENDED "true")
+afr_set_board_metadata(IDE_MCUXpresso_NAME "MCUXpresso")
+afr_set_board_metadata(IDE_MCUXpresso_COMPILER "GCC")
+afr_set_board_metadata(IDE_MCUXpresso_RECOMMENDED "false")
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+afr_mcu_port(compiler)
+
+# Defined symbols
+set(defined_symbols
+    __REDLIB__
+    MXL12835F
+    __USE_CMSIS
+    BOARD_DEBUG_UART_TYPE=DEBUG_CONSOLE_DEVICE_TYPE_USBCDC
+    IMG_BAUDRATE=96000000
+    XIP_IMAGE
+    BOARD_USE_VIRTUALCOM
+    USB_STACK_USE_DEDICATED_RAM=1
+    SDK_DEBUGCONSOLE=1
+    CPU_LPC54018JET180=1
+    PRINTF_FLOAT_ENABLE=0
+    USB_STACK_FREERTOS
+    USE_RTOS=1
+    FSL_RTOS_FREE_RTOS
+    A_LITTLE_ENDIAN
+    CR_INTEGER_PRINTF
+    USB_DEVICE_CONFIG_LPCIP3511HS=1
+    __MCUXPRESSO
+    DEBUG
+    SDK_OS_FREE_RTOS
+    CPU_LPC54018JET180_cm4
+    CPU_LPC54018JET180
+)
+
+target_compile_definitions(
+    AFR::compiler::mcu_port
+    INTERFACE $<$<NOT:$<COMPILE_LANGUAGE:ASM>>:${defined_symbols}>
+)
+
+set(common_flags "-mcpu=cortex-m4" "-mfpu=fpv4-sp-d16" "-mfloat-abi=hard" "-mthumb")
+
+set(c_flags "-std=gnu99" "-O0" "-fno-common" "-g" "-Wall" "-c" "-ffunction-sections" "-fdata-sections" "-ffreestanding" "-fno-builtin" "-fomit-frame-pointer")
+
+set(asm_flags "-c" "-x" "assembler-with-cpp")
+
+# Compiler flags
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        ${common_flags}
+        $<$<NOT:$<COMPILE_LANGUAGE:ASM>>:${c_flags}>
+        -specs=redlib.specs -MMD -MP
+)
+
+# Assembler flags
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        ${common_flags}
+        $<$<COMPILE_LANGUAGE:ASM>:${asm_flags}>
+)
+
+# Linker flags
+target_link_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        -nostdlib
+        "SHELL:-Xlinker -print-memory-usage" "SHELL:-Xlinker --gc-sections" "SHELL:-Xlinker -Map=aws_demos.map"
+        ${common_flags}
+)
+
+target_link_directories(
+    AFR::compiler::mcu_port
+    INTERFACE
+         "${lpc54018_dir}/mcuxpresso"
+)
+
+target_link_libraries(
+    AFR::compiler::mcu_port
+    INTERFACE
+        "${lpc54018_dir}/mcuxpresso/libpower_hardabi.a"
+)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS portable layers
+# -------------------------------------------------------------------------------------------------
+
+
+afr_glob_src(lpc54018_src DIRECTORY "${lpc54018_dir}")
+
+afr_glob_src(usb_device_src DIRECTORY "${lpc54018_dir}/middleware/usb/device")
+
+# All sources files under wifi_qca are needed
+afr_glob_src(wifi_qca_src DIRECTORY "${lpc54018_dir}/middleware/wifi_qca" RECURSE)
+
+set(usb_osa_src
+    ${lpc54018_dir}/middleware/usb/osa/usb_osa_freertos.c
+)
+
+set(mcuxpresso_src
+    ${lpc54018_dir}/mcuxpresso/startup_lpc54018.c
+)
+
+set(utilities_src
+    ${lpc54018_dir}/utilities/str/fsl_str.c
+    ${lpc54018_dir}/utilities/log/fsl_log.c
+    ${lpc54018_dir}/utilities/io/swo/fsl_swo.c
+    ${lpc54018_dir}/utilities/io/fsl_io.c
+    ${lpc54018_dir}/utilities/fsl_assert.c
+    ${lpc54018_dir}/utilities/fsl_debug_console.c
+    ${lpc54018_dir}/utilities/usb_device_cdc_acm.c
+    ${lpc54018_dir}/utilities/usb_device_ch9.c
+    ${lpc54018_dir}/utilities/usb_device_descriptor.c
+    ${lpc54018_dir}/utilities/virtual_com.c
+)
+
+set(drivers_src
+    ${lpc54018_dir}/drivers/fsl_clock.c
+    ${lpc54018_dir}/drivers/fsl_common.c
+    ${lpc54018_dir}/drivers/fsl_dma.c
+    ${lpc54018_dir}/drivers/fsl_emc.c
+    ${lpc54018_dir}/drivers/fsl_flexcomm.c
+    ${lpc54018_dir}/drivers/fsl_gpio.c
+    ${lpc54018_dir}/drivers/fsl_inputmux.c
+    ${lpc54018_dir}/drivers/fsl_pint.c
+    ${lpc54018_dir}/drivers/fsl_power.c
+    ${lpc54018_dir}/drivers/fsl_reset.c
+    ${lpc54018_dir}/drivers/fsl_sha.c
+    ${lpc54018_dir}/drivers/fsl_spi.c
+    ${lpc54018_dir}/drivers/fsl_spi_dma.c
+    ${lpc54018_dir}/drivers/fsl_spifi.c
+    ${lpc54018_dir}/drivers/fsl_spifi_dma.c
+    ${lpc54018_dir}/drivers/fsl_usart.c
+    ${lpc54018_dir}/drivers/mflash_drv.c
+    ${lpc54018_dir}/drivers/mflash_file.c
+)
+
+set(lpc54018_includes
+    "${lpc54018_dir}"
+    "${lpc54018_dir}/drivers"
+    "${lpc54018_dir}/cmsis_drivers"
+    "${lpc54018_dir}/middleware/wifi_qca"
+    "${lpc54018_dir}/middleware/wifi_qca/common_src/hcd"
+    "${lpc54018_dir}/middleware/wifi_qca/common_src/include"
+    "${lpc54018_dir}/middleware/wifi_qca/common_src/stack_common"
+    "${lpc54018_dir}/middleware/wifi_qca/common_src/wmi"
+    "${lpc54018_dir}/middleware/wifi_qca/custom_src/include"
+    "${lpc54018_dir}/middleware/wifi_qca/custom_src/stack_custom"
+    "${lpc54018_dir}/middleware/wifi_qca/include"
+    "${lpc54018_dir}/middleware/wifi_qca/include/AR6002"
+    "${lpc54018_dir}/middleware/wifi_qca/include/AR6002/hw2.0/hw"
+    "${lpc54018_dir}/middleware/wifi_qca/port"
+    "${lpc54018_dir}/middleware/wifi_qca/port/boards/lpc54018iotmodule/freertos"
+    "${lpc54018_dir}/middleware/wifi_qca/port/boards/lpc54018iotmodule/freertos/gt202"
+    "${lpc54018_dir}/middleware/wifi_qca/port/drivers/flexcomm_freertos"
+    "${lpc54018_dir}/middleware/wifi_qca/port/env/freertos"
+    "${lpc54018_dir}/middleware/usb/device"
+    "${lpc54018_dir}/middleware/usb/include"
+    "${lpc54018_dir}/middleware/usb/osa"
+    "${lpc54018_dir}/utilities"
+    "${lpc54018_dir}/utilities/io"
+    "${lpc54018_dir}/utilities/log"
+    "${lpc54018_dir}/utilities/str"
+    "${lpc54018_dir}/CMSIS/Include"
+)
+
+# Kernel
+afr_mcu_port(kernel)
+
+target_sources(
+    AFR::kernel::mcu_port
+    INTERFACE
+        ${lpc54018_src}
+        ${drivers_src}
+        ${mcuxpresso_src}
+        ${usb_device_src}
+        ${usb_osa_src}
+        ${wifi_qca_src}
+        ${utilities_src}
+        "${AFR_KERNEL_DIR}/portable/GCC/ARM_CM4F/port.c"
+        "${AFR_KERNEL_DIR}/portable/GCC/ARM_CM4F/portmacro.h"
+        "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
+)
+
+set(kernel_inc_dirs
+    ${lpc54018_includes}
+    "${AFR_KERNEL_DIR}/portable/GCC/ARM_CM4F"
+    "${AFR_KERNEL_DIR}/portable/CCS/ARM_CM3"
+    "${lpc54018_app_dir}/config_files"
+    "${lpc54018_app_dir}/application_code/nxp_code"
+    "$<IF:${AFR_IS_TESTING},${AFR_TEST_DIR},${AFR_DEMOS_DIR}>/include"
+
+)
+
+target_include_directories(
+    AFR::kernel::mcu_port
+    INTERFACE $<$<NOT:$<COMPILE_LANGUAGE:ASM>>:${kernel_inc_dirs}>
+)
+
+
+# WiFi
+afr_mcu_port(wifi)
+target_sources(
+    AFR::wifi::mcu_port
+    INTERFACE "${lpc54018_ports_dir}/wifi/aws_wifi.c"
+)
+
+# PKCS11
+afr_mcu_port(pkcs11)
+target_sources(
+    AFR::pkcs11::mcu_port
+    INTERFACE
+        "${lpc54018_ports_dir}/pkcs11/aws_pkcs11_pal.c"
+        "${lpc54018_ports_dir}/pkcs11/hw_poll.c"
+)
+
+target_link_libraries(
+    AFR::pkcs11::mcu_port
+    INTERFACE
+        3rdparty::mbedtls
+        AFR::pkcs11_mbedtls
+        AFR::crypto
+)
+
+# Secure sockets
+afr_mcu_port(secure_sockets)
+target_link_libraries(
+    AFR::secure_sockets::mcu_port
+    INTERFACE
+        AFR::tls
+        AFR::wifi
+)
+
+target_sources(
+    AFR::secure_sockets::mcu_port
+    INTERFACE "${lpc54018_ports_dir}/secure_sockets/aws_secure_sockets.c"
+)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS demos and tests
+# -------------------------------------------------------------------------------------------------
+set(CMAKE_EXECUTABLE_SUFFIX ".axf")
+
+if(AFR_IS_TESTING)
+    set(exe_target aws_tests)
+else()
+    set(exe_target aws_demos)
+endif()
+
+afr_glob_src(board_code_src DIRECTORY "${lpc54018_app_dir}/application_code/nxp_code")
+afr_glob_src(config_files_src DIRECTORY "${lpc54018_app_dir}/config_files")
+
+add_executable(${exe_target}
+    ${board_code_src}
+    ${config_files_src}
+    "${lpc54018_app_dir}/application_code/main.c"
+    # TODO, It is unknown why hw_poll.c has to be included here
+    "${lpc54018_ports_dir}/pkcs11/hw_poll.c"
+)
+
+target_link_libraries(
+    ${exe_target}
+    PRIVATE
+        AFR::wifi
+        AFR::utils
+)
+
+# TODO, Figure out how to generate those linker scripts.
+# file(COPY "${lpc54018_dir}/mcuxpresso/aws_demos_Debug.ld" DESTINATION . )
+# file(COPY "${lpc54018_dir}/mcuxpresso/aws_demos_Debug_memory.ld" DESTINATION . )
+# file(COPY "${lpc54018_dir}/mcuxpresso/aws_demos_Debug_library.ld" DESTINATION . )
+# target_link_options(
+#     ${exe_target}
+#     PRIVATE
+#         -T "aws_demos_Debug.ld"
+# )
+
+# find_program(gcc_objcopy arm-none-eabi-objcopy)
+
+# if(NOT gcc_objcopy)
+#     message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
+# endif()
+
+# set(output_file "$<TARGET_FILE_DIR:${exe_target}>/${exe_target}.hex")
+# add_custom_command(
+#     TARGET ${exe_target} POST_BUILD
+#     COMMAND "${gcc_objcopy}" -v -O ihex "$<TARGET_FILE:${exe_target}>" "${output_file}"
+# )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/common/application_code/main.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/common/application_code/main.c
@@ -53,9 +53,9 @@
  * http://www.FreeRTOS.org
  */
 
-///////////////////////////////////////////////////////////////////////////////
-//  Includes
-///////////////////////////////////////////////////////////////////////////////
+/*///////////////////////////////////////////////////////////////////////////// */
+/*  Includes */
+/*///////////////////////////////////////////////////////////////////////////// */
 
 /* SDK Included Files */
 #include "board.h"
@@ -83,20 +83,21 @@
 #include "usb_device_descriptor.h"
 #include "virtual_com.h"
 #include "fsl_power.h"
+
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
-/* The lpc54018 usb logging driver calls a blocking write function. Since this 
+/* The lpc54018 usb logging driver calls a blocking write function. Since this
  * task is the lowest priority, all of the demo's priorities must be higher than
  * this to run. */
-#define mainLOGGING_TASK_PRIORITY       (tskIDLE_PRIORITY)
-#define mainLOGGING_TASK_STACK_SIZE     (configMINIMAL_STACK_SIZE * 4)
-#define mainLOGGING_QUEUE_LENGTH        (16)
+#define mainLOGGING_TASK_PRIORITY        ( tskIDLE_PRIORITY )
+#define mainLOGGING_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define mainLOGGING_QUEUE_LENGTH         ( 16 )
 
-/* The task delay for allowing the lower priority logging task to print out Wi-Fi 
+/* The task delay for allowing the lower priority logging task to print out Wi-Fi
  * failure status before blocking indefinitely. */
-#define mainLOGGING_WIFI_STATUS_DELAY   pdMS_TO_TICKS( 1000 )
+#define mainLOGGING_WIFI_STATUS_DELAY    pdMS_TO_TICKS( 1000 )
 
 /*******************************************************************************
  * Prototypes
@@ -110,99 +111,109 @@ static void prvWifiConnect( void );
 
 extern usb_cdc_vcom_struct_t s_cdcVcom;
 
-#if (defined(USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS > 0U))
-void USB0_IRQHandler(void)
-{
-    USB_DeviceLpcIp3511IsrFunction(s_cdcVcom.deviceHandle);
-}
-#endif
-#if (defined(USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS > 0U))
-void USB1_IRQHandler(void)
-{
-    USB_DeviceLpcIp3511IsrFunction(s_cdcVcom.deviceHandle);
-}
-#endif
-void USB_DeviceClockInit(void)
-{
-#if defined(USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS > 0U)
-    /* enable USB IP clock */
-    CLOCK_EnableUsbfs0DeviceClock(kCLOCK_UsbSrcFro, CLOCK_GetFroHfFreq());
-#if defined(FSL_FEATURE_USB_USB_RAM) && (FSL_FEATURE_USB_USB_RAM)
-    for (int i = 0; i < FSL_FEATURE_USB_USB_RAM; i++)
-    {
-        ((uint8_t *)FSL_FEATURE_USB_USB_RAM_BASE_ADDRESS)[i] = 0x00U;
-    }
-#endif
+#if ( defined( USB_DEVICE_CONFIG_LPCIP3511FS ) && ( USB_DEVICE_CONFIG_LPCIP3511FS > 0U ) )
+    /*-----------------------------------------------------------*/
 
-#endif
-#if defined(USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS > 0U)
-    /* enable USB IP clock */
-    CLOCK_EnableUsbhs0DeviceClock(kCLOCK_UsbSrcUsbPll, 0U);
-#if defined(FSL_FEATURE_USBHSD_USB_RAM) && (FSL_FEATURE_USBHSD_USB_RAM)
-    for (int i = 0; i < FSL_FEATURE_USBHSD_USB_RAM; i++)
+    void USB0_IRQHandler( void )
     {
-        ((uint8_t *)FSL_FEATURE_USBHSD_USB_RAM_BASE_ADDRESS)[i] = 0x00U;
+        USB_DeviceLpcIp3511IsrFunction( s_cdcVcom.deviceHandle );
     }
 #endif
+#if ( defined( USB_DEVICE_CONFIG_LPCIP3511HS ) && ( USB_DEVICE_CONFIG_LPCIP3511HS > 0U ) )
+    /*-----------------------------------------------------------*/
+
+    void USB1_IRQHandler( void )
+    {
+        USB_DeviceLpcIp3511IsrFunction( s_cdcVcom.deviceHandle );
+    }
 #endif
+/*-----------------------------------------------------------*/
+
+void USB_DeviceClockInit( void )
+{
+    #if defined( USB_DEVICE_CONFIG_LPCIP3511FS ) && ( USB_DEVICE_CONFIG_LPCIP3511FS > 0U )
+        /* enable USB IP clock */
+        CLOCK_EnableUsbfs0DeviceClock( kCLOCK_UsbSrcFro, CLOCK_GetFroHfFreq() );
+        #if defined( FSL_FEATURE_USB_USB_RAM ) && ( FSL_FEATURE_USB_USB_RAM )
+            for( int i = 0; i < FSL_FEATURE_USB_USB_RAM; i++ )
+            {
+                ( ( uint8_t * ) FSL_FEATURE_USB_USB_RAM_BASE_ADDRESS )[ i ] = 0x00U;
+            }
+        #endif
+    #endif
+    #if defined( USB_DEVICE_CONFIG_LPCIP3511HS ) && ( USB_DEVICE_CONFIG_LPCIP3511HS > 0U )
+        /* enable USB IP clock */
+        CLOCK_EnableUsbhs0DeviceClock( kCLOCK_UsbSrcUsbPll, 0U );
+        #if defined( FSL_FEATURE_USBHSD_USB_RAM ) && ( FSL_FEATURE_USBHSD_USB_RAM )
+            for( int i = 0; i < FSL_FEATURE_USBHSD_USB_RAM; i++ )
+            {
+                ( ( uint8_t * ) FSL_FEATURE_USBHSD_USB_RAM_BASE_ADDRESS )[ i ] = 0x00U;
+            }
+        #endif
+    #endif
 }
-void USB_DeviceIsrEnable(void)
+/*-----------------------------------------------------------*/
+
+void USB_DeviceIsrEnable( void )
 {
     uint8_t irqNumber;
-#if defined(USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS > 0U)
-    uint8_t usbDeviceIP3511Irq[] = USB_IRQS;
-    irqNumber = usbDeviceIP3511Irq[CONTROLLER_ID - kUSB_ControllerLpcIp3511Fs0];
-#endif
-#if defined(USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS > 0U)
-    uint8_t usbDeviceIP3511Irq[] = USBHSD_IRQS;
-    irqNumber = usbDeviceIP3511Irq[CONTROLLER_ID - kUSB_ControllerLpcIp3511Hs0];
-#endif
-/* Install isr, set priority, and enable IRQ. */
-    NVIC_SetPriority((IRQn_Type)irqNumber, USB_DEVICE_INTERRUPT_PRIORITY);
-    EnableIRQ((IRQn_Type)irqNumber);
+
+    #if defined( USB_DEVICE_CONFIG_LPCIP3511FS ) && ( USB_DEVICE_CONFIG_LPCIP3511FS > 0U )
+        uint8_t usbDeviceIP3511Irq[] = USB_IRQS;
+        irqNumber = usbDeviceIP3511Irq[ CONTROLLER_ID - kUSB_ControllerLpcIp3511Fs0 ];
+    #endif
+    #if defined( USB_DEVICE_CONFIG_LPCIP3511HS ) && ( USB_DEVICE_CONFIG_LPCIP3511HS > 0U )
+        uint8_t usbDeviceIP3511Irq[] = USBHSD_IRQS;
+        irqNumber = usbDeviceIP3511Irq[ CONTROLLER_ID - kUSB_ControllerLpcIp3511Hs0 ];
+    #endif
+    /* Install isr, set priority, and enable IRQ. */
+    NVIC_SetPriority( ( IRQn_Type ) irqNumber, USB_DEVICE_INTERRUPT_PRIORITY );
+    EnableIRQ( ( IRQn_Type ) irqNumber );
 }
 
 
-int main(void)
+/*-----------------------------------------------------------*/
+
+int main( void )
 {
     /* attach 12 MHz clock to FLEXCOMM0 (debug console) */
-    CLOCK_AttachClk(BOARD_DEBUG_UART_CLK_ATTACH);
+    CLOCK_AttachClk( BOARD_DEBUG_UART_CLK_ATTACH );
 
     /* reset USB0 and USB1 device */
-    RESET_PeripheralReset(kUSB0D_RST_SHIFT_RSTn);
-    RESET_PeripheralReset(kUSB1D_RST_SHIFT_RSTn);
-    RESET_PeripheralReset(kUSB0HMR_RST_SHIFT_RSTn);
-    RESET_PeripheralReset(kUSB0HSL_RST_SHIFT_RSTn);
-    RESET_PeripheralReset(kUSB1H_RST_SHIFT_RSTn);
+    RESET_PeripheralReset( kUSB0D_RST_SHIFT_RSTn );
+    RESET_PeripheralReset( kUSB1D_RST_SHIFT_RSTn );
+    RESET_PeripheralReset( kUSB0HMR_RST_SHIFT_RSTn );
+    RESET_PeripheralReset( kUSB0HSL_RST_SHIFT_RSTn );
+    RESET_PeripheralReset( kUSB1H_RST_SHIFT_RSTn );
 
-    NVIC_ClearPendingIRQ(USB0_IRQn);
-    NVIC_ClearPendingIRQ(USB0_NEEDCLK_IRQn);
-    NVIC_ClearPendingIRQ(USB1_IRQn);
-    NVIC_ClearPendingIRQ(USB1_NEEDCLK_IRQn);
+    NVIC_ClearPendingIRQ( USB0_IRQn );
+    NVIC_ClearPendingIRQ( USB0_NEEDCLK_IRQn );
+    NVIC_ClearPendingIRQ( USB1_IRQn );
+    NVIC_ClearPendingIRQ( USB1_NEEDCLK_IRQn );
 
     BOARD_InitPins();
     BOARD_BootClockFROHF96M();
 
-#if (defined USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS)
-    POWER_DisablePD(kPDRUNCFG_PD_USB1_PHY);
-    /* enable usb1 host clock */
-    CLOCK_EnableClock(kCLOCK_Usbh1);
-    /*According to reference mannual, device mode setting has to be set by access usb host register */
-    *((uint32_t *)(USBHSH_BASE + 0x50)) |= USBHSH_PORTMODE_DEV_ENABLE_MASK;
-    /* enable usb1 host clock */
-    CLOCK_DisableClock(kCLOCK_Usbh1);
-#endif
-#if (defined USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS)
-    POWER_DisablePD(kPDRUNCFG_PD_USB0_PHY); /*< Turn on USB Phy */
-    CLOCK_SetClkDiv(kCLOCK_DivUsb0Clk, 1, false);
-    CLOCK_AttachClk(kFRO_HF_to_USB0_CLK);
-    /* enable usb0 host clock */
-    CLOCK_EnableClock(kCLOCK_Usbhsl0);
-    /*According to reference mannual, device mode setting has to be set by access usb host register */
-    *((uint32_t *)(USBFSH_BASE + 0x5C)) |= USBFSH_PORTMODE_DEV_ENABLE_MASK;
-    /* disable usb0 host clock */
-    CLOCK_DisableClock(kCLOCK_Usbhsl0);
-#endif
+    #if ( defined USB_DEVICE_CONFIG_LPCIP3511HS ) && ( USB_DEVICE_CONFIG_LPCIP3511HS )
+        POWER_DisablePD( kPDRUNCFG_PD_USB1_PHY );
+        /* enable usb1 host clock */
+        CLOCK_EnableClock( kCLOCK_Usbh1 );
+        /*According to reference mannual, device mode setting has to be set by access usb host register */
+        *( ( uint32_t * ) ( USBHSH_BASE + 0x50 ) ) |= USBHSH_PORTMODE_DEV_ENABLE_MASK;
+        /* enable usb1 host clock */
+        CLOCK_DisableClock( kCLOCK_Usbh1 );
+    #endif
+    #if ( defined USB_DEVICE_CONFIG_LPCIP3511FS ) && ( USB_DEVICE_CONFIG_LPCIP3511FS )
+        POWER_DisablePD( kPDRUNCFG_PD_USB0_PHY ); /*< Turn on USB Phy */
+        CLOCK_SetClkDiv( kCLOCK_DivUsb0Clk, 1, false );
+        CLOCK_AttachClk( kFRO_HF_to_USB0_CLK );
+        /* enable usb0 host clock */
+        CLOCK_EnableClock( kCLOCK_Usbhsl0 );
+        /*According to reference mannual, device mode setting has to be set by access usb host register */
+        *( ( uint32_t * ) ( USBFSH_BASE + 0x5C ) ) |= USBFSH_PORTMODE_DEV_ENABLE_MASK;
+        /* disable usb0 host clock */
+        CLOCK_DisableClock( kCLOCK_Usbhsl0 );
+    #endif
 
     BOARD_InitDebugConsole();
 
@@ -211,9 +222,13 @@ int main(void)
                             mainLOGGING_QUEUE_LENGTH );
 
     vTaskStartScheduler();
-    for (;;)
-        ;
+
+    for( ; ; )
+    {
+    }
 }
+
+/*-----------------------------------------------------------*/
 
 void vApplicationDaemonTaskStartupHook( void )
 {
@@ -236,7 +251,7 @@ static void prvWifiConnect( void )
 {
     WIFINetworkParams_t xNetworkParams;
     WIFIReturnCode_t xWifiStatus;
-    uint8_t ucTempIp[4];
+    uint8_t ucTempIp[ 4 ];
 
     /* Setup WiFi parameters to connect to access point. */
     xNetworkParams.pcSSID = clientcredentialWIFI_SSID;
@@ -245,10 +260,11 @@ static void prvWifiConnect( void )
     xNetworkParams.ucPasswordLength = sizeof( clientcredentialWIFI_PASSWORD );
     xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
     xNetworkParams.cChannel = 0;
-    
+
     configPRINTF( ( "Starting Wi-Fi...\r\n" ) );
 
     xWifiStatus = WIFI_On();
+
     if( xWifiStatus == eWiFiSuccess )
     {
         configPRINTF( ( "Wi-Fi module initialized. Connecting to AP...\r\n" ) );
@@ -256,7 +272,7 @@ static void prvWifiConnect( void )
     else
     {
         configPRINTF( ( "Wi-Fi module failed to initialize.\r\n" ) );
-        
+
         /* Delay to allow the lower priority logging task to print the above status. */
         vTaskDelay( mainLOGGING_WIFI_STATUS_DELAY );
 
@@ -266,12 +282,14 @@ static void prvWifiConnect( void )
     }
 
     xWifiStatus = WIFI_ConnectAP( &xNetworkParams );
+
     if( xWifiStatus == eWiFiSuccess )
     {
         configPRINTF( ( "Wi-Fi connected to AP %s.\r\n", xNetworkParams.pcSSID ) );
 
         xWifiStatus = WIFI_GetIP( ucTempIp );
-        if ( eWiFiSuccess == xWifiStatus ) 
+
+        if( eWiFiSuccess == xWifiStatus )
         {
             configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
                             ucTempIp[ 0 ], ucTempIp[ 1 ], ucTempIp[ 2 ], ucTempIp[ 3 ] ) );
@@ -302,110 +320,16 @@ static void prvWifiConnect( void )
 
 /*-----------------------------------------------------------*/
 
-/* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an
- * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
- * used by the Idle task. */
-void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
-                                   StackType_t **ppxIdleTaskStackBuffer,
-                                   uint32_t *pulIdleTaskStackSize)
+void * pvPortCalloc( size_t xNum,
+                     size_t xSize )
 {
-    /* If the buffers to be provided to the Idle task are declared inside this
-     * function then they must be declared static - otherwise they will be allocated on
-     * the stack and so not exists after this function exits. */
-    static StaticTask_t xIdleTaskTCB;
-    static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE];
+    void * pvReturn;
 
-    /* Pass out a pointer to the StaticTask_t structure in which the Idle
-     * task's state will be stored. */
-    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+    pvReturn = pvPortMalloc( xNum * xSize );
 
-    /* Pass out the array that will be used as the Idle task's stack. */
-    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
-
-    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-     * Note that, as the array is necessarily of type StackType_t,
-     * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
-    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
-}
-
-/*-----------------------------------------------------------*/
-
-/* configUSE_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
- * application must provide an implementation of vApplicationGetTimerTaskMemory()
- * to provide the memory that is used by the Timer service task. */
-void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
-                                    StackType_t **ppxTimerTaskStackBuffer,
-                                    uint32_t *pulTimerTaskStackSize)
-{
-    /* If the buffers to be provided to the Timer task are declared inside this
-     * function then they must be declared static - otherwise they will be allocated on
-     * the stack and so not exists after this function exits. */
-    static StaticTask_t xTimerTaskTCB;
-    static StackType_t uxTimerTaskStack[configTIMER_TASK_STACK_DEPTH];
-
-    /* Pass out a pointer to the StaticTask_t structure in which the Timer
-     * task's state will be stored. */
-    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
-
-    /* Pass out the array that will be used as the Timer task's stack. */
-    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
-
-    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
-     * Note that, as the array is necessarily of type StackType_t,
-     * configTIMER_TASK_STACK_DEPTH is specified in words, not bytes. */
-    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
-}
-
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Warn user if pvPortMalloc fails.
- *
- * Called if a call to pvPortMalloc() fails because there is insufficient
- * free memory available in the FreeRTOS heap.  pvPortMalloc() is called
- * internally by FreeRTOS API functions that create tasks, queues, software
- * timers, and semaphores.  The size of the FreeRTOS heap is set by the
- * configTOTAL_HEAP_SIZE configuration constant in FreeRTOSConfig.h.
- *
- */
-void vApplicationMallocFailedHook()
-{
-    taskDISABLE_INTERRUPTS();
-    for( ;; );
-}
-
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Loop forever if stack overflow is detected.
- *
- * If configCHECK_FOR_STACK_OVERFLOW is set to 1,
- * this hook provides a location for applications to
- * define a response to a stack overflow.
- *
- * Use this hook to help identify that a stack overflow
- * has occurred.
- *
- */
-void vApplicationStackOverflowHook( TaskHandle_t xTask,
-                                    char * pcTaskName )
-{
-    portDISABLE_INTERRUPTS();
-
-    /* Loop forever */
-    for( ; ; );
-}
-
-/*-----------------------------------------------------------*/
-
-void *pvPortCalloc(size_t xNum, size_t xSize)
-{
-    void *pvReturn;
-
-    pvReturn = pvPortMalloc(xNum * xSize);
-    if (pvReturn != NULL)
+    if( pvReturn != NULL )
     {
-        memset(pvReturn, 0x00, xNum * xSize);
+        memset( pvReturn, 0x00, xNum * xSize );
     }
 
     return pvReturn;

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/secure_sockets/aws_secure_sockets.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/secure_sockets/aws_secure_sockets.c
@@ -37,9 +37,6 @@
 #include "aws_tls.h"
 #include "task.h"
 
-/* Logging includes. */
-#include "aws_logging_task.h"
-
 /* Third-party wifi driver include. */
 #include "qcom_api.h"
 #include "aws_wifi.h"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- add CMakefile for nxp mcuxpresso
- exclude cborpretty.c because it includes a bad header "inttype.h"
- fix multi-definition problem in demo


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
