### PR TITLE
Fix PIC32 Ethernet compile error when PIC32_MAC_DEBUG_COMMANDS is 1

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/lib/FreeRTOS-Plus-TCP/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -187,12 +187,15 @@
         static int _Command_NetInfo( SYS_CMD_DEVICE_NODE * pCmdIO,
                                      int argc,
                                      char ** argv );
+        static int _Command_Version( SYS_CMD_DEVICE_NODE * pCmdIO,
+                                     int argc,
+                                     char ** argv );
 
         static const SYS_CMD_DESCRIPTOR macCmdTbl[] =
         {
             { "macinfo", _Command_MacInfo, ": Check MAC statistics" },
             { "netinfo", _Command_NetInfo, ":Net info"              },
-            {"version",     _Command_Version,              ":Version info"},
+            { "version", _Command_Version, ":Version info"          },
         };
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 


### PR DESCRIPTION
Description
-----------
When `PIC32_MAC_DEBUG_COMMANDS` is set to 1 and using `PIC32_USE_ETHERNET` (both of which are not by default), there is a compilation error from a missing function declaration for one of the system commands. This adds it and fixes compilation. Also aligned formatting of the version entry in array

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.
