### PR TITLE
Add network manager include path to fix build.

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -102,6 +102,7 @@ target_include_directories(
         "${esp_idf_dir}/components/bt/bluedroid/api/include/api"
         "${esp_idf_dir}/components/bt/include"
         "${afr_ports_dir}/ble"
+        "${AFR_DEMOS_DIR}/network_manager"
 )
 
 # PKCS11


### PR DESCRIPTION
<!--- Title -->
CMake: Add network manager include path to fix build.

Description
-----------
<!--- Describe your changes in detail -->
Build fails when compiling ota demo:
demos/wifi_provisioning/aws_wifi_connect_task.c:38:41: fatal error: iot_network_manager_private.h: No such file or directory
 #include "iot_network_manager_private.h"
                                         ^
compilation terminated.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
