### PR TITLE
Fix Cmake dependency for wifi connect task

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -94,7 +94,6 @@ target_sources(
         "${afr_ports_dir}/ble/aws_ble_hal_common_gap.c"
         "${afr_ports_dir}/ble/aws_ble_hal_gap.c"
         "${afr_ports_dir}/ble/aws_ble_hal_gatt_server.c"
-        "${AFR_DEMOS_DIR}/wifi_provisioning/aws_wifi_connect_task.c"
 )
 target_include_directories(
     AFR::ble::mcu_port
@@ -162,6 +161,7 @@ else()
     set(
         extra_exe_sources
         "${AFR_DEMOS_DIR}/ble/iot_ble_numericComparison.c"
+        "${AFR_DEMOS_DIR}/wifi_provisioning/aws_wifi_connect_task.c"
         ${NETWORK_MANAGER_SOURCES}
     )
 endif()


### PR DESCRIPTION
Fix CMAKE dependency for wifi connect task

Description
-----------
Wifi Connect task is a demo task and should only be included for demos when ble ( wifi provisioning is enabled).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
