### PR TITLE
CBMC harnesses for FreeRTOS_ARP.c

### DIFF
--- a/tools/cbmc/proofs/ARP/ARPAgeCache/ARPAgeCache_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPAgeCache/ARPAgeCache_harness.c
@@ -1,0 +1,22 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+//We assume that the pxGetNetworkBufferWithDescriptor function is implemented correctly and returns a valid data structure.
+//This is the mock to mimic the correct expected bahvior. If this allocation fails, this might invalidate the proof.
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	NetworkBufferDescriptor_t *pxNetworkBuffer = (NetworkBufferDescriptor_t *) malloc(sizeof(NetworkBufferDescriptor_t));
+	pxNetworkBuffer->pucEthernetBuffer = malloc(xRequestedSizeBytes);
+	pxNetworkBuffer->xDataLength = xRequestedSizeBytes;
+	return pxNetworkBuffer;
+}
+
+void harness()
+{
+  vARPAgeCache();
+}

--- a/tools/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
@@ -1,0 +1,18 @@
+{
+  "ENTRY": "ARPAgeCache",
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset vARPAgeCache.0:7",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto",
+    "$(FREERTOS)/lib/FreeRTOS/tasks.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPAgeCache/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPAgeCache/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPAgeCache.0:7;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPAgeCache.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPAgeCache/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPAgeCache/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPAgeCache.0:7;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;vARPAgeCache.0:7;--nondet-static='
 goto: ARPAgeCache.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/ARPGenerateRequestPacket_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/ARPGenerateRequestPacket_harness.c
@@ -1,0 +1,24 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+void harness()
+{
+	/*
+	 * The assumption made here is that the buffer pointed by pucEthernerBuffer
+	 * is at least allocated to sizeof(ARPPacket_t) size but eventually a even larger buffer.
+	 * This is not checked inside vARPGenerateRequestPacket.
+	 */
+	uint8_t ucBUFFER_SIZE;
+	__CPROVER_assume( ucBUFFER_SIZE >= sizeof(ARPPacket_t) && ucBUFFER_SIZE < 2 * sizeof(ARPPacket_t) );
+	void *xBuffer = malloc(ucBUFFER_SIZE);
+
+	NetworkBufferDescriptor_t xNetworkBuffer2;
+	xNetworkBuffer2.pucEthernetBuffer = xBuffer;
+	vARPGenerateRequestPacket( &xNetworkBuffer2 );
+}

--- a/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
@@ -1,0 +1,15 @@
+{
+  "ENTRY": "ARPGenerateRequestPacket",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1='
 goto: ARPGenerateRequestPacket.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPGenerateRequestPacket/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPGenerateRequestPacket.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
@@ -1,0 +1,17 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+
+void harness()
+{
+  uint32_t ulIPAddress;
+  MACAddress_t xMACAddress;
+
+  eARPGetCacheEntry( &ulIPAddress, &xMACAddress );
+}

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntry/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntry/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "ARPGetCacheEntry",
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset prvCacheLookup.0:7",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntry/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntry/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;prvCacheLookup.0:7;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPGetCacheEntry.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntry/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntry/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;prvCacheLookup.0:7;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;prvCacheLookup.0:7;--nondet-static='
 goto: ARPGetCacheEntry.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
@@ -1,0 +1,15 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+void harness()
+{
+  ARPPacket_t xARPFrame;
+
+  eARPProcessPacket( &xARPFrame );
+}

--- a/tools/cbmc/proofs/ARP/ARPProcessPacket/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPProcessPacket/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "ARPProcessPacket",
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPProcessPacket/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPProcessPacket/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--nondet-static='
 goto: ARPProcessPacket.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPProcessPacket/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPProcessPacket/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--nondet-static;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPProcessPacket.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/ARPRefreshCacheEntry_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/ARPRefreshCacheEntry_harness.c
@@ -1,0 +1,15 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_ARP.h"
+
+void harness()
+{
+  MACAddress_t xMACAddress;
+  uint32_t ulIPAddress;
+  vARPRefreshCacheEntry( &xMACAddress, ulIPAddress );
+  vARPRefreshCacheEntry( NULL, ulIPAddress );
+}

--- a/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "ARPRefreshCacheEntry",
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPRefreshCacheEntry.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPRefreshCacheEntry/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;vARPRefreshCacheEntry.0:7,memcmp.0:17;--nondet-static='
 goto: ARPRefreshCacheEntry.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPSendGratuitous/ARPSendGratuitous_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPSendGratuitous/ARPSendGratuitous_harness.c
@@ -1,0 +1,13 @@
+// /* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_ARP.h"
+
+
+void harness()
+{
+  vARPSendGratuitous();
+}

--- a/tools/cbmc/proofs/ARP/ARPSendGratuitous/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPSendGratuitous/Makefile.json
@@ -1,0 +1,15 @@
+{
+  "ENTRY": "ARPSendGratuitous",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPSendGratuitous/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPSendGratuitous/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1='
 goto: ARPSendGratuitous.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARPSendGratuitous/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARPSendGratuitous/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ARPSendGratuitous.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
@@ -1,0 +1,13 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_ARP.h"
+
+void harness()
+{
+	FreeRTOS_ClearARP();
+}
+

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/Makefile.json
@@ -1,0 +1,15 @@
+{
+  "ENTRY": "ClearARP",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1='
 goto: ClearARP.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: ClearARP.goto
+expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Makefile.json
@@ -1,0 +1,15 @@
+{
+  "ENTRY": "OutputARPRequest",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
@@ -1,0 +1,37 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+
+ARPPacket_t xARPPacket;
+NetworkBufferDescriptor_t xNetworkBuffer;
+
+/* 
+ * We assume that the pxGetNetworkBufferWithDescriptor function is
+ * implemented correctly and returns a valid data structure.
+ * This is the mock to mimic the expected behavior.
+ * If this allocation fails, this might invalidate the proof.
+ * FreeRTOS_OutputARPRequest calls pxGetNetworkBufferWithDescriptor
+ * to get a NetworkBufferDescriptor. Then it calls vARPGenerateRequestPacket
+ * passing this buffer along in the function call. vARPGenerateRequestPacket
+ * casts the pointer xNetworkBuffer.pucEthernetBuffer into an ARPPacket_t pointer
+ * and writes a complete ARPPacket to it. Therefore the buffer has to be at least of the size
+ * of an ARPPacket to gurantee memory safety.
+ */
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	xNetworkBuffer.pucEthernetBuffer = malloc(xRequestedSizeBytes);
+	xNetworkBuffer.xDataLength = xRequestedSizeBytes;
+	return &xNetworkBuffer;
+}
+
+
+void harness()
+{
+	uint32_t ulIPAddress;
+	FreeRTOS_OutputARPRequest( ulIPAddress );
+}

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1='
 goto: OutputARPRequest.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--unwind;1;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+goto: OutputARPRequest.goto
+expected: SUCCESSFUL


### PR DESCRIPTION
<!--- CBMC harnesses for FreeRTOS_ARP.c -->

Description
-----------
Theses harnesses proof in general the memory safety of the ARP code base.
There are a few assumptions made about the code:
- pointer passed as an pointer to an ARPPacket_t are really pointing to a piece of memory of sizeof(ARPPacket_t)
- pxGetNetworkBufferWithDescriptor work correctly (There are proofs in the pipeline for this as well.)
- xNetworkInterfaceOutput is out of scope for this proofs and abstracted away.
- xSendEventToIPTask  is out of scope for this proofs and abstracted away.
The program is safe until the call of abstracted functions. There might be a memory problem inside the xNetworkInterfaceOutput or xSendEventToIPTask function, that is not catched in this call.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [  ] My code is Linted.