### PR TITLE
refactor: Move the 2nd test WIFI AP to a header file

### DIFF
--- a/tests/common/include/aws_test_wifi.h
+++ b/tests/common/include/aws_test_wifi.h
@@ -1,0 +1,33 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+#ifndef _AWS_TEST_WIFI_H_
+#define _AWS_TEST_WIFI_H_
+
+/* Second set of valid Wi-Fi credentials for testing the connection loop. */
+#define testwifiWIFI_SSID        "Guest"
+#define testwifiWIFI_PASSWORD    "Dummy"
+#define testwifiWIFI_SECURITY    eWiFiSecurityOpen
+
+#endif /* ifndef AWS_TEST_WIFI_H */

--- a/tests/common/wifi/aws_test_wifi.c
+++ b/tests/common/wifi/aws_test_wifi.c
@@ -45,6 +45,7 @@
 #include "aws_test_runner.h"
 #include "aws_test_tcp.h"
 #include "aws_test_utils.h"
+#include "aws_test_wifi.h"
 #include "aws_test_wifi_config.h"
 
 /* Testing configurations defintions. */
@@ -94,11 +95,6 @@
 #define testwifiINVALID_WIFI_SECURITY \
     eWiFiSecurityWEP   /* This must be a security type that is mismatched from the \
                         * valid AP configured in aws_clientcredentials.h. */
-
-/* Second set of valid Wi-Fi credentials for testing the connection loop. */
-#define testwifiWIFI_SSID        "Guest"
-#define testwifiWIFI_PASSWORD    "Dummy"
-#define testwifiWIFI_SECURITY    eWiFiSecurityOpen
 
 /* 14 total channels in the 2.4 GHz band. Set to the number of channels
  * available in your region. This can be configured in aws_test_wifi_config.h.


### PR DESCRIPTION
Description
-----------
refactor: Move the 2nd test WIFI AP to a header file

Checklist:
----------
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
