### PR TITLE
tests: Add more feedback to wifi multitask test.

### DIFF
--- a/modules/ports/wifi/test/aws_test_wifi.c
+++ b/modules/ports/wifi/test/aws_test_wifi.c
@@ -2358,13 +2358,15 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d failed to connect to the AP %s with error code %d.\r\n",
+                      "FAILURE: Task %d failed to connect to the AP %s with error code %d.\r\n",
                       pxTaskParams->usTaskId,
                       xTestNetworkParams.pcSSID,
                       xWiFiConnectStatus );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
+
+        configPRINTF( ( "INFO: Task %d connected to AP %s.\r\n", pxTaskParams->usTaskId, xTestNetworkParams.pcSSID ) );
 
         /* Delay. */
         vTaskDelay( testwifiCONNECTION_DELAY );
@@ -2377,12 +2379,14 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d failed to connect to the AP %s with error code %d.\r\n",
+                      "FAILURE: Task %d failed to connect to the AP %s with error code %d.\r\n",
                       pxTaskParams->usTaskId, xClientNetworkParams.pcSSID,
                       xWiFiConnectStatus );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
+
+        configPRINTF( ( "INFO: Task %d connected to AP %s.\r\n", pxTaskParams->usTaskId, xClientNetworkParams.pcSSID ) );
 
         /* Delay. */
         vTaskDelay( testwifiCONNECTION_DELAY );
@@ -2399,7 +2403,7 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d timeout waiting for the other task to finish "
+                      "FAILURE: Task %d timeout waiting for the other task to finish "
                       "connection.\r\n",
                       pxTaskParams->usTaskId );
 
@@ -2413,7 +2417,7 @@ static void prvConnectionTask( void * pvParameters )
         if( xIsConnected == pdFALSE )
         {
             configPRINTF(
-                ( "Task %d indicates from WIFI_IsConnected() that it is not "
+                ( "FAILURE: Task %d indicates from WIFI_IsConnected() that it is not "
                   "connected.\r\n",
                   pxTaskParams->usTaskId ) );
             break;
@@ -2426,11 +2430,13 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d failed the round-trip test after connect.\r\n",
+                      "FAILURE: Task %d failed the round-trip test after connect.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
+
+        configPRINTF( ( "INFO: Task %d Finished Connection verification Round trip test.\r\n", pxTaskParams->usTaskId ) );
 
         /* Wait for the other tasks before moving on to disconnecting. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
@@ -2446,7 +2452,7 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d timeout waiting for the other task to finish round-trip "
+                      "FAILURE: Task %d timeout waiting for the other task to finish round-trip "
                       "test after connect.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
@@ -2461,10 +2467,12 @@ static void prvConnectionTask( void * pvParameters )
 
         if( xWiFiConnectStatus != eWiFiSuccess )
         {
-            configPRINTF( ( "Task %d failed to disconnect with Wi-Fi error code %d\r\n",
+            configPRINTF( ( "FAILURE: Task %d failed to disconnect with Wi-Fi error code %d\r\n",
                             pxTaskParams->usTaskId, xWiFiConnectStatus ) );
             break;
         }
+
+        configPRINTF( ( "INFO: Task %d disconnected from AP %s.\r\n", pxTaskParams->usTaskId, xTestNetworkParams.pcSSID ) );
 
         /* Delay. */
         vTaskDelay( testwifiCONNECTION_DELAY );
@@ -2481,7 +2489,7 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d timeout waiting for the other task to finish "
+                      "FAILURE: Task %d timeout waiting for the other task to finish "
                       "disconnection.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
@@ -2495,7 +2503,7 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d returned eWiFiSuccess from WIFI_Disconnect(), but is not "
+                      "FAILURE: Task %d returned eWiFiSuccess from WIFI_Disconnect(), but is not "
                       "disconnected.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
@@ -2509,12 +2517,14 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d completed the round-trip test after supposedly "
+                      "FAILURE: Task %d completed the round-trip test after supposedly "
                       "disconnecting.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );
             break;
         }
+
+        configPRINTF( ( "INFO: Task %d Finished disconnection verification Round trip test.\r\n", pxTaskParams->usTaskId ) );
 
         /* Wait for the other tasks. */
         if( ( xTaskConnectDisconnectSyncEventGroupHandle != NULL ) &&
@@ -2528,7 +2538,7 @@ static void prvConnectionTask( void * pvParameters )
         {
             snprintf( pxTaskParams->cStatusMsg,
                       sizeof( pxTaskParams->cStatusMsg ),
-                      "Task %d timeout waiting for the other task to finish the round "
+                      "FAILURE: Task %d timeout waiting for the other task to finish the round "
                       "trip after disconnect.\r\n",
                       pxTaskParams->usTaskId );
             configPRINTF( ( pxTaskParams->cStatusMsg ) );


### PR DESCRIPTION
- Made connection status and made task failures more clear in AFQP_WiFiSeperateTasksConnectingAndDisconnectingAtOnce.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
