### PR TITLE
Fix handling of an option at the end of the DHCP response packet.

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
@@ -108,11 +108,6 @@ are located. */
 located. */
 #define dhcpFIRST_OPTION_BYTE_OFFSET			( 0xf0 )
 
-/* When walking the variable length options field, the following value is used
-to ensure the walk has not gone past the end of the valid options.  2 bytes is
-made up of the length byte, and minimum one byte value. */
-#define dhcpMIN_OPTION_LENGTH_OF_INTEREST		( 2L )
-
 /* Standard DHCP port numbers and magic cookie value. */
 #if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 	#define dhcpCLIENT_PORT 0x4400u
@@ -651,7 +646,7 @@ const uint32_t ulMandatoryOptions = 2ul; /* DHCP server address, and the correct
                 invalid byte). */
 				pucLastByte = pucUDPPayload + lBytes - 1;
 
-				while( pucByte <= ( pucLastByte - ( dhcpMIN_OPTION_LENGTH_OF_INTEREST - 1 ) ) )
+				while( pucByte <= pucLastByte )
 				{
 					ucOptionCode = pucByte[ 0 ];
 					if( ucOptionCode == dhcpOPTION_END_BYTE )
@@ -670,6 +665,7 @@ const uint32_t ulMandatoryOptions = 2ul; /* DHCP server address, and the correct
 					/* Stop if the response is malformed. */
 					if( pucByte < pucLastByte )
 					{
+                        /* There are at least two bytes left. */
 						ucLength = pucByte[ 1 ];
 						pucByte += 2;
 

--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DHCP.c
@@ -111,7 +111,7 @@ located. */
 /* When walking the variable length options field, the following value is used
 to ensure the walk has not gone past the end of the valid options.  2 bytes is
 made up of the length byte, and minimum one byte value. */
-#define dhcpMAX_OPTION_LENGTH_OF_INTEREST		( 2L )
+#define dhcpMIN_OPTION_LENGTH_OF_INTEREST		( 2L )
 
 /* Standard DHCP port numbers and magic cookie value. */
 #if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
@@ -647,9 +647,11 @@ const uint32_t ulMandatoryOptions = 2ul; /* DHCP server address, and the correct
 				/* Walk through the options until the dhcpOPTION_END_BYTE byte
 				is found, taking care not to walk off the end of the options. */
 				pucByte = &( pxDHCPMessage->ucFirstOptionByte );
-				pucLastByte = &( pucUDPPayload[ lBytes - dhcpMAX_OPTION_LENGTH_OF_INTEREST ] );
+                /* Maintain a pointer to the last valid byte (i.e. not the first
+                invalid byte). */
+				pucLastByte = pucUDPPayload + lBytes - 1;
 
-				while( pucByte < pucLastByte )
+				while( pucByte <= ( pucLastByte - ( dhcpMIN_OPTION_LENGTH_OF_INTEREST - 1 ) ) )
 				{
 					ucOptionCode = pucByte[ 0 ];
 					if( ucOptionCode == dhcpOPTION_END_BYTE )
@@ -666,12 +668,12 @@ const uint32_t ulMandatoryOptions = 2ul; /* DHCP server address, and the correct
 					}
 
 					/* Stop if the response is malformed. */
-					if( pucByte < pucLastByte - 1 )
+					if( pucByte < pucLastByte )
 					{
 						ucLength = pucByte[ 1 ];
 						pucByte += 2;
 
-						if( pucByte >= pucLastByte - ucLength )
+						if( pucByte + ucLength > pucLastByte )
 						{
 							break;
 						}

--- a/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
@@ -18,7 +18,7 @@
 
 ################################################################
 # Buffer payload
-  "BUFFER_PAYLOAD": "__eval 1 if {BUFFER_SIZE} <= {BUFFER_HEADER} else {BUFFER_SIZE} - {BUFFER_HEADER}",
+  "BUFFER_PAYLOAD": "__eval 1 if {BUFFER_SIZE} <= {BUFFER_HEADER} else {BUFFER_SIZE} - {BUFFER_HEADER} + 2",
 
 ################################################################
 

--- a/tools/cbmc/proofs/ProcessDHCPReplies/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--object-bits;7;--unwind;0;--unwindset;memcmp.0:7,prvProcessDHCPReplies.0:59;--unwinding-assertions;--32;--bounds-check;--pointer-check='
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwindset;memcmp.0:7,prvProcessDHCPReplies.0:61;--unwinding-assertions='
 goto: ProcessDHCPReplies.goto
 expected: SUCCESSFUL

--- a/tools/cbmc/proofs/make-common-makefile.py
+++ b/tools/cbmc/proofs/make-common-makefile.py
@@ -202,7 +202,7 @@ cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@
 	@echo "jobos: ubuntu16" >> $@
-	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS))" >> $@
+	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS) --unwinding-assertions)" >> $@
 	@echo "goto: $(ENTRY).goto" >> $@
 	@echo "expected: SUCCESSFUL" >> $@
 


### PR DESCRIPTION
Fix handling of an option occurring at the end of a DHCP response packet. See #559.