### PR TITLE
Fix handling of disconnected socket states in prvTCPSendCheck.

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_Sockets.c
@@ -2382,7 +2382,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		{
 			xResult = -pdFREERTOS_ERRNO_ENOMEM;
 		}
-		else if( pxSocket->u.xTCP.ucTCPState == eCLOSED )
+		else if( pxSocket->u.xTCP.ucTCPState == eCLOSED ||
+                 pxSocket->u.xTCP.ucTCPState == eCLOSE_WAIT ||
+                 pxSocket->u.xTCP.ucTCPState == eCLOSING )
 		{
 			xResult = -pdFREERTOS_ERRNO_ENOTCONN;
 		}


### PR DESCRIPTION
prvTCPSendCheck needs to handle eCLOSED, eCLOSE_WAIT, and eCLOSING as as a disconnected socket. See #566.