### PR TITLE
ESP IDF : CMake build system related changes

### DIFF
--- a/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
+++ b/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
@@ -131,6 +131,9 @@ target_sources(
 # Amazon FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------
 
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 if(AFR_IS_TESTING)
     set(exe_target aws_tests)
 else()
@@ -224,7 +227,11 @@ get_filename_component(
 )
 
 set(IDF_EXTRA_COMPONENT_DIRS ${ABS_EXTRA_COMPONENT_DIRS})
-set(IDF_PROJECT_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/${exe_target}")
+
+# Since AFR target name has no .elf extension, manually append it to
+# IDF project executable name and make it dependent on the AFR target
+set(IDF_PROJECT_EXECUTABLE "${exe_target}${CMAKE_EXECUTABLE_SUFFIX}")
+add_custom_target("${IDF_PROJECT_EXECUTABLE}" ALL DEPENDS ${exe_target})
 
 # Wraps add_subdirectory() to create library targets for components, and then `return` them using the given variable.
 # In this case the variable is named `component`
@@ -232,3 +239,14 @@ idf_import_components(components ${espressif_dir} esp-idf)
 
 # Wraps target_link_libraries() to link processed components by idf_import_components to target
 idf_link_components(${exe_target} "${components}")
+
+# Monitor target for running idf_monitor.py
+add_custom_target(monitor
+    DEPENDS "${IDF_PROJECT_EXECUTABLE}"
+    COMMAND ${CMAKE_COMMAND}
+    -D IDF_PATH="${espressif_dir}"
+    -D PROJECT_ELF="${IDF_PROJECT_EXECUTABLE}"
+    -D ELF_DIR="${CMAKE_BINARY_DIR}"
+    -P run_idf_monitor.cmake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    )

--- a/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
+++ b/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
@@ -187,6 +187,12 @@ string(REGEX REPLACE "partitions_example.csv" "${board_dir}/../make/partitions_e
 file(WRITE "${CMAKE_BINARY_DIR}/sdkconfig.defaults" "${file_sdkconfig_default}")
 set(IDF_SDKCONFIG_DEFAULTS "${CMAKE_BINARY_DIR}/sdkconfig.defaults")
 
+# Set sdkconfig generation path inside build
+set(SDKCONFIG "${AFR_ROOT_DIR}/build/sdkconfig")
+
+# Remove previously generated sdkconfig file
+file(REMOVE "${CMAKE_BINARY_DIR}/sdkconfig")
+
 # Do some configuration for idf_import_components. This enables creation of artifacts (which might not be
 # needed) for some projects
 set(IDF_BUILD_ARTIFACTS ON)

--- a/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/run_idf_monitor.cmake
+++ b/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/run_idf_monitor.cmake
@@ -1,0 +1,47 @@
+# A CMake script to run idf_monitor commands from within ninja or make
+# or another cmake-based build runner
+#
+# (Needed to expand environment variables, for backwards compatibility.)
+#
+# It is recommended to NOT USE this CMake script if you have the option of
+# running idf_monitor.py directly. This script exists only for use inside CMake builds.
+#
+cmake_minimum_required(VERSION 3.5)
+
+if(NOT IDF_PATH OR NOT PROJECT_ELF OR NOT ELF_DIR)
+    message(FATAL_ERROR "IDF_PATH, PROJECT_ELF and ELF_DIR must "
+        "be specified on the CMake command line. For direct monitor execution, it is "
+        "strongly recommended to run idf_monitor.py directly.")
+endif()
+
+# Note: we can't expand these environment variables in the main IDF CMake build,
+# because we want to expand them when running monitor not at CMake runtime (so they can change
+# without needing a CMake re-run)
+set(ESPPORT $ENV{ESPPORT})
+if(NOT ESPPORT)
+    message("Note: Using default serial port /dev/ttyUSB0. To modify, set ESPPORT environment variable.")
+else()
+    set(port_arg "--port ${ESPPORT}")
+endif()
+
+set(MONITORBAUD $ENV{MONITORBAUD})
+if(NOT MONITORBAUD)
+    message("Note: Using default baud rate 115200. To modify, set MONITORBAUD environment variable.")
+else()
+    set(baud_arg "--baud ${MONITORBAUD}")
+endif()
+
+include("${IDF_PATH}/tools/cmake/utilities.cmake")
+
+set(cmd "${IDF_PATH}/tools/idf_monitor.py ${port_arg} ${baud_arg} ${PROJECT_ELF}")
+spaces2list(cmd)
+
+execute_process(COMMAND ${cmd}
+    WORKING_DIRECTORY "${ELF_DIR}"
+    RESULT_VARIABLE result
+    )
+
+if(${result})
+    # No way to have CMake silently fail, unfortunately
+    message(FATAL_ERROR "idf_monitor.py failed")
+endif()


### PR DESCRIPTION
List of changes:
* sdkconfig generation path now inside build folder
* sdkconfig is regenerated on running cmake
* support added for monitor target