### PR TITLE
Fix formatting of endAddress in ota_image_generator.py

### DIFF
--- a/demos/common/ota/bootloader/utility/ota_image_generator.py
+++ b/demos/common/ota/bootloader/utility/ota_image_generator.py
@@ -336,7 +336,7 @@ def getOTADescriptor(userConfigFilePath, inputImagePath, ruleFolderPath, hardwar
     # 7. calculate and validate the end address
     fileSize = getFileSize(inputImagePath)
     endAddress = getEndAddress(fileSize, int(startAddress, 16))  # get end address in decimal format
-    endAddress = hex(endAddress).upper()  # convert to hexadecimal format
+    endAddress = format32BitHexStr(hex(endAddress)) # convert to hexadecimal format
 
     # make sure minAddrHardwarePlatform < endAddress <= maxAddressHardwarePlatform
     endMin = format32BitHexStr(hex(int(minAddrHardwarePlatform, 16) + 1))


### PR DESCRIPTION
On some platforms, endAddress variable was rendered with the long "L"
designation at the end (ex 0x01234567L) which was not interpreted
properly by subsequent functions.  This commit uses the
format32BitHexStr to address all string formatting.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
