### PR TITLE
Fix ACK number check for RST packet handling.

### DIFF
--- a/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
+++ b/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_TCP_IP.c
@@ -3011,7 +3011,7 @@ BaseType_t xResult = pdPASS;
                 {
                     /* Per the above RFC, "In the SYN-SENT state ... the RST is 
                     acceptable if the ACK field acknowledges the SYN." */
-                    if( ulAckNumber == pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber )
+                    if( ulAckNumber == pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber + 1 )
                     {
                         vTCPStateChange( pxSocket, eCLOSED );
                     }


### PR DESCRIPTION
This fixes the ACK number check that ensures that inbound RST packets received during the SYN-SENT state. Per the TCP RFC, the ACK number should be one more than the current sequence number in our window state structure.