### PR TITLE
Add a configuration unfolding script for CBMC proof configurations.

### DIFF
--- a/tools/cbmc/README.md
+++ b/tools/cbmc/README.md
@@ -57,11 +57,13 @@ Setting up the proofs
 
 Change into the `proofs` directory. On Windows, run
 ```
+python make-configuration-directories.py
 python make-common-makefile.py
 python make-proof-makefiles.py
 ```
 On macOS or Linux, run
 ```
+./make-configuration-directories.py
 ./make-common-makefile.py
 ./make-proof-makefiles.py
 ```

--- a/tools/cbmc/proofs/make-common-makefile.py
+++ b/tools/cbmc/proofs/make-common-makefile.py
@@ -198,7 +198,7 @@ define encode_options
 '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
 endef
 
-cbmc-batch.yaml: Makefile ../Makefile.common
+cbmc-batch.yaml:
 	@echo "Building $@"
 	@$(RM) $@
 	@echo "jobos: ubuntu16" >> $@

--- a/tools/cbmc/proofs/make-configuration-directories.py
+++ b/tools/cbmc/proofs/make-configuration-directories.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+#
+# Generation of Makefile.json from Configurations.json for CBMC proofs.
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import logging
+import os
+import pathlib
+import shutil
+import textwrap
+
+logging.basicConfig(format="{script}: %(levelname)s %(message)s".format(
+    script=os.path.basename(__file__)))
+
+LOGGER = logging.getLogger("ComputeConfigurations")
+
+def prolog():
+    return textwrap.dedent("""\
+        This script Generates Makefile.json from Configrations.json.
+
+        Starting in the current directory, it walks down every subdirectory
+        looking for Configurations.json files. Every found Configurations.json
+        file is assumed to look similar to the following format:
+
+        {
+          "ENTRY": "ARPProcessPacket",
+          "CBMCFLAGS":
+          [
+              "--unwind 1",
+              "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17",
+              "--nondet-static"
+          ],
+          "OBJS":
+          [
+            "$(ENTRY)_harness.goto",
+            "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+          ],
+          "DEF":
+          [
+            {"disableClashDetection": ["ipconfigARP_USE_CLASH_DETECTION=0"]},
+            {"enableClashDetection": ["ipconfigARP_USE_CLASH_DETECTION=1"]}
+          ]
+        }
+
+        The format is mainly taken from the Makefile.json files.
+        The only difference is that it expects a list of json object in the DEF
+        section. This script will generate a Makefile.json in a subdirectory and
+        copy the harness to each subdirectory.
+        The key is later taken as the name for the configuration subdirectory
+        prexied by 'config_'.
+
+        So for the above script, we get two subdirectories:
+        -config_disableClashDetection
+        -config_enableClashDetection
+
+        As an example, the resulting Makefile.json for the
+        config_disableClashDetection directory will be:
+
+        {
+          "ENTRY": "ARPProcessPacket",
+          "CBMCFLAGS": [
+            "--unwind 1",
+            "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17",
+            "--nondet-static"
+          ],
+          "OBJS": [
+            "$(ENTRY)_harness.goto",
+            "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+          ],
+          "DEF": [
+            "ipconfigARP_USE_CLASH_DETECTION=0"
+          ]
+        }
+
+        These Makefile.json files then can be turned into Makefiles for running
+        the proof by executing the make-proof-makefiles.py script.
+        """)
+
+
+def process(folder, files):
+    with open(os.path.join(folder, "Configurations.json"), "r") as source:
+        content = "".join([line for line in source if not line.startswith("#")])
+        json_content = json.loads(content)
+    try:
+        def_list = json_content["DEF"]
+    except KeyError:
+        LOGGER.error("Expected DEF as key in a Configurations.json files.")
+        return
+    for config in def_list:
+        logging.debug(config)
+        try:
+            configname = list(config.keys())[0]
+            configbody = config[configname]
+        except (AttributeError, IndexError) as e:
+            LOGGER.error(e)
+            LOGGER.error(textwrap.dedent("""\
+            The expected layout for an entry in the Configurations.json
+            file is a dictonary. Here is an example of the expected format:
+
+            "DEF":
+            [
+              {"disableClashDetection": ["ipconfigARP_USE_CLASH_DETECTION=0"]},
+              {"enableClashDetection": ["ipconfigARP_USE_CLASH_DETECTION=1"]}
+            ]
+                """))
+            LOGGER.error("The offending entry is %s", config)
+            return
+        new_config_folder = os.path.join(folder, "config_" + configname)
+        pathlib.Path(new_config_folder).mkdir(exist_ok=True, parents=True)
+        harness_copied = False
+        for file in files:
+            if file.endswith("harness.c"):
+                shutil.copy(os.path.join(folder, file),
+                            os.path.join(new_config_folder, file))
+                harness_copied = True
+
+        if not harness_copied:
+            LOGGER.error("Could not find a harness in folder %s.", folder)
+            LOGGER.error("This folder is not processed do the end!")
+            return
+        current_config = dict(json_content)
+        current_config["DEF"] = configbody
+        with open(os.path.join(new_config_folder, "Makefile.json"),
+                  "w") as output_file:
+            json.dump(current_config, output_file, indent=2)
+
+
+if __name__ == '__main__':
+    for fldr, _, fyles in os.walk("."):
+        if "Configurations.json" in fyles:
+            process(fldr, fyles)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The make-configuration-directories.py script takes a Configurations.json file and unfold the define section into a single proof directory per define set.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.
