### PR TITLE
Add CBMC memory-safety proof for DHCPProcess

### DIFF
--- a/tools/cbmc/proofs/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCPProcess/DHCPProcess_harness.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_DHCP.h"
+
+/*
+ * CBMC automatically unwinds strlen on a fixed string
+ */
+const char * pcApplicationHostnameHook(void) {
+  return "hostname";
+}
+
+/*
+ * This stub allows us to overcome the unwinding error obtained
+ * in the do-while loop within function prvCreatePartDHCPMessage.
+ * The behaviour is similar to the original function, but failed allocations
+ * are not considered here (this is a safe assumption that avoids the error)
+ */
+void *FreeRTOS_GetUDPPayloadBuffer( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks )
+{
+  NetworkBufferDescriptor_t xNetworkBuffer;
+  void *pvReturn;
+
+  xNetworkBuffer.xDataLength = ipUDP_PAYLOAD_OFFSET_IPv4 + xRequestedSizeBytes;
+  xNetworkBuffer.pucEthernetBuffer = malloc( xNetworkBuffer.xDataLength );
+  pvReturn = (void *) &( xNetworkBuffer.pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+  return pvReturn;
+}
+
+/*
+ * In this stub we allocate a buffer within the specified range
+ * Note that the values for BUFFER_SIZE and prvProcessDHCPReplies.0
+ * are correlated, and their current values have been adjusted in order
+ * to obtain maximum coverage in the shortest amount of time
+ */
+int32_t FreeRTOS_recvfrom(
+  Socket_t xSocket, void *pvBuffer, size_t xBufferLength,
+  BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress,
+  socklen_t *pxSourceAddressLength )
+{
+  __CPROVER_assert(xFlags & FREERTOS_ZERO_COPY, "I can only do ZERO_COPY");
+
+  size_t xBufferSize;
+  /* A DHCP message (min. size 241B) is preceded by the IP buffer padding (10B) and the UDP payload (42B) */
+  __CPROVER_assume(xBufferSize >= ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4);
+  /* The last field of a DHCP message (Options) is variable in length, but 6 additional bytes are enough */
+  /* to obtain maximum coverage with this proof. Hence, we have BUFFER_SIZE=299 */
+  __CPROVER_assume(xBufferSize <= BUFFER_SIZE);
+
+  /* The buffer gets allocated and we set the pointer past the UDP payload (i.e., start of DHCP message) */
+  *((char **)pvBuffer) = malloc(xBufferSize) + ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4;
+
+  return xBufferSize - ipUDP_PAYLOAD_OFFSET_IPv4 - ipBUFFER_PADDING;
+}
+
+/*
+ * The harness test proceeds to call DHCPProcess with an unconstrained value
+ */
+void harness()
+{
+  BaseType_t xReset;
+  vDHCPProcess( xReset );
+}

--- a/tools/cbmc/proofs/DHCPProcess/Makefile.json
+++ b/tools/cbmc/proofs/DHCPProcess/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "DHCPProcess",
+  "CBMCFLAGS": "--unwind 4 --unwindset strlen.0:11,memcmp.0:7,prvProcessDHCPReplies.0:8 --nondet-static",
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+# Minimal buffer size for maximum coverage, see harness for details.
+  "BUFFER_SIZE": 299,
+  "DEF":
+  [
+    "BUFFER_SIZE={BUFFER_SIZE}"
+  ]
+}

--- a/tools/cbmc/proofs/DHCPProcess/README.md
+++ b/tools/cbmc/proofs/DHCPProcess/README.md
@@ -1,0 +1,7 @@
+This proof demonstrates the memory safety of the DHCPProcess function, which is
+the function that triggers the DHCP protocol. The main stubs in this proof deal
+with buffer management, which assume that the buffer is large enough to
+accomodate a DHCP message plus a few additional bytes for options (which is the
+last, variable-sized field in a DHCP message). We have abstracted away sockets,
+concurrency and third-party code. For more details, please check the comments
+on the harness file.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR includes the CBMC proof for memory safety of the DHCPProcess function, which is
the function that triggers the DHCP protocol in FreeRTOS.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Changes have been tested.
- [x] Configuration files are included.
- [x] Documentation for proof and parts of the test harness.
- [ ] My code is Linted.
