### PR TITLE
Add CBMC harnesses for non default functions

### DIFF
--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
@@ -1,0 +1,14 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+
+void harness(){
+	MACAddress_t xMACAddress;
+	uint32_t ulIPAddress;
+	eARPGetCacheEntryByMac( &xMACAddress, &ulIPAddress );
+}

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "ARPGetCacheEntryByMac",
+  "CBMCFLAGS":
+  [
+      "--unwind 7",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_ARP_REVERSED_LOOKUP=1", "ipconfigARP_CACHE_ENTRIES=6"
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/README.md
+++ b/tools/cbmc/proofs/ARP/ARPGetCacheEntryByMac/README.md
@@ -1,0 +1,4 @@
+ARPGetCacheEntryByMac is memory safe,
+if it is enabled.
+
+ARPGetCacheEntryByMac does not use multiple configurations internally.

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/FreeRTOS_PrintARPCache_harness.c
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/FreeRTOS_PrintARPCache_harness.c
@@ -1,0 +1,14 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOS_ARP.h"
+
+void harness()
+{
+	FreeRTOS_PrintARPCache();
+}

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/Makefile.json
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "FreeRTOS_PrintARPCache",
+  "CBMCFLAGS":
+  [
+      "--unwind 7",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_ARP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigARP_CACHE_ENTRIES=6"
+  ]
+}

--- a/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/README.md
+++ b/tools/cbmc/proofs/ARP/ARP_FreeRTOS_PrintARPCache/README.md
@@ -1,0 +1,4 @@
+FreeRTOS_PrintARPCache_harness.c is memory safe,
+assuming vLoggingPrintf is correct and memory safe.
+
+FreeRTOS_PrintARPCache does not use multiple configurations.


### PR DESCRIPTION

Description
-----------
<!--- Describe your changes in detail -->
While eARPGetCacheEntryByMac and FreeRTOS_PrintARPCache are compiled out by default,
the provided proofs ensure that they are memory safe, if compiled in on occasion.

