### PR TITLE
IDF CMake : Circular dependency fixed in ELF generation

### DIFF
--- a/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
+++ b/cmake/vendors/espressif/esp32_devkitc_esp_wrover_kit/CMakeLists.txt
@@ -131,7 +131,6 @@ target_sources(
 # Amazon FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------
 
-set(CMAKE_EXECUTABLE_SUFFIX ".elf")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if(AFR_IS_TESTING)
@@ -227,11 +226,7 @@ get_filename_component(
 )
 
 set(IDF_EXTRA_COMPONENT_DIRS ${ABS_EXTRA_COMPONENT_DIRS})
-
-# Since AFR target name has no .elf extension, manually append it to
-# IDF project executable name and make it dependent on the AFR target
-set(IDF_PROJECT_EXECUTABLE "${exe_target}${CMAKE_EXECUTABLE_SUFFIX}")
-add_custom_target("${IDF_PROJECT_EXECUTABLE}" ALL DEPENDS ${exe_target})
+set(IDF_PROJECT_EXECUTABLE ${exe_target})
 
 # Wraps add_subdirectory() to create library targets for components, and then `return` them using the given variable.
 # In this case the variable is named `component`


### PR DESCRIPTION
.elf suffix removed and target app directly depends on exe_target