### PR TITLE
Add CBMC memory-safety proof for SendEventToIPTask

### DIFF
--- a/tools/cbmc/proofs/SendEventToIPTask/Makefile.json
+++ b/tools/cbmc/proofs/SendEventToIPTask/Makefile.json
@@ -1,0 +1,13 @@
+{
+  "ENTRY": "SendEventToIPTask",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+  	"--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ]
+}

--- a/tools/cbmc/proofs/SendEventToIPTask/README.md
+++ b/tools/cbmc/proofs/SendEventToIPTask/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of SendEventToIPTask, a function used
+for sending different events to IP-Task. We have abstracted away queues.

--- a/tools/cbmc/proofs/SendEventToIPTask/SendEventToIPTask_harness.c
+++ b/tools/cbmc/proofs/SendEventToIPTask/SendEventToIPTask_harness.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+// The harness test proceeds to call SendEventToIPTask with an unconstrained value
+void harness()
+{
+  eIPEvent_t eEvent;
+  xSendEventToIPTask( eEvent );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR includes the CBMC proof that demonstrates the memory safety of SendEventToIPTask, a function used for sending different events to IP-Task.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Changes have been tested.
- [x] Configuration files are included.
- [x] Documentation for proof and parts of the test harness.
