### PR TITLE
fix: Reboot issue on cypress with release-1.5

### DIFF
--- a/demos/demo_runner/iot_demo_afr.c
+++ b/demos/demo_runner/iot_demo_afr.c
@@ -320,10 +320,6 @@ void runDemoTask( void * pArgument )
                                 &credentials,
                                 pNetworkInterface );
 
-        /* Report heap usage. */
-        IotLogInfo( "Demo minimum ever free heap: %lu bytes.",
-                    ( unsigned long ) xPortGetMinimumEverFreeHeapSize() );
-
         /* Log the demo status. */
         if( status == EXIT_SUCCESS )
         {

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
@@ -57,7 +57,7 @@ $(NAME)_SOURCES :=  $(AMAZON_FREERTOS_PATH)freertos_kernel/event_groups.c \
                     $(AMAZON_FREERTOS_PATH)freertos_kernel/tasks.c \
                     $(AMAZON_FREERTOS_PATH)freertos_kernel/timers.c \
                     $(AMAZON_FREERTOS_PATH)freertos_kernel/stream_buffer.c \
-                    $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/MemMang/heap_4.c
+                    $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/MemMang/heap_3.c
 
 # Win32_x86 specific sources and includes
 $(NAME)_Win32_x86_SOURCES  := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/MSVC-MingW/port.c

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/common/application_code/main.c
@@ -149,9 +149,6 @@ void vApplicationDaemonTaskStartupHook( void )
     /* Initialize the AWS Libraries system. */
     if( SYSTEM_Init() == pdPASS )
     {
-        /* Connect to the Wi-Fi before running the demos. */
-        prvWifiConnect();
-
         /* Generate seed for PRNG */
         prvGenerateRandomSeed();
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/common/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/common/config_files/FreeRTOSConfig.h
@@ -70,7 +70,7 @@
     #define configMAX_PRIORITIES                       ( 10 )
     #define configTICK_RATE_HZ                         ( ( TickType_t ) SYSTICK_FREQUENCY )
     #define configMINIMAL_STACK_SIZE                   ( ( uint16_t ) 256 )
-    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 200U * 1024U ) )
+    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
         #define configUSE_TRACE_FACILITY               ( 0 )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/application_code/main.c
@@ -147,9 +147,6 @@ void vApplicationDaemonTaskStartupHook( void )
     /* Initialize the AWS Libraries system. */
     if( SYSTEM_Init() == pdPASS )
     {
-        /* Connect to the Wi-Fi before running the tests. */
-        prvWifiConnect();
-
         /* Generate seed for PRNG */
         prvGenerateRandomSeed();
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/application_code/main.c
@@ -58,14 +58,15 @@
 /* DNS addresses used seed in PRNG seed generation
  * 7 total addresses to for 7 DNS queries
  * TODO Define these addresses as macros (configXYZ) */
-static const char *pcDnsNames[] = {
-        "www.amazon.com",
-        "aws.amazon.com",
-        "www.imdb.com",
-        "www.zappos.com",
-        "www.amazon.co.uk",
-        "www.amazon.co.in",
-        "www.a9.com"
+static const char * pcDnsNames[] =
+{
+    "www.amazon.com",
+    "aws.amazon.com",
+    "www.imdb.com",
+    "www.zappos.com",
+    "www.amazon.co.uk",
+    "www.amazon.co.in",
+    "www.a9.com"
 };
 
 /**
@@ -99,7 +100,7 @@ static void prvMiscInitialization( void );
 
 uint32_t ulSeedValid = 0;
 uint32_t ulSeed = 0;
-static TaskHandle_t  system_monitor_thread_handle;
+static TaskHandle_t system_monitor_thread_handle;
 void system_monitor_thread_main( wiced_thread_arg_t arg );
 /*-----------------------------------------------------------*/
 
@@ -131,10 +132,10 @@ static void prvMiscInitialization( void )
     /* Perform any hardware initializations, that don't require the RTOS to be
      * running, here.
      */
-    configPRINT_STRING(( "Test Message" ));
-#ifndef WICED_DISABLE_WATCHDOG
-    xTaskCreate( (TaskFunction_t) system_monitor_thread_main, "system monitor", 512/sizeof( portSTACK_TYPE ), NULL, RTOS_HIGHEST_PRIORITY, &system_monitor_thread_handle);
-#endif
+    configPRINT_STRING( ( "Test Message" ) );
+    #ifndef WICED_DISABLE_WATCHDOG
+        xTaskCreate( ( TaskFunction_t ) system_monitor_thread_main, "system monitor", 512 / sizeof( portSTACK_TYPE ), NULL, RTOS_HIGHEST_PRIORITY, &system_monitor_thread_handle );
+    #endif
 }
 /*-----------------------------------------------------------*/
 
@@ -168,7 +169,7 @@ void prvWifiConnect( void )
 {
     WIFINetworkParams_t xNetworkParams;
     WIFIReturnCode_t xWifiStatus;
-    uint8_t ucTempIp[4] = { 0 };
+    uint8_t ucTempIp[ 4 ] = { 0 };
 
     xWifiStatus = WIFI_On();
 
@@ -204,7 +205,8 @@ void prvWifiConnect( void )
         configPRINTF( ( "Wi-Fi Connected to AP. Creating tasks which use network...\r\n" ) );
 
         xWifiStatus = WIFI_GetIP( ucTempIp );
-        if ( eWiFiSuccess == xWifiStatus )
+
+        if( eWiFiSuccess == xWifiStatus )
         {
             configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
                             ucTempIp[ 0 ], ucTempIp[ 1 ], ucTempIp[ 2 ], ucTempIp[ 3 ] ) );
@@ -226,21 +228,25 @@ void prvWifiConnect( void )
 /*-----------------------------------------------------------*/
 static void prvGenerateRandomSeed()
 {
-    uint8_t ucAdddressCount = sizeof( pcDnsNames  )/sizeof( char* );
-    TickType_t xTickCount = platform_tick_get_time(PLATFORM_TICK_GET_SLOW_TIME_STAMP);
+    uint8_t ucAdddressCount = sizeof( pcDnsNames ) / sizeof( char * );
+    TickType_t xTickCount = platform_tick_get_time( PLATFORM_TICK_GET_SLOW_TIME_STAMP );
+
     /* Populate first 4 bits based on the current clock after wifi init */
     ulSeed |= xTickCount & 0x0F;
+
     /* Populate remaining bits after 7 DNS queries */
-    for( uint8_t ucCount = 0; ucCount < ucAdddressCount ; ucCount++ )
+    for( uint8_t ucCount = 0; ucCount < ucAdddressCount; ucCount++ )
     {
-        SOCKETS_GetHostByName( pcDnsNames[ucCount] );
-        xTickCount = platform_tick_get_time(PLATFORM_TICK_GET_SLOW_TIME_STAMP);
+        SOCKETS_GetHostByName( pcDnsNames[ ucCount ] );
+        xTickCount = platform_tick_get_time( PLATFORM_TICK_GET_SLOW_TIME_STAMP );
         ulSeed <<= 4UL;
         ulSeed |= xTickCount & 0x0F;
     }
+
     ulSeedValid = 1;
 }
 /*-----------------------------------------------------------*/
+
 /**
  * @brief This is to provide memory that is used by the Idle task.
  *
@@ -369,8 +375,8 @@ void vApplicationIdleHook( void )
 /*-----------------------------------------------------------*/
 
 /**
-* @brief User defined application hook to process names returned by the DNS server.
-*/
+ * @brief User defined application hook to process names returned by the DNS server.
+ */
 #if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
     BaseType_t xApplicationDNSQueryHook( const char * pcName )
     {
@@ -404,27 +410,27 @@ void vApplicationIdleHook( void )
  * @brief User defined assertion call. This function is plugged into configASSERT.
  * See FreeRTOSConfig.h to define configASSERT to something different.
  */
-void vAssertCalled(const char * pcFile,
-    uint32_t ulLine)
+void vAssertCalled( const char * pcFile,
+                    uint32_t ulLine )
 {
     /* FIX ME. If necessary, update to applicable assertion routine actions. */
 
     const uint32_t ulLongSleep = 1000UL;
     volatile uint32_t ulBlockVariable = 0UL;
-    volatile char * pcFileName = (volatile char *)pcFile;
+    volatile char * pcFileName = ( volatile char * ) pcFile;
     volatile uint32_t ulLineNumber = ulLine;
 
-    (void)pcFileName;
-    (void)ulLineNumber;
+    ( void ) pcFileName;
+    ( void ) ulLineNumber;
 
-    printf("vAssertCalled %s, %ld\n", pcFile, (long)ulLine);
-    fflush(stdout);
+    printf( "vAssertCalled %s, %ld\n", pcFile, ( long ) ulLine );
+    fflush( stdout );
 
     /* Setting ulBlockVariable to a non-zero value in the debugger will allow
-    * this function to be exited. */
+     * this function to be exited. */
     taskDISABLE_INTERRUPTS();
     {
-        while (ulBlockVariable == 0UL)
+        while( ulBlockVariable == 0UL )
         {
             vTaskDelay( pdMS_TO_TICKS( ulLongSleep ) );
         }
@@ -437,7 +443,7 @@ void vAssertCalled(const char * pcFile,
  * @brief User defined application hook need by the FreeRTOS-Plus-TCP library.
  */
 #if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
-    const char * pcApplicationHostnameHook(void)
+    const char * pcApplicationHostnameHook( void )
     {
         /* FIX ME: If necessary, update to applicable registration name. */
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/FreeRTOSConfig.h
@@ -74,7 +74,7 @@
     #define configMAX_PRIORITIES                       ( 10 )
     #define configTICK_RATE_HZ                         ( ( TickType_t ) SYSTICK_FREQUENCY )
     #define configMINIMAL_STACK_SIZE                   ( ( uint16_t ) 256 )
-    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 200U * 1024U ) )
+    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
         #define configUSE_TRACE_FACILITY               ( 0 )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -1,6 +1,6 @@
 /*
  * Amazon FreeRTOS V1.1.4
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -31,22 +31,27 @@
 
 #define testrunnerUNSUPPORTED                      0
 
-/* Enable tests by setting defines to 1 */
-#define testrunnerFULL_OTA_CBOR_ENABLED            0
-#define testrunnerFULL_OTA_AGENT_ENABLED           0
-#define testrunnerFULL_OTA_PAL_ENABLED             0
-#define testrunnerFULL_MQTT_ALPN_ENABLED           0
-#define testrunnerFULL_PKCS11_ENABLED              0
-#define testrunnerFULL_CRYPTO_ENABLED              0
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
+/* Unsupported tests. */
+#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_AGENT_ENABLED           testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_PAL_ENABLED             testrunnerUNSUPPORTED
+
+
+/* Supported tests. 0 = Disabled, 1 = Enabled */
 #define testrunnerFULL_MQTT_AGENT_ENABLED          0
-#define testrunnerFULL_TCP_ENABLED                 0
+#define testrunnerFULL_MQTT_ALPN_ENABLED           0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
+#define testrunnerFULL_MQTTv4_ENABLED              0
+#define testrunnerFULL_TCP_ENABLED                 1
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_SHADOWv4_ENABLED            0
+#define testrunnerFULL_PKCS11_ENABLED              0
+#define testrunnerFULL_CRYPTO_ENABLED              0
 #define testrunnerFULL_WIFI_ENABLED                0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0
+#define testrunnerFULL_POSIX_ENABLED               0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -1,6 +1,6 @@
 /*
  * Amazon FreeRTOS V1.1.4
- * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -29,12 +29,12 @@
 /* Uncomment this line if you want to run AFQP tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                      0
+#define testrunnerUNSUPPORTED               0
 
 /* Unsupported tests. */
-#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_AGENT_ENABLED           testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_PAL_ENABLED             testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED     testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_AGENT_ENABLED    testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_PAL_ENABLED      testrunnerUNSUPPORTED
 
 
 /* Supported tests. 0 = Disabled, 1 = Enabled */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/common/application_code/main.c
@@ -151,9 +151,6 @@ void vApplicationDaemonTaskStartupHook( void )
     /* Initialize the AWS Libraries system. */
     if( SYSTEM_Init() == pdPASS )
     {
-        /* Connect to the Wi-Fi before running the demos. */
-        prvWifiConnect();
-
         /* Generate seed for PRNG */
         prvGenerateRandomSeed();
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/common/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/common/config_files/FreeRTOSConfig.h
@@ -70,7 +70,7 @@
     #define configMAX_PRIORITIES                       ( 10 )
     #define configTICK_RATE_HZ                         ( ( TickType_t ) SYSTICK_FREQUENCY )
     #define configMINIMAL_STACK_SIZE                   ( ( uint16_t ) 256 )
-    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 200U * 1024U ) )
+    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
         #define configUSE_TRACE_FACILITY               ( 0 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/application_code/main.c
@@ -147,9 +147,6 @@ void vApplicationDaemonTaskStartupHook( void )
     /* Initialize the AWS Libraries system. */
     if( SYSTEM_Init() == pdPASS )
     {
-        /* Connect to the Wi-Fi before running the tests. */
-        prvWifiConnect();
-
         /* Generate seed for PRNG */
         prvGenerateRandomSeed();
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/application_code/main.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/application_code/main.c
@@ -58,14 +58,15 @@
 /* DNS addresses used seed in PRNG seed generation
  * 7 total addresses to for 7 DNS queries
  * TODO Define these addresses as macros (configXYZ) */
-static const char *pcDnsNames[] = {
-        "www.amazon.com",
-        "aws.amazon.com",
-        "www.imdb.com",
-        "www.zappos.com",
-        "www.amazon.co.uk",
-        "www.amazon.co.in",
-        "www.a9.com"
+static const char * pcDnsNames[] =
+{
+    "www.amazon.com",
+    "aws.amazon.com",
+    "www.imdb.com",
+    "www.zappos.com",
+    "www.amazon.co.uk",
+    "www.amazon.co.in",
+    "www.a9.com"
 };
 
 /**
@@ -99,7 +100,7 @@ static void prvMiscInitialization( void );
 
 uint32_t ulSeedValid = 0;
 uint32_t ulSeed = 0;
-static TaskHandle_t  system_monitor_thread_handle;
+static TaskHandle_t system_monitor_thread_handle;
 void system_monitor_thread_main( wiced_thread_arg_t arg );
 /*-----------------------------------------------------------*/
 
@@ -131,10 +132,10 @@ static void prvMiscInitialization( void )
     /* Perform any hardware initializations, that don't require the RTOS to be
      * running, here.
      */
-    configPRINT_STRING(( "Test Message" ));
-#ifndef WICED_DISABLE_WATCHDOG
-    xTaskCreate( (TaskFunction_t) system_monitor_thread_main, "system monitor", 512/sizeof( portSTACK_TYPE ), NULL, RTOS_HIGHEST_PRIORITY, &system_monitor_thread_handle);
-#endif
+    configPRINT_STRING( ( "Test Message" ) );
+    #ifndef WICED_DISABLE_WATCHDOG
+        xTaskCreate( ( TaskFunction_t ) system_monitor_thread_main, "system monitor", 512 / sizeof( portSTACK_TYPE ), NULL, RTOS_HIGHEST_PRIORITY, &system_monitor_thread_handle );
+    #endif
 }
 /*-----------------------------------------------------------*/
 
@@ -168,7 +169,7 @@ void prvWifiConnect( void )
 {
     WIFINetworkParams_t xNetworkParams;
     WIFIReturnCode_t xWifiStatus;
-    uint8_t ucTempIp[4] = { 0 };
+    uint8_t ucTempIp[ 4 ] = { 0 };
 
     xWifiStatus = WIFI_On();
 
@@ -204,7 +205,8 @@ void prvWifiConnect( void )
         configPRINTF( ( "Wi-Fi Connected to AP. Creating tasks which use network...\r\n" ) );
 
         xWifiStatus = WIFI_GetIP( ucTempIp );
-        if ( eWiFiSuccess == xWifiStatus )
+
+        if( eWiFiSuccess == xWifiStatus )
         {
             configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
                             ucTempIp[ 0 ], ucTempIp[ 1 ], ucTempIp[ 2 ], ucTempIp[ 3 ] ) );
@@ -226,21 +228,25 @@ void prvWifiConnect( void )
 /*-----------------------------------------------------------*/
 static void prvGenerateRandomSeed()
 {
-    uint8_t ucAdddressCount = sizeof( pcDnsNames  )/sizeof( char* );
-    TickType_t xTickCount = platform_tick_get_time(PLATFORM_TICK_GET_SLOW_TIME_STAMP);
+    uint8_t ucAdddressCount = sizeof( pcDnsNames ) / sizeof( char * );
+    TickType_t xTickCount = platform_tick_get_time( PLATFORM_TICK_GET_SLOW_TIME_STAMP );
+
     /* Populate first 4 bits based on the current clock after wifi init */
     ulSeed |= xTickCount & 0x0F;
+
     /* Populate remaining bits after 7 DNS queries */
-    for( uint8_t ucCount = 0; ucCount < ucAdddressCount ; ucCount++ )
+    for( uint8_t ucCount = 0; ucCount < ucAdddressCount; ucCount++ )
     {
-        SOCKETS_GetHostByName( pcDnsNames[ucCount] );
-        xTickCount = platform_tick_get_time(PLATFORM_TICK_GET_SLOW_TIME_STAMP);
+        SOCKETS_GetHostByName( pcDnsNames[ ucCount ] );
+        xTickCount = platform_tick_get_time( PLATFORM_TICK_GET_SLOW_TIME_STAMP );
         ulSeed <<= 4UL;
         ulSeed |= xTickCount & 0x0F;
     }
+
     ulSeedValid = 1;
 }
 /*-----------------------------------------------------------*/
+
 /**
  * @brief This is to provide memory that is used by the Idle task.
  *
@@ -369,8 +375,8 @@ void vApplicationIdleHook( void )
 /*-----------------------------------------------------------*/
 
 /**
-* @brief User defined application hook to process names returned by the DNS server.
-*/
+ * @brief User defined application hook to process names returned by the DNS server.
+ */
 #if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
     BaseType_t xApplicationDNSQueryHook( const char * pcName )
     {
@@ -404,27 +410,27 @@ void vApplicationIdleHook( void )
  * @brief User defined assertion call. This function is plugged into configASSERT.
  * See FreeRTOSConfig.h to define configASSERT to something different.
  */
-void vAssertCalled(const char * pcFile,
-    uint32_t ulLine)
+void vAssertCalled( const char * pcFile,
+                    uint32_t ulLine )
 {
     /* FIX ME. If necessary, update to applicable assertion routine actions. */
 
     const uint32_t ulLongSleep = 1000UL;
     volatile uint32_t ulBlockVariable = 0UL;
-    volatile char * pcFileName = (volatile char *)pcFile;
+    volatile char * pcFileName = ( volatile char * ) pcFile;
     volatile uint32_t ulLineNumber = ulLine;
 
-    (void)pcFileName;
-    (void)ulLineNumber;
+    ( void ) pcFileName;
+    ( void ) ulLineNumber;
 
-    printf("vAssertCalled %s, %ld\n", pcFile, (long)ulLine);
-    fflush(stdout);
+    printf( "vAssertCalled %s, %ld\n", pcFile, ( long ) ulLine );
+    fflush( stdout );
 
     /* Setting ulBlockVariable to a non-zero value in the debugger will allow
-    * this function to be exited. */
+     * this function to be exited. */
     taskDISABLE_INTERRUPTS();
     {
-        while (ulBlockVariable == 0UL)
+        while( ulBlockVariable == 0UL )
         {
             vTaskDelay( pdMS_TO_TICKS( ulLongSleep ) );
         }
@@ -437,7 +443,7 @@ void vAssertCalled(const char * pcFile,
  * @brief User defined application hook need by the FreeRTOS-Plus-TCP library.
  */
 #if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
-    const char * pcApplicationHostnameHook(void)
+    const char * pcApplicationHostnameHook( void )
     {
         /* FIX ME: If necessary, update to applicable registration name. */
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/FreeRTOSConfig.h
@@ -74,7 +74,7 @@
     #define configMAX_PRIORITIES                       ( 10 )
     #define configTICK_RATE_HZ                         ( ( TickType_t ) SYSTICK_FREQUENCY )
     #define configMINIMAL_STACK_SIZE                   ( ( uint16_t ) 256 )
-    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 200U * 1024U ) )
+    #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
         #define configUSE_TRACE_FACILITY               ( 0 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -1,6 +1,6 @@
 /*
  * Amazon FreeRTOS V1.1.4
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -31,22 +31,27 @@
 
 #define testrunnerUNSUPPORTED                      0
 
-/* Enable tests by setting defines to 1 */
-#define testrunnerFULL_OTA_CBOR_ENABLED            0
-#define testrunnerFULL_OTA_AGENT_ENABLED           0
-#define testrunnerFULL_OTA_PAL_ENABLED             0
-#define testrunnerFULL_MQTT_ALPN_ENABLED           0
-#define testrunnerFULL_PKCS11_ENABLED              0
-#define testrunnerFULL_CRYPTO_ENABLED              0
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
+/* Unsupported tests. */
+#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_AGENT_ENABLED           testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_PAL_ENABLED             testrunnerUNSUPPORTED
+
+
+/* Supported tests. 0 = Disabled, 1 = Enabled */
 #define testrunnerFULL_MQTT_AGENT_ENABLED          0
-#define testrunnerFULL_TCP_ENABLED                 0
+#define testrunnerFULL_MQTT_ALPN_ENABLED           0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
+#define testrunnerFULL_MQTTv4_ENABLED              0
+#define testrunnerFULL_TCP_ENABLED                 1
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_SHADOWv4_ENABLED            0
+#define testrunnerFULL_PKCS11_ENABLED              0
+#define testrunnerFULL_CRYPTO_ENABLED              0
 #define testrunnerFULL_WIFI_ENABLED                0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0
+#define testrunnerFULL_POSIX_ENABLED               0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -1,6 +1,6 @@
 /*
  * Amazon FreeRTOS V1.1.4
- * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/common/config_files/aws_test_runner_config.h
@@ -29,12 +29,12 @@
 /* Uncomment this line if you want to run AFQP tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                      0
+#define testrunnerUNSUPPORTED               0
 
 /* Unsupported tests. */
-#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_AGENT_ENABLED           testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_PAL_ENABLED             testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED     testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_AGENT_ENABLED    testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_PAL_ENABLED      testrunnerUNSUPPORTED
 
 
 /* Supported tests. 0 = Disabled, 1 = Enabled */


### PR DESCRIPTION
Changes:
1. Remove double intialization of wifi in main() by removing `prvWifiConnect()`
2. Move back to heap_3 as cypress was qualified with heap_3 and the reboot resolves
   with switching back to heap_3
3. Remove the line `xPortGetMinimumEverFreeHeapSize` in iot_demo_afr.c as heap_3
   doesn't have that function.
4. Change the test runner config to run the new defined tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
