### PR TITLE
Don't assume that Thing name is a static string define (see #219).

### DIFF
--- a/demos/common/defender/aws_defender_demo.c
+++ b/demos/common/defender/aws_defender_demo.c
@@ -181,7 +181,7 @@ static void prvLogReportStatus( DefenderReportStatus_t eReportStatus )
     switch( eReportStatus )
     {
         case eDefenderRepSuccess:
-            configPRINTF( ( "Device Defender Acknowledged the report.\r\n" ) );
+            configPRINTF( ( "Device Defender acknowledged the report.\r\n" ) );
             break;
 
         case eDefenderRepInit:
@@ -189,12 +189,12 @@ static void prvLogReportStatus( DefenderReportStatus_t eReportStatus )
             break;
 
         case eDefenderRepRejected:
-            configPRINTF( ( "Device defender service received and rejected the "
+            configPRINTF( ( "Device Defender service received and rejected the "
                             "metrics report.\r\n" ) );
             break;
 
         case eDefenderRepNoAck:
-            configPRINTF( ( "Device defender servie did not acknowledge the metrics "
+            configPRINTF( ( "Device Defender service did not acknowledge the metrics "
                             "within the expected time.\r\n" ) );
             break;
 

--- a/lib/defender/aws_defender.c
+++ b/lib/defender/aws_defender.c
@@ -60,9 +60,9 @@ static TaskHandle_t xDefenderTaskHandle = NULL;
 static TickType_t xMQTTTimeoutPeriodTicks = pdMS_TO_TICKS( 10U * 1000U );
 
 /* Device-specific MQTT topic for defender metrics. */
-#define defenderMQTT_TOPIC_PUBLISH      "$aws/things/%s/defender/metrics/cbor"
-#define defenderMQTT_TOPIC_ACCEPTED     "$aws/things/%s/defender/metrics/cbor/accepted"
-#define defenderMQTT_TOPIC_REJECTED     "$aws/things/%s/defender/metrics/cbor/rejected"
+#define defenderMQTT_TOPIC_PUBLISH     "$aws/things/%s/defender/metrics/cbor"
+#define defenderMQTT_TOPIC_ACCEPTED    "$aws/things/%s/defender/metrics/cbor/accepted"
+#define defenderMQTT_TOPIC_REJECTED    "$aws/things/%s/defender/metrics/cbor/rejected"
 
 /**
  * @brief      Publishes metrics report to service
@@ -283,7 +283,7 @@ static DefenderState_t prvStateSubscribe( void )
 
 static char * prvGetDefenderMqttTopicString( char * pcTopicTemplate )
 {
-    char* pcTopic = NULL;
+    char * pcTopic = NULL;
     uint32_t ulTopicLength = 0;
     uint32_t ulCharsWritten = 0;
 
@@ -329,8 +329,9 @@ static DEFENDERBool_t prvSubscribeToAcceptCbor( void )
 
     /* Initialize non-static field values. */
     xSubParams.pucTopic = ( const uint8_t * )
-        prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_ACCEPTED );
-    xSubParams.usTopicLength = ( uint16_t )strlen( ( const char * )xSubParams.pucTopic );
+                          prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_ACCEPTED );
+    xSubParams.usTopicLength = ( uint16_t ) 
+                               strlen( ( const char * ) xSubParams.pucTopic );
 
     if( NULL == xSubParams.pucTopic )
     {
@@ -349,7 +350,7 @@ static DEFENDERBool_t prvSubscribeToAcceptCbor( void )
 
     if( NULL != xSubParams.pucTopic )
     {
-        vPortFree( ( void * )xSubParams.pucTopic );
+        vPortFree( ( void * ) xSubParams.pucTopic );
     }
 
     return xError;
@@ -379,8 +380,10 @@ static DEFENDERBool_t prvSubscribeToRejectCbor( void )
     DEFENDERBool_t xError = eDefenderFalse;
 
     /* Initialize non-static field values. */
-    xSubParams.pucTopic = ( const uint8_t * )prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_REJECTED );
-    xSubParams.usTopicLength = ( uint16_t ) strlen( ( const char * )xSubParams.pucTopic );
+    xSubParams.pucTopic = ( const uint8_t * ) 
+                          prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_REJECTED );
+    xSubParams.usTopicLength = ( uint16_t ) 
+                               strlen( ( const char * ) xSubParams.pucTopic );
 
     if( NULL == xSubParams.pucTopic )
     {
@@ -390,8 +393,8 @@ static DEFENDERBool_t prvSubscribeToRejectCbor( void )
     if( eDefenderFalse == xError )
     {
         if( 0 != MQTT_AGENT_Subscribe( xDefenderMQTTAgent,
-            &xSubParams,
-            xMQTTTimeoutPeriodTicks ) )
+                                       &xSubParams,
+                                       xMQTTTimeoutPeriodTicks ) )
         {
             xError = eDefenderTrue;
         }
@@ -399,7 +402,7 @@ static DEFENDERBool_t prvSubscribeToRejectCbor( void )
 
     if( NULL != xSubParams.pucTopic )
     {
-        vPortFree( ( void * )xSubParams.pucTopic );
+        vPortFree( ( void * ) xSubParams.pucTopic );
     }
 
     return xError;
@@ -457,8 +460,10 @@ static DEFENDERBool_t prvPublishCborToDevDef( CBORHandle_t xReport )
     DEFENDERBool_t xError = eDefenderFalse;
 
     /* Initialize non-static field values. */
-    xPubRecParams.pucTopic = ( const uint8_t * )prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_PUBLISH );
-    xPubRecParams.usTopicLength = ( uint16_t ) strlen( ( const char * )xPubRecParams.pucTopic );
+    xPubRecParams.pucTopic = ( const uint8_t * )
+                             prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_PUBLISH );
+    xPubRecParams.usTopicLength = ( uint16_t ) 
+                                  strlen( ( const char * ) xPubRecParams.pucTopic );
     xPubRecParams.pvData = pucBuffer;
     xPubRecParams.ulDataLength = lBufLen;
 
@@ -470,8 +475,8 @@ static DEFENDERBool_t prvPublishCborToDevDef( CBORHandle_t xReport )
     if( eDefenderFalse == xError )
     {
         if( 0 != MQTT_AGENT_Publish( xDefenderMQTTAgent,
-            &xPubRecParams,
-            xMQTTTimeoutPeriodTicks ) )
+                                     &xPubRecParams,
+                                     xMQTTTimeoutPeriodTicks ) )
         {
             xError = eDefenderTrue;
             eDefenderReportStatus = eDefenderRepNotSent;
@@ -484,7 +489,7 @@ static DEFENDERBool_t prvPublishCborToDevDef( CBORHandle_t xReport )
 
     if( NULL != xPubRecParams.pucTopic )
     {
-        vPortFree( ( void * )xPubRecParams.pucTopic );
+        vPortFree( ( void * ) xPubRecParams.pucTopic );
     }
 
     return eDefenderFalse;

--- a/lib/defender/aws_defender.c
+++ b/lib/defender/aws_defender.c
@@ -304,7 +304,7 @@ static char * prvGetDefenderMqttTopicString( char * pcTopicTemplate )
                                    pcTopicTemplate,
                                    clientcredentialIOT_THING_NAME );
 
-        if( ulCharsWritten >= ulTopicLength )
+        if( ulCharsWritten != ulTopicLength - 1 )
         {
             vPortFree( pcTopic );
             pcTopic = NULL;

--- a/lib/defender/aws_defender.c
+++ b/lib/defender/aws_defender.c
@@ -330,7 +330,7 @@ static DEFENDERBool_t prvSubscribeToAcceptCbor( void )
     /* Initialize non-static field values. */
     xSubParams.pucTopic = ( const uint8_t * )
                           prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_ACCEPTED );
-    xSubParams.usTopicLength = ( uint16_t ) 
+    xSubParams.usTopicLength = ( uint16_t )
                                strlen( ( const char * ) xSubParams.pucTopic );
 
     if( NULL == xSubParams.pucTopic )
@@ -380,9 +380,9 @@ static DEFENDERBool_t prvSubscribeToRejectCbor( void )
     DEFENDERBool_t xError = eDefenderFalse;
 
     /* Initialize non-static field values. */
-    xSubParams.pucTopic = ( const uint8_t * ) 
+    xSubParams.pucTopic = ( const uint8_t * )
                           prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_REJECTED );
-    xSubParams.usTopicLength = ( uint16_t ) 
+    xSubParams.usTopicLength = ( uint16_t )
                                strlen( ( const char * ) xSubParams.pucTopic );
 
     if( NULL == xSubParams.pucTopic )
@@ -462,7 +462,7 @@ static DEFENDERBool_t prvPublishCborToDevDef( CBORHandle_t xReport )
     /* Initialize non-static field values. */
     xPubRecParams.pucTopic = ( const uint8_t * )
                              prvGetDefenderMqttTopicString( defenderMQTT_TOPIC_PUBLISH );
-    xPubRecParams.usTopicLength = ( uint16_t ) 
+    xPubRecParams.usTopicLength = ( uint16_t )
                                   strlen( ( const char * ) xPubRecParams.pucTopic );
     xPubRecParams.pvData = pucBuffer;
     xPubRecParams.ulDataLength = lBufLen;

--- a/lib/defender/aws_defender.c
+++ b/lib/defender/aws_defender.c
@@ -287,8 +287,11 @@ static char * prvGetDefenderMqttTopicString( char * pcTopicTemplate )
     uint32_t ulTopicLength = 0;
     uint32_t ulCharsWritten = 0;
 
-    /* Determine the maximum resulting string length. */
-    ulTopicLength = 1 + strlen( pcTopicTemplate ) + strlen( clientcredentialIOT_THING_NAME );
+    /* Determine the maximum resulting string length including NULL terminator.
+    The input parameter is assumed to include a %s for inserting the Thing 
+    name.*/
+    ulTopicLength = strlen( pcTopicTemplate ) +
+                    strlen( clientcredentialIOT_THING_NAME ) - 1;
 
     /* Allocate memory. */
     pcTopic = pvPortMalloc( ulTopicLength );
@@ -301,11 +304,7 @@ static char * prvGetDefenderMqttTopicString( char * pcTopicTemplate )
                                    pcTopicTemplate,
                                    clientcredentialIOT_THING_NAME );
 
-        if( ulCharsWritten < ulTopicLength )
-        {
-            pcTopic[ ulTopicLength - 1 ] = 0;
-        }
-        else
+        if( ulCharsWritten >= ulTopicLength )
         {
             vPortFree( pcTopic );
             pcTopic = NULL;

--- a/lib/defender/aws_defender.c
+++ b/lib/defender/aws_defender.c
@@ -288,8 +288,8 @@ static char * prvGetDefenderMqttTopicString( char * pcTopicTemplate )
     uint32_t ulCharsWritten = 0;
 
     /* Determine the maximum resulting string length including NULL terminator.
-    The input parameter is assumed to include a %s for inserting the Thing 
-    name.*/
+     * The input parameter is assumed to include a %s for inserting the Thing
+     * name.*/
     ulTopicLength = strlen( pcTopicTemplate ) +
                     strlen( clientcredentialIOT_THING_NAME ) - 1;
 


### PR DESCRIPTION
Per #219 the analogous fix to our Greengrass Discovery library was previously made. This fix allows the Defender client code to use Thing names that are determined at runtime rather than statically.