### PR TITLE
enable metrics of secure socket in windows test

### DIFF
--- a/modules/libraries/aws/defender/test/aws_iot_tests_defender_api.c
+++ b/modules/libraries/aws/defender/test/aws_iot_tests_defender_api.c
@@ -36,6 +36,7 @@
 #include "platform/iot_clock.h"
 #include "platform/iot_threads.h"
 #include "platform/iot_network_afr.h"
+#include "platform/iot_metrics.h"
 
 #include "iot_serializer.h"
 

--- a/modules/libraries/standard/metrics/src/aws_secure_sockets_wrapper_metrics.c
+++ b/modules/libraries/standard/metrics/src/aws_secure_sockets_wrapper_metrics.c
@@ -28,9 +28,6 @@
  * It updates metrics of sockets in relevant socket functions.
  */
 
-/* The config header is always included first. */
-#include "iot_config.h"
-
 /* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
  * from redefining in aws_secure_sockets_wrapper_metrics.h */
 #define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
@@ -43,7 +40,7 @@
 
 #undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
-#ifdef AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED
+#if AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED == 1
 
 /*-----------------------------------------------------------*/
 

--- a/modules/ports/secure_sockets/include/aws_secure_sockets_config_defaults.h
+++ b/modules/ports/secure_sockets/include/aws_secure_sockets_config_defaults.h
@@ -61,4 +61,12 @@
     #define socketsconfigDEFAULT_RECV_TIMEOUT    ( 10000 )
 #endif
 
+/**
+ * @brief By default, metircs of secure socket is disabled.
+ *
+ */
+#ifndef AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED
+    #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 0 )
+#endif
+
 #endif /* AWS_INC_SECURE_SOCKETS_CONFIG_DEFAULTS_H_ */

--- a/modules/ports/secure_sockets/include/aws_secure_sockets_wrapper_metrics.h
+++ b/modules/ports/secure_sockets/include/aws_secure_sockets_wrapper_metrics.h
@@ -28,7 +28,7 @@
 
 /* This file redefines Secure Sockets functions to be called through a wrapper macro,
  * but only if metrics is enabled explicitly. */
-#ifdef AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED
+#if AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED == 1
 
 /* This macro is included in aws_secure_socket.c and aws_secure_socket_wrapper_metrics.c.
  * It will prevent the redefine in those source files. */

--- a/vendors/pc/boards/windows/aws_tests/common/config_files/aws_secure_sockets_config.h
+++ b/vendors/pc/boards/windows/aws_tests/common/config_files/aws_secure_sockets_config.h
@@ -36,16 +36,21 @@
  *
  * Valid values are pdLITTLE_ENDIAN and pdBIG_ENDIAN.
  */
-#define socketsconfigBYTE_ORDER              pdLITTLE_ENDIAN
+#define socketsconfigBYTE_ORDER                   pdLITTLE_ENDIAN
 
 /**
  * @brief Default socket send timeout.
  */
-#define socketsconfigDEFAULT_SEND_TIMEOUT    ( 10000 )
+#define socketsconfigDEFAULT_SEND_TIMEOUT         ( 10000 )
 
 /**
  * @brief Default socket receive timeout.
  */
-#define socketsconfigDEFAULT_RECV_TIMEOUT    ( 10000 )
+#define socketsconfigDEFAULT_RECV_TIMEOUT         ( 10000 )
+
+/**
+ * @brief Enable metrics of secure socket.
+ */
+//#define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )
 
 #endif /* _AWS_SECURE_SOCKETS_CONFIG_H_ */

--- a/vendors/pc/boards/windows/aws_tests/common/config_files/aws_secure_sockets_config.h
+++ b/vendors/pc/boards/windows/aws_tests/common/config_files/aws_secure_sockets_config.h
@@ -51,6 +51,6 @@
 /**
  * @brief Enable metrics of secure socket.
  */
-//#define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )
+#define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )
 
 #endif /* _AWS_SECURE_SOCKETS_CONFIG_H_ */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- move socket metrics configuration to socket header

Tests pass: https://amazon-freertos-ci.corp.amazon.com/view/5-CMake/job/afr_test_cmake/272/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
