### PR TITLE
Fix reboot on cypress tests

### DIFF
--- a/vendors/cypress/WICED_SDK/WICED/network/LwIP/WICED/wiced_network.c
+++ b/vendors/cypress/WICED_SDK/WICED/network/LwIP/WICED/wiced_network.c
@@ -608,12 +608,12 @@ wiced_result_t wiced_ip_up( wiced_interface_t interface, wiced_network_config_t 
 
 #if LWIP_IPV6
     /* Wait until the address has been properly advertised */
-    while ( ip6_addr_istentative( netif_ip6_addr_state( &IP_HANDLE(interface), 0 )))
-    {
+    /*while ( ip6_addr_istentative( netif_ip6_addr_state( &IP_HANDLE(interface), 0 )))
+    {*/
         /* Give LwIP time to change the state */
-        WPRINT_NETWORK_DEBUG(( "Waiting for IPv6 address validation\n"));
+        /*WPRINT_NETWORK_DEBUG(( "Waiting for IPv6 address validation\n"));
         host_rtos_delay_milliseconds( ND6_TMR_INTERVAL );
-    }
+    }*/
 
     if ( ip6_addr_isvalid( netif_ip6_addr_state( &IP_HANDLE(interface), 0 )))
     {

--- a/vendors/cypress/WICED_SDK/WICED/network/LwIP/WICED/wiced_network.c
+++ b/vendors/cypress/WICED_SDK/WICED/network/LwIP/WICED/wiced_network.c
@@ -607,6 +607,8 @@ wiced_result_t wiced_ip_up( wiced_interface_t interface, wiced_network_config_t 
     }
 
 #if LWIP_IPV6
+    /*The code commented below causes reboot in the cypress tests. Further investigation
+    is required for the root cause of the reboot.*/
     /* Wait until the address has been properly advertised */
     /*while ( ip6_addr_istentative( netif_ip6_addr_state( &IP_HANDLE(interface), 0 )))
     {*/


### PR DESCRIPTION
Description
-----------
Waiting for IPV6 address to be advertised causes reboot on Cypress boards. Commented out the code which only waits for IPv6 validation.

**This change needs further investigation. It is being tracked on :https://sim.amazon.com/issues/TS-7386** 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
