### PR TITLE
CBMC memory-safety proof for DNSgetHostByName_cancel

### DIFF
--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
@@ -1,0 +1,51 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+
+
+/* This proof assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN. This also abstracts the concurrency. */ 
+
+void vDNSInitialise(void);
+
+void vDNSSetCallBack(const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t xIdentifier);
+
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Abstraction of xTaskCheckForTimeOut from task pool. This also abstracts the concurrency. */ 
+BaseType_t xTaskCheckForTimeOut(TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait) { }
+
+/* Abstraction of xTaskResumeAll from task pool. This also abstracts the concurrency. */ 
+BaseType_t xTaskResumeAll(void) { }
+
+/* The function func mimics the callback function.*/ 
+void func(const char * pcHostName, void * pvSearchID, uint32_t ulIPAddress) {}
+
+void harness() {
+	if (ipconfigDNS_USE_CALLBACKS == 1) {
+		vDNSInitialise(); /* We initialize the callbacklist in order to be able to check for functions that timed out. */ 
+		size_t pvSearchID;
+		FOnDNSEvent pCallback = func;
+		TickType_t xTimeout;
+		TickType_t xIdentifier;
+		size_t len;
+		__CPROVER_assume(len >= 0 && len <= MAX_HOSTNAME_LEN);
+		char *pcHostName = safeMalloc(len); 
+		if (len && pcHostName) {
+			pcHostName[len-1] = NULL;
+		}
+		vDNSSetCallBack( pcHostName, &pvSearchID, pCallback, xTimeout, xIdentifier); /* Add an item to be able to check the cancel function if the list is non-empty. */
+		FreeRTOS_gethostbyname_cancel(&pvSearchID);
+	}
+}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -1,0 +1,28 @@
+{
+  "ENTRY": "DNSgetHostByName_cancel",
+  ################################################################
+	# This configuration flag sets callback to 1. It also sets MAX_HOSTNAME_LEN to 10 for performance issues.
+  # According to the specification MAX_HOST_NAME is upto 255.
+  "callback": 1,
+  "MAX_HOSTNAME_LEN": 10,
+  "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvProcessDNSCache.0:5,strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},vDNSCheckCallBack.0:2,strcpy.0:{HOSTNAME_UNWIND}",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigDNS_USE_CALLBACKS={callback}",
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+  ],
+  "OPT" : "-m32"
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR includes the CBMC proof for memory safety of the DNSgetHostByName_cancel function, which removes old entries from the list of call-back structures.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
