### PR TITLE
CBMC memory-safety proof for DNSgetHostByName_a

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -420,6 +420,7 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
+if(pcHostName) {
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
 	and return. */
@@ -482,6 +483,7 @@ TickType_t xIdentifier = 0;
 	}
 
 	return ulIPAddress;
+  }
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -420,7 +420,7 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
-if(pcHostName) {
+if(pcHostName != NULL) {
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
 	and return. */
@@ -481,9 +481,10 @@ if(pcHostName) {
 	{
 		ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
 	}
-
-	return ulIPAddress;
   }
+
+  return ulIPAddress;
+
 }
 /*-----------------------------------------------------------*/
 

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -1,0 +1,78 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* This proof assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by 
+MAX_REQ_SIZE. This also abstracts the concurrency. */ 
+
+void *safeMalloc(size_t xWantedSize) { /* This returns a NULL pointer if the requested size is 0. */
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Abstraction of pvPortMalloc which calls safemalloc internally. */
+void *pvPortMalloc(size_t xWantedSize) {
+	return safeMalloc(xWantedSize);
+}
+
+/* Abstraction of FreeRTOS_GetUDPPayloadBuffer.
+We always return MAX_REQ_SIZE bytes to keep the proof performant.
+This is safe because:
+- If the caller requested more bytes, then there is a risk that they
+    will write past the end of the returned buffer. This proof
+    therefore shows that the code is memory safe even if
+    xRequestedSizeBytes > MAX_REQ_SIZE.
+- If the caller requested fewer bytes, then they will not be
+    iterating past the end of the buffer anyway.*/
+void * FreeRTOS_GetUDPPayloadBuffer(size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ) {
+	void *pvReturn = safeMalloc(MAX_REQ_SIZE);
+	return pvReturn;
+}
+
+/* Abstraction of FreeRTOS_socket. This abstraction allocates a memory of size Socket_t. */
+Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol ){
+	Socket_t xCreatedSocket = safeMalloc(sizeof(Socket_t)); // replacing malloc with safeMalloc
+	return xCreatedSocket;
+}
+
+/* This function FreeRTOS_gethostbyname_a only uses the return value of prvParseDNSReply. Hence it returns an unconstrained uint32 value */
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+
+/* Abstraction of xTaskResumeAll from task pool. This also abstracts the concurrency. */
+BaseType_t xTaskResumeAll(void) { }
+
+/* The function func mimics the callback function.*/
+void func(const char * pcHostName, void * pvSearchID, uint32_t ulIPAddress) { }
+
+typedef struct xDNS_Callback {
+	TickType_t xRemaningTime;		/* Timeout in ms */
+	FOnDNSEvent pCallbackFunction;	/* Function to be called when the address has been found or when a timeout has beeen reached */
+	TimeOut_t xTimeoutState;
+	void *pvSearchID;
+	struct xLIST_ITEM xListItem;
+	char pcName[ 1 ];
+} DNSCallback_t;
+
+void harness() {
+	FOnDNSEvent pCallback = func;
+	TickType_t xTimeout;
+	void *pvSearchID;
+	size_t len;
+	__CPROVER_assume(len >= 0 && len <= MAX_HOSTNAME_LEN);
+	char *pcHostName = safeMalloc(len); // replacing malloc with safeMalloc
+	if (len && pcHostName) {
+		pcHostName[len-1] = NULL;
+	}
+	if (pcHostName) { // Guarding against NULL pointer
+		FreeRTOS_gethostbyname_a(pcHostName, pCallback, pvSearchID, xTimeout);
+	}
+}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -8,10 +8,11 @@
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IP_Private.h"
 
-/* This proof assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by 
-MAX_REQ_SIZE. This also abstracts the concurrency. */ 
+/* This proof assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by
+MAX_REQ_SIZE. This also abstracts the concurrency. */
 
-void *safeMalloc(size_t xWantedSize) { /* This returns a NULL pointer if the requested size is 0. */
+void *safeMalloc(size_t xWantedSize) { /* This returns a NULL pointer if the requested size is 0.
+	The implementation of malloc does not return a NULL pointer instead returns a pointer for which there is no memory allocation. */
 	if(xWantedSize == 0) {
 		return NULL;
 	}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -1,0 +1,29 @@
+{
+  "ENTRY": "DNSgetHostByName_a",
+  ################################################################
+  # This configuration flag sets callback to 1. It also sets MAX_HOSTNAME_LEN to 10 and MAX_REQ_SIZE to 50 for performance issues.
+  # According to the specification MAX_HOST_NAME is upto 255.
+  "callback": 1,
+  "MAX_HOSTNAME_LEN": 10,
+  "MAX_REQ_SIZE": 50,
+  "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvCreateDNSMessage.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.1:{HOSTNAME_UNWIND},prvGetHostByName.0:{HOSTNAME_UNWIND},prvProcessDNSCache.0:5,strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},strcmp.0:{HOSTNAME_UNWIND},xTaskResumeAll.0:{HOSTNAME_UNWIND},xTaskResumeAll.1:{HOSTNAME_UNWIND},strcpy.0:{HOSTNAME_UNWIND}",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigDNS_USE_CALLBACKS={callback}",
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
+  ],
+  "OPT" : "-m32"
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the DNSgetHostByName_a function, which prepares and sends a message to a DNS server along with callback.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
