### PR TITLE
CBMC memory-safety proof for DNSHandlePacket

### DIFF
--- a/tools/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
@@ -1,0 +1,29 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* Function prvParseDNSReply is proven to be correct separately. 
+The proof can be found here: https://github.com/aws/amazon-freertos/tree/master/tools/cbmc/proofs/ParseDNSReply */
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+
+struct xDNSMessage {
+	uint16_t usIdentifier;
+	uint16_t usFlags;
+	uint16_t usQuestions;
+	uint16_t usAnswers;
+	uint16_t usAuthorityRRs;
+	uint16_t usAdditionalRRs;
+};
+
+typedef struct xDNSMessage DNSMessage_t;
+
+void harness() {
+	NetworkBufferDescriptor_t xNetworkBuffer;
+	xNetworkBuffer.pucEthernetBuffer = malloc(sizeof(UDPPacket_t)+sizeof(DNSMessage_t));
+	ulDNSHandlePacket(&xNetworkBuffer);
+}

--- a/tools/cbmc/proofs/DNS/DNSHandlePacket/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSHandlePacket/Makefile.json
@@ -1,0 +1,12 @@
+{
+  "ENTRY": "DNSHandlePacket",
+  "CBMCFLAGS": "--unwind 1",
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.goto"
+  ],
+  "DEF":
+  [
+  ]  
+}

--- a/tools/cbmc/proofs/DNS/DNSHandlePacket/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/DNS/DNSHandlePacket/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--unwinding-assertions='
+goto: DNSHandlePacket.goto
+expected: SUCCESSFUL


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the DNShandlePacket function, which handles a DNS packet.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
