### PR TITLE
CBMC memory-safety proof for DNSlookup

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1338,6 +1338,8 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 	BaseType_t xFound = pdFALSE;
 	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000;
 	static BaseType_t xFreeEntry = 0;
+	configASSERT(pcName);
+
 
 		/* For each entry in the DNS cache table. */
 		for( x = 0; x < ipconfigDNS_CACHE_ENTRIES; x++ )

--- a/tools/cbmc/proofs/DNS/DNSlookup/DNSlookup_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSlookup/DNSlookup_harness.c
@@ -1,0 +1,32 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* This assumes that the length of the hostname is bounded by MAX_HOSTNAME_LEN. */
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+void harness() {
+	if(ipconfigUSE_DNS_CACHE != 0) {
+		size_t len;
+		__CPROVER_assume(len >= 0 && len <= MAX_HOSTNAME_LEN);
+		char *pcHostName = safeMalloc(len); /* malloc is replaced by safeMalloc */
+		if (len && pcHostName) {
+			pcHostName[len-1] = NULL;
+		}
+		if (pcHostName) { /* guarding against NULL pointer */
+			FreeRTOS_dnslookup(pcHostName);	
+		}
+	}	
+}

--- a/tools/cbmc/proofs/DNS/DNSlookup/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSlookup/Makefile.json
@@ -1,0 +1,26 @@
+{
+  "ENTRY": "DNSlookup",
+  ################################################################
+  # This configuration uses DNS cache and the MAX_HOSTNAME_LEN is set to 255 according to the specification
+  "MAX_HOSTNAME_LEN": 255,
+  "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+  "USE_CACHE": 1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvProcessDNSCache.0:5,strcmp.0:{HOSTNAME_UNWIND}",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_DNS_CACHE={USE_CACHE}",
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+  ],
+  "OPT" : "-m32"
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the DNSlookup function, which looks for the indicated host name in the DNS cache

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
