### PR TITLE
CBMC memory-safety proof for DNSclear

### DIFF
--- a/tools/cbmc/proofs/DNS/DNSclear/DNSclear_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSclear/DNSclear_harness.c
@@ -1,0 +1,16 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+
+
+void harness() {
+	if( ipconfigUSE_DNS_CACHE != 0 ) {
+		FreeRTOS_dnsclear();
+	}	
+	
+}

--- a/tools/cbmc/proofs/DNS/DNSclear/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSclear/Makefile.json
@@ -1,0 +1,20 @@
+{
+  "ENTRY": "DNSclear",
+  ################################################################
+  # This configuration flag uses DNS cache
+  "USE_CACHE":1,
+  "CBMCFLAGS": 
+  [
+  	"--unwind 1",
+	"--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/lib/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_DNS_CACHE={USE_CACHE}"
+  ]
+}

--- a/tools/cbmc/proofs/DNS/DNSclear/cbmc-batch.yaml
+++ b/tools/cbmc/proofs/DNS/DNSclear/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: '=--object-bits;7;--32;--bounds-check;--pointer-check;--unwind;1;--nondet-static;--unwinding-assertions='
+goto: DNSclear.goto
+expected: SUCCESSFUL


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the DNSgetHostByName function, which removes entries from the DNS cache.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
