### PR TITLE
Add secure sockets file for Defender tests

### DIFF
--- a/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
+++ b/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
@@ -140,7 +140,6 @@ $(NAME)_SOURCES    := $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/
                       $(AFR_AWS_PATH)defender/src/aws_iot_defender_mqtt.c \
                       $(AFR_AWS_PATH)defender/src/aws_iot_defender_v1.c \
                       $(AFR_AWS_PATH)defender/test/aws_iot_tests_defender_api.c \
-                      $(AFR_STANDARD_PATH)tls/test/aws_test_tls.c \
                       $(AFR_STANDARD_PATH)crypto/test/aws_test_crypto.c \
                       $(AFR_STANDARD_PATH)provisioning/src/aws_dev_mode_key_provisioning.c \
                       $(AFR_STANDARD_PATH)common/taskpool/iot_taskpool.c \
@@ -160,6 +159,7 @@ $(NAME)_SOURCES    := $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/
                       $(AFR_STANDARD_PATH)common/iot_init.c \
                       $(AFR_STANDARD_PATH)common/iot_json_utils.c \
                       $(AFR_STANDARD_PATH)metrics/src/iot_metrics.c \
+                      $(AFR_STANDARD_PATH)metrics/src/aws_secure_sockets_wrapper_metrics.c \
                       $(AFR_STANDARD_PATH)freertos_plus_tcp/test/aws_test_freertos_tcp.c \
                       $(AFR_STANDARD_PATH)freertos_plus_tcp/test/aws_freertos_tcp_test_access_dns_define.h \
                       $(AFR_STANDARD_PATH)freertos_plus_tcp/test/aws_freertos_tcp_test_access_tcp_define.h \


### PR DESCRIPTION
Description
-----------
Defender tests have a new dependency on secure sockets. Adding the `aws_secure_sockets_wrapper_metrics.c` file to the tests.
Removing double inclusion of `aws_test_tls.c`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
