### PR TITLE
Fix multiple spellings in TaskPool documentation

### DIFF
--- a/modules/libraries/standard/common/include/iot_taskpool.h
+++ b/modules/libraries/standard/common/include/iot_taskpool.h
@@ -82,7 +82,7 @@
  *
  * This function should be called once by the application to initialize the one single instance of the system task pool.
  * An application should initialize the system task pool early in the boot sequence, before initializing any other library
- * that uses the system task pool. such as MQTT, Shadow, Defernder, etc.. An application should also initialize the system
+ * that uses the system task pool. such as MQTT, Shadow, Defender, etc.. An application should also initialize the system
  * task pool before posting any jobs. Early initialization it typically easy to accomplish by creating the system task pool
  * before the scheduler is started.
  *
@@ -109,7 +109,7 @@ IotTaskPoolError_t IotTaskPool_CreateSystemTaskPool( const IotTaskPoolInfo_t * c
 /**
  * @brief Retrieves the one and only instance of a system task pool
  *
- * This function retrieves the sytem task pool created with @ref IotTaskPool_CreateSystemTaskPool, and it is functionally
+ * This function retrieves the system task pool created with @ref IotTaskPool_CreateSystemTaskPool, and it is functionally
  * equivalent to using the shortcut @ref IOT_SYSTEM_TASKPOOL.
  *
  * @return The system task pool handle.
@@ -126,7 +126,7 @@ IotTaskPool_t IotTaskPool_GetSystemTaskPool( void );
 /**
  * @brief Creates one instance of a task pool.
  *
- * This function should be called by the user to initialiaze one instance of a task
+ * This function should be called by the user to initialize one instance of a task
  * pool. The task pool instance will be created around the storage pointed to by the `pTaskPool`
  * parameter. This function will create the minimum number of threads requested by the user
  * through an instance of the #IotTaskPoolInfo_t type specified with the `pInfo` parameter.
@@ -137,7 +137,7 @@ IotTaskPool_t IotTaskPool_GetSystemTaskPool( void );
  * @param[in] pInfo A pointer to the task pool initialization data.
  * @param[out] pTaskPool A pointer to the task pool handle to be used after initialization.
  * The pointer `pTaskPool` will hold a valid handle only if (@ref IotTaskPool_Create)
- * completes succesfully.
+ * completes successfully.
  *
  * @return One of the following:
  * - #IOT_TASKPOOL_SUCCESS
@@ -205,7 +205,7 @@ IotTaskPoolError_t IotTaskPool_SetMaxThreads( IotTaskPool_t taskPool,
  * @param[in] pUserContext A user-specified context for the callback.
  * @param[in] pJobStorage The storage for the job data structure.
  * @param[out] pJob A pointer to an instance of @ref IotTaskPoolJob_t that will be initialized when this
- * function returns succesfully. This handle can be used to inspect the job status with
+ * function returns successfully. This handle can be used to inspect the job status with
  * @ref IotTaskPool_GetStatus or cancel the job with @ref IotTaskPool_TryCancel, etc....
  *
  * @return One of the following:
@@ -231,7 +231,7 @@ IotTaskPoolError_t IotTaskPool_CreateJob( IotTaskPoolRoutine_t userCallback,
  * @param[in] userCallback A user-specified callback for the job.
  * @param[in] pUserContext A user-specified context for the callback.
  * @param[out] pJob A pointer to an instance of @ref IotTaskPoolJob_t that will be initialized when this
- * function returns succesfully. This handle can be used to inspect the job status with
+ * function returns successfully. This handle can be used to inspect the job status with
  * @ref IotTaskPool_GetStatus or cancel the job with @ref IotTaskPool_TryCancel, etc....
  *
  * @return One of the following:
@@ -253,7 +253,7 @@ IotTaskPoolError_t IotTaskPool_CreateRecyclableJob( IotTaskPool_t taskPool,
 /* @[declare_taskpool_createrecyclablejob] */
 
 /**
- * @brief This function uninitializes a job.
+ * @brief This function un-initializes a job.
  *
  * This function will destroy a job created with @ref IotTaskPool_CreateRecyclableJob.
  * A job should not be destroyed twice. A job that was previously scheduled but has not completed yet should not be destroyed,
@@ -284,7 +284,7 @@ IotTaskPoolError_t IotTaskPool_DestroyRecyclableJob( IotTaskPool_t taskPool,
 /* @[declare_taskpool_destroyrecyclablejob] */
 
 /**
- * @brief Rrecycles a job into the task pool job cache.
+ * @brief Recycles a job into the task pool job cache.
  *
  * This function will try and recycle the job into the task pool cache. If the cache is full,
  * the job memory is destroyed as if the user called @ref IotTaskPool_DestroyRecyclableJob. The job should be recycled into
@@ -310,7 +310,7 @@ IotTaskPoolError_t IotTaskPool_DestroyRecyclableJob( IotTaskPool_t taskPool,
  *
  * @warning This function should be used to recycle a job in the task pool cache when after the job executed.
  * Failing to call either this function or @ref IotTaskPool_DestroyRecyclableJob will result is a memory leak. Statically
- * alloted jobs do not need to be recycled or destroyed.
+ * allocated jobs do not need to be recycled or destroyed.
  *
  */
 /* @[declare_taskpool_recyclejob] */
@@ -494,7 +494,7 @@ IotTaskPoolError_t IotTaskPool_TryCancel( IotTaskPool_t taskPool,
 
 /**
  * @brief Returns a pointer to the job storage from an instance of a job handle 
- * of type @ref IotTaskPoolJob_t. This function is guarateed to succeed for a 
+ * of type @ref IotTaskPoolJob_t. This function is guaranteed to succeed for a 
  * valid job handle.
  *
  * @param[in] pJob The job handle.
@@ -544,7 +544,7 @@ const char * IotTaskPool_strerror( IotTaskPoolError_t status );
 #endif
 
 /**
- * @brief The maximum timeout i milliseconds to wait for a job to be scheduled before waking up a worker thread.
+ * @brief The maximum timeout in milliseconds to wait for a job to be scheduled before waking up a worker thread.
  * A worker thread that wakes up as a result of a timeout may exit to allow the task pool to fold back to its
  * minimum number of threads.
  */

--- a/modules/libraries/standard/common/include/iot_taskpool.h
+++ b/modules/libraries/standard/common/include/iot_taskpool.h
@@ -82,9 +82,8 @@
  *
  * This function should be called once by the application to initialize the one single instance of the system task pool.
  * An application should initialize the system task pool early in the boot sequence, before initializing any other library
- * that uses the system task pool. such as MQTT, Shadow, Defender, etc.. An application should also initialize the system
- * task pool before posting any jobs. Early initialization it typically easy to accomplish by creating the system task pool
- * before the scheduler is started.
+ * and before posting any jobs. Early initialization it typically easy to accomplish by creating the system task pool
+ * before starting the scheduler.
  *
  * This function does not allocate memory to hold the task pool data structures and state, but it
  * may allocate memory to hold the dependent entities and data structures, e.g. the threads of the task

--- a/modules/libraries/standard/common/include/types/iot_taskpool_types.h
+++ b/modules/libraries/standard/common/include/types/iot_taskpool_types.h
@@ -251,7 +251,7 @@ typedef struct _taskPoolJob * IotTaskPoolJob_t;
  * @brief Callback type for a user callback.
  *
  * This type identifies the user callback signature to execute a task pool job. This callback will be invoked
- * by the task pool threads with the `pUserContext` parameter, as speficied by the user when
+ * by the task pool threads with the `pUserContext` parameter, as specified by the user when
  * calling @ref IotTaskPool_Schedule.
  *
  */

--- a/modules/libraries/standard/common/taskpool/iot_taskpool.c
+++ b/modules/libraries/standard/common/taskpool/iot_taskpool.c
@@ -1351,7 +1351,7 @@ static void _recycleJob( _taskPoolCache_t * const pCache,
         pJob->userCallback = NULL;
         pJob->pUserContext = NULL;
 
-        /* Reset the status for added debugability. */
+        /* Reset the status for added debuggability. */
         pJob->status = IOT_TASKPOOL_STATUS_UNDEFINED;
 
         IotListDouble_InsertTail( &pCache->freeList, &pJob->link );
@@ -1374,7 +1374,7 @@ static void _destroyJob( _taskPoolJob_t * const pJob )
     pJob->userCallback = NULL;
     pJob->pUserContext = NULL;
 
-    /* Reset the status for added debugability. */
+    /* Reset the status for added debuggability. */
     pJob->status = IOT_TASKPOOL_STATUS_UNDEFINED;
 
     /* Only dispose of dynamically allocated jobs. */

--- a/modules/libraries/standard/common/taskpool/iot_taskpool.c
+++ b/modules/libraries/standard/common/taskpool/iot_taskpool.c
@@ -89,7 +89,7 @@ static void _initJobsCache( _taskPoolCache_t * const pCache );
  * @param[in] pJob The job to initialize.
  * @param[in] userCallback The user callback for the job.
  * @param[in] pUserContext The context tp be passed to the callback.
- * @param[in] isStatic A flag to indicate whether the job is statically or synamically allocated.
+ * @param[in] isStatic A flag to indicate whether the job is statically or dynamically allocated.
  */
 static void _initializeJob( _taskPoolJob_t * const pJob,
                             IotTaskPoolRoutine_t userCallback,
@@ -97,7 +97,7 @@ static void _initializeJob( _taskPoolJob_t * const pJob,
                             bool isStatic );
 
 /**
- * @brief Extracts and initializes one instance of a job from the cache or, if there is none available, it allocates and initialized a new one.
+ * @brief Extracts and initializes one instance of a job from the cache or, if there is none available, it allocates and initializes a new one.
  *
  * @param[in] pCache The instance of the cache to extract the job from.
  */
@@ -146,7 +146,7 @@ static int32_t _timerEventCompare( const IotLink_t * const pTimerEventLink1,
  * Reschedules the timer for handling deferred jobs to the next timeout.
  *
  * param[in] pTimer The timer to reschedule.
- * param[in] pFirstTimerEvent The timer event that carries the timeout and job inforamtion.
+ * param[in] pFirstTimerEvent The timer event that carries the timeout and job information.
  */
 static void _rescheduleDeferredJobsTimer( IotTimer_t * const pTimer,
                                           _taskPoolTimerEvent_t * const pFirstTimerEvent );
@@ -217,7 +217,7 @@ static void _signalShutdown( _taskPool_t * const pTaskPool,
 /**
  * Places a job in the dispatch queue.
  *
- * @param[in] pTaskPool The task pool to scheduel the job with.
+ * @param[in] pTaskPool The task pool to schedule the job with.
  * @param[in] pJob The job to schedule.
  * @param[in] flags The job flags.
  *
@@ -941,10 +941,10 @@ static IotTaskPoolError_t _initTaskPoolControlStructures( const IotTaskPoolInfo_
     bool timerInit = false;
 
     /* Zero out all data structures. */
-    memset( ( void * ) pTaskPool, 0x00, sizeof( IotTaskPool_t ) );
+    memset( ( void * ) pTaskPool, 0x00, sizeof( _taskPool_t ) );
 
     /* Initialize a job data structures that require no de-initialization.
-     * All other data structures carry a value of 'NULL' before initailization.
+     * All other data structures carry a value of 'NULL' before initialization.
      */
     IotDeQueue_Create( &pTaskPool->dispatchQueue );
     IotListDouble_Create( &pTaskPool->timerEventsList );
@@ -1040,7 +1040,7 @@ static IotTaskPoolError_t _createTaskPool( const IotTaskPoolInfo_t * const pInfo
     IotTaskPool_Assert( pInfo->minThreads == pTaskPool->minThreads );
     IotTaskPool_Assert( pInfo->maxThreads == pTaskPool->maxThreads );
 
-    /* The task pool will initialize the minimum number of threads reqeusted by the user upon start. */
+    /* The task pool will initialize the minimum number of threads requested by the user upon start. */
     /* When a thread is created, it will signal a semaphore to signify that it is about to wait on incoming */
     /* jobs. A thread can be woken up for exit or for new jobs only at that point in time.  */
     /* The exit condition is setting the maximum number of threads to 0. */
@@ -1120,7 +1120,7 @@ static void _taskPoolWorker( void * pUserContext )
     /* Signal that this worker completed initialization and it is ready to receive notifications. */
     IotSemaphore_Post( &pTaskPool->startStopSignal );
 
-    /* OUTER LOOP: it controls the lifetiem of the worker thread: exit condition for a worker thread
+    /* OUTER LOOP: it controls the lifetime of the worker thread: exit condition for a worker thread
      * is setting maxThreads to zero. A worker thread is running until the maximum number of allowed
      * threads is not zero and the active threads are less than the maximum number of allowed threads.
      */
@@ -1158,9 +1158,9 @@ static void _taskPoolWorker( void * pUserContext )
             }
 
             /* Check if this thread needs to exit because 'max threads' quota was exceeded.
-             * In that case, let is run once, so we can support the case for scheduling 'high priority'
+             * In that case, let it run once, so we can support the case for scheduling 'high priority'
              * jobs that causes exceeding the max threads quota for the purpose of executing
-             * the high-piority task. */
+             * the high-priority task. */
             if( pTaskPool->activeThreads > pTaskPool->maxThreads )
             {
                 IotLogDebug( "Worker thread will exit because maximum quota was exceeded." );
@@ -1174,10 +1174,12 @@ static void _taskPoolWorker( void * pUserContext )
             /* Check if this thread needs to exit  because the worker woke up after a timeout. */
             else if( jobAvailable == false )
             {
-                /* If there was a timeout, shrink back the task pool to the minimum nunber of threads. */
+                /* If there was a timeout, shrink back the task pool to the minimum number of threads. */
                 if( pTaskPool->activeThreads > pTaskPool->minThreads )
                 {
-                    /* After waking up from a timeout, the thread will try and pick up a new job, but . */
+                    /* After waking up from a timeout, the thread will try and pick up a new job.
+                     * But if there is no job available, the thread will exit to ensure that
+                     * the taskpool does not have more than minimum number of active threads. */
                     IotLogDebug( "Worker will exit because task pool is shrinking." );
 
                     /* Decrease the number of active threads pro-actively. */
@@ -1319,7 +1321,7 @@ static _taskPoolJob_t * _fetchOrAllocateJob( _taskPoolCache_t * const pCache )
         }
         else
         {
-            /* Log alocation failure for troubleshooting purposes. */
+            /* Log allocation failure for troubleshooting purposes. */
             IotLogInfo( "Failed to allocate job." );
         }
     }
@@ -1345,11 +1347,11 @@ static void _recycleJob( _taskPoolCache_t * const pCache,
     /* We will recycle the job if there is space in the cache. */
     if( pCache->freeCount < IOT_TASKPOOL_JOBS_RECYCLE_LIMIT )
     {
-        /* Destroy user data, for added safety&security. */
+        /* Destroy user data, for added safety & security. */
         pJob->userCallback = NULL;
         pJob->pUserContext = NULL;
 
-        /* Reset the status for added debuggability. */
+        /* Reset the status for added debugability. */
         pJob->status = IOT_TASKPOOL_STATUS_UNDEFINED;
 
         IotListDouble_InsertTail( &pCache->freeList, &pJob->link );
@@ -1372,7 +1374,7 @@ static void _destroyJob( _taskPoolJob_t * const pJob )
     pJob->userCallback = NULL;
     pJob->pUserContext = NULL;
 
-    /* Reset the status for added debuggability. */
+    /* Reset the status for added debugability. */
     pJob->status = IOT_TASKPOOL_STATUS_UNDEFINED;
 
     /* Only dispose of dynamically allocated jobs. */
@@ -1399,7 +1401,7 @@ static void _signalShutdown( _taskPool_t * const pTaskPool,
     /* Set the exit condition. */
     pTaskPool->maxThreads = 0;
 
-    /* Broadcast to all active threads to wake-up. Active threads do check the exit condition right after wakein up. */
+    /* Broadcast to all active threads to wake-up. Active threads do check the exit condition right after wakeing up. */
     for( count = 0; count < threads; ++count )
     {
         IotSemaphore_Post( &pTaskPool->dispatchSignal );
@@ -1424,7 +1426,7 @@ static IotTaskPoolError_t _scheduleInternal( _taskPool_t * const pTaskPool,
     pTaskPool->activeJobs++;
 
     /* If all threads are busy, try and create a new one. Failing to create a new thread
-     * only has performance implications on correctly exeuting th scheduled job.
+     * only has performance implications on correctly executing the scheduled job.
      */
     uint32_t activeThreads = pTaskPool->activeThreads;
 
@@ -1499,7 +1501,7 @@ static IotTaskPoolError_t _scheduleInternal( _taskPool_t * const pTaskPool,
     else
     {
         /* Scheduling can only fail to allocate a new worker, which is an error
-         * only for high prority tasks. */
+         * only for high priority tasks. */
         IotTaskPool_Assert( mustGrow == true );
 
         /* Revert updating the number of active jobs. */
@@ -1550,12 +1552,12 @@ static IotTaskPoolError_t _tryCancelInternal( _taskPool_t * const pTaskPool,
             break;
 
         case IOT_TASKPOOL_STATUS_COMPLETED:
-            /* Log mesggesong purposes. */
+            /* Log message for debugging purposes. */
             IotLogWarn( "Attempt to cancel a job that is already executing, or canceled." );
             break;
 
         default:
-            /* Log mesggesong purposes. */
+            /* Log message for debugging purposes. */
             IotLogError( "Attempt to cancel a job with an undefined state." );
             break;
     }

--- a/modules/libraries/standard/common/taskpool/iot_taskpool.c
+++ b/modules/libraries/standard/common/taskpool/iot_taskpool.c
@@ -1401,7 +1401,7 @@ static void _signalShutdown( _taskPool_t * const pTaskPool,
     /* Set the exit condition. */
     pTaskPool->maxThreads = 0;
 
-    /* Broadcast to all active threads to wake-up. Active threads do check the exit condition right after wakeing up. */
+    /* Broadcast to all active threads to wake-up. Active threads do check the exit condition right after waking up. */
     for( count = 0; count < threads; ++count )
     {
         IotSemaphore_Post( &pTaskPool->dispatchSignal );


### PR DESCRIPTION

Description
-----------
This commit also fixes one minor initialization issue where memset was
not passed the correct length. Other than than all the changes are in
comments only.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
