### PR TITLE
Add configPRECONDITION

### DIFF
--- a/lib/include/FreeRTOS.h
+++ b/lib/include/FreeRTOS.h
@@ -241,6 +241,18 @@ extern "C" {
 	#define configASSERT_DEFINED 1
 #endif
 
+/* configPRECONDITION should be resolve to configASSERT.
+   The CBMC proofs need a way to track assumptions and assertions.
+   A configPRECONDITION statement should express an implicit invariant or assumption made.
+   A configASSERT statement should express an invariant that must hold explicit before calling
+   the code. */
+#ifndef configPRECONDITION
+	#define configPRECONDITION( x ) configASSERT(X)
+	#define configPRECONDITION_DEFINED 0
+#else
+	#define configPRECONDITION_DEFINED 1
+#endif
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 


### PR DESCRIPTION
configPRECONDITION

Description
-----------
For different CBMC proofs, I want to have a fine granular control about which assertions should be resolved to `__CPROVER_assert` and which should be resolved to `__CPROVER_assume`.
There fore, I introduce `configPRECONDITION` and resolve this in the makefiles to `__CPROVER_assume`. For normal testing, `configPRECONDITION` should default to `configASSERT`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.