### PR TITLE
Update tasks.c

### DIFF
--- a/lib/FreeRTOS/tasks.c
+++ b/lib/FreeRTOS/tasks.c
@@ -1165,13 +1165,20 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 			pxTCB = prvGetTCBFromHandle( xTaskToDelete );
 
 			/* Remove task from the ready list. */
-			if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+			if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ ( pxTCB )->uxPriority ] ), &( ( pxTCB )->xStateListItem ) == pdTRUE )
 			{
-				taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+				if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+				{
+					taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+				}
+				else
+				{
+					mtCOVERAGE_TEST_MARKER();
+				}
 			}
 			else
 			{
-				mtCOVERAGE_TEST_MARKER();
+				( void ) uxListRemove( &( pxTCB->xStateListItem ) );
 			}
 
 			/* Is the task waiting on an event also? */


### PR DESCRIPTION
There may be a bug in vTaskDelete ( ).
If the deleted task is not in the ready list, vTaskDelete can cause other ready task with the same priority never being scheduled.

In using original codes, try to think about a situation:
1.	User #define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
        So, portRESET_READY_PRIORITY( , ) is valid.
2.	There are 2 tasks ( task1 & task2 ) in the system sharing the same priority 3.
        At a time, task1 is delayed, which stateListItem is listed on DelayedTaskList,
                         task2 is ready, which stateListItem is listed on pxReadyTasksLists [ 3 ].
3.	At the same time, task3 call vTaskDelete ( task1 ).
        When there is no other delayed task besides task1, the reture value of uxListRemove ( &( pxTCB->xStateListItem ) ) is 0.
        Then, taskRESET_READY_PRIORITY( pxTCB->uxPriority ) will be called, which means there is no ready task for priority 3.
        Therefore, task2 (prio 3) will never be scheduled by scheduler.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
