### PR TITLE
making aws_test_ble_hal.c os agnostic

### DIFF
--- a/libraries/abstractions/platform/include/platform/iot_alloc.h
+++ b/libraries/abstractions/platform/include/platform/iot_alloc.h
@@ -1,0 +1,52 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef IOT_ALLOC_H
+#define IOT_ALLOC_H
+
+#include "FreeRTOS.h"
+
+// ======================================================= //
+
+/**
+ * @brief Allocates memory from heap.
+ *
+ * @param[in] WantedSize The size of the memory to be allocated.
+ *
+ * @return Pointer to the memory region if the allocation is successful, NULL
+ * otherwise.
+ */
+#define iot_Malloc(WantedSize) pvPortMalloc(WantedSize)
+
+/**
+ * @brief Frees the previously allocated memory.
+ *
+ * @param[in] pv Pointer to the memory to be freed.
+ */
+#define iot_AllocFree( pv ) vPortFree(pv)
+
+// ======================================================= //
+
+#endif /* IOT_ALLOC_H */

--- a/libraries/abstractions/platform/include/platform/iot_callback_groups.h
+++ b/libraries/abstractions/platform/include/platform/iot_callback_groups.h
@@ -1,0 +1,50 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef IOT_CALLBACK_GROUPS_H
+#define IOT_CALLBACK_GROUPS_H
+
+#include "iot_os_common.h"
+#include "FreeRTOS.h"
+#include "event_groups.h"
+
+typedef StaticEventGroup_t		iot_StaticCallbackGroup_t;
+typedef EventGroupHandle_t 		iot_CallbackGroupHandle_t;
+typedef EventBits_t				iot_CallbackBits_t;
+
+// ======================================================= //
+
+#define iot_CallbackGroupCreateStatic( pxEventGroupBuffer ) \
+			xEventGroupCreateStatic( pxEventGroupBuffer )
+
+#define iot_CallbackGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait ) \
+			xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
+
+#define iot_CallbackGroupSetBits( xEventGroup, uxBitsToSet ) \
+			xEventGroupSetBits( xEventGroup, uxBitsToSet )
+
+// ======================================================= //
+
+#endif /* IOT_CALLBACK_GROUPS_H */

--- a/libraries/abstractions/platform/include/platform/iot_os_common.h
+++ b/libraries/abstractions/platform/include/platform/iot_os_common.h
@@ -1,0 +1,38 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef IOT_OS_COMMON_H
+#define IOT_OS_COMMON_H
+
+#include "FreeRTOS.h"
+
+#define iotTRUE  pdTRUE
+#define iotFALSE pdFALSE
+
+typedef BaseType_t			iotBaseType_t;
+typedef UBaseType_t 		UiotBaseType_t;
+typedef TickType_t			iotTimeType_t;
+
+#endif /* IOT_OS_COMMON_H */

--- a/libraries/abstractions/platform/include/platform/iot_queue.h
+++ b/libraries/abstractions/platform/include/platform/iot_queue.h
@@ -1,0 +1,54 @@
+/*
+ * Amazon FreeRTOS
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef IOT_QUEUE_H
+#define IOT_QUEUE_H
+
+#include "iot_os_common.h"
+#include "FreeRTOS.h"
+#include "queue.h"
+// ======================================================= //
+
+#define iot_QueueReceive(Queue, Buffer, TimeToWait) \
+	xQueueReceive( Queue, Buffer, pdMS_TO_TICKS(TimeToWait) )
+
+// ======================================================= //
+
+#define iot_QueueCreate(QueueLength, ItemSize) \
+	xQueueCreate( QueueLength, ItemSize )
+
+// ======================================================= //
+
+#define iot_QueueSend(Queue, ItemTpQueue, TimeToWait) \
+	xQueueSend( Queue, ItemTpQueue, pdMS_TO_TICKS( TimeToWait))
+
+// ======================================================= //
+
+#define iot_QueueDelete(Queue) \
+	vQueueDelete( Queue )
+
+// ======================================================= //
+
+#endif /* IOT_QUEUE_H */


### PR DESCRIPTION
Making aws_test_ble_hal.c OS agnostic

Description
-----------
I have separated any FreeRTOS dependency from the aws_test_ble.c by including additional os abstraction libraries.

Checklist:
----------
- [yes] I have tested my changes. No regression in existing tests.
--I have tested my changes by using feature/ble-beta branch as I couldn't compile it on the release-1.5 branch for esp32 board
- [yes] My code is Linted.
--I have used the already existing Full_BLE test group to verify my code
