### PR TITLE
Remove duplicate getName method in specific test cases

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_back_to_back_downloads.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_back_to_back_downloads.py
@@ -39,9 +39,6 @@ class OtaTestBackToBackDownloads( OtaTestCase ):
             flashComm
         )
 
-    def getName(self):
-        return self._name
-
     def __buildAndOtaInputVersion(self, x, y, z):
         # Build x.y.z for download
         self._otaProject.setApplicationVersion(x, y, z)

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_after_signing.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_after_signing.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 import json
 
 class OtaTestCorruptImageAfterSigning( OtaTestCase ):

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_before_signing.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_image_before_signing.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestCorruptImageBeforeSigning( OtaTestCase ):
     """This test uploads and OTA's a non-runnable image before code signing.
@@ -49,9 +48,6 @@ class OtaTestCorruptImageBeforeSigning( OtaTestCase ):
         for i in range(0, 2500):
           outfile.write(oroboros.encode())
         outfile.close()
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Upload the bad image to s3.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_signature.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_corrupt_signature.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 import json
 
 class OtaTestCorruptSignature( OtaTestCase ):

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_dummy_test.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_dummy_test.py
@@ -42,9 +42,6 @@ class OtaTestDummyTest( OtaTestCase ):
             flashComm
         )
 
-    def getName(self):
-        return self._name
-
     def setup(self):
         print('Ran OtaTestDummyTest::setup.')
         # Adding empty list for return to indicate the successful setup.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_factory.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_factory.py
@@ -36,7 +36,6 @@ from .aws_ota_test_case_missing_filename import OtaTestMissingFilename
 from .aws_ota_test_case_incorrect_platform import OtaTestIncorrectPlatform
 from .aws_ota_test_case_back_to_back_downloads import OtaTestBackToBackDownloads
 from .aws_ota_test_case_incorrect_wifi_password import OtaTestIncorrectWifiPassword
-from .aws_ota_test_case_missing_filename import OtaTestMissingFilename
 from .aws_ota_test_case_dummy_test import OtaTestDummyTest
 
 """
@@ -56,7 +55,6 @@ AllOtaTestCases = {
     OtaTestMissingFilename.NAME : OtaTestMissingFilename,
     OtaTestBackToBackDownloads.NAME : OtaTestBackToBackDownloads,
     OtaTestIncorrectWifiPassword.NAME : OtaTestIncorrectWifiPassword,
-    OtaTestMissingFilename.NAME: OtaTestMissingFilename,
     OtaTestDummyTest.NAME : OtaTestDummyTest
 }
 

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestGreaterVersion( OtaTestCase ):
     NAME = 'OtaTestGreaterVersion'
@@ -38,9 +37,6 @@ class OtaTestGreaterVersion( OtaTestCase ):
             otaAwsAgent,
             flashComm
         )
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Increase the version of the OTA image.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_incorrect_platform.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_incorrect_platform.py
@@ -27,7 +27,6 @@ from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
 import boto3
 import os
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestIncorrectPlatform( OtaTestCase ):
     NAME = "OtaTestIncorrectPlatform"
@@ -50,9 +49,6 @@ class OtaTestIncorrectPlatform( OtaTestCase ):
             self._incorrectPlatform = 'AmazonFreeRTOS-TI-CC3220SF'
             self._signingAlgorithm = 'RSA'
             self._hashingAlgorithm = 'SHA1'
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Increase the version of the OTA image.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_incorrect_wifi_password.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_incorrect_wifi_password.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestIncorrectWifiPassword( OtaTestCase ):
     NAME = "OtaTestIncorrectWifiPassword"
@@ -38,9 +37,6 @@ class OtaTestIncorrectWifiPassword( OtaTestCase ):
             otaAwsAgent,
             flashComm
         )
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Increase the version of the OTA image.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_missing_filename.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_missing_filename.py
@@ -25,10 +25,9 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestMissingFilename( OtaTestCase ):
-    NAME = 'OtaTestMissingImageName'
+    NAME = 'OtaTestMissingFilename'
     def __init__(self, boardConfig, otaProject, otaAwsAgent, flashComm):
         super(OtaTestMissingFilename, self).__init__(
             OtaTestMissingFilename.NAME,

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_previous_version.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_previous_version.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestPreviousVersion( OtaTestCase ):
     NAME = 'OtaTestPreviousVersion'
@@ -38,9 +37,6 @@ class OtaTestPreviousVersion( OtaTestCase ):
             otaAwsAgent,
             flashComm
         )
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Decrease the version of the OTA image.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_same_version.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_same_version.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestSameVersion( OtaTestCase ):
     NAME = 'OtaTestSameVersion'
@@ -38,9 +37,6 @@ class OtaTestSameVersion( OtaTestCase ):
             otaAwsAgent,
             flashComm
         )
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Keep the same version of the image from setup() called in the superclass.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_single_byte_image.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_single_byte_image.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestSingleByteImage( OtaTestCase ):
     NAME = "OtaTestSingleByteImage"
@@ -44,9 +43,6 @@ class OtaTestSingleByteImage( OtaTestCase ):
         outfile = open(self.singleByteFileName, 'wb')
         charToWrite = "a"
         outfile.write(charToWrite.encode())
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Upload the bad image to s3.

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_unsigned_image.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_unsigned_image.py
@@ -25,7 +25,6 @@ http://www.FreeRTOS.org
 """
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestUnsignedImage( OtaTestCase ):
     NAME = 'OtaTestUnsignedImage'

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_untrusted_certificate.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_untrusted_certificate.py
@@ -26,7 +26,6 @@ http://www.FreeRTOS.org
 from .aws_ota_test_case import *
 from .aws_ota_aws_agent import *
 import os
-from .aws_ota_test_result import OtaTestResult
 
 class OtaTestUntrustedCertificate( OtaTestCase ):
     NAME = "OtaTestUntrustedCertificate"
@@ -44,9 +43,6 @@ class OtaTestUntrustedCertificate( OtaTestCase ):
         self._bogusSignerArn = "%s"%self._otaConfig['aws_untrusted_signer_certificate_arn']
         # Set a semi-unique 'signing type' name based on the invalid certificate's ARN to avoid conflicts.
         self._signingProfileName = "%s%s"%(self._bogusSignerArn[-10:], self._otaAwsAgent._boardName[:10])
-
-    def getName(self):
-        return self._name
 
     def run(self):
         # Increase the version of the OTA image.


### PR DESCRIPTION
Remove duplicate getName method in specific test cases

Description
-----------
Remove duplicate getName method in specific test cases. Meanwhile, correct the test case name for OtaTestMissingFilename.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
