### PR TITLE
Header files to access static functions for IP header proof

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -2316,3 +2316,9 @@ BaseType_t FreeRTOS_IsNetworkUp( void )
 	}
 #endif
 /*-----------------------------------------------------------*/
+
+/* Provide access to private members for verification. */
+#ifdef FREERTOS_TCP_ENABLE_VERIFICATION
+	#include "aws_freertos_ip_verification_access_ip_define.h"
+#endif
+

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -3346,3 +3346,8 @@ BaseType_t xResult = pdFALSE;
 	#include "iot_freertos_tcp_test_access_tcp_define.h"
 #endif
 
+/* Provide access to private members for verification. */
+#ifdef FREERTOS_TCP_ENABLE_VERIFICATION
+	#include "aws_freertos_tcp_verification_access_tcp_define.h"
+#endif
+

--- a/tools/cbmc/include/aws_freertos_ip_verification_access_ip_define.h
+++ b/tools/cbmc/include/aws_freertos_ip_verification_access_ip_define.h
@@ -1,0 +1,3 @@
+eFrameProcessingResult_t publicProcessIPPacket( IPPacket_t * const pxIPPacket, NetworkBufferDescriptor_t * const pxNetworkBuffer ) {
+	prvProcessIPPacket(pxIPPacket, pxNetworkBuffer);
+}

--- a/tools/cbmc/include/aws_freertos_tcp_verification_access_tcp_define.h
+++ b/tools/cbmc/include/aws_freertos_tcp_verification_access_tcp_define.h
@@ -1,0 +1,12 @@
+int32_t publicTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength ) {
+	prvTCPPrepareSend( pxSocket, ppxNetworkBuffer, uxOptionsLength );
+}
+
+BaseType_t publicTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer ) {
+	prvTCPHandleState(pxSocket, ppxNetworkBuffer);
+}
+
+void publicTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer,
+	uint32_t ulLen, BaseType_t xReleaseAfterSend ) {
+	prvTCPReturnPacket(pxSocket, pxNetworkBuffer, ulLen, xReleaseAfterSend );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
These headers files are required to access the static functions in FreeRTOS_TCP_IP and FreeRTOS_IP.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
