### PR TITLE
Adding CBMC proof for Process IP header (Depends on pull requests #760 and #761)

### DIFF
--- a/tools/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
+++ b/tools/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "ProcessIPPacket",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto"
+  ],
+  "DEF":
+  [
+    "AMAZON_FREERTOS_ENABLE_UNIT_TESTS"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/parsing/ProcessIPPacket/ProcessIPPacket_harness.c
+++ b/tools/cbmc/proofs/parsing/ProcessIPPacket/ProcessIPPacket_harness.c
@@ -1,0 +1,29 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* proof is done separately */
+BaseType_t xProcessReceivedTCPPacket(NetworkBufferDescriptor_t *pxNetworkBuffer) { }
+
+/* proof is done separately */
+BaseType_t xProcessReceivedUDPPacket(NetworkBufferDescriptor_t *pxNetworkBuffer, uint16_t usPort) { }
+
+/* This proof was done before. Hence we assume it to be correct here. */
+void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress, const uint32_t ulIPAddress ) { }
+
+eFrameProcessingResult_t publicProcessIPPacket( IPPacket_t * const pxIPPacket, NetworkBufferDescriptor_t * const pxNetworkBuffer);
+
+void harness() {
+
+	NetworkBufferDescriptor_t * const pxNetworkBuffer = malloc(sizeof(NetworkBufferDescriptor_t));
+	/* Pointer to the start of the Ethernet frame. It should be able to access the whole Ethernet frame.*/
+	pxNetworkBuffer->pucEthernetBuffer = malloc(ipTOTAL_ETHERNET_FRAME_SIZE); 
+	/* Minimum length of the pxNetworkBuffer->xDataLength is at least the size of the IPPacket_t. */
+	__CPROVER_assume(pxNetworkBuffer->xDataLength >= sizeof(IPPacket_t)  && pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE);
+	IPPacket_t * const pxIPPacket = malloc(sizeof(IPPacket_t));
+	publicProcessIPPacket(pxIPPacket, pxNetworkBuffer);
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvProcessIPPacket function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
