### PR TITLE
Adding CBMC proof for Process received UDP packet

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
@@ -240,6 +240,9 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t *pxNetworkBuffer
 {
 BaseType_t xReturn = pdPASS;
 FreeRTOS_Socket_t *pxSocket;
+configASSERT(pxNetworkBuffer);
+configASSERT(pxNetworkBuffer->pucEthernetBuffer);
+
 
 UDPPacket_t *pxUDPPacket = (UDPPacket_t *) pxNetworkBuffer->pucEthernetBuffer;
 

--- a/tools/cbmc/proofs/parsing/ProcessReceivedUDPPacket/Makefile.json
+++ b/tools/cbmc/proofs/parsing/ProcessReceivedUDPPacket/Makefile.json
@@ -1,0 +1,23 @@
+{
+  "ENTRY": "ProcessReceivedUDPPacket",
+  "MAX_RX_PACKETS":1,
+  "USE_LLMNR":1,
+  "USE_NBNS":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUDP_MAX_RX_PACKETS={MAX_RX_PACKETS}",
+    "ipconfigUSE_LLMNR={USE_LLMNR}",
+    "ipconfigUSE_NBNS={USE_NBNS}"
+  ]
+}

--- a/tools/cbmc/proofs/parsing/ProcessReceivedUDPPacket/ProcessReceivedUDPPacket_harness.c
+++ b/tools/cbmc/proofs/parsing/ProcessReceivedUDPPacket/ProcessReceivedUDPPacket_harness.c
@@ -1,0 +1,46 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_TCP_IP.h"
+
+/*This proof assumes that pxUDPSocketLookup is implemented correctly. */
+
+/* This proof was done before. Hence we assume it to be correct here. */
+void vARPRefreshCacheEntry(const MACAddress_t * pxMACAddress, const uint32_t ulIPAddress) { }
+
+/* This proof was done before. Hence we assume it to be correct here. */
+BaseType_t xIsDHCPSocket(Socket_t xSocket) { }
+
+/* This proof was done before. Hence we assume it to be correct here. */
+uint32_t ulDNSHandlePacket(NetworkBufferDescriptor_t *pxNetworkBuffer) { }
+
+/* Implementation of safe malloc */
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Abstraction of pxUDPSocketLookup */
+FreeRTOS_Socket_t *pxUDPSocketLookup( UBaseType_t uxLocalPort ) {
+	return safeMalloc(sizeof(FreeRTOS_Socket_t));
+}
+
+void harness() {
+	NetworkBufferDescriptor_t *pxNetworkBuffer = safeMalloc(sizeof(NetworkBufferDescriptor_t));
+	if(pxNetworkBuffer) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(UDPPacket_t));
+	}
+	uint16_t usPort;
+	if (pxNetworkBuffer && pxNetworkBuffer->pucEthernetBuffer) {
+		xProcessReceivedUDPPacket(pxNetworkBuffer, usPort);
+	}
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the xProcessReceivedUDPPacket function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
