### PR TITLE
 Adding CBMC proof for Process received TCP packet (Depends on pull requests #760 and #761)

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -2914,6 +2914,8 @@ uint16_t xRemotePort;
 uint32_t ulSequenceNumber;
 uint32_t ulAckNumber;
 BaseType_t xResult = pdPASS;
+configASSERT(pxNetworkBuffer);
+configASSERT(pxNetworkBuffer->pucEthernetBuffer);
 
 	/* Check for a minimum packet size. */
 	if( pxNetworkBuffer->xDataLength >= ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )

--- a/tools/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
+++ b/tools/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
@@ -1,0 +1,31 @@
+{
+  "ENTRY": "ProcessReceivedTCPPacket",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvTCPSendRepeated.0:13",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body prvSingleStepTCPHeaderOptions",
+    "--remove-function-body prvCheckOptions",
+    "--remove-function-body prvTCPPrepareSend",
+    "--remove-function-body prvTCPReturnPacket",
+    "--remove-function-body prvTCPHandleState"
+  ],
+  "DEF":
+  [
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}
+

--- a/tools/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
+++ b/tools/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
@@ -1,0 +1,62 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_Stream_Buffer.h"
+
+/* This proof assumes FreeRTOS_socket, pxTCPSocketLookup and 
+pxGetNetworkBufferWithDescriptor are implemented correctly.
+
+It also assumes prvSingleStepTCPHeaderOptions, prvCheckOptions, prvTCPPrepareSend,
+prvTCPHandleState and prvTCPReturnPacket are correct. These functions are
+proved to be correct separately. */
+
+/* Implementation of safe malloc */
+void *safeMalloc(size_t xWantedSize ){
+	if(xWantedSize == 0){
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Abstraction of FreeRTOS_socket */
+Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol) {
+	return safeMalloc(sizeof(FreeRTOS_Socket_t));
+}
+
+/* Abstraction of pxTCPSocketLookup */
+FreeRTOS_Socket_t *pxTCPSocketLookup(uint32_t ulLocalIP, UBaseType_t uxLocalPort, uint32_t ulRemoteIP, UBaseType_t uxRemotePort) {
+	FreeRTOS_Socket_t * xRetSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	if (xRetSocket) {
+		xRetSocket->u.xTCP.txStream = safeMalloc(sizeof(StreamBuffer_t));
+		xRetSocket->u.xTCP.pxPeerSocket = safeMalloc(sizeof(StreamBuffer_t));
+	}	
+	return xRetSocket;
+}
+
+/* Abstraction of pxGetNetworkBufferWithDescriptor */
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	NetworkBufferDescriptor_t *pxNetworkBuffer = safeMalloc(sizeof(NetworkBufferDescriptor_t));
+	if(pxNetworkBuffer) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(xRequestedSizeBytes);
+		__CPROVER_assume(pxNetworkBuffer->xDataLength == ipSIZE_OF_ETH_HEADER + sizeof(int32_t));
+	}	
+	return pxNetworkBuffer;
+}
+
+void harness() {
+	NetworkBufferDescriptor_t *pxNetworkBuffer = safeMalloc(sizeof(NetworkBufferDescriptor_t));
+	if (pxNetworkBuffer) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+	}
+	if (pxNetworkBuffer && pxNetworkBuffer->pucEthernetBuffer) {
+		xProcessReceivedTCPPacket(pxNetworkBuffer);
+
+	}
+
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the xProcessReceivedTCPPacket function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
