### PR TITLE
Adding CBMC proof for TCP handle state

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -2665,6 +2665,8 @@ int32_t lRxSpace;
  */
 static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer )
 {
+configASSERT(pxSocket);
+configASSERT(ppxNetworkBuffer);
 TCPPacket_t *pxTCPPacket = ( TCPPacket_t * ) ( (*ppxNetworkBuffer)->pucEthernetBuffer );
 TCPHeader_t *pxTCPHeader = &( pxTCPPacket->xTCPHeader );
 BaseType_t xSendLength = 0;

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -1,0 +1,31 @@
+{
+  "ENTRY": "TCPHandleState",
+  "TX_DRIVER":1,
+  "RX_MESSAGES":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvWinScaleFactor.0:2",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigZERO_COPY_TX_DRIVER={TX_DRIVER}",
+    "ipconfigUSE_LINKED_RX_MESSAGES={RX_MESSAGES}",
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body prvTCPPrepareSend",
+    "--remove-function-body prvTCPReturnPacket"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -1,0 +1,37 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that prvTCPPrepareSend and prvTCPReturnPacket are correct.
+These functions are proved to be correct separately. */
+
+BaseType_t publicTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer );
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	if (ensure_memory_is_valid(pxSocket)) {
+		pxSocket->u.xTCP.rxStream = ensure_FreeRTOS_StreamBuffer_t_is_allocated();
+		pxSocket->u.xTCP.txStream = ensure_FreeRTOS_StreamBuffer_t_is_allocated();
+		pxSocket->u.xTCP.pxPeerSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+		__CPROVER_assume(pxSocket->u.xTCP.xTCPWindow.ucOptionLength == sizeof(uint32_t) * ipSIZE_TCP_OPTIONS/sizeof(uint32_t));
+		__CPROVER_assume(pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof(size_t));
+		__CPROVER_assume(pxSocket->u.xTCP.usInitMSS == sizeof(uint16_t));
+	}
+
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if(ensure_memory_is_valid(pxNetworkBuffer)) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+	}
+	if (ensure_memory_is_valid(pxSocket) && ensure_memory_is_valid(pxNetworkBuffer) &&
+		ensure_memory_is_valid(pxNetworkBuffer->pucEthernetBuffer)) {
+		publicTCPHandleState(pxSocket, &pxNetworkBuffer);
+
+	}
+}

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,25 @@
+#define ensure_memory_is_valid( px ) (px != NULL)
+
+/* Implementation of safe malloc */
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	return safeMalloc(sizeof(FreeRTOS_Socket_t));
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}
+
+/* Memory assignment for FreeRTOS_StreamBuffer_t */
+StreamBuffer_t * ensure_FreeRTOS_StreamBuffer_t_is_allocated() {
+	return safeMalloc(sizeof(StreamBuffer_t));
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvTCPHandleState function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
