### PR TITLE
Adding CBMC proof for TCP prepare send

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1692,6 +1692,7 @@ uint32_t ulDataGot, ulDistance;
 TCPWindow_t *pxTCPWindow;
 NetworkBufferDescriptor_t *pxNewBuffer;
 int32_t lStreamPos;
+configASSERT(pxSocket);
 
 	if( ( *ppxNetworkBuffer ) != NULL )
 	{

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TCPPrepareSend",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
@@ -1,0 +1,41 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_Stream_Buffer.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that pxGetNetworkBufferWithDescriptor is implemented correctly. */
+int32_t publicTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength );
+
+/* Abstraction of pxGetNetworkBufferWithDescriptor */
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	NetworkBufferDescriptor_t *pxBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated ();
+	if (ensure_memory_is_valid(pxBuffer)) {
+		pxBuffer->pucEthernetBuffer = malloc(xRequestedSizeBytes);
+		pxBuffer->xDataLength = xRequestedSizeBytes;
+	}
+	return pxBuffer;
+}
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if (ensure_memory_is_valid(pxNetworkBuffer)) {
+		pxNetworkBuffer->pucEthernetBuffer = malloc(sizeof(TCPPacket_t));
+		__CPROVER_assume(pxNetworkBuffer->xDataLength == sizeof(TCPPacket_t));
+	}
+	UBaseType_t uxOptionsLength;
+	if(ensure_memory_is_valid(pxSocket)) {
+		pxSocket->u.xTCP.rxStream = ensure_FreeRTOS_StreamBuffer_t_is_allocated();
+		pxSocket->u.xTCP.txStream = ensure_FreeRTOS_StreamBuffer_t_is_allocated();
+		pxSocket->u.xTCP.pxPeerSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+		publicTCPPrepareSend(pxSocket, &pxNetworkBuffer, uxOptionsLength );
+
+	}
+}

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,25 @@
+#define ensure_memory_is_valid( px ) (px != NULL)
+
+/* Implementation of safe malloc */
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	return safeMalloc(sizeof(FreeRTOS_Socket_t));
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}
+
+/* Memory assignment for FreeRTOS_StreamBuffer_t */
+StreamBuffer_t * ensure_FreeRTOS_StreamBuffer_t_is_allocated() {
+	return safeMalloc(sizeof(StreamBuffer_t));
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvTCPPrepareSend function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
