### PR TITLE
Adding CBMC proof for TCP return

### DIFF
--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
@@ -1,0 +1,23 @@
+{
+  "ENTRY": "TCPReturnPacket",
+  "RX_MESSAGES":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_LINKED_RX_MESSAGES={RX_MESSAGES}",
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -1,0 +1,41 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that pxDuplicateNetworkBufferWithDescriptor is implemented correctly. */
+
+void publicTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer, uint32_t ulLen, BaseType_t xReleaseAfterSend );
+
+/* Abstraction of pxDuplicateNetworkBufferWithDescriptor*/
+NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+	BaseType_t xNewLength ) {
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if (ensure_memory_is_valid(pxNetworkBuffer)) {
+		pxNetworkBuffer->pucEthernetBuffer = malloc(sizeof(TCPPacket_t));
+	}
+	return pxNetworkBuffer;
+}
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	if (ensure_memory_is_valid(pxSocket)) {
+		pxSocket->u.xTCP.rxStream = ensure_FreeRTOS_StreamBuffer_t_is_allocated();
+	}
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if (ensure_memory_is_valid(pxNetworkBuffer)) {
+		pxNetworkBuffer->pucEthernetBuffer = malloc(sizeof(TCPPacket_t));
+	}
+	uint32_t ulLen;
+	BaseType_t xReleaseAfterSend;
+	__CPROVER_assume(pxSocket != NULL || pxNetworkBuffer != NULL); /* Both can not be NULL at the same time. */
+
+	publicTCPReturnPacket(pxSocket, pxNetworkBuffer, ulLen, xReleaseAfterSend);
+
+}

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,25 @@
+#define ensure_memory_is_valid( px ) (px != NULL)
+
+/* Implementation of safe malloc */
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	return safeMalloc(sizeof(FreeRTOS_Socket_t));
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}
+
+/* Memory assignment for FreeRTOS_StreamBuffer_t */
+StreamBuffer_t * ensure_FreeRTOS_StreamBuffer_t_is_allocated() {
+	return safeMalloc(sizeof(StreamBuffer_t));
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvTCPReturn function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
