### PR TITLE
Fix the certificate configuration tool to reflect updated aws_clientc…

### DIFF
--- a/tools/certificate_configuration/js/generator.js
+++ b/tools/certificate_configuration/js/generator.js
@@ -105,20 +105,11 @@ function generateCertificateConfigurationHeader() {
 \ * \"...base64 data...\\n\"\\\n\
 \ * \"-----END CERTIFICATE-----\"\n\
 \ *\/\n\
-#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM  NULL\n\
+#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM  \"\"\n\
 \n";
 
     header_end_text =
-"\/\* The constants above are set to const char * pointers defined in aws_dev_mode_key_provisioning.c,\n\
-\ * and externed here for use in C files.  NOTE!  THIS IS DONE FOR CONVENIENCE\n\
-\ * DURING AN EVALUATION PHASE AND IS NOT GOOD PRACTICE FOR PRODUCTION SYSTEMS\n\
-\ * WHICH MUST STORE KEYS SECURELY. *\/\n\
-extern const char clientcredentialCLIENT_CERTIFICATE_PEM\[\];\n\
-extern const char* clientcredentialJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM;\n\
-extern const char clientcredentialCLIENT_PRIVATE_KEY_PEM\[\];\n\
-extern const uint32_t clientcredentialCLIENT_CERTIFICATE_LENGTH;\n\
-extern const uint32_t clientcredentialCLIENT_PRIVATE_KEY_LENGTH;\n\
-\n\
+"\n\
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H *\/\n";
 
     //Start first async read - other calls are chained inline


### PR DESCRIPTION
…redential_keys.h

Removes externed variables, defaults the JITR cert to ""


TESTED by generating and building locally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
