### PR TITLE
Add device identifier and device metrics computation

### DIFF
--- a/demos/demo_runner/iot_demo_afr.c
+++ b/demos/demo_runner/iot_demo_afr.c
@@ -74,6 +74,8 @@ const IotMqttSerializer_t * demoGetMqttSerializer( void )
 #endif
 /*-----------------------------------------------------------*/
 
+void generateDeviceIdentifierAndMetrics( void );
+
 static uint32_t _getConnectedNetworkForDemo( demoContext_t * pDemoContext )
 {
     uint32_t ret = ( AwsIotNetworkManager_GetConnectedNetworks() & pDemoContext->networkTypes );
@@ -178,6 +180,9 @@ static int _initialize( demoContext_t * pContext )
     bool commonLibrariesInitailized = false;
     bool semaphoreCreated = false;
 
+    /* Generate device identifier and device metrics. */
+    generateDeviceIdentifierAndMetrics();
+
     /* Initialize common libraries required by network manager and demo. */
     if( IotSdk_Init() == true )
     {
@@ -276,7 +281,6 @@ static void _cleanup( void )
 }
 
 /*-----------------------------------------------------------*/
-
 void runDemoTask( void * pArgument )
 {
     /* On Amazon FreeRTOS, credentials and server info are defined in a header
@@ -400,4 +404,204 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
     for( ; ; )
     {
     }
+}
+
+/*
+ * @brief Total length of the hash in bytes.
+ */
+#define _MD5_HASH_LENGTH_BYTES    ( 16 )
+
+/*
+ * @brief Length in 32-bit words of each chunk used for hash computation .
+ */
+#define _MD5_CHUNK_LENGTH_WORDS   ( 16 )
+
+/*
+ * @brief Length in bytes of each chunk used for hash computation.
+ */
+#define _MD5_CHUNK_LENGTH_BYTES   ( _MD5_CHUNK_LENGTH_WORDS * 4 )
+
+#define LEFT_ROTATE( x, c ) ( ( x << c ) | ( x >> ( 32 - c ) ) )
+
+static const char S[64] = {
+    7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
+    5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,
+    4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,
+    6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21
+};
+
+static const unsigned int K[64] = {
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee,
+    0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa,
+    0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+    0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05,
+    0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039,
+    0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1
+};
+
+/*
+ * @brief MD5 hashing algorithm to generate a unique identifier for a sequeunce of bytes.
+ * The hash algorithm is adapted from wikipedia and does not dependent of any third party libraries.
+ */
+static void _generateHash( const char *pData, size_t dataLength, uint8_t *pHash, size_t hashLength )
+{
+    uint32_t A, B, C, D, E, F, G;
+    uint32_t chunk[ _MD5_CHUNK_LENGTH_WORDS ] = { 0 };
+    const uint32_t *pCurrent = NULL;
+    uint32_t *pOutput = ( uint32_t * )pHash;
+    size_t i;
+
+    //Initialize variables
+    pOutput[ 0 ] = 0x67452301;
+    pOutput[ 1 ] = 0xefcdab89;
+    pOutput[ 2 ] = 0x98badcfe;
+    pOutput[ 3 ] = 0x10325476;
+
+    configASSERT( hashLength >= _MD5_HASH_LENGTH_BYTES );
+
+    while( dataLength > 0 )
+    {
+        A = pOutput[ 0 ];
+        B = pOutput[ 1 ];
+        C = pOutput[ 2 ];
+        D = pOutput[ 3 ];
+
+        E = F = G = 0;
+
+        if( dataLength < _MD5_CHUNK_LENGTH_BYTES )
+        {
+            memcpy( chunk, pData, dataLength );
+            pCurrent = chunk;
+            pData += _MD5_CHUNK_LENGTH_BYTES;
+            dataLength = 0;
+        }
+        else
+        {
+            pCurrent = ( uint32_t * ) pData;
+            pData += _MD5_CHUNK_LENGTH_BYTES;
+            dataLength -= _MD5_CHUNK_LENGTH_BYTES;
+        }
+
+        for( i = 0; i < 64; i++ )
+        {
+            if( i < 16 )
+            {
+                F = ( B & C ) | ( ( ~B ) & D );
+                G = i;
+            }
+            else if( i < 32 )
+            {
+                F = ( D & B ) | ( ( ~D ) & C );
+                G = ( ( 5 * i ) + 1 ) % 16;
+            }
+            else if( i < 48 )
+            {
+                F = ( B ^ C ) ^ D;
+                G = ( ( 3 * i ) + 5 ) % 16;
+            }
+            else
+            {
+                F = C ^ ( B | ( ~D ) );
+                G = ( 7 * i ) % 16;
+            }
+
+            F = F + A + K[ i ] + pCurrent[ G ];
+            A = D;
+            D = C;
+            C = B;
+            B = B + LEFT_ROTATE( F, S[ i ] );
+        }
+
+        pOutput[ 0 ] += A;
+        pOutput[ 1 ] += B;
+        pOutput[ 2 ] += C;
+        pOutput[ 3 ] += D;
+    }
+}
+
+/*
+ * @brief Length of device identifier.
+ * Device identifier is represented as hex string of MD5 hash of the device certificate.
+ */
+#define AWS_IOT_DEVICE_IDENTIFIER_LENGTH ( _MD5_HASH_LENGTH_BYTES * 2 )
+
+/**
+ * @brief Device metrics name format
+ */
+#define AWS_IOT_METRICS_NAME "?SDK=" IOT_SDK_NAME "&Version=4.0.0&Platform=" IOT_PLATFORM_NAME "&AFRDevID=%.*s"
+
+ /**
+  * @brief Length of #AWS_IOT_METRICS_NAME.
+  */
+#define AWS_IOT_METRICS_NAME_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_NAME ) + AWS_IOT_DEVICE_IDENTIFIER_LENGTH ) )
+
+/**
+ * @brief Unique identifier for the device.
+ */
+static char deviceIdentifier[ AWS_IOT_DEVICE_IDENTIFIER_LENGTH + 1] = { 0 };
+
+/*
+  @brief Device metrics sent to the cloud.
+ */
+static char deviceMetrics[AWS_IOT_METRICS_NAME_LENGTH + 1] = { 0 };
+
+
+static void _generateDeviceMetrics(void)
+{
+    size_t length;
+    length = snprintf( deviceMetrics,
+        AWS_IOT_METRICS_NAME_LENGTH,
+        AWS_IOT_METRICS_NAME,
+        AWS_IOT_DEVICE_IDENTIFIER_LENGTH,
+        deviceIdentifier );
+    configASSERT(length > 0);
+
+    configPRINTF(( "%s\r\n", deviceMetrics ));
+}
+
+/*
+ * @brief Generates a unique identifier for the device and metrics sent by the device to cloud.
+ * Function should only be called once at intialization.
+ */
+void generateDeviceIdentifierAndMetrics( void )
+{
+    const char *pCert = keyCLIENT_CERTIFICATE_PEM;
+    size_t certLength = strlen( keyCLIENT_CERTIFICATE_PEM );
+    uint8_t hash[ _MD5_HASH_LENGTH_BYTES ] = { 0 };
+    char *pBuffer = deviceIdentifier;
+    int i;
+    _generateHash( pCert, certLength, hash, _MD5_HASH_LENGTH_BYTES );
+
+    for( i = 0; i < _MD5_HASH_LENGTH_BYTES; i++ )
+    {
+        sprintf( pBuffer, "%02X", hash[ i ] );
+        pBuffer += 2;
+    }
+
+    _generateDeviceMetrics();
+}
+
+/*
+ * @brief Retrieves the unique identifier for the device.
+ */
+const char *getDeviceIdentifier( void )
+{
+    return deviceIdentifier;
+}
+
+/*
+ * @brief Retrieves the device metrics to be sent to cloud.
+ */
+const char *getDeviceMetrics( void )
+{
+    return deviceMetrics;
 }

--- a/demos/demo_runner/iot_demo_afr.c
+++ b/demos/demo_runner/iot_demo_afr.c
@@ -564,8 +564,6 @@ static void _generateDeviceMetrics(void)
         AWS_IOT_DEVICE_IDENTIFIER_LENGTH,
         deviceIdentifier );
     configASSERT(length > 0);
-
-    configPRINTF(( "%s\r\n", deviceMetrics ));
 }
 
 /*

--- a/demos/include/iot_config_common.h
+++ b/demos/include/iot_config_common.h
@@ -169,7 +169,14 @@
  * @brief Unique identifier used to recognize a device by the cloud.
  * This could be SHA-256 of the device certificate.
  */
-#define IOT_DEVICE_IDENTIFIER                ""
+extern const char *getDeviceIdentifier( void );
+#define IOT_DEVICE_IDENTIFIER                getDeviceIdentifier()
+
+/**
+ * @brief Metrics emitted by the device.
+ */
+extern const char *getDeviceMetrics( void );
+#define IOT_DEVICE_METRICS     getDeviceMetrics()
 
 /* Define the data type of metrics connection id as same as Socket_t in aws_secure_socket.h */
 #define IotMetricsConnectionId_t            void *


### PR DESCRIPTION
Add unique identifier for device and generate metrics with device identifier

Description
-----------
Inorder to identify devices emitting metrics behind a proxy, a unique identifier for device needs to be emitted.
Identifier is generated using MD5 hash of device certificate and encoded as a 32 character hex string.

Sample output:
10 1033 [iot_thread] ?SDK=AmazonFreeRTOS&Version=4.0.0&Platform=WinSim&AFRDevID=8CC7EB90972FF50A4F17C459EBC5BCD2



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
