### PR TITLE
Improving ble stack initialization sequence

### DIFF
--- a/libraries/abstractions/ble_hal/test/aws_test_ble_hal.c
+++ b/libraries/abstractions/ble_hal/test/aws_test_ble_hal.c
@@ -655,6 +655,7 @@ void prvRequestExecWriteCb( uint16_t usConnId,
 void prvBondedCb( BTStatus_t xStatus,
                   BTBdaddr_t * pxRemoteBdAddr,
                   bool bIsBonded );
+BTStatus_t bleStackInit( void );
 
 static BTCallbacks_t xBTManagerCb =
 {
@@ -1729,6 +1730,14 @@ void prvDeviceStateChangedCb( BTState_t xState )
 
 void prvGroupInit()
 {
+	BTStatus_t xStatus;
+
+	xStatus = bleStackInit( );
+	if(xStatus != eBTStatusSuccess)
+	{
+		configPRINTF(("Unable to initialize BLE stask\n"));
+	}
+
     /* Initialize event group before tests. */
     ( void ) xEventGroupCreateStatic( ( StaticEventGroup_t * ) &xWaitOperationComplete );
 

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -97,6 +97,7 @@ static bool bleEnabled = false;
         }
     }
     /*-----------------------------------------------------------*/
+    extern BTStatus_t bleStackInit( void );
 
     static BaseType_t _BLEEnable( void )
     {
@@ -107,12 +108,18 @@ static bool bleEnabled = false;
 
         if( bInitBLE == false )
         {
-            xStatus = IotBle_Init();
+        	/* Initialize low level drivers for BLE */
+        	xStatus = bleStackInit( );
 
-            if( xStatus == eBTStatusSuccess )
-            {
-                bInitBLE = true;
-            }
+        	if( xStatus == eBTStatusSuccess )
+        	{
+				xStatus = IotBle_Init();
+
+				if( xStatus == eBTStatusSuccess )
+				{
+					bInitBLE = true;
+				}
+        	}
         }
         else
         {

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/application_code/main.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/application_code/main.c
@@ -276,6 +276,15 @@ static void prvUartInit( void )
     APP_ERROR_CHECK( xErrCode );
 }
 
+/**
+ * @brief Initialize BLE stask for Nordic.
+ * On Nordic it is just a stub.
+ */
+BTStatus_t bleStackInit( void )
+{
+  return eBTStatusSuccess;
+}
+
 /*-----------------------------------------------------------*/
 
 /**@brief Function for initializing the nrf log module.


### PR DESCRIPTION
Improving ble stack initialization sequence

Description
-----------
Before:
In the main during initialization, if BLE test were not being run, memory for BLE would be cleared.
That memory needs to be released to allow memory hungry test like last will and testament to succeed.

The issue with that approach is that is needs to check on flags in test_runner_config.h.
This conflict with our test system and IDT.

Now:
Only BT classic memory is released.
BLE stack is initialized when network is selected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.