### PR TITLE
Fix: Ignore duplicate data blocks when sending OTA status update to service

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1544,13 +1544,13 @@ static void prvOTAUpdateTask( void * pvUnused )
                                     }
                                     else
                                     {
-									    if( xResult == eIngest_Result_Accepted_Continue )
-										{
+                                        if( xResult == eIngest_Result_Accepted_Continue )
+                                        {
                                             /* We're actively receiving a file so update the job status as needed. */
                                             /* First reset the momentum counter since we received a good block. */
                                             C->ulRequestMomentum = 0;
                                             prvUpdateJobStatus( C, eJobStatus_InProgress, ( int32_t ) eJobReason_Receiving, ( int32_t ) NULL );
-										}
+                                        }
                                     }
                                 }
                             }

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1543,10 +1543,14 @@ static void prvOTAUpdateTask( void * pvUnused )
                                         }
                                     }
                                     else
-                                    { /* We're actively receiving a file so update the job status as needed. */
-                                      /* First reset the momentum counter since we received a good block. */
-                                        C->ulRequestMomentum = 0;
-                                        prvUpdateJobStatus( C, eJobStatus_InProgress, ( int32_t ) eJobReason_Receiving, ( int32_t ) NULL );
+                                    {
+									    if( xResult == eIngest_Result_Accepted_Continue )
+										{
+                                            /* We're actively receiving a file so update the job status as needed. */
+                                            /* First reset the momentum counter since we received a good block. */
+                                            C->ulRequestMomentum = 0;
+                                            prvUpdateJobStatus( C, eJobStatus_InProgress, ( int32_t ) eJobReason_Receiving, ( int32_t ) NULL );
+										}
                                     }
                                 }
                             }


### PR DESCRIPTION

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This fix adds a filter for accepted data blocks before sending OTA job status update to service. This ensures that when duplicate data blocks are received we do not send any OTA job status thus reducing the overhead and number of MQTT messages.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.