### PR TITLE
Add WiFi Security value check in quick start script

### DIFF
--- a/tools/aws_config_quick_start/SetupAWS.py
+++ b/tools/aws_config_quick_start/SetupAWS.py
@@ -16,10 +16,21 @@ def check_aws_configuration():
         print("AWS not configured. Please run `aws configure`.")
         sys.exit(1)
 
+def validate_json_text(json_text):
+    #Check that WiFi Security contains a valid value.
+    wifi_security = json_text['wifi_security']
+    if wifi_security not in ['eWiFiSecurityOpen', 'eWiFiSecurityWEP', 'eWiFiSecurityWPA', 'eWiFiSecurityWPA2']:
+        print("{} is not a valid wifi_security value.".format(wifi_security))
+        print("wifi_security value must be one of ['eWiFiSecurityOpen', 'eWiFiSecurityWEP', 'eWiFiSecurityWPA', 'eWiFiSecurityWPA2'].")
+        print("Please correct wifi_security value in configure.json.")
+        sys.exit(1)
 
 def prereq():
     with open('configure.json') as file:
         json_text = json.load(file)
+
+    # Validate that the entries in the JSON are valid.
+    validate_json_text(json_text)
 
     # Create a Thing
     thing_name = json_text['thing_name']


### PR DESCRIPTION
Description
-----------

The quick start script uses configuration values supplied by the user in
configure.json file. The WiFi security value is not a free form string
and must be one of the following values: eWiFiSecurityOpen,
eWiFiSecurityWEP, eWiFiSecurityWPA, eWiFiSecurityWPA2. This change makes
sure that we terminate the script and provide a useful error message if
the user has supplied incorrect WiFi security value.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.