### PR TITLE
Change CBMC include path to absolute

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -30,7 +30,7 @@
 	"$(FREERTOS)/libraries/3rdparty/win_pcap",
 	"$(FREERTOS)/libraries/c_sdk/standard/serializer/src/cbor",
 	"$(FREERTOS)/libraries/c_sdk/aws/defender/include",
-	"../../include"
+	"$(FREERTOS)/tools/cbmc/include"
     ],
 
     "CBMCFLAGS ": [


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Set CBMC include path to absolute in MakefileCommon.json. The change is required for proofs grouped in subfolders that include `cbmc.h` (since the proof folder structure is not flat anymore).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.