### PR TITLE
Add configPRECONDITION to FreeRTOS.h

### DIFF
--- a/freertos_kernel/include/FreeRTOS.h
+++ b/freertos_kernel/include/FreeRTOS.h
@@ -241,6 +241,18 @@ extern "C" {
 	#define configASSERT_DEFINED 1
 #endif
 
+/* configPRECONDITION should be resolve to configASSERT.
+   The CBMC proofs need a way to track assumptions and assertions.
+   A configPRECONDITION statement should express an implicit invariant or assumption made.
+   A configASSERT statement should express an invariant that must hold explicit before calling
+   the code. */
+#ifndef configPRECONDITION
+	#define configPRECONDITION( X ) configASSERT(X)
+	#define configPRECONDITION_DEFINED 0
+#else
+	#define configPRECONDITION_DEFINED 1
+#endif
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -9,7 +9,9 @@
 	"_WIN32_WINNT=0x0500",
 	"WINVER=0x400",
 	"_CRT_SECURE_NO_WARNINGS",
-	"__PRETTY_FUNCTION__=__FUNCTION__"
+	"__PRETTY_FUNCTION__=__FUNCTION__",
+	"'configASSERT(X)=__CPROVER_assert(X, \"Assertion Error\")'",
+    "'configPRECONDITION(X)=__CPROVER_assume(X)'"
     ],
 
     "INC ": [


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
I introduce `configPRECONDITION` which is resolved to `configASSERT` in the default case,
but allows finer control for dealing with an assertion in CBMC proofs.
There are a couple of implicit invariants, I will introduce as `configPRECONDTION` along with test harnesses to the code base.
Other invariants are explicit and kept as `configASSERT`.
The idea is to resolve `configPRECONDITION` to `__CPROVER_assume` for proofs and `configASSERT` to `__CPROVER_assert` for proofs.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.