### PR TITLE
Update CFLAGS to always include -m32

### DIFF
--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -34,6 +34,7 @@ CFLAGS = \
   $(CFLAGS2) \
   $(C_DEF) $(O_DEF) $(H_DEF) $(DEF) \
   $(C_OPT) $(O_OPT) $(H_OPT) $(OPT) \
+  -m32 \
   # empty
 
 CBMCFLAGS = \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This flag enforces that goto-cc compiles all data structures assuming 32 bits.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.