### PR TITLE
Add CBMC proof for IsDHCPSocket

### DIFF
--- a/tools/cbmc/proofs/IsDHCPSocket/IsDHCPSocket_harness.c
+++ b/tools/cbmc/proofs/IsDHCPSocket/IsDHCPSocket_harness.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_DHCP.h"
+
+/*
+ * The harness test proceeds to call IsDHCPSocket with an unconstrained value
+ */
+void harness()
+{
+  Socket_t xSocket;
+  BaseType_t xResult;
+  
+  xResult = xIsDHCPSocket( xSocket );
+}

--- a/tools/cbmc/proofs/IsDHCPSocket/Makefile.json
+++ b/tools/cbmc/proofs/IsDHCPSocket/Makefile.json
@@ -1,0 +1,12 @@
+{
+  "ENTRY": "IsDHCPSocket",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto"
+  ]
+}

--- a/tools/cbmc/proofs/IsDHCPSocket/README.md
+++ b/tools/cbmc/proofs/IsDHCPSocket/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of IsDCHPSocket. No abstractions nor
+assumptions are needed since the function just compares a reference.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of `IsDHCPSocket`, the remaining non-third party function appearing in `FreeRTOS_DHCP.h`. It could be put together with the proof for `DHCPProcess` (#597) in a subfolder.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.