### PR TITLE
Remove `./tools` from cbmc-viewer srcexclude args

### DIFF
--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -124,7 +124,7 @@ report: cbmc.txt property.xml coverage.xml
 	--srcdir $(FREERTOS) \
 	--blddir $(FREERTOS) \
 	--htmldir html \
-	--srcexclude "(./doc|./tests|./tools|./vendors)" \
+	--srcexclude "(./doc|./tests|./vendors)" \
 	--result cbmc.txt \
 	--property property.xml \
 	--block coverage.xml


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The cbmc-viewer --srcexclude arguments in Makefile.common allow to exclude directories in the coverage report. Excluding `./tools` here causes the report to not generate reports for the harness and any other files included in the proof directory. Therefore, this PR avoids excluding `./tools` from report generation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.