### PR TITLE
Add CBMC memory-safety proof for TaskGetTickCount

### DIFF
--- a/tools/cbmc/proofs/TaskPool/TaskGetTickCount/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTickCount/Makefile.json
@@ -1,0 +1,12 @@
+{
+  "ENTRY": "TaskGetTickCount",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetTickCount/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTickCount/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of the TaskIncrementTick function.
+No assumptions nor abstractions are required for single-threaded computation.

--- a/tools/cbmc/proofs/TaskPool/TaskGetTickCount/TaskGetTickCount_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTickCount/TaskGetTickCount_harness.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void harness()
+{
+	TickType_t xTickCount;
+
+	xTickCount = xTaskGetTickCount();
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskGetTickCount.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.