### PR TITLE
 Add CBMC memory-safety proof for TaskIncrementTick

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskIncrementTick/Configurations.json
+++ b/tools/cbmc/proofs/TaskPool/TaskIncrementTick/Configurations.json
@@ -1,0 +1,34 @@
+{
+  "ENTRY": "TaskIncrementTick",
+  "DEF":
+  [
+    { "default":
+      [
+        "FREERTOS_MODULE_TEST",
+        "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+      ]
+    },
+    { "useTickHook1":
+      [
+        "FREERTOS_MODULE_TEST",
+        "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+        "configUSE_TICK_HOOK=1"
+      ]
+    }
+  ],
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:2,xTaskIncrementTick.0:4"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskIncrementTick/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskIncrementTick/README.txt
+++ b/tools/cbmc/proofs/TaskPool/TaskIncrementTick/README.txt
@@ -1,0 +1,8 @@
+This proof demonstrates the memory safety of the TaskIncrementTick function.
+We assume that task lists are initialized and filled with a few list items. We
+also assign nondeterministic values to some global variables.
+
+Configurations available:
+ * `default`: The default configuration.  `useTickHook1`: The default
+ * configuration with `configUSE_TICK_HOOK=1`
+

--- a/tools/cbmc/proofs/TaskPool/TaskIncrementTick/TaskIncrementTick_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskIncrementTick/TaskIncrementTick_harness.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vSetGlobalVariables();
+BaseType_t xPrepareTaskLists( void );
+
+/*
+ * The harness test first calls two functions included in the tasks.c file
+ * that initialize the task lists and other global variables
+ */
+void harness()
+{
+	BaseType_t xTick;
+	BaseType_t xTasksPrepared;
+
+	vSetGlobalVariables();
+	xTasksPrepared = xPrepareTaskLists();
+
+	if ( xTasksPrepared != pdFAIL )
+	{
+		xTick = xTaskIncrementTick();
+	}
+}

--- a/tools/cbmc/proofs/TaskPool/TaskIncrementTick/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskIncrementTick/tasks_test_access_functions.h
@@ -1,0 +1,99 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	__CPROVER_assume( pxTCB->uxPriority < configMAX_PRIORITIES );
+
+	vListInitialiseItem( &( pxTCB->xStateListItem ) );
+	vListInitialiseItem( &( pxTCB->xEventListItem ) );
+
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xStateListItem ), pxTCB );
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xEventListItem ), pxTCB );
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), portMAX_DELAY );
+	}
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), portMAX_DELAY );
+	}
+	return pxTCB;
+}
+
+/*
+ * We set the values of relevant global
+ * variables to nondeterministic values
+ */
+void vSetGlobalVariables()
+{
+	uxPendedTicks = nondet();
+	uxSchedulerSuspended = nondet();
+	xYieldPending = nondet();
+	xTickCount = nondet();
+}
+
+/*
+ * We initialise and fill the task lists so coverage is optimal.
+ * This initialization is not guaranteed to be minimal, but it
+ * is quite efficient and it serves the same purpose
+ */
+BaseType_t xPrepareTaskLists( void )
+{
+	TCB_t * pxTCB = NULL;
+
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	/* This task will be moved to a ready list, granting coverage
+	 * on lines 2780-2786 (tasks.c) */
+	pxTCB = xUnconstrainedTCB();
+	if ( pxTCB == NULL )
+	{
+		return pdFAIL;
+	}
+	vListInsert( pxOverflowDelayedTaskList, &( pxTCB->xStateListItem ) );
+
+	/* Use of this macro ensures coverage on line 185 (list.c) */
+	listGET_OWNER_OF_NEXT_ENTRY( pxTCB , pxOverflowDelayedTaskList );
+
+	pxTCB = xUnconstrainedTCB();
+	if ( pxTCB == NULL )
+	{
+		return pdFAIL;
+	}
+	vListInsert( &xPendingReadyList, &( pxTCB->xStateListItem ) );
+
+	/* This nondeterministic choice ensure coverage in line 2746 (tasks.c) */
+	if ( nondet_bool() )
+	{
+		vListInsert( pxOverflowDelayedTaskList, &( pxTCB->xEventListItem ) );
+	}
+
+	pxCurrentTCB = xUnconstrainedTCB();
+	if ( pxCurrentTCB == NULL )
+	{
+		return pdFAIL;
+	}
+	vListInsert( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ], &( pxCurrentTCB->xStateListItem ) );
+
+	return pdPASS;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskIncrementTick.

This proof depends on #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.