### PR TITLE
Add MSVC-MingW folder to patchable paths

### DIFF
--- a/tools/cbmc/patches/patches_constants.py
+++ b/tools/cbmc/patches/patches_constants.py
@@ -31,6 +31,13 @@ shared_prefix = [
     "..", "..", "..", "vendors", "pc", "boards", "windows", "aws_demos",
     "config_files"
 ]
+shared_prefix_port = [
+    "..", "..", "..", "freertos_kernel", "portable", "MSVC-MingW"
+]
+
 absolute_prefix = os.path.abspath(os.path.join(PATCHES_DIR, *shared_prefix))
+absolute_prefix_port = os.path.abspath(os.path.join(PATCHES_DIR, *shared_prefix_port))
+
 HEADERS = [os.path.join(absolute_prefix, "FreeRTOSConfig.h"),
-           os.path.join(absolute_prefix, "FreeRTOSIPConfig.h")]
+           os.path.join(absolute_prefix, "FreeRTOSIPConfig.h"),
+           os.path.join(absolute_prefix_port, "portmacro.h")]


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the path to `portmacro.h` to the directories scanned when computing automatic patches. This is required for some proofs in TaskPool where macros in `portmacro.h` must be redefined (e.g., TaskSwitchContext).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.