### PR TITLE
Add support for multiline definitions in patch computing

### DIFF
--- a/tools/cbmc/patches/compute_patch.py
+++ b/tools/cbmc/patches/compute_patch.py
@@ -93,11 +93,17 @@ def manipulate_headerfile(defines, header_file):
             if (match and
                     match.group(1) in defines and
                     not last.lstrip().startswith("#ifndef")):
+                full_def = line
+                # this loop deals with multiline definitions
+                while line.rstrip().endswith("\\"):
+                    line = next(source)
+                    full_def += line
+                # indentation for multiline definitions can be improved
                 modified_content += textwrap.dedent("""\
                     #ifndef {target}
                         {original}\
                     #endif
-                    """.format(target=match.group(1), original=line))
+                    """.format(target=match.group(1), original=full_def))
             else:
                 modified_content += line
             last = line


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds support for multiline definitions in patch computing. This is required for some proofs in TaskPool where macros must be redefined (e.g., TaskSwitchContext).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.