### PR TITLE
Move metrics generation code to common folder

### DIFF
--- a/demos/include/iot_config_common.h
+++ b/demos/include/iot_config_common.h
@@ -37,6 +37,9 @@
 /* Used to get the cloud broker endpoint for FreeRTOS. */
 #include "aws_clientcredential.h"
 
+/* Used to get the certificate used by the device. */
+#include "aws_clientcredential_keys.h"
+
 /* SDK version. */
 #define IOT_SDK_VERSION    "4.0.0"
 
@@ -168,6 +171,9 @@
 
 /* Cloud endpoint to which the device connects to. */
 #define IOT_CLOUD_ENDPOINT                    clientcredentialMQTT_BROKER_ENDPOINT
+
+/* Certificate for the device. */
+#define IOT_DEVICE_CERTIFICATE                keyCLIENT_CERTIFICATE_PEM
 
 /**
  * @brief Unique identifier used to recognize a device by the cloud.

--- a/libraries/c_sdk/standard/common/CMakeLists.txt
+++ b/libraries/c_sdk/standard/common/CMakeLists.txt
@@ -32,6 +32,9 @@ afr_module_sources(
         # Static memory
         "${src_dir}/iot_static_memory_common.c"
 
+	# Device metrics
+	"${src_dir}/iot_device_metrics.c"
+
         # Task pool
         "${src_dir}/taskpool/iot_taskpool.c"
         "${src_dir}/taskpool/iot_taskpool_static_memory.c"

--- a/libraries/c_sdk/standard/common/iot_device_metrics.c
+++ b/libraries/c_sdk/standard/common/iot_device_metrics.c
@@ -34,7 +34,6 @@
 #include <string.h>
 
 #include "iot_config.h"
-#include "aws_clientcredential_keys.h"
 
 #include "platform/iot_clock.h"
 #include "iot_atomic.h"
@@ -78,7 +77,7 @@
 /**
  * @brief Device metrics name format
  */
-#define AWS_IOT_METRICS_FORMAT              "?SDK=" IOT_SDK_NAME "&Version=4.0.0&Platform=" IOT_PLATFORM_NAME "&AFRDevID=%.*s"
+#define AWS_IOT_METRICS_FORMAT              "?SDK=" IOT_SDK_NAME "&Version=" IOT_SDK_VERSION "&Platform=" IOT_PLATFORM_NAME "&AFRDevID=%.*s"
 
 /**
  * @brief Length of #AWS_IOT_METRICS_FORMAT.
@@ -372,7 +371,7 @@ static void _generateUniqueIdentifier( const char * pInput,
  */
 const char * getDeviceIdentifier( void )
 {
-    const char * pCert = keyCLIENT_CERTIFICATE_PEM;
+    const char * pCertificate = IOT_DEVICE_CERTIFICATE;
     static uint32_t lock = 0;
 
     if( deviceIdentifier[ 0 ] == '\0' )
@@ -381,10 +380,10 @@ const char * getDeviceIdentifier( void )
 
         if( deviceIdentifier[ 0 ] == '\0' )
         {
-            if( ( pCert != NULL ) &&
-                ( strcmp( pCert, "" ) != 0 ) )
+            if( (pCertificate != NULL ) &&
+                ( strcmp(pCertificate, "" ) != 0 ) )
             {
-                _generateUniqueIdentifier( pCert, strlen( pCert ), deviceIdentifier, sizeof( deviceIdentifier ) );
+                _generateUniqueIdentifier( pCertificate, strlen( pCertificate ), deviceIdentifier, sizeof( deviceIdentifier ) );
             }
             else
             {

--- a/libraries/c_sdk/standard/mqtt/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt/CMakeLists.txt
@@ -33,7 +33,6 @@ afr_module_sources(
         "${src_dir}/iot_mqtt_static_memory.c"
         "${src_dir}/iot_mqtt_subscription.c"
         "${src_dir}/iot_mqtt_validate.c"
-        "${src_dir}/iot_mqtt_metrics.c"
         ${extra_mqtt_sources}
 )
 

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c
@@ -34,7 +34,7 @@
 /* Test framework includes. */
 #include "unity_fixture.h"
 
-#include "aws_clientcredential_keys.h"
+#include "iot_config.h"
 
 extern void Utils_generateMD5Hash( const char * pData,
                                    size_t dataLength,
@@ -48,14 +48,16 @@ extern const char * getDeviceMetrics( void );
 extern uint16_t getDeviceMetricsLength( void );
 
 
-#define _MD5_HASH_LENGTH             ( 16 )
+#define MD5_HASH_LENGTH             ( 16 )
 
-#define _DEVICE_IDENTIFIER_LENGTH    ( 2 * _MD5_HASH_LENGTH )
+#define DEVICE_IDENTIFIER_LENGTH    ( 2 * MD5_HASH_LENGTH )
 
 /*
  * @brief Following test data is copied from RFC 1321 for MD5 hashing.
  */
-#define _NUM_TEST_DATA               ( 7 )
+#define NUM_TEST_DATA               ( 7 )
+
+#define METRICS_PREFIX              "?SDK=" IOT_SDK_NAME "&Version=" IOT_SDK_VERSION "&Platform=" IOT_PLATFORM_NAME
 
 static const char * inputData[] =
 {
@@ -99,8 +101,6 @@ TEST_GROUP_RUNNER( MQTT_Unit_Metrics )
     RUN_TEST_CASE( MQTT_Unit_Metrics, Get_DeviceMetrics )
 }
 
-
-
 /**
  * @brief Tests the generate MD5 hash algorithm against the test data defined in
  * RFC 1321 ( https://tools.ietf.org/html/rfc1321 )
@@ -108,9 +108,9 @@ TEST_GROUP_RUNNER( MQTT_Unit_Metrics )
 TEST( MQTT_Unit_Metrics, Generate_MD5Hash )
 {
     int i;
-    uint8_t hash[ _MD5_HASH_LENGTH ];
+    uint8_t hash[ MD5_HASH_LENGTH ];
 
-    for( i = 0; i < _NUM_TEST_DATA; i++ )
+    for( i = 0; i < NUM_TEST_DATA; i++ )
     {
         memset( hash, 0x00, sizeof( hash ) );
         Utils_generateMD5Hash( inputData[ i ], strlen( inputData[ i ] ), hash, sizeof( hash ) );
@@ -129,7 +129,7 @@ TEST( MQTT_Unit_Metrics, Get_DeviceIdentifier )
     }
     else
     {
-        TEST_ASSERT_EQUAL( _DEVICE_IDENTIFIER_LENGTH, strlen( pDeviceIdentifier ) );
+        TEST_ASSERT_EQUAL( DEVICE_IDENTIFIER_LENGTH, strlen( pDeviceIdentifier ) );
     }
 }
 
@@ -139,10 +139,11 @@ TEST( MQTT_Unit_Metrics, Get_DeviceMetrics )
     const char * pDeviceMetrics = getDeviceMetrics();
     size_t deviceMetricsLength = getDeviceMetricsLength();
     int ret;
+    char expected[ DEVICE_IDENTIFIER_LENGTH + 10 ] = { 0 };
 
-    char expected[ _DEVICE_IDENTIFIER_LENGTH + 10 ] = { 0 };
-
-    ret = snprintf( expected, sizeof( expected ), "AFRDevID=%s", pDeviceIdentifier );
+    ret = snprintf( expected, sizeof(expected), "AFRDevID=%s", pDeviceIdentifier );
     TEST_ASSERT( ret > 0 );
+    TEST_ASSERT( deviceMetricsLength > 0 );
+    TEST_ASSERT_NOT_NULL(strstr(pDeviceMetrics, METRICS_PREFIX));
     TEST_ASSERT_NOT_NULL( strstr( pDeviceMetrics, expected ) );
 }

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c
@@ -141,9 +141,9 @@ TEST( MQTT_Unit_Metrics, Get_DeviceMetrics )
     int ret;
     char expected[ DEVICE_IDENTIFIER_LENGTH + 10 ] = { 0 };
 
-    ret = snprintf( expected, sizeof(expected), "AFRDevID=%s", pDeviceIdentifier );
+    ret = snprintf( expected, sizeof( expected ), "AFRDevID=%s", pDeviceIdentifier );
     TEST_ASSERT( ret > 0 );
     TEST_ASSERT( deviceMetricsLength > 0 );
-    TEST_ASSERT_NOT_NULL(strstr(pDeviceMetrics, METRICS_PREFIX));
+    TEST_ASSERT_NOT_NULL( strstr( pDeviceMetrics, METRICS_PREFIX ) );
     TEST_ASSERT_NOT_NULL( strstr( pDeviceMetrics, expected ) );
 }

--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
@@ -282,6 +282,11 @@
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/include/types/iot_network_types.h</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_static_memory_common.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>

--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
@@ -327,6 +327,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/include/types/iot_network_types.h</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_static_memory_common.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
@@ -675,6 +680,11 @@
 			<name>libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</locationURI>
+		</link>
+		<link>
+			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c</name>

--- a/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
@@ -287,6 +287,11 @@
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>

--- a/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_tests/.project
+++ b/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_tests/.project
@@ -332,6 +332,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -675,6 +680,11 @@
 			<name>libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</locationURI>
+		</link>
+		<link>
+			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c</name>

--- a/projects/espressif/esp32/make/aws_demos/.project
+++ b/projects/espressif/esp32/make/aws_demos/.project
@@ -1407,6 +1407,11 @@
 			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<location>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</location>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_init.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_init.c</locationURI>
@@ -2510,11 +2515,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</name>

--- a/projects/espressif/esp32/make/aws_tests/.project
+++ b/projects/espressif/esp32/make/aws_tests/.project
@@ -1686,6 +1686,11 @@
 			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<location>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</location>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_init.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_init.c</locationURI>
@@ -3124,11 +3129,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</name>

--- a/projects/infineon/xmc4800_iotkit/dave4/aws_demos/.project
+++ b/projects/infineon/xmc4800_iotkit/dave4/aws_demos/.project
@@ -519,6 +519,11 @@
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -757,11 +762,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AFR_HOME/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/infineon/xmc4800_iotkit/dave4/aws_tests/.project
+++ b/projects/infineon/xmc4800_iotkit/dave4/aws_tests/.project
@@ -509,6 +509,11 @@
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -747,11 +752,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AFR_HOME/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AFR_HOME/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/marvell/mw300_rd/make/aws_demos/.project
+++ b/projects/marvell/mw300_rd/make/aws_demos/.project
@@ -1611,6 +1611,11 @@
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_init.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_static_memory_common.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>

--- a/projects/marvell/mw300_rd/make/aws_tests/.project
+++ b/projects/marvell/mw300_rd/make/aws_tests/.project
@@ -1681,6 +1681,11 @@
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_init.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/iot_static_memory_common.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
@@ -4164,6 +4169,11 @@
 			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_serialize_ble.c</name>
 			<type>1</type>
 			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_serialize_ble.c</locationURI>
+		</link>
+		<link>
+			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</name>
+			<type>1</type>
+			<locationURI>PARENT-1-BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c</name>

--- a/projects/mediatek/mt7697hx-dev-kit/uvision/aws_demos/aws_demos.uvprojx
+++ b/projects/mediatek/mt7697hx-dev-kit/uvision/aws_demos/aws_demos.uvprojx
@@ -1019,6 +1019,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</FilePath>
 						</File>
+						<File>
+							<FileName>iot_device_metrics.c</FileName>
+							<FileType>1</FileType>
+							<FilePath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</FilePath>
+						</File>
 					</Files>
 				</Group>
 				<Group>
@@ -1563,11 +1568,6 @@
 							<FileName>iot_mqtt_validate.c</FileName>
 							<FileType>1</FileType>
 							<FilePath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</FilePath>
-						</File>
-						<File>
-							<FileName>iot_mqtt_metrics.c</FileName>
-							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</FilePath>
 						</File>
 						<File>
 							<FileName>iot_mqtt_agent.c</FileName>

--- a/projects/mediatek/mt7697hx-dev-kit/uvision/aws_tests/aws_tests.uvprojx
+++ b/projects/mediatek/mt7697hx-dev-kit/uvision/aws_tests/aws_tests.uvprojx
@@ -1024,6 +1024,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</FilePath>
 						</File>
+						<File>
+							<FileName>iot_device_metrics.c</FileName>
+							<FileType>1</FileType>
+							<FilePath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</FilePath>
+						</File>
 					</Files>
 				</Group>
 				<Group>
@@ -1568,11 +1573,6 @@
 							<FileName>iot_mqtt_validate.c</FileName>
 							<FileType>1</FileType>
 							<FilePath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</FilePath>
-						</File>
-						<File>
-							<FileName>iot_mqtt_metrics.c</FileName>
-							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</FilePath>
 						</File>
 						<File>
 							<FileName>iot_mqtt_agent.c</FileName>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -118,6 +118,7 @@
 							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
 						</logicalFolder>
 						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
+						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
 						<logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
 							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
@@ -132,7 +133,6 @@
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
 						</logicalFolder>
 					</logicalFolder>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -85,6 +85,7 @@
 							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
 						</logicalFolder>
 						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
+						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
 						<logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
 							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
@@ -103,7 +104,6 @@
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</itemPath>
 							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
 						</logicalFolder>
 						<logicalFolder name="test" displayName="test" projectFiles="true">

--- a/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
+++ b/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
@@ -227,6 +227,7 @@
             <folder Name="taskpool">
               <file file_name="../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c" />
             </folder>
+            <file file_name="../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c" />
           </folder>
           <folder Name="mqtt">
             <file file_name="../../../../../libraries/c_sdk/standard/mqtt/CMakeLists.txt" />
@@ -246,7 +247,6 @@
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c" />
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c" />
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c" />
-              <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c" />
             </folder>
           </folder>
           <folder Name="serializer">

--- a/projects/nordic/nrf52840-dk/ses/aws_tests/aws_tests.emProject
+++ b/projects/nordic/nrf52840-dk/ses/aws_tests/aws_tests.emProject
@@ -235,6 +235,7 @@
               <file file_name="../../../../../libraries/c_sdk/standard/common/test/iot_memory_leak.c" />
               <file file_name="../../../../../libraries/c_sdk/standard/common/test/iot_tests_taskpool.c" />
             </folder>
+            <file file_name="../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c" />
           </folder>
           <folder Name="mqtt">
             <file file_name="../../../../../libraries/c_sdk/standard/mqtt/CMakeLists.txt" />
@@ -254,7 +255,6 @@
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c" />
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c" />
               <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c" />
-              <file file_name="../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c" />
             </folder>
             <folder Name="test">
               <folder Name="system">

--- a/projects/nxp/lpc54018iotmodule/iar/aws_demos/aws_demos.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/aws_demos/aws_demos.ewp
@@ -2043,6 +2043,9 @@
 					<file>
 						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c</name>
 					</file>
+					<file>
+						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c</name>
+					</file>
 					<group>
 						<name>taskpool</name>
 						<file>
@@ -2077,9 +2080,6 @@
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c</name>
-						</file>
-						<file>
-							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c</name>
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c</name>

--- a/projects/nxp/lpc54018iotmodule/iar/aws_tests/aws_tests.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/aws_tests/aws_tests.ewp
@@ -1990,6 +1990,9 @@
 					<file>
 						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c</name>
 					</file>
+					<file>
+						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c</name>
+					</file>
 					<group>
 						<name>taskpool</name>
 						<file>
@@ -2033,9 +2036,6 @@
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c</name>
-						</file>
-						<file>
-							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c</name>
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c</name>

--- a/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_demos/.project
+++ b/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_demos/.project
@@ -988,6 +988,11 @@
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -1231,11 +1236,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>BASE_DIR/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj
+++ b/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj
@@ -450,6 +450,7 @@
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_static_memory.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_subscription.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c" />
@@ -457,7 +458,6 @@
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool_static_memory.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c" />
-    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c" />

--- a/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj.filters
+++ b/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj.filters
@@ -1514,8 +1514,8 @@
     <ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\pem2der.c">
       <Filter>demos\dev_mode_key_provisioning\src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c">
-      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c">
+      <Filter>libraries\c_sdk\standard\common</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
+++ b/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
@@ -438,6 +438,7 @@
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\test\system\aws_iot_tests_shadow_system.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\test\unit\aws_iot_tests_shadow_api.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\test\unit\aws_iot_tests_shadow_parser.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c" />
@@ -447,7 +448,6 @@
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\test\iot_tests_taskpool.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c" />
-    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c" />
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c" />

--- a/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj.filters
+++ b/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj.filters
@@ -1682,11 +1682,11 @@
     <ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\pem2der.c">
       <Filter>demos\dev_mode_key_provisioning\src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c">
-      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\test\unit\iot_tests_mqtt_metrics.c">
       <Filter>libraries\c_sdk\standard\mqtt\test\unit</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c">
+      <Filter>libraries\c_sdk\standard\common</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/projects/renesas/rx65n-rsk/e2studio/aws_demos/.project
+++ b/projects/renesas/rx65n-rsk/e2studio/aws_demos/.project
@@ -1007,6 +1007,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -1370,11 +1375,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/renesas/rx65n-rsk/e2studio/aws_tests/.project
+++ b/projects/renesas/rx65n-rsk/e2studio/aws_tests/.project
@@ -992,6 +992,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -1355,11 +1360,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/st/stm32l475_discovery/ac6/aws_demos/.project
+++ b/projects/st/stm32l475_discovery/ac6/aws_demos/.project
@@ -1273,6 +1273,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -1511,11 +1516,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/st/stm32l475_discovery/ac6/aws_tests/.project
+++ b/projects/st/stm32l475_discovery/ac6/aws_tests/.project
@@ -1263,6 +1263,11 @@
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -1501,11 +1506,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/ti/cc3220_launchpad/ccs/aws_demos/.project
+++ b/projects/ti/cc3220_launchpad/ccs/aws_demos/.project
@@ -463,6 +463,11 @@
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -671,11 +676,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/ti/cc3220_launchpad/ccs/aws_tests/.project
+++ b/projects/ti/cc3220_launchpad/ccs/aws_tests/.project
@@ -453,6 +453,11 @@
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -661,11 +666,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>BASE_DIR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/ti/cc3220_launchpad/iar/aws_demos/aws_demos.ewp
+++ b/projects/ti/cc3220_launchpad/iar/aws_demos/aws_demos.ewp
@@ -1679,6 +1679,9 @@
 					<file>
 						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c</name>
 					</file>
+					<file>
+						<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c</name>
+					</file>
 					<group>
 						<name>taskpool</name>
 						<file>
@@ -1713,9 +1716,6 @@
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c</name>
-						</file>
-						<file>
-							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_metrics.c</name>
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c</name>

--- a/projects/xilinx/microzed/xsdk/aws_demos/.project
+++ b/projects/xilinx/microzed/xsdk/aws_demos/.project
@@ -288,6 +288,11 @@
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -661,11 +666,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AFR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/projects/xilinx/microzed/xsdk/aws_tests/.project
+++ b/projects/xilinx/microzed/xsdk/aws_tests/.project
@@ -273,6 +273,11 @@
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/iot_static_memory_common.c</locationURI>
 		</link>
 		<link>
+			<name>libraries/c_sdk/standard/common/iot_device_metrics.c</name>
+			<type>1</type>
+			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/iot_device_metrics.c</locationURI>
+		</link>
+		<link>
 			<name>libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</name>
 			<type>1</type>
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</locationURI>
@@ -646,11 +651,6 @@
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</name>
 			<type>1</type>
 			<locationURI>AFR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</locationURI>
-		</link>
-		<link>
-			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</name>
-			<type>1</type>
-			<locationURI>AFR_ROOT/libraries/c_sdk/standard/mqtt/src/iot_mqtt_metrics.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</name>

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -162,6 +162,9 @@
 /* Cloud endpoint to which the device connects to. */
 #define IOT_CLOUD_ENDPOINT                    clientcredentialMQTT_BROKER_ENDPOINT
 
+/* Certificate for the device.*/
+#define IOT_DEVICE_CERTIFICATE                keyCLIENT_CERTIFICATE_PEM
+
  /**
   * @brief Unique identifier used to recognize a device by the cloud.
   * This could be SHA-256 of the device certificate.


### PR DESCRIPTION
Move metrics generation code to common folder

Description
-----------
Metrics generation code is consumed by both BLE and MQTT libraries. So it should be moved to common folder.
Updated all project files.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.