### PR TITLE
Added a check for a failed process job message.

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1481,10 +1481,12 @@ static void prvOTAUpdateTask( void * pvUnused )
                                             ( void ) prvResetDevice(); /* Ignore return code since there's nothing we can do if we can't force reset. */
                                         }
 									}
-                                    else if (OTA_GetImageState() == eOTA_ImageState_Unknown)
+                                    else
                                     {
-										/* If the job context returned NULL and the image state is unknown, then an error
-										 * occurred parsing the OTA job message.  Abort the OTA job with a parse error.
+										/* If the job context returned NULL and the image state is not in the self_test state,
+										 * then an error occurred parsing the OTA job message.  Abort the OTA job with a parse error.
+										 *
+										 * If there is a valid job id, then a job status update will be sent.
 										 */
 										( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, kOTA_Err_JobParserError );
 									}

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1480,7 +1480,14 @@ static void prvOTAUpdateTask( void * pvUnused )
                                             ( void ) prvSetImageStateWithReason( eOTA_ImageState_Rejected, kOTA_Err_ImageStateMismatch );
                                             ( void ) prvResetDevice(); /* Ignore return code since there's nothing we can do if we can't force reset. */
                                         }
-                                    }
+									}
+                                    else if (OTA_GetImageState() == eOTA_ImageState_Unknown)
+                                    {
+										/* If the job context returned NULL and the image state is unknown, then an error
+										 * occurred parsing the OTA job message.  Abort the OTA job with a parse error.
+										 */
+										( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, kOTA_Err_JobParserError );
+									}
                                 }
                                 else
                                 {


### PR DESCRIPTION
This change adds a check that if the prvProcessOTAJobMsg returns NULL
and the image state is still unknown, the OTA job is aborted with
a job parse error

<!--- Title -->

Description
-----------
If "prvProcessOTAJobMsg" returns NULL, a test is made to see if the image state is in the "self_test" phase.  However "prvProcessOTAJobMsg" will also return NULL if there is an error in parsing the OTA job data.  

This changes checks for that condition by checking if the image state is still in the "unknown" state and if so, aborts the OTA job with a parse error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.