### PR TITLE
 Add CBMC proof for TaskSwitchContext

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/patches/compute_patch.py
+++ b/tools/cbmc/patches/compute_patch.py
@@ -98,11 +98,18 @@ def manipulate_headerfile(defines, header_file):
             if (match and
                     match.group(1) in defines and
                     not last.lstrip().startswith("#ifndef")):
+                full_def = [line]
+                # this loop deals with multiline definitions
+                while line.rstrip().endswith("\\"):
+                    line = next(source)
+                    full_def += [line]
+                full_def = "".join(full_def)
+                # indentation for multiline definitions can be improved
                 modified_content += textwrap.dedent("""\
                     #ifndef {target}
                         {original}\
                     #endif
-                    """.format(target=match.group(1), original=line))
+                    """.format(target=match.group(1), original=full_def))
             else:
                 modified_content += line
             last = line

--- a/tools/cbmc/patches/patches_constants.py
+++ b/tools/cbmc/patches/patches_constants.py
@@ -31,6 +31,13 @@ shared_prefix = [
     "..", "..", "..", "vendors", "pc", "boards", "windows", "aws_demos",
     "config_files"
 ]
+shared_prefix_port = [
+    "..", "..", "..", "freertos_kernel", "portable", "MSVC-MingW"
+]
+
 absolute_prefix = os.path.abspath(os.path.join(PATCHES_DIR, *shared_prefix))
+absolute_prefix_port = os.path.abspath(os.path.join(PATCHES_DIR, *shared_prefix_port))
+
 HEADERS = [os.path.join(absolute_prefix, "FreeRTOSConfig.h"),
-           os.path.join(absolute_prefix, "FreeRTOSIPConfig.h")]
+           os.path.join(absolute_prefix, "FreeRTOSIPConfig.h"),
+           os.path.join(absolute_prefix_port, "portmacro.h")]

--- a/tools/cbmc/proofs/TaskPool/TaskSwitchContext/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskSwitchContext/Makefile.json
@@ -1,0 +1,24 @@
+{
+  "ENTRY": "TaskSwitchContext",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'portGET_HIGHEST_PRIORITY(uxTopPriority, uxReadyPriorities)=__CPROVER_assume( uxTopPriority < configMAX_PRIORITIES )'",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset prvInitialiseTaskLists.0:8,xPrepareTaskLists.0:8,vListInsert.0:2"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskSwitchContext/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskSwitchContext/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskSwitchContext/README.md
@@ -1,0 +1,4 @@
+This proof demonstrates the memory safety of the TaskSwitchContext function.
+We assume task ready lists to be initialized and filled with one element each,
+and `pxCurrentTCB` to be the highest priority task.  We also set
+`uxSchedulerSuspended` to a nondeterministic value.

--- a/tools/cbmc/proofs/TaskPool/TaskSwitchContext/TaskSwitchContext_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskSwitchContext/TaskSwitchContext_harness.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vSetGlobalVariables( void );
+BaseType_t xPrepareTaskLists( void );
+
+/*
+ * We prepare task lists by inserting one item in each list,
+ * and with the macro redefinition we ensure only valid ready
+ * task lists are checked in `taskSELECT_HIGHEST_PRIORITY_TASK()`
+ */
+void harness()
+{
+	BaseType_t xTasksPrepared;
+
+	vSetGlobalVariables();
+	xTasksPrepared = xPrepareTaskLists();
+
+	if ( xTasksPrepared != pdFAIL )
+	{
+		vTaskSwitchContext();
+	}
+}

--- a/tools/cbmc/proofs/TaskPool/TaskSwitchContext/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskSwitchContext/tasks_test_access_functions.h
@@ -1,0 +1,75 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( UBaseType_t uxPriority )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	/* uxPriority is set to a specific priority */
+	pxTCB->uxPriority = uxPriority;
+
+	vListInitialiseItem( &( pxTCB->xStateListItem ) );
+	vListInitialiseItem( &( pxTCB->xEventListItem ) );
+
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xStateListItem ), pxTCB );
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xEventListItem ), pxTCB );
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), portMAX_DELAY );
+	}
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), portMAX_DELAY );
+	}
+	return pxTCB;
+}
+
+/*
+ * We set the values of relevant global
+ * variables to nondeterministic values
+ */
+void vSetGlobalVariables( void )
+{
+	uxSchedulerSuspended = nondet();
+}
+
+/*
+ * We initialize and fill with one item each ready tasks list
+ * so that the assertion on line 175 (tasks.c) does not fail
+ */
+BaseType_t xPrepareTaskLists( void )
+{
+	TCB_t * pxTCB = NULL;
+
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	for ( int i = 0; i < configMAX_PRIORITIES; ++i )
+	{
+		pxTCB = xUnconstrainedTCB( i );
+		if ( pxTCB == NULL )
+		{
+			return pdFAIL;
+		}
+		vListInsert( &pxReadyTasksLists[ pxTCB->uxPriority ], &( pxTCB->xStateListItem ) );
+	}
+	listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB, &pxReadyTasksLists[ configMAX_PRIORITIES - 1 ] );
+
+	return pdPASS;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskSwitchContext.

This proofs depends on #774 #846 #845 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.