### PR TITLE
 Add CBMC proof for TaskCreate

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskCreate/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskCreate/Makefile.json
@@ -1,0 +1,24 @@
+{
+  "ENTRY": "TaskCreate",
+  "DEF":
+  [
+    "STACK_DEPTH=10",
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset prvInitialiseNewTask.0:16,prvInitialiseNewTask.1:4,prvInitialiseTaskLists.0:8"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskCreate/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskCreate/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskCreate/README.md
@@ -1,0 +1,4 @@
+This proof demonstrates the memory safety of the TaskCreate function.  We
+assume task lists to be initialized, and nondet. set `pxCurrentTCB`,
+`uxCurrentNumberOfTasks`, `pcName` and `pxCreateTask`. STACK_DEPTH is set to a
+fixed number (10) since it is not possible to specify a range.

--- a/tools/cbmc/proofs/TaskPool/TaskCreate/TaskCreate_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskCreate/TaskCreate_harness.c
@@ -1,0 +1,39 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vNondetSetCurrentTCB( void );
+void vSetGlobalVariables( void );
+void vPrepareTaskLists( void );
+TaskHandle_t *pxNondetSetTaskHandle( void );
+char *pcNondetSetString( size_t xSizeLength );
+
+void harness()
+{
+	TaskFunction_t pxTaskCode;
+	char * pcName;
+	configSTACK_DEPTH_TYPE usStackDepth = STACK_DEPTH;
+	void * pvParameters;
+	UBaseType_t uxPriority;
+	TaskHandle_t * pxCreatedTask;
+
+	vNondetSetCurrentTCB();
+	vSetGlobalVariables();
+	vPrepareTaskLists();
+
+	pxCreatedTask = pxNondetSetTaskHandle();
+	pcName = pcNondetSetString( configMAX_TASK_NAME_LEN );
+
+	xTaskCreate(pxTaskCode,
+				pcName,
+				usStackDepth,
+				pvParameters,
+				uxPriority,
+				pxCreatedTask );
+}

--- a/tools/cbmc/proofs/TaskPool/TaskCreate/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskCreate/tasks_test_access_functions.h
@@ -1,0 +1,56 @@
+#include "cbmc.h"
+
+/* 
+ * pvPortMalloc is nondeterministic by definition, thus we do not need
+ * to check for NULL allocation in this function
+ */
+void vNondetSetCurrentTCB( void )
+{
+	pxCurrentTCB = pvPortMalloc( sizeof(TCB_t) );
+}
+/*
+ * We just require task lists to be initialized for this proof
+ */
+void vPrepareTaskLists( void )
+{
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+}
+
+/*
+ * We set the values of relevant global
+ * variables to nondeterministic values
+ */
+void vSetGlobalVariables( void )
+{
+	xSchedulerRunning = nondet();
+	uxCurrentNumberOfTasks = nondet();
+}
+
+/*
+ * pvPortMalloc is nondeterministic by definition, thus we do not need
+ * to check for NULL allocation in this function
+ */
+TaskHandle_t *pxNondetSetTaskHandle( void )
+{
+	TaskHandle_t *pxNondetTaskHandle = pvPortMalloc( sizeof(TaskHandle_t) );
+	return pxNondetTaskHandle;
+}
+
+/*
+ * Tries to allocate a string of size xStringLength and sets the string
+ * to be terminated using a nondeterministic index if allocation was successful
+ */
+char *pcNondetSetString( size_t xStringLength )
+{
+	char *pcName = pvPortMalloc( xStringLength );
+
+	if ( pcName != NULL ) {
+		uint8_t uNondetIndex;
+		__CPROVER_assume( uNondetIndex < xStringLength );
+		pcName[uNondetIndex] = '\0';
+	}
+
+	return pcName;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskCreate.

This proofs depends on #774 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.