### PR TITLE
Add CBMC proof for TaskSuspendAll

### DIFF
--- a/tools/cbmc/proofs/TaskPool/TaskSuspendAll/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskSuspendAll/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TaskSuspendAll",
+  "DEF":
+  [
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskSuspendAll/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskSuspendAll/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskSuspendAll/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of the TaskSuspendAll function.
+No assumption or abstraction is required for this memory-safety proof.

--- a/tools/cbmc/proofs/TaskPool/TaskSuspendAll/TaskSuspendAll_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskSuspendAll/TaskSuspendAll_harness.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+/*
+ * We just call vTaskSuspendAll(). No assumption
+ * or abstraction is required for this proof
+ */
+void harness()
+{
+	vTaskSuspendAll();
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the memory-safety proof for TaskSuspendAll.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.