### PR TITLE
Add CBMC proof for TaskSetTimeOutState

### DIFF
--- a/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/Makefile.json
@@ -1,0 +1,20 @@
+{
+  "ENTRY": "TaskSetTimeOutState",
+  "DEF":
+  [
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of the TaskSetTimeOutState function.
+No assumption is required other than its single argument being non-NULL.

--- a/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/TaskSetTimeOutState_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskSetTimeOutState/TaskSetTimeOutState_harness.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+/*
+ * We assume xTime to allocated since the function includes a configASSERT
+ * call at the beginning to make sure the pointer to it is not NULL
+ */
+void harness()
+{
+	TimeOut_t xTime;
+
+	vTaskSetTimeOutState( &xTime );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskSetTimeOutState.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.