### PR TITLE
DNS allow asynchronous look-up

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
@@ -169,6 +169,14 @@ from the FreeRTOSIPConfig.h configuration header file. */
 	#define	ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME	portMAX_DELAY
 #endif
 
+
+#ifndef	ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS
+	#define	ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS	pdMS_TO_TICKS( 500u )
+#endif
+
+#ifndef	ipconfigDNS_SEND_BLOCK_TIME_TICKS
+	#define	ipconfigDNS_SEND_BLOCK_TIME_TICKS		pdMS_TO_TICKS( 500u )
+#endif
 /*
  * FreeRTOS debug logging routine (proposal)
  * The macro will be called in the printf() style. Users can define
@@ -375,6 +383,14 @@ from the FreeRTOSIPConfig.h configuration header file. */
 	#endif /* _WINDOWS_ */
 #endif /* ipconfigMAXIMUM_DISCOVER_TX_PERIOD */
 
+#if( ipconfigUSE_DNS == 0 )
+	/* The DNS module will not be included. */
+	#if( ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) )
+		/* LLMNR and NBNS depend on DNS because those protocols share a lot of code. */
+		#error When either LLMNR or NBNS is used, ipconfigUSE_DNS must be defined
+	#endif
+#endif
+
 #ifndef ipconfigUSE_DNS
 	#define ipconfigUSE_DNS						1
 #endif
@@ -406,13 +422,6 @@ from the FreeRTOSIPConfig.h configuration header file. */
 #ifndef ipconfigUSE_LLMNR
 	/* Include support for LLMNR: Link-local Multicast Name Resolution (non-Microsoft) */
 	#define ipconfigUSE_LLMNR					( 0 )
-#endif
-
-#if( !defined( ipconfigUSE_DNS ) )
-	#if( ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) )
-		/* LLMNR and NBNS depend on DNS because those protocols share a lot of code. */
-		#error When either LLMNR or NBNS is used, ipconfigUSE_DNS must be defined
-	#endif
 #endif
 
 #ifndef ipconfigREPLY_TO_INCOMING_PINGS

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -47,58 +47,58 @@
 #if( ipconfigUSE_DNS != 0 )
 
 #if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-	#define dnsDNS_PORT						0x3500u
-	#define dnsONE_QUESTION					0x0100u
-	#define dnsOUTGOING_FLAGS				0x0001u /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x0f80u /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x0080u /* Should be a response, without any errors. */
+	#define dnsDNS_PORT				0x3500u
+	#define dnsONE_QUESTION			0x0100u
+	#define dnsOUTGOING_FLAGS		0x0001u     /* Standard query. */
+	#define dnsRX_FLAGS_MASK		0x0f80u     /* The bits of interest in the flags field of incoming DNS messages. */
+	#define dnsEXPECTED_RX_FLAGS	0x0080u     /* Should be a response, without any errors. */
 #else
-	#define dnsDNS_PORT						0x0035u
-	#define dnsONE_QUESTION					0x0001u
-	#define dnsOUTGOING_FLAGS				0x0100u /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x800fu /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x8000u /* Should be a response, without any errors. */
+	#define dnsDNS_PORT				0x0035u
+	#define dnsONE_QUESTION			0x0001u
+	#define dnsOUTGOING_FLAGS		0x0100u     /* Standard query. */
+	#define dnsRX_FLAGS_MASK		0x800fu     /* The bits of interest in the flags field of incoming DNS messages. */
+	#define dnsEXPECTED_RX_FLAGS	0x8000u     /* Should be a response, without any errors. */
 
 #endif /* ipconfigBYTE_ORDER */
 
 /* The maximum number of times a DNS request should be sent out if a response
 is not received, before giving up. */
 #ifndef ipconfigDNS_REQUEST_ATTEMPTS
-	#define ipconfigDNS_REQUEST_ATTEMPTS		5
+	#define ipconfigDNS_REQUEST_ATTEMPTS    5
 #endif
 
 /* If the top two bits in the first character of a name field are set then the
 name field is an offset to the string, rather than the string itself. */
-#define dnsNAME_IS_OFFSET					( ( uint8_t ) 0xc0 )
+#define dnsNAME_IS_OFFSET					 ( ( uint8_t ) 0xc0 )
 
 /* NBNS flags. */
-#define dnsNBNS_FLAGS_RESPONSE				0x8000u
-#define dnsNBNS_FLAGS_OPCODE_MASK			0x7800u
-#define dnsNBNS_FLAGS_OPCODE_QUERY			0x0000u
-#define dnsNBNS_FLAGS_OPCODE_REGISTRATION	0x2800u
+#define dnsNBNS_FLAGS_RESPONSE				 0x8000u
+#define dnsNBNS_FLAGS_OPCODE_MASK			 0x7800u
+#define dnsNBNS_FLAGS_OPCODE_QUERY			 0x0000u
+#define dnsNBNS_FLAGS_OPCODE_REGISTRATION	 0x2800u
 
 /* Host types. */
-#define dnsTYPE_A_HOST						0x01u
-#define dnsCLASS_IN							0x01u
+#define dnsTYPE_A_HOST						 0x01u
+#define dnsCLASS_IN							 0x01u
 
 /* LLMNR constants. */
-#define dnsLLMNR_TTL_VALUE					300000uL
-#define dnsLLMNR_FLAGS_IS_REPONSE  			0x8000u
+#define dnsLLMNR_TTL_VALUE					 300000uL
+#define dnsLLMNR_FLAGS_IS_REPONSE			 0x8000u
 
 /* NBNS constants. */
-#define dnsNBNS_TTL_VALUE					3600uL /* 1 hour valid */
-#define dnsNBNS_TYPE_NET_BIOS				0x0020u
-#define dnsNBNS_CLASS_IN					0x01u
-#define dnsNBNS_NAME_FLAGS					0x6000u
-#define dnsNBNS_ENCODED_NAME_LENGTH			32
+#define dnsNBNS_TTL_VALUE					 3600uL /* 1 hour valid */
+#define dnsNBNS_TYPE_NET_BIOS				 0x0020u
+#define dnsNBNS_CLASS_IN					 0x01u
+#define dnsNBNS_NAME_FLAGS					 0x6000u
+#define dnsNBNS_ENCODED_NAME_LENGTH			 32
 
 /* If the queried NBNS name matches with the device's name,
 the query will be responded to with these flags: */
-#define dnsNBNS_QUERY_RESPONSE_FLAGS	( 0x8500u )
+#define dnsNBNS_QUERY_RESPONSE_FLAGS		 ( 0x8500u )
 
 /* Flag DNS parsing errors in situations where an IPv4 address is the return
 type. */
-#define dnsPARSE_ERROR					  0uL
+#define dnsPARSE_ERROR						 0uL
 
 /*
  * Create a socket and bind it to the standard DNS port number.  Return the
@@ -109,50 +109,66 @@ static Socket_t prvCreateDNSSocket( void );
 /*
  * Create the DNS message in the zero copy buffer passed in the first parameter.
  */
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t uxIdentifier );
+static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
+								   const char *pcHostName,
+								   TickType_t uxIdentifier );
 
 /*
  * Simple routine that jumps over the NAME field of a resource record.
  */
-static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen );
+static uint8_t * prvSkipNameField( uint8_t *pucByte,
+								   size_t xSourceLen );
 
 /*
  * Process a response packet from a DNS server.
  * The parameter 'xExpected' indicates whether the identifier in the reply
  * was expected, and thus if the DNS cache may be updated with the reply.
  */
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, BaseType_t xExpected );
+static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
+								  size_t xBufferLength,
+								  BaseType_t xExpected );
 
 /*
  * Prepare and send a message to a DNS server.  'uxReadTimeOut_ticks' will be passed as
  * zero, in case the user has supplied a call-back function.
  */
-static uint32_t prvGetHostByName( const char *pcHostName, TickType_t uxIdentifier, TickType_t uxReadTimeOut_ticks );
+static uint32_t prvGetHostByName( const char *pcHostName,
+								  TickType_t uxIdentifier,
+								  TickType_t uxReadTimeOut_ticks );
 
 /*
  * The NBNS and the LLMNR protocol share this reply function.
  */
 #if( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
-	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer, BaseType_t lNetLength );
+	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer,
+									BaseType_t lNetLength );
 #endif
 
 #if( ipconfigUSE_NBNS == 1 )
-	static portINLINE void prvTreatNBNS( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, uint32_t ulIPAddress );
+	static portINLINE void prvTreatNBNS( uint8_t *pucUDPPayloadBuffer,
+										 size_t xBufferLength,
+										 uint32_t ulIPAddress );
 #endif /* ipconfigUSE_NBNS */
 
 
 #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
-	static uint8_t *prvReadNameField( uint8_t *pucByte, size_t xSourceLen, char *pcName, size_t xLen );
-#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+	static uint8_t * prvReadNameField( uint8_t *pucByte,
+									   size_t xSourceLen,
+									   char *pcName,
+									   size_t xLen );
+#endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 
 #if( ipconfigUSE_DNS_CACHE == 1 )
-	static void prvProcessDNSCache( const char *pcName, uint32_t *pulIP, uint32_t ulTTL, BaseType_t xLookUp );
+	static void prvProcessDNSCache( const char *pcName,
+									uint32_t *pulIP,
+									uint32_t ulTTL,
+									BaseType_t xLookUp );
 
 	typedef struct xDNS_CACHE_TABLE_ROW
 	{
-		uint32_t ulIPAddress;		/* The IP address of an ARP cache entry. */
-		char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ];  /* The name of the host */
-		uint32_t ulTTL; /* Time-to-Live (in seconds) from the DNS server. */
+		uint32_t ulIPAddress;                         /* The IP address of an ARP cache entry. */
+		char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ]; /* The name of the host */
+		uint32_t ulTTL;                               /* Time-to-Live (in seconds) from the DNS server. */
 		uint32_t ulTimeWhenAddedInSeconds;
 	} DNSCacheRow_t;
 
@@ -166,7 +182,7 @@ static uint32_t prvGetHostByName( const char *pcHostName, TickType_t uxIdentifie
 
 #if( ipconfigUSE_LLMNR == 1 )
 	const MACAddress_t xLLMNR_MacAdress = { { 0x01, 0x00, 0x5e, 0x00, 0x00, 0xfc } };
-#endif	/* ipconfigUSE_LLMNR == 1 */
+#endif /* ipconfigUSE_LLMNR == 1 */
 
 /*-----------------------------------------------------------*/
 
@@ -214,7 +230,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	struct xLLMNRAnswer
 	{
 		uint8_t ucNameCode;
-		uint8_t ucNameOffset;	/* The name is not repeated in the answer, only the offset is given with "0xc0 <offs>" */
+		uint8_t ucNameOffset;   /* The name is not repeated in the answer, only the offset is given with "0xc0 <offs>" */
 		uint16_t usType;
 		uint16_t usClass;
 		uint32_t ulTTL;
@@ -253,13 +269,13 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 		uint16_t usClass;
 		uint32_t ulTTL;
 		uint16_t usDataLength;
-		uint16_t usNbFlags;		/* NetBIOS flags 0x6000 : IP-address, big-endian */
+		uint16_t usNbFlags;     /* NetBIOS flags 0x6000 : IP-address, big-endian */
 		uint32_t ulIPAddress;
 	}
 	#include "pack_struct_end.h"
 	typedef struct xNBNSAnswer NBNSAnswer_t;
 
-#endif /* ipconfigUSE_NBNS == 1 */
+	#endif /* ipconfigUSE_NBNS == 1 */
 
 /*-----------------------------------------------------------*/
 
@@ -267,6 +283,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	uint32_t FreeRTOS_dnslookup( const char *pcHostName )
 	{
 	uint32_t ulIPAddress = 0UL;
+
 		prvProcessDNSCache( pcHostName, &ulIPAddress, 0, pdTRUE );
 		return ulIPAddress;
 	}
@@ -275,9 +292,10 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 #if( ipconfigDNS_USE_CALLBACKS != 0 )
 
-	typedef struct xDNS_Callback {
-		TickType_t xRemaningTime;		/* Timeout in ms */
-		FOnDNSEvent pCallbackFunction;	/* Function to be called when the address has been found or when a timeout has beeen reached */
+	typedef struct xDNS_Callback
+	{
+		TickType_t xRemaningTime;       /* Timeout in ms */
+		FOnDNSEvent pCallbackFunction;  /* Function to be called when the address has been found or when a timeout has beeen reached */
 		TimeOut_t xTimeoutState;
 		void *pvSearchID;
 		struct xLIST_ITEM xListItem;
@@ -289,7 +307,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	/* Define FreeRTOS_gethostbyname() as a normal blocking call. */
 	uint32_t FreeRTOS_gethostbyname( const char *pcHostName )
 	{
-		return FreeRTOS_gethostbyname_a( pcHostName, ( FOnDNSEvent ) NULL, ( void* )NULL, 0 );
+		return FreeRTOS_gethostbyname_a( pcHostName, ( FOnDNSEvent ) NULL, ( void * ) NULL, 0 );
 	}
 	/*-----------------------------------------------------------*/
 
@@ -310,17 +328,19 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	void vDNSCheckCallBack( void *pvSearchID )
 	{
 	const ListItem_t *pxIterator;
-	const MiniListItem_t* xEnd = ( const MiniListItem_t* )listGET_END_MARKER( &xCallbackList );
+	const MiniListItem_t * xEnd = ( const MiniListItem_t * ) listGET_END_MARKER( &xCallbackList );
 
 		vTaskSuspendAll();
 		{
 			for( pxIterator  = ( const ListItem_t * ) listGET_NEXT( xEnd );
 				 pxIterator != ( const ListItem_t * ) xEnd;
-				  )
+				 )
 			{
-				DNSCallback_t *pxCallback = ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+			DNSCallback_t *pxCallback = ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+
 				/* Move to the next item because we might remove this item */
-				pxIterator  = ( const ListItem_t * ) listGET_NEXT( pxIterator );
+				pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator );
+
 				if( ( pvSearchID != NULL ) && ( pvSearchID == pxCallback->pvSearchID ) )
 				{
 					uxListRemove( &pxCallback->xListItem );
@@ -352,14 +372,23 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 	/* FreeRTOS_gethostbyname_a() was called along with callback parameters.
 	Store them in a list for later reference. */
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier );
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier )
+	static void vDNSSetCallBack( const char *pcHostName,
+								 void *pvSearchID,
+								 FOnDNSEvent pCallbackFunction,
+								 TickType_t xTimeout,
+								 TickType_t uxIdentifier );
+	static void vDNSSetCallBack( const char *pcHostName,
+								 void *pvSearchID,
+								 FOnDNSEvent pCallbackFunction,
+								 TickType_t xTimeout,
+								 TickType_t uxIdentifier )
 	{
-		size_t lLength = strlen( pcHostName );
-		DNSCallback_t *pxCallback = ( DNSCallback_t * )pvPortMalloc( sizeof( *pxCallback ) + lLength );
+	size_t lLength = strlen( pcHostName );
+	DNSCallback_t *pxCallback = ( DNSCallback_t * ) pvPortMalloc( sizeof( *pxCallback ) + lLength );
 
 		/* Translate from ms to number of clock ticks. */
 		xTimeout /= portTICK_PERIOD_MS;
+
 		if( pxCallback != NULL )
 		{
 			if( listLIST_IS_EMPTY( &xCallbackList ) )
@@ -367,12 +396,13 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 				/* This is the first one, start the DNS timer to check for timeouts */
 				vIPReloadDNSTimer( FreeRTOS_min_uint32( 1000U, xTimeout ) );
 			}
+
 			strcpy( pxCallback->pcName, pcHostName );
 			pxCallback->pCallbackFunction = pCallbackFunction;
 			pxCallback->pvSearchID = pvSearchID;
 			pxCallback->xRemaningTime = xTimeout;
 			vTaskSetTimeOutState( &pxCallback->xTimeoutState );
-			listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ( void* ) pxCallback );
+			listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ( void * ) pxCallback );
 			listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), uxIdentifier );
 			vTaskSuspendAll();
 			{
@@ -385,12 +415,16 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 	/* A DNS reply was received, see if there is any matching entry and
 	call the handler.  Returns pdTRUE if uxIdentifier was recognised. */
-	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress );
-	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress )
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
+									  const char *pcName,
+									  uint32_t ulIPAddress );
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
+									  const char *pcName,
+									  uint32_t ulIPAddress )
 	{
 	BaseType_t xResult = pdFALSE;
 	const ListItem_t *pxIterator;
-	const MiniListItem_t* xEnd = ( const MiniListItem_t* )listGET_END_MARKER( &xCallbackList );
+	const MiniListItem_t * xEnd = ( const MiniListItem_t * ) listGET_END_MARKER( &xCallbackList );
 
 		vTaskSuspendAll();
 		{
@@ -401,15 +435,18 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 				/* The cast will take away the 'configLIST_VOLATILE' */
 				if( uxIdentifier == ( TickType_t ) listGET_LIST_ITEM_VALUE( pxIterator ) )
 				{
-					DNSCallback_t *pxCallback = ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+				DNSCallback_t *pxCallback = ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+
 					pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, ulIPAddress );
 					uxListRemove( &pxCallback->xListItem );
 					vPortFree( pxCallback );
+
 					if( listLIST_IS_EMPTY( &xCallbackList ) )
 					{
 						/* The list of outstanding requests is empty. No need for periodic polling. */
 						vIPSetDnsTimerEnableState( pdFALSE );
 					}
+
 					xResult = pdTRUE;
 					break;
 				}
@@ -419,13 +456,16 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 		return xResult;
 	}
 
-#endif	/* ipconfigDNS_USE_CALLBACKS != 0 */
+#endif /* ipconfigDNS_USE_CALLBACKS != 0 */
 /*-----------------------------------------------------------*/
 
 #if( ipconfigDNS_USE_CALLBACKS == 0 )
-uint32_t FreeRTOS_gethostbyname( const char *pcHostName )
+	uint32_t FreeRTOS_gethostbyname( const char *pcHostName )
 #else
-uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback, void *pvSearchID, TickType_t xTimeout )
+	uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName,
+									   FOnDNSEvent pCallback,
+									   void *pvSearchID,
+									   TickType_t xTimeout )
 #endif
 {
 uint32_t ulIPAddress = 0UL;
@@ -447,6 +487,7 @@ TickType_t uxIdentifier = 0;
 		if( ulIPAddress == 0UL )
 		{
 			ulIPAddress = FreeRTOS_dnslookup( pcHostName );
+
 			if( ulIPAddress != 0 )
 			{
 				FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
@@ -463,7 +504,7 @@ TickType_t uxIdentifier = 0;
 	if( 0 == ulIPAddress )
 	{
 		/* DNS identifiers are 16-bit. */
-		uxIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffffu );
+		uxIdentifier = ( TickType_t ) ( ipconfigRAND32() & 0xffffu );
 		/* ipconfigRAND32() may not return a non-zero value. */
 	}
 
@@ -477,7 +518,7 @@ TickType_t uxIdentifier = 0;
 				if( uxIdentifier != ( TickType_t ) 0u )
 				{
 					uxReadTimeOut_ticks = 0;
-					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )uxIdentifier );
+					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t ) uxIdentifier );
 				}
 			}
 			else
@@ -487,7 +528,7 @@ TickType_t uxIdentifier = 0;
 			}
 		}
 	}
-	#endif
+	#endif /* if ( ipconfigDNS_USE_CALLBACKS != 0 ) */
 
 	if( ( ulIPAddress == 0UL ) && ( uxIdentifier != ( TickType_t ) 0u ) )
 	{
@@ -498,7 +539,9 @@ TickType_t uxIdentifier = 0;
 }
 /*-----------------------------------------------------------*/
 
-static uint32_t prvGetHostByName( const char *pcHostName, TickType_t uxIdentifier, TickType_t uxReadTimeOut_ticks )
+static uint32_t prvGetHostByName( const char *pcHostName,
+								  TickType_t uxIdentifier,
+								  TickType_t uxReadTimeOut_ticks )
 {
 struct freertos_sockaddr xAddress;
 Socket_t xDNSSocket;
@@ -518,7 +561,8 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 	if not then LLMNR can be used as the lookup method. */
 	#if( ipconfigUSE_LLMNR == 1 )
 	{
-		const char *pucPtr;
+	const char *pucPtr;
+
 		for( pucPtr = pcHostName; *pucPtr; pucPtr++ )
 		{
 			if( *pucPtr == '.' )
@@ -563,8 +607,8 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 				if( bHasDot == pdFALSE )
 				{
 					/* Use LLMNR addressing. */
-					( ( DNSMessage_t * ) pucUDPPayloadBuffer) -> usFlags = 0;
-					xAddress.sin_addr = ipLLMNR_IP_ADDR;	/* Is in network byte order. */
+					( ( DNSMessage_t * ) pucUDPPayloadBuffer )->usFlags = 0;
+					xAddress.sin_addr = ipLLMNR_IP_ADDR; /* Is in network byte order. */
 					xAddress.sin_port = FreeRTOS_ntohs( ipLLMNR_PORT );
 				}
 				else
@@ -597,12 +641,13 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 							/* The reply was not expected. */
 							xExpected = pdFALSE;
 						}
+
 						/* The reply was received.  Process it. */
 					#if( ipconfigDNS_USE_CALLBACKS == 0 )
 						/* It is useless to analyse the unexpected reply
 						unless asynchronous look-ups are enabled. */
 						if( xExpected != pdFALSE )
-					#endif	/* ipconfigDNS_USE_CALLBACKS == 0 */
+					#endif /* ipconfigDNS_USE_CALLBACKS == 0 */
 						{
 							ulIPAddress = prvParseDNSReply( pucUDPPayloadBuffer, ( size_t ) lBytes, xExpected );
 						}
@@ -626,6 +671,7 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 					FreeRTOS_ReleaseUDPPayloadBuffer( ( void * ) pucUDPPayloadBuffer );
 				}
 			}
+
 			if( uxReadTimeOut_ticks == 0u )
 			{
 				/* This DNS lookup is asynchronous, using a call-back:
@@ -642,19 +688,21 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 }
 /*-----------------------------------------------------------*/
 
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t uxIdentifier )
+static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
+								   const char *pcHostName,
+								   TickType_t uxIdentifier )
 {
 DNSMessage_t *pxDNSMessageHeader;
 uint8_t *pucStart, *pucByte;
 DNSTail_t *pxTail;
 static const DNSMessage_t xDefaultPartDNSHeader =
 {
-	0,					/* The identifier will be overwritten. */
-	dnsOUTGOING_FLAGS,	/* Flags set for standard query. */
-	dnsONE_QUESTION,	/* One question is being asked. */
-	0,					/* No replies are included. */
-	0,					/* No authorities. */
-	0					/* No additional authorities. */
+	0,                 /* The identifier will be overwritten. */
+	dnsOUTGOING_FLAGS, /* Flags set for standard query. */
+	dnsONE_QUESTION,   /* One question is being asked. */
+	0,                 /* No replies are included. */
+	0,                 /* No authorities. */
+	0                  /* No additional authorities. */
 };
 
 	/* Copy in the const part of the header. */
@@ -698,15 +746,14 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 		( *pucStart )--;
 
 		pucStart = pucByte;
-
 	} while( *pucByte != 0x00 );
 
 	/* Finish off the record. */
 
-	pxTail = (DNSTail_t *)( pucByte + 1 );
+	pxTail = ( DNSTail_t * ) ( pucByte + 1 );
 
-	vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST );	/* Type A: host */
-	vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );	/* 1: Class IN */
+	vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST ); /* Type A: host */
+	vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );   /* 1: Class IN */
 
 	/* Return the total size of the generated message, which is the space from
 	the last written byte to the beginning of the buffer. */
@@ -716,7 +763,10 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
 
-	static uint8_t *prvReadNameField( uint8_t *pucByte, size_t xSourceLen, char *pcName, size_t xDestLen )
+	static uint8_t * prvReadNameField( uint8_t *pucByte,
+									   size_t xSourceLen,
+									   char *pcName,
+									   size_t xDestLen )
 	{
 	size_t xNameLen = 0;
 	BaseType_t xCount;
@@ -753,13 +803,13 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 				}
 
 				/* Process the first/next sub-string. */
-				for( xCount = *(pucByte++), xSourceLen--;
+				for( xCount = *( pucByte++ ), xSourceLen--;
 					 xCount-- && xSourceLen > 1;
 					 pucByte++, xSourceLen-- )
 				{
 					if( xNameLen < xDestLen - 1 )
 					{
-						pcName[ xNameLen++ ] = *( ( char * )pucByte );
+						pcName[ xNameLen++ ] = *( ( char * ) pucByte );
 					}
 					else
 					{
@@ -788,12 +838,13 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 		return pucByte;
 	}
-#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+#endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 /*-----------------------------------------------------------*/
 
-static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
+static uint8_t * prvSkipNameField( uint8_t *pucByte,
+								   size_t xSourceLen )
 {
-	size_t xChunkLength;
+size_t xChunkLength;
 
 	if( 0 == xSourceLen )
 	{
@@ -859,10 +910,10 @@ static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
 		if( pxNetworkBuffer->xDataLength >= sizeof( DNSMessage_t ) )
 		{
 			pxDNSMessageHeader =
-				( DNSMessage_t * )( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
+				( DNSMessage_t * ) ( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
 
 			/* The parameter pdFALSE indicates that the reply was not expected. */
-			prvParseDNSReply( ( uint8_t * )pxDNSMessageHeader,
+			prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
 							  pxNetworkBuffer->xDataLength,
 							  pdFALSE );
 		}
@@ -871,11 +922,11 @@ static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
 		return pdFAIL;
 	}
 	/*-----------------------------------------------------------*/
-#endif
+#endif /* if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
 #if( ipconfigUSE_NBNS == 1 )
 
-	uint32_t ulNBNSHandlePacket (NetworkBufferDescriptor_t *pxNetworkBuffer )
+	uint32_t ulNBNSHandlePacket( NetworkBufferDescriptor_t * pxNetworkBuffer )
 	{
 	UDPPacket_t *pxUDPPacket = ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 	uint8_t *pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
@@ -893,7 +944,9 @@ static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
 #endif /* ipconfigUSE_NBNS */
 /*-----------------------------------------------------------*/
 
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, BaseType_t xExpected )
+static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
+								  size_t xBufferLength,
+								  BaseType_t xExpected )
 {
 DNSMessage_t *pxDNSMessageHeader;
 DNSAnswerRecord_t *pxDNSAnswerRecord;
@@ -917,6 +970,7 @@ BaseType_t xDoStore = xExpected;
 	{
 		return dnsPARSE_ERROR;
 	}
+
 	xSourceBytesRemaining = xBufferLength;
 
 	/* Parse the DNS message header. */
@@ -931,6 +985,7 @@ BaseType_t xDoStore = xExpected;
 
 		/* Skip any question records. */
 		usQuestions = FreeRTOS_ntohs( pxDNSMessageHeader->usQuestions );
+
 		for( x = 0; x < usQuestions; x++ )
 		{
 			#if( ipconfigUSE_LLMNR == 1 )
@@ -955,6 +1010,7 @@ BaseType_t xDoStore = xExpected;
 				{
 					return dnsPARSE_ERROR;
 				}
+
 				xSourceBytesRemaining = ( pucUDPPayloadBuffer + xBufferLength ) - pucByte;
 			}
 			else
@@ -969,6 +1025,7 @@ BaseType_t xDoStore = xExpected;
 				{
 					return dnsPARSE_ERROR;
 				}
+
 				xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
 			}
 
@@ -1009,16 +1066,16 @@ BaseType_t xDoStore = xExpected;
 				{
 					return dnsPARSE_ERROR;
 				}
-				xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
 
+				xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
 
 				/* Is there enough data for an IPv4 A record answer and, if so,
 				is this an A record? */
-				if( xSourceBytesRemaining >= sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) &&
-					usChar2u16( pucByte ) == dnsTYPE_A_HOST )
+				if( ( xSourceBytesRemaining >= ( sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) ) ) &&
+					( usChar2u16( pucByte ) == dnsTYPE_A_HOST ) )
 				{
 					/* This is the required record type and is of sufficient size. */
-					pxDNSAnswerRecord = ( DNSAnswerRecord_t * )pucByte;
+					pxDNSAnswerRecord = ( DNSAnswerRecord_t * ) pucByte;
 
 					/* Sanity check the data length of an IPv4 answer. */
 					if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == sizeof( uint32_t ) )
@@ -1038,7 +1095,7 @@ BaseType_t xDoStore = xExpected;
 								xDoStore = pdTRUE;
 							}
 						}
-						#endif	/* ipconfigDNS_USE_CALLBACKS != 0 */
+						#endif /* ipconfigDNS_USE_CALLBACKS != 0 */
 						#if( ipconfigUSE_DNS_CACHE == 1 )
 						{
 							/* The reply will only be stored in the DNS cache when the
@@ -1047,13 +1104,13 @@ BaseType_t xDoStore = xExpected;
 							{
 								prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
 							}
+
 							/* Show what has happened. */
 							FreeRTOS_printf( ( "DNS[0x%04X]: The answer to '%s' (%xip) will%s be stored\n",
-								( unsigned )pxDNSMessageHeader->usIdentifier,
-								pcName,
-								( unsigned )FreeRTOS_ntohl( ulIPAddress ),
-								xDoStore ? "" : " NOT" ) );
-
+											   ( unsigned ) pxDNSMessageHeader->usIdentifier,
+											   pcName,
+											   ( unsigned ) FreeRTOS_ntohl( ulIPAddress ),
+											   xDoStore ? "" : " NOT" ) );
 						}
 						#endif /* ipconfigUSE_DNS_CACHE */
 					}
@@ -1066,7 +1123,7 @@ BaseType_t xDoStore = xExpected;
 				{
 					/* It's not an A record, so skip it. Get the header location
 					and then jump over the header. */
-					pxDNSAnswerRecord = ( DNSAnswerRecord_t * )pucByte;
+					pxDNSAnswerRecord = ( DNSAnswerRecord_t * ) pucByte;
 					pucByte += sizeof( DNSAnswerRecord_t );
 					xSourceBytesRemaining -= sizeof( DNSAnswerRecord_t );
 
@@ -1087,12 +1144,13 @@ BaseType_t xDoStore = xExpected;
 				}
 			}
 		}
+
 #if( ipconfigUSE_LLMNR == 1 )
 		else if( usQuestions && ( usType == dnsTYPE_A_HOST ) && ( usClass == dnsCLASS_IN ) )
 		{
 			/* If this is not a reply to our DNS request, it might an LLMNR
 			request. */
-			if( xApplicationDNSQueryHook ( ( pcRequestedName + 1 ) ) )
+			if( xApplicationDNSQueryHook( ( pcRequestedName + 1 ) ) )
 			{
 			int16_t usLength;
 			NetworkBufferDescriptor_t *pxNewBuffer = NULL;
@@ -1108,6 +1166,7 @@ BaseType_t xDoStore = xExpected;
 					must be duplicaed into a bigger buffer */
 					pxNetworkBuffer->xDataLength = xDataLength;
 					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, xDataLength + 16 );
+
 					if( pxNewBuffer != NULL )
 					{
 					BaseType_t xOffset1, xOffset2;
@@ -1121,7 +1180,6 @@ BaseType_t xDoStore = xExpected;
 						pucByte = pucUDPPayloadBuffer + xOffset1;
 						pcRequestedName = ( char * ) ( pucUDPPayloadBuffer + xOffset2 );
 						pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
-
 					}
 					else
 					{
@@ -1129,21 +1187,22 @@ BaseType_t xDoStore = xExpected;
 						pxNetworkBuffer = NULL;
 					}
 				}
+
 				if( pxNetworkBuffer != NULL )
 				{
-					pxAnswer = (LLMNRAnswer_t *)pucByte;
+					pxAnswer = ( LLMNRAnswer_t * ) pucByte;
 
 					/* We leave 'usIdentifier' and 'usQuestions' untouched */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usFlags, dnsLLMNR_FLAGS_IS_REPONSE );	/* Set the response flag */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAnswers, 1 );	/* Provide a single answer */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAuthorityRRs, 0 );	/* No authority */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAdditionalRRs, 0 );	/* No additional info */
+					vSetField16( pxDNSMessageHeader, DNSMessage_t, usFlags, dnsLLMNR_FLAGS_IS_REPONSE ); /* Set the response flag */
+					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAnswers, 1 );                       /* Provide a single answer */
+					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAuthorityRRs, 0 );                  /* No authority */
+					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAdditionalRRs, 0 );                 /* No additional info */
 
 					pxAnswer->ucNameCode = dnsNAME_IS_OFFSET;
-					pxAnswer->ucNameOffset = ( uint8_t )( pcRequestedName - ( char * ) pucUDPPayloadBuffer );
+					pxAnswer->ucNameOffset = ( uint8_t ) ( pcRequestedName - ( char * ) pucUDPPayloadBuffer );
 
-					vSetField16( pxAnswer, LLMNRAnswer_t, usType, dnsTYPE_A_HOST );	/* Type A: host */
-					vSetField16( pxAnswer, LLMNRAnswer_t, usClass, dnsCLASS_IN );	/* 1: Class IN */
+					vSetField16( pxAnswer, LLMNRAnswer_t, usType, dnsTYPE_A_HOST ); /* Type A: host */
+					vSetField16( pxAnswer, LLMNRAnswer_t, usClass, dnsCLASS_IN );   /* 1: Class IN */
 					vSetField32( pxAnswer, LLMNRAnswer_t, ulTTL, dnsLLMNR_TTL_VALUE );
 					vSetField16( pxAnswer, LLMNRAnswer_t, usDataLength, 4 );
 					vSetField32( pxAnswer, LLMNRAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
@@ -1167,18 +1226,21 @@ BaseType_t xDoStore = xExpected;
 		/* Do not return a valid IP-address in case the reply was not expected. */
 		ulIPAddress = 0uL;
 	}
+
 	return ulIPAddress;
 }
 /*-----------------------------------------------------------*/
 
 #if( ipconfigUSE_NBNS == 1 )
 
-	static void prvTreatNBNS( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, uint32_t ulIPAddress )
+	static void prvTreatNBNS( uint8_t *pucUDPPayloadBuffer,
+							  size_t xBufferLength,
+							  uint32_t ulIPAddress )
 	{
-		uint16_t usFlags, usType, usClass;
-		uint8_t *pucSource, *pucTarget;
-		uint8_t ucByte;
-		uint8_t ucNBNSName[ 17 ];
+	uint16_t usFlags, usType, usClass;
+	uint8_t *pucSource, *pucTarget;
+	uint8_t ucByte;
+	uint8_t ucNBNSName[ 17 ];
 
 		/* Check for minimum buffer size. */
 		if( xBufferLength < sizeof( NBNSRequest_t ) )
@@ -1195,10 +1257,11 @@ BaseType_t xDoStore = xExpected;
 			usClass = usChar2u16( pucUDPPayloadBuffer + offsetof( NBNSRequest_t, usClass ) );
 
 			/* Not used for now */
-			( void )usClass;
+			( void ) usClass;
+
 			/* For NBNS a name is 16 bytes long, written with capitals only.
 			Make sure that the copy is terminated with a zero. */
-			pucTarget = ucNBNSName + sizeof(ucNBNSName ) - 2;
+			pucTarget = ucNBNSName + sizeof( ucNBNSName ) - 2;
 			pucTarget[ 1 ] = '\0';
 
 			/* Start with decoding the last 2 bytes. */
@@ -1257,13 +1320,14 @@ BaseType_t xDoStore = xExpected;
 				{
 				NetworkBufferDescriptor_t *pxNewBuffer;
 				BaseType_t xDataLength = pxNetworkBuffer->xDataLength + sizeof( UDPHeader_t ) +
-					sizeof( EthernetHeader_t ) + sizeof( IPHeader_t );
+										 sizeof( EthernetHeader_t ) + sizeof( IPHeader_t );
 
 					/* The field xDataLength was set to the length of the UDP payload.
 					The answer (reply) will be longer than the request, so the packet
 					must be duplicated into a bigger buffer */
 					pxNetworkBuffer->xDataLength = xDataLength;
 					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, xDataLength + 16 );
+
 					if( pxNewBuffer != NULL )
 					{
 						pucUDPPayloadBuffer = pxNewBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
@@ -1279,7 +1343,7 @@ BaseType_t xDoStore = xExpected;
 				/* Should not occur: pucUDPPayloadBuffer is part of a xNetworkBufferDescriptor */
 				if( pxNetworkBuffer != NULL )
 				{
-					pxMessage = (DNSMessage_t *)pucUDPPayloadBuffer;
+					pxMessage = ( DNSMessage_t * ) pucUDPPayloadBuffer;
 
 					/* As the fields in the structures are not word-aligned, we have to
 					copy the values byte-by-byte using macro's vSetField16() and vSetField32() */
@@ -1289,12 +1353,12 @@ BaseType_t xDoStore = xExpected;
 					vSetField16( pxMessage, DNSMessage_t, usAuthorityRRs, 0 );
 					vSetField16( pxMessage, DNSMessage_t, usAdditionalRRs, 0 );
 
-					pxAnswer = (NBNSAnswer_t *)( pucUDPPayloadBuffer + offsetof( NBNSRequest_t, usType ) );
+					pxAnswer = ( NBNSAnswer_t * ) ( pucUDPPayloadBuffer + offsetof( NBNSRequest_t, usType ) );
 
-					vSetField16( pxAnswer, NBNSAnswer_t, usType, usType );	/* Type */
-					vSetField16( pxAnswer, NBNSAnswer_t, usClass, dnsNBNS_CLASS_IN );	/* Class */
+					vSetField16( pxAnswer, NBNSAnswer_t, usType, usType );            /* Type */
+					vSetField16( pxAnswer, NBNSAnswer_t, usClass, dnsNBNS_CLASS_IN ); /* Class */
 					vSetField32( pxAnswer, NBNSAnswer_t, ulTTL, dnsNBNS_TTL_VALUE );
-					vSetField16( pxAnswer, NBNSAnswer_t, usDataLength, 6 ); /* 6 bytes including the length field */
+					vSetField16( pxAnswer, NBNSAnswer_t, usDataLength, 6 );           /* 6 bytes including the length field */
 					vSetField16( pxAnswer, NBNSAnswer_t, usNbFlags, dnsNBNS_NAME_FLAGS );
 					vSetField32( pxAnswer, NBNSAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
 
@@ -1306,7 +1370,7 @@ BaseType_t xDoStore = xExpected;
 		}
 	}
 
-#endif	/* ipconfigUSE_NBNS */
+#endif /* ipconfigUSE_NBNS */
 /*-----------------------------------------------------------*/
 
 static Socket_t prvCreateDNSSocket( void )
@@ -1340,13 +1404,14 @@ BaseType_t xReturn;
 
 #if( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
 
-	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer, BaseType_t lNetLength )
+	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer,
+									BaseType_t lNetLength )
 	{
 	UDPPacket_t *pxUDPPacket;
 	IPHeader_t *pxIPHeader;
 	UDPHeader_t *pxUDPHeader;
 
-		pxUDPPacket = (UDPPacket_t *) pxNetworkBuffer->pucEthernetBuffer;
+		pxUDPPacket = ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 		pxIPHeader = &pxUDPPacket->xIPHeader;
 		pxUDPHeader = &pxUDPPacket->xUDPHeader;
 		/* HT: started using defines like 'ipSIZE_OF_xxx' */
@@ -1368,7 +1433,7 @@ BaseType_t xReturn;
 			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
 			/* calculate the UDP checksum for outgoing package */
-			usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, lNetLength, pdTRUE );
+			usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, lNetLength, pdTRUE );
 		}
 		#endif
 
@@ -1384,7 +1449,10 @@ BaseType_t xReturn;
 
 #if( ipconfigUSE_DNS_CACHE == 1 )
 
-	static void prvProcessDNSCache( const char *pcName, uint32_t *pulIP, uint32_t ulTTL, BaseType_t xLookUp )
+	static void prvProcessDNSCache( const char *pcName,
+									uint32_t *pulIP,
+									uint32_t ulTTL,
+									BaseType_t xLookUp )
 	{
 	BaseType_t x;
 	BaseType_t xFound = pdFALSE;
@@ -1445,6 +1513,7 @@ BaseType_t xReturn;
 					xDNSCache[ xFreeEntry ].ulTimeWhenAddedInSeconds = ulCurrentTimeSeconds;
 
 					xFreeEntry++;
+
 					if( xFreeEntry == ipconfigDNS_CACHE_ENTRIES )
 					{
 						xFreeEntry = 0;
@@ -1469,4 +1538,3 @@ BaseType_t xReturn;
 #ifdef AMAZON_FREERTOS_ENABLE_UNIT_TESTS
 	#include "iot_freertos_tcp_test_access_dns_define.h"
 #endif
-

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -47,17 +47,17 @@
 #if( ipconfigUSE_DNS != 0 )
 
 #if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-	#define dnsDNS_PORT						0x3500
-	#define dnsONE_QUESTION					0x0100
-	#define dnsOUTGOING_FLAGS				0x0001 /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x0f80 /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x0080 /* Should be a response, without any errors. */
+	#define dnsDNS_PORT						0x3500u
+	#define dnsONE_QUESTION					0x0100u
+	#define dnsOUTGOING_FLAGS				0x0001u /* Standard query. */
+	#define dnsRX_FLAGS_MASK				0x0f80u /* The bits of interest in the flags field of incoming DNS messages. */
+	#define dnsEXPECTED_RX_FLAGS			0x0080u /* Should be a response, without any errors. */
 #else
-	#define dnsDNS_PORT						0x0035
-	#define dnsONE_QUESTION					0x0001
-	#define dnsOUTGOING_FLAGS				0x0100 /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x800f /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x8000 /* Should be a response, without any errors. */
+	#define dnsDNS_PORT						0x0035u
+	#define dnsONE_QUESTION					0x0001u
+	#define dnsOUTGOING_FLAGS				0x0100u /* Standard query. */
+	#define dnsRX_FLAGS_MASK				0x800fu /* The bits of interest in the flags field of incoming DNS messages. */
+	#define dnsEXPECTED_RX_FLAGS			0x8000u /* Should be a response, without any errors. */
 
 #endif /* ipconfigBYTE_ORDER */
 
@@ -72,33 +72,33 @@ name field is an offset to the string, rather than the string itself. */
 #define dnsNAME_IS_OFFSET					( ( uint8_t ) 0xc0 )
 
 /* NBNS flags. */
-#define dnsNBNS_FLAGS_RESPONSE				0x8000
-#define dnsNBNS_FLAGS_OPCODE_MASK			0x7800
-#define dnsNBNS_FLAGS_OPCODE_QUERY			0x0000
-#define dnsNBNS_FLAGS_OPCODE_REGISTRATION	0x2800
+#define dnsNBNS_FLAGS_RESPONSE				0x8000u
+#define dnsNBNS_FLAGS_OPCODE_MASK			0x7800u
+#define dnsNBNS_FLAGS_OPCODE_QUERY			0x0000u
+#define dnsNBNS_FLAGS_OPCODE_REGISTRATION	0x2800u
 
 /* Host types. */
-#define dnsTYPE_A_HOST						0x01
-#define dnsCLASS_IN							0x01
+#define dnsTYPE_A_HOST						0x01u
+#define dnsCLASS_IN							0x01u
 
 /* LLMNR constants. */
-#define dnsLLMNR_TTL_VALUE					300000
-#define dnsLLMNR_FLAGS_IS_REPONSE  			0x8000
+#define dnsLLMNR_TTL_VALUE					300000uL
+#define dnsLLMNR_FLAGS_IS_REPONSE  			0x8000u
 
 /* NBNS constants. */
-#define dnsNBNS_TTL_VALUE					3600 /* 1 hour valid */
-#define dnsNBNS_TYPE_NET_BIOS				0x0020
-#define dnsNBNS_CLASS_IN					0x01
-#define dnsNBNS_NAME_FLAGS					0x6000
+#define dnsNBNS_TTL_VALUE					3600uL /* 1 hour valid */
+#define dnsNBNS_TYPE_NET_BIOS				0x0020u
+#define dnsNBNS_CLASS_IN					0x01u
+#define dnsNBNS_NAME_FLAGS					0x6000u
 #define dnsNBNS_ENCODED_NAME_LENGTH			32
 
 /* If the queried NBNS name matches with the device's name,
 the query will be responded to with these flags: */
-#define dnsNBNS_QUERY_RESPONSE_FLAGS	( 0x8500 )
+#define dnsNBNS_QUERY_RESPONSE_FLAGS	( 0x8500u )
 
 /* Flag DNS parsing errors in situations where an IPv4 address is the return
 type. */
-#define dnsPARSE_ERROR					  0UL
+#define dnsPARSE_ERROR					  0uL
 
 /*
  * Create a socket and bind it to the standard DNS port number.  Return the
@@ -109,7 +109,7 @@ static Socket_t prvCreateDNSSocket( void );
 /*
  * Create the DNS message in the zero copy buffer passed in the first parameter.
  */
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t xIdentifier );
+static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t uxIdentifier );
 
 /*
  * Simple routine that jumps over the NAME field of a resource record.
@@ -118,14 +118,16 @@ static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen );
 
 /*
  * Process a response packet from a DNS server.
+ * The parameter 'xExpected' indicates whether the identifier in the reply
+ * was expected, and thus if the DNS cache may be updated with the reply.
  */
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier );
+static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, BaseType_t xExpected );
 
 /*
- * Prepare and send a message to a DNS server.  'xReadTimeOut_ms' will be passed as
+ * Prepare and send a message to a DNS server.  'uxReadTimeOut_ticks' will be passed as
  * zero, in case the user has supplied a call-back function.
  */
-static uint32_t prvGetHostByName( const char *pcHostName, TickType_t xIdentifier, TickType_t xReadTimeOut_ms );
+static uint32_t prvGetHostByName( const char *pcHostName, TickType_t uxIdentifier, TickType_t uxReadTimeOut_ticks );
 
 /*
  * The NBNS and the LLMNR protocol share this reply function.
@@ -138,8 +140,12 @@ static uint32_t prvGetHostByName( const char *pcHostName, TickType_t xIdentifier
 	static portINLINE void prvTreatNBNS( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, uint32_t ulIPAddress );
 #endif /* ipconfigUSE_NBNS */
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
+
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
 	static uint8_t *prvReadNameField( uint8_t *pucByte, size_t xSourceLen, char *pcName, size_t xLen );
+#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+
+#if( ipconfigUSE_DNS_CACHE == 1 )
 	static void prvProcessDNSCache( const char *pcName, uint32_t *pulIP, uint32_t ulTTL, BaseType_t xLookUp );
 
 	typedef struct xDNS_CACHE_TABLE_ROW
@@ -152,10 +158,10 @@ static uint32_t prvGetHostByName( const char *pcHostName, TickType_t xIdentifier
 
 	static DNSCacheRow_t xDNSCache[ ipconfigDNS_CACHE_ENTRIES ];
 
-    void FreeRTOS_dnsclear()
-    {
-        memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
-    }
+	void FreeRTOS_dnsclear()
+	{
+		memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
+	}
 #endif /* ipconfigUSE_DNS_CACHE == 1 */
 
 #if( ipconfigUSE_LLMNR == 1 )
@@ -346,8 +352,8 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 	/* FreeRTOS_gethostbyname_a() was called along with callback parameters.
 	Store them in a list for later reference. */
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t xIdentifier );
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t xIdentifier )
+	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier );
+	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier )
 	{
 		size_t lLength = strlen( pcHostName );
 		DNSCallback_t *pxCallback = ( DNSCallback_t * )pvPortMalloc( sizeof( *pxCallback ) + lLength );
@@ -367,7 +373,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 			pxCallback->xRemaningTime = xTimeout;
 			vTaskSetTimeOutState( &pxCallback->xTimeoutState );
 			listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ( void* ) pxCallback );
-			listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), xIdentifier );
+			listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), uxIdentifier );
 			vTaskSuspendAll();
 			{
 				vListInsertEnd( &xCallbackList, &pxCallback->xListItem );
@@ -378,12 +384,13 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	/*-----------------------------------------------------------*/
 
 	/* A DNS reply was received, see if there is any matching entry and
-	call the handler. */
-	static void vDNSDoCallback( TickType_t xIdentifier, const char *pcName, uint32_t ulIPAddress );
-	static void vDNSDoCallback( TickType_t xIdentifier, const char *pcName, uint32_t ulIPAddress )
+	call the handler.  Returns pdTRUE if uxIdentifier was recognised. */
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress );
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress )
 	{
-		const ListItem_t *pxIterator;
-		const MiniListItem_t* xEnd = ( const MiniListItem_t* )listGET_END_MARKER( &xCallbackList );
+	BaseType_t xResult = pdFALSE;
+	const ListItem_t *pxIterator;
+	const MiniListItem_t* xEnd = ( const MiniListItem_t* )listGET_END_MARKER( &xCallbackList );
 
 		vTaskSuspendAll();
 		{
@@ -391,7 +398,8 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 				 pxIterator != ( const ListItem_t * ) xEnd;
 				 pxIterator  = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
 			{
-				if( listGET_LIST_ITEM_VALUE( pxIterator ) == xIdentifier )
+				/* The cast will take away the 'configLIST_VOLATILE' */
+				if( uxIdentifier == ( TickType_t ) listGET_LIST_ITEM_VALUE( pxIterator ) )
 				{
 					DNSCallback_t *pxCallback = ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
 					pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, ulIPAddress );
@@ -399,13 +407,16 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 					vPortFree( pxCallback );
 					if( listLIST_IS_EMPTY( &xCallbackList ) )
 					{
+						/* The list of outstanding requests is empty. No need for periodic polling. */
 						vIPSetDnsTimerEnableState( pdFALSE );
 					}
+					xResult = pdTRUE;
 					break;
 				}
 			}
 		}
 		xTaskResumeAll();
+		return xResult;
 	}
 
 #endif	/* ipconfigDNS_USE_CALLBACKS != 0 */
@@ -418,8 +429,8 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 #endif
 {
 uint32_t ulIPAddress = 0UL;
-TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
-TickType_t xIdentifier = 0;
+TickType_t uxReadTimeOut_ticks = ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS;
+TickType_t uxIdentifier = 0;
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
 	and return. */
@@ -442,7 +453,7 @@ TickType_t xIdentifier = 0;
 			}
 			else
 			{
-				/* prvGetHostByName will be called to start a DNS lookup */
+				/* prvGetHostByName will be called to start a DNS lookup. */
 			}
 		}
 	}
@@ -451,7 +462,9 @@ TickType_t xIdentifier = 0;
 	/* Generate a unique identifier. */
 	if( 0 == ulIPAddress )
 	{
-		xIdentifier = ( TickType_t )ipconfigRAND32( );
+		/* DNS identifiers are 16-bit. */
+		uxIdentifier = ( TickType_t )( ipconfigRAND32( ) & 0xffffu );
+		/* ipconfigRAND32() may not return a non-zero value. */
 	}
 
 	#if( ipconfigDNS_USE_CALLBACKS != 0 )
@@ -461,10 +474,10 @@ TickType_t xIdentifier = 0;
 			if( ulIPAddress == 0UL )
 			{
 				/* The user has provided a callback function, so do not block on recvfrom() */
-				if( 0 != xIdentifier )
+				if( uxIdentifier != ( TickType_t ) 0u )
 				{
-					xReadTimeOut_ms = 0;
-					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )xIdentifier );
+					uxReadTimeOut_ticks = 0;
+					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )uxIdentifier );
 				}
 			}
 			else
@@ -476,16 +489,16 @@ TickType_t xIdentifier = 0;
 	}
 	#endif
 
-	if( ( ulIPAddress == 0UL ) && ( 0 != xIdentifier ) )
+	if( ( ulIPAddress == 0UL ) && ( uxIdentifier != ( TickType_t ) 0u ) )
 	{
-		ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
+		ulIPAddress = prvGetHostByName( pcHostName, uxIdentifier, uxReadTimeOut_ticks );
 	}
 
 	return ulIPAddress;
 }
 /*-----------------------------------------------------------*/
 
-static uint32_t prvGetHostByName( const char *pcHostName, TickType_t xIdentifier, TickType_t xReadTimeOut_ms )
+static uint32_t prvGetHostByName( const char *pcHostName, TickType_t uxIdentifier, TickType_t uxReadTimeOut_ticks )
 {
 struct freertos_sockaddr xAddress;
 Socket_t xDNSSocket;
@@ -494,8 +507,8 @@ uint8_t *pucUDPPayloadBuffer;
 uint32_t ulAddressLength = sizeof( struct freertos_sockaddr );
 BaseType_t xAttempt;
 int32_t lBytes;
-size_t xPayloadLength, xExpectedPayloadLength;
-TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
+size_t uxPayloadLength, uxExpectedPayloadLength;
+TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 
 #if( ipconfigUSE_LLMNR == 1 )
 	BaseType_t bHasDot = pdFALSE;
@@ -519,26 +532,26 @@ TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
 
 	/* Two is added at the end for the count of characters in the first
 	subdomain part and the string end byte. */
-	xExpectedPayloadLength = sizeof( DNSMessage_t ) + strlen( pcHostName ) + sizeof( uint16_t ) + sizeof( uint16_t ) + 2u;
+	uxExpectedPayloadLength = sizeof( DNSMessage_t ) + strlen( pcHostName ) + sizeof( uint16_t ) + sizeof( uint16_t ) + 2u;
 
 	xDNSSocket = prvCreateDNSSocket();
 
 	if( xDNSSocket != NULL )
 	{
-		FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_SNDTIMEO, ( void * ) &xWriteTimeOut_ms, sizeof( TickType_t ) );
-		FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_RCVTIMEO, ( void * ) &xReadTimeOut_ms,  sizeof( TickType_t ) );
+		FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_SNDTIMEO, ( void * ) &uxWriteTimeOut_ticks, sizeof( TickType_t ) );
+		FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_RCVTIMEO, ( void * ) &uxReadTimeOut_ticks,  sizeof( TickType_t ) );
 
 		for( xAttempt = 0; xAttempt < ipconfigDNS_REQUEST_ATTEMPTS; xAttempt++ )
 		{
 			/* Get a buffer.  This uses a maximum delay, but the delay will be
 			capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
 			still needs to be tested. */
-			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xExpectedPayloadLength, portMAX_DELAY );
+			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( uxExpectedPayloadLength, portMAX_DELAY );
 
 			if( pucUDPPayloadBuffer != NULL )
 			{
 				/* Create the message in the obtained buffer. */
-				xPayloadLength = prvCreateDNSMessage( pucUDPPayloadBuffer, pcHostName, xIdentifier );
+				uxPayloadLength = prvCreateDNSMessage( pucUDPPayloadBuffer, pcHostName, uxIdentifier );
 
 				iptraceSENDING_DNS_REQUEST();
 
@@ -564,15 +577,35 @@ TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
 
 				ulIPAddress = 0UL;
 
-				if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, xPayloadLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) != 0 )
+				if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, uxPayloadLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) != 0 )
 				{
 					/* Wait for the reply. */
 					lBytes = FreeRTOS_recvfrom( xDNSSocket, &pucUDPPayloadBuffer, 0, FREERTOS_ZERO_COPY, &xAddress, &ulAddressLength );
 
 					if( lBytes > 0 )
 					{
+					BaseType_t xExpected;
+					DNSMessage_t *pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
+
+						/* See if the identifiers match. */
+						if( uxIdentifier == ( TickType_t ) pxDNSMessageHeader->usIdentifier )
+						{
+							xExpected = pdTRUE;
+						}
+						else
+						{
+							/* The reply was not expected. */
+							xExpected = pdFALSE;
+						}
 						/* The reply was received.  Process it. */
-						ulIPAddress = prvParseDNSReply( pucUDPPayloadBuffer, lBytes, xIdentifier );
+					#if( ipconfigDNS_USE_CALLBACKS == 0 )
+						/* It is useless to analyse the unexpected reply
+						unless asynchronous look-ups are enabled. */
+						if( xExpected != pdFALSE )
+					#endif	/* ipconfigDNS_USE_CALLBACKS == 0 */
+						{
+							ulIPAddress = prvParseDNSReply( pucUDPPayloadBuffer, ( size_t ) lBytes, xExpected );
+						}
 
 						/* Finished with the buffer.  The zero copy interface
 						is being used, so the buffer must be freed by the
@@ -593,6 +626,12 @@ TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
 					FreeRTOS_ReleaseUDPPayloadBuffer( ( void * ) pucUDPPayloadBuffer );
 				}
 			}
+			if( uxReadTimeOut_ticks == 0u )
+			{
+				/* This DNS lookup is asynchronous, using a call-back:
+				send the request only once. */
+				break;
+			}
 		}
 
 		/* Finished with the socket. */
@@ -603,7 +642,7 @@ TickType_t xWriteTimeOut_ms = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
 }
 /*-----------------------------------------------------------*/
 
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t xIdentifier )
+static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer, const char *pcHostName, TickType_t uxIdentifier )
 {
 DNSMessage_t *pxDNSMessageHeader;
 uint8_t *pucStart, *pucByte;
@@ -623,7 +662,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 	/* Write in a unique identifier. */
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
-	pxDNSMessageHeader->usIdentifier = ( uint16_t ) xIdentifier;
+	pxDNSMessageHeader->usIdentifier = ( uint16_t ) uxIdentifier;
 
 	/* Create the resource record at the end of the header.  First
 	find the end of the header. */
@@ -675,7 +714,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
 
 	static uint8_t *prvReadNameField( uint8_t *pucByte, size_t xSourceLen, char *pcName, size_t xDestLen )
 	{
@@ -749,7 +788,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 		return pucByte;
 	}
-#endif	/* ipconfigUSE_DNS_CACHE == 1 */
+#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 /*-----------------------------------------------------------*/
 
 static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
@@ -812,24 +851,27 @@ static uint8_t *prvSkipNameField( uint8_t *pucByte, size_t xSourceLen )
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-DNSMessage_t *pxDNSMessageHeader;
+#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+	uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer )
+	{
+	DNSMessage_t *pxDNSMessageHeader;
 
-    if( pxNetworkBuffer->xDataLength >= sizeof( DNSMessage_t ) )
-    {
-        pxDNSMessageHeader = 
-            ( DNSMessage_t * )( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
+		if( pxNetworkBuffer->xDataLength >= sizeof( DNSMessage_t ) )
+		{
+			pxDNSMessageHeader =
+				( DNSMessage_t * )( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
 
-        prvParseDNSReply( ( uint8_t * )pxDNSMessageHeader,
-                          pxNetworkBuffer->xDataLength,
-                          ( uint32_t )pxDNSMessageHeader->usIdentifier );
-    }
+			/* The parameter pdFALSE indicates that the reply was not expected. */
+			prvParseDNSReply( ( uint8_t * )pxDNSMessageHeader,
+							  pxNetworkBuffer->xDataLength,
+							  pdFALSE );
+		}
 
-	/* The packet was not consumed. */
-	return pdFAIL;
-}
-/*-----------------------------------------------------------*/
+		/* The packet was not consumed. */
+		return pdFAIL;
+	}
+	/*-----------------------------------------------------------*/
+#endif
 
 #if( ipconfigUSE_NBNS == 1 )
 
@@ -838,11 +880,11 @@ DNSMessage_t *pxDNSMessageHeader;
 	UDPPacket_t *pxUDPPacket = ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 	uint8_t *pucUDPPayloadBuffer = pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t );
 
-        /* The network buffer data length has already been set to the 
-        length of the UDP payload. */
+		/* The network buffer data length has already been set to the
+		length of the UDP payload. */
 		prvTreatNBNS( pucUDPPayloadBuffer,
-						pxNetworkBuffer->xDataLength,
-						pxUDPPacket->xIPHeader.ulSourceIPAddress );
+					  pxNetworkBuffer->xDataLength,
+					  pxUDPPacket->xIPHeader.ulSourceIPAddress );
 
 		/* The packet was not consumed. */
 		return pdFAIL;
@@ -851,7 +893,7 @@ DNSMessage_t *pxDNSMessageHeader;
 #endif /* ipconfigUSE_NBNS */
 /*-----------------------------------------------------------*/
 
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier )
+static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, BaseType_t xExpected )
 {
 DNSMessage_t *pxDNSMessageHeader;
 DNSAnswerRecord_t *pxDNSAnswerRecord;
@@ -862,10 +904,11 @@ uint32_t ulIPAddress = 0UL;
 uint8_t *pucByte;
 size_t xSourceBytesRemaining;
 uint16_t x, usDataLength, usQuestions;
+BaseType_t xDoStore = xExpected;
 #if( ipconfigUSE_LLMNR == 1 )
 	uint16_t usType = 0, usClass = 0;
 #endif
-#if( ipconfigUSE_DNS_CACHE == 1 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
 	char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ] = "";
 #endif
 
@@ -874,15 +917,13 @@ uint16_t x, usDataLength, usQuestions;
 	{
 		return dnsPARSE_ERROR;
 	}
-	else
-	{
-		xSourceBytesRemaining = xBufferLength;
-	}
+	xSourceBytesRemaining = xBufferLength;
 
 	/* Parse the DNS message header. */
 	pxDNSMessageHeader = ( DNSMessage_t * ) pucUDPPayloadBuffer;
 
-	if( pxDNSMessageHeader->usIdentifier == ( uint16_t ) xIdentifier )
+	/* Introduce a do {} while (0) to allow the use of breaks. */
+	do
 	{
 		/* Start at the first byte after the header. */
 		pucByte = pucUDPPayloadBuffer + sizeof( DNSMessage_t );
@@ -901,7 +942,7 @@ uint16_t x, usDataLength, usQuestions;
 			}
 			#endif
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
 			if( x == 0 )
 			{
 				pucByte = prvReadNameField( pucByte,
@@ -914,13 +955,10 @@ uint16_t x, usDataLength, usQuestions;
 				{
 					return dnsPARSE_ERROR;
 				}
-				else
-				{
-					xSourceBytesRemaining = ( pucUDPPayloadBuffer + xBufferLength ) - pucByte;
-				}
+				xSourceBytesRemaining = ( pucUDPPayloadBuffer + xBufferLength ) - pucByte;
 			}
 			else
-#endif /* ipconfigUSE_DNS_CACHE */
+#endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 			{
 				/* Skip the variable length pcName field. */
 				pucByte = prvSkipNameField( pucByte,
@@ -931,10 +969,7 @@ uint16_t x, usDataLength, usQuestions;
 				{
 					return dnsPARSE_ERROR;
 				}
-				else
-				{
-					xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
-				}
+				xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
 			}
 
 			/* Check the remaining buffer size. */
@@ -942,7 +977,7 @@ uint16_t x, usDataLength, usQuestions;
 			{
 				#if( ipconfigUSE_LLMNR == 1 )
 				{
-					/* usChar2u16 returns value in host endianness */
+					/* usChar2u16 returns value in host endianness. */
 					usType = usChar2u16( pucByte );
 					usClass = usChar2u16( pucByte + 2 );
 				}
@@ -974,10 +1009,8 @@ uint16_t x, usDataLength, usQuestions;
 				{
 					return dnsPARSE_ERROR;
 				}
-				else
-				{
-					xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
-				}
+				xSourceBytesRemaining = pucUDPPayloadBuffer + xBufferLength - pucByte;
+
 
 				/* Is there enough data for an IPv4 A record answer and, if so,
 				is this an A record? */
@@ -995,17 +1028,34 @@ uint16_t x, usDataLength, usQuestions;
 								pucByte + sizeof( DNSAnswerRecord_t ),
 								sizeof( uint32_t ) );
 
-						#if( ipconfigUSE_DNS_CACHE == 1 )
-						{
-							prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
-						}
-						#endif /* ipconfigUSE_DNS_CACHE */
 						#if( ipconfigDNS_USE_CALLBACKS != 0 )
 						{
 							/* See if any asynchronous call was made to FreeRTOS_gethostbyname_a() */
-							vDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress );
+							if( xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress ) != pdFALSE )
+							{
+								/* This device has requested this DNS look-up.
+								The result may be stored in the DNS cache. */
+								xDoStore = pdTRUE;
+							}
 						}
 						#endif	/* ipconfigDNS_USE_CALLBACKS != 0 */
+						#if( ipconfigUSE_DNS_CACHE == 1 )
+						{
+							/* The reply will only be stored in the DNS cache when the
+							request was issued by this device. */
+							if( xDoStore != pdFALSE )
+							{
+								prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
+							}
+							/* Show what has happened. */
+							FreeRTOS_printf( ( "DNS[0x%04X]: The answer to '%s' (%xip) will%s be stored\n",
+								( unsigned )pxDNSMessageHeader->usIdentifier,
+								pcName,
+								( unsigned )FreeRTOS_ntohl( ulIPAddress ),
+								xDoStore ? "" : " NOT" ) );
+
+						}
+						#endif /* ipconfigUSE_DNS_CACHE */
 					}
 
 					pucByte += sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t );
@@ -1110,8 +1160,13 @@ uint16_t x, usDataLength, usQuestions;
 			}
 		}
 #endif /* ipconfigUSE_LLMNR == 1 */
-	}
+	} while( 0 );
 
+	if( xExpected != pdFALSE )
+	{
+		/* Do not return a valid IP-address in case the reply was not expected. */
+		ulIPAddress = 0uL;
+	}
 	return ulIPAddress;
 }
 /*-----------------------------------------------------------*/
@@ -1259,7 +1314,6 @@ static Socket_t prvCreateDNSSocket( void )
 Socket_t xSocket = NULL;
 struct freertos_sockaddr xAddress;
 BaseType_t xReturn;
-TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 
 	/* This must be the first time this function has been called.  Create
 	the socket. */
@@ -1277,9 +1331,7 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 	}
 	else
 	{
-		/* Set the send and receive timeouts. */
-		FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVTIMEO, ( void * ) &xTimeoutTime, sizeof( TickType_t ) );
-		FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDTIMEO, ( void * ) &xTimeoutTime, sizeof( TickType_t ) );
+		/* The send and receive timeouts will be set later on. */
 	}
 
 	return xSocket;
@@ -1311,9 +1363,9 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
 		{
 			/* calculate the IP header checksum */
-			pxIPHeader->usHeaderChecksum	   = 0x00;
-			pxIPHeader->usHeaderChecksum	   = usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-			pxIPHeader->usHeaderChecksum	   = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+			pxIPHeader->usHeaderChecksum = 0x00;
+			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
 			/* calculate the UDP checksum for outgoing package */
 			usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, lNetLength, pdTRUE );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1425,6 +1425,9 @@ BaseType_t xReturn;
 		pxUDPHeader->usLength			   = FreeRTOS_htons( lNetLength + ipSIZE_OF_UDP_HEADER );
 		vFlip_16( pxUDPPacket->xUDPHeader.usSourcePort, pxUDPPacket->xUDPHeader.usDestinationPort );
 
+		/* Important: tell NIC driver how many bytes must be sent */
+		pxNetworkBuffer->xDataLength = ( size_t ) ( lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
+
 		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
 		{
 			/* calculate the IP header checksum */
@@ -1433,12 +1436,9 @@ BaseType_t xReturn;
 			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
 			/* calculate the UDP checksum for outgoing package */
-			usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, lNetLength, pdTRUE );
+			usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
 		}
 		#endif
-
-		/* Important: tell NIC driver how many bytes must be sent */
-		pxNetworkBuffer->xDataLength = ( size_t ) ( lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
 
 		/* This function will fill in the eth addresses and send the packet */
 		vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1436,7 +1436,7 @@ BaseType_t xReturn;
 			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
 			/* calculate the UDP checksum for outgoing package */
-			usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+			usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
 		}
 		#endif
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -902,7 +902,7 @@ size_t xChunkLength;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+#if( ipconfigDNS_USE_CALLBACKS == 1 )
 	uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer )
 	{
 	DNSMessage_t *pxDNSMessageHeader;
@@ -922,7 +922,7 @@ size_t xChunkLength;
 		return pdFAIL;
 	}
 	/*-----------------------------------------------------------*/
-#endif /* if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 ) */
+#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
 #if( ipconfigUSE_NBNS == 1 )
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -902,7 +902,7 @@ size_t xChunkLength;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
+#if( ipconfigDNS_USE_CALLBACKS == 1 ) || ( ipconfigUSE_LLMNR == 1 )
 	uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer )
 	{
 	DNSMessage_t *pxDNSMessageHeader;
@@ -922,7 +922,7 @@ size_t xChunkLength;
 		return pdFAIL;
 	}
 	/*-----------------------------------------------------------*/
-#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
+#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) */
 
 #if( ipconfigUSE_NBNS == 1 )
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1221,7 +1221,7 @@ BaseType_t xDoStore = xExpected;
 #endif /* ipconfigUSE_LLMNR == 1 */
 	} while( 0 );
 
-	if( xExpected != pdFALSE )
+	if( xExpected == pdFALSE )
 	{
 		/* Do not return a valid IP-address in case the reply was not expected. */
 		ulIPAddress = 0uL;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -151,7 +151,7 @@ static uint32_t prvGetHostByName( const char *pcHostName,
 #endif /* ipconfigUSE_NBNS */
 
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
 	static uint8_t * prvReadNameField( uint8_t *pucByte,
 									   size_t xSourceLen,
 									   char *pcName,
@@ -290,7 +290,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 #endif /* ipconfigUSE_DNS_CACHE == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
+#if( ipconfigDNS_USE_CALLBACKS == 1 )
 
 	typedef struct xDNS_Callback
 	{
@@ -456,7 +456,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 		return xResult;
 	}
 
-#endif /* ipconfigDNS_USE_CALLBACKS != 0 */
+#endif /* ipconfigDNS_USE_CALLBACKS == 1 */
 /*-----------------------------------------------------------*/
 
 #if( ipconfigDNS_USE_CALLBACKS == 0 )
@@ -508,7 +508,7 @@ TickType_t uxIdentifier = 0;
 		/* ipconfigRAND32() may not return a non-zero value. */
 	}
 
-	#if( ipconfigDNS_USE_CALLBACKS != 0 )
+	#if( ipconfigDNS_USE_CALLBACKS == 1 )
 	{
 		if( pCallback != NULL )
 		{
@@ -528,7 +528,7 @@ TickType_t uxIdentifier = 0;
 			}
 		}
 	}
-	#endif /* if ( ipconfigDNS_USE_CALLBACKS != 0 ) */
+	#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
 	if( ( ulIPAddress == 0UL ) && ( uxIdentifier != ( TickType_t ) 0u ) )
 	{
@@ -761,7 +761,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
 
 	static uint8_t * prvReadNameField( uint8_t *pucByte,
 									   size_t xSourceLen,
@@ -961,7 +961,7 @@ BaseType_t xDoStore = xExpected;
 #if( ipconfigUSE_LLMNR == 1 )
 	uint16_t usType = 0, usClass = 0;
 #endif
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
 	char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ] = "";
 #endif
 
@@ -997,7 +997,7 @@ BaseType_t xDoStore = xExpected;
 			}
 			#endif
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS != 0 )
+#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
 			if( x == 0 )
 			{
 				pucByte = prvReadNameField( pucByte,
@@ -1085,7 +1085,7 @@ BaseType_t xDoStore = xExpected;
 								pucByte + sizeof( DNSAnswerRecord_t ),
 								sizeof( uint32_t ) );
 
-						#if( ipconfigDNS_USE_CALLBACKS != 0 )
+						#if( ipconfigDNS_USE_CALLBACKS == 1 )
 						{
 							/* See if any asynchronous call was made to FreeRTOS_gethostbyname_a() */
 							if( xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress ) != pdFALSE )
@@ -1095,7 +1095,7 @@ BaseType_t xDoStore = xExpected;
 								xDoStore = pdTRUE;
 							}
 						}
-						#endif /* ipconfigDNS_USE_CALLBACKS != 0 */
+						#endif /* ipconfigDNS_USE_CALLBACKS == 1 */
 						#if( ipconfigUSE_DNS_CACHE == 1 )
 						{
 							/* The reply will only be stored in the DNS cache when the

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
@@ -347,6 +347,19 @@ UDPPacket_t *pxUDPPacket = (UDPPacket_t *) pxNetworkBuffer->pucEthernetBuffer;
 		/* There is no socket listening to the target port, but still it might
 		be for this node. */
 
+		#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+			/* A DNS reply, check for the source port.  Although the DNS client
+			does open a UDP socket to send a messages, this socket will be
+			closed after a short timeout.  Messages that come late (after the
+			socket is closed) will be treated here. */
+			if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ipDNS_PORT )
+			{
+				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+				xReturn = ( BaseType_t )ulDNSHandlePacket( pxNetworkBuffer );
+			}
+			else
+		#endif
+
 		#if( ipconfigUSE_LLMNR == 1 )
 			/* a LLMNR request, check for the destination port. */
 			if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||


### PR DESCRIPTION
<!--- Title -->

DNS allow asynchronous look-up
-----------
<!--- Describe your changes in detail -->

This PR will replace [PR#293](https://github.com/aws/amazon-freertos/pull/293)

When `ipconfigDNS_USE_CALLBACKS` is defined as 1, it is possible to do an asynchronous DNS look-up by calling `FreeRTOS_gethostbyname_a()`.
For every returning DNS reply, it must be checked if it was expected or not. Only when the identifier in the reply was expected, it may update the DNS cache.


By default, the macro `ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME` is defined as `portMAX_DELAY`. As a consequence, the function `FreeRTOS_gethostbyname()` may block for ever.

In stead, I'd like to introduce time-out config parameters for the DNS socket. They are set in `FreeRTOSIPConfigDefaults.h` as follows:

    #define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 500u )
    #define ipconfigDNS_SEND_BLOCK_TIME_TICKS       pdMS_TO_TICKS( 500u )

Also, there was a bit of confusion between time-outs in ms versus ticks. It should have been ticks and not ms.


Some of the DNS macro's express a value that is compared to an unsigned short, such as:

    #define dnsEXPECTED_RX_FLAGS   0x8000

Of course these values need a trailing 'u' to make them unsigned.


Both `ipconfigUSE_LLMNR` and `ipconfigUSE_NBNS` need `ipconfigUSE_DNS` to be defined as non-zero. This relationship was tested in FreeRTOSIPConfigDefaults.h but not in a correct way.

The is not yet linted, I'd like to do that in a separate PR.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.