### PR TITLE
aws_tcp_echo_client_single_task.c : a time-out is not fatal (second version)

### DIFF
--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -198,15 +198,19 @@ static void prvEchoClientTask( void * pvParameters )
     char * pcReceivedString;
     TickType_t xTimeOnEntering;
 
-#if ( ipconfigUSE_TCP_WIN == 1 )
-    WinProperties_t xWinProps;
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        WinProperties_t xWinProps;
+    #endif
 
-    /* Fill in the buffer and window sizes that will be used by the socket. */
-    xWinProps.lTxBufSize = ipconfigTCP_TX_BUFFER_LENGTH;
-    xWinProps.lTxWinSize = configECHO_CLIENT_TX_WINDOW_SIZE;
-    xWinProps.lRxBufSize = ipconfigTCP_RX_BUFFER_LENGTH;
-    xWinProps.lRxWinSize = configECHO_CLIENT_RX_WINDOW_SIZE;
-#endif /* ipconfigUSE_TCP_WIN */
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        {
+            /* Fill in the buffer and window sizes that will be used by the socket. */
+            xWinProps.lTxBufSize = ipconfigTCP_TX_BUFFER_LENGTH;
+            xWinProps.lTxWinSize = configECHO_CLIENT_TX_WINDOW_SIZE;
+            xWinProps.lRxBufSize = ipconfigTCP_RX_BUFFER_LENGTH;
+            xWinProps.lRxWinSize = configECHO_CLIENT_RX_WINDOW_SIZE;
+        }
+    #endif /* ipconfigUSE_TCP_WIN */
 
     /* This task can be created a number of times.  Each instance is numbered
      * to enable each instance to use a different Rx and Tx buffer.  The number is

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -343,9 +343,9 @@ static void prvEchoClientTask( void * pvParameters )
                         break;
                     }
                 }
-                else if( xReceivedBytes < 0 )
+                else if( xReceivedBytes == -pdFREERTOS_ERRNO_ENOTCONN )
                 {
-                    /* SOCKETS_Recv() returned an error. */
+                    /* The connection got closed. */
                     break;
                 }
                 else

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -198,17 +198,15 @@ static void prvEchoClientTask( void * pvParameters )
     char * pcReceivedString;
     TickType_t xTimeOnEntering;
 
-    #if ( ipconfigUSE_TCP_WIN == 1 )
-        {
-            WinProperties_t xWinProps;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    WinProperties_t xWinProps;
 
-            /* Fill in the buffer and window sizes that will be used by the socket. */
-            xWinProps.lTxBufSize = ipconfigTCP_TX_BUFFER_LENGTH;
-            xWinProps.lTxWinSize = configECHO_CLIENT_TX_WINDOW_SIZE;
-            xWinProps.lRxBufSize = ipconfigTCP_RX_BUFFER_LENGTH;
-            xWinProps.lRxWinSize = configECHO_CLIENT_RX_WINDOW_SIZE;
-        }
-    #endif /* ipconfigUSE_TCP_WIN */
+    /* Fill in the buffer and window sizes that will be used by the socket. */
+    xWinProps.lTxBufSize = ipconfigTCP_TX_BUFFER_LENGTH;
+    xWinProps.lTxWinSize = configECHO_CLIENT_TX_WINDOW_SIZE;
+    xWinProps.lRxBufSize = ipconfigTCP_RX_BUFFER_LENGTH;
+    xWinProps.lRxWinSize = configECHO_CLIENT_RX_WINDOW_SIZE;
+#endif /* ipconfigUSE_TCP_WIN */
 
     /* This task can be created a number of times.  Each instance is numbered
      * to enable each instance to use a different Rx and Tx buffer.  The number is

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -154,31 +154,31 @@ static char cTxBuffers[ echoNUM_ECHO_CLIENTS ][ echoBUFFER_SIZES ],
 /*-----------------------------------------------------------*/
 
 int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
-                 const char * pIdentifier,
-                 void * pNetworkServerInfo,
-                 void * pNetworkCredentialInfo,
-                 const IotNetworkInterface_t * pNetworkInterface )
+                                          const char * pIdentifier,
+                                          void * pNetworkServerInfo,
+                                          void * pNetworkCredentialInfo,
+                                          const IotNetworkInterface_t * pNetworkInterface )
 {
     BaseType_t xX;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
 
     /* Unused parameters */
-    ( void )awsIotMqttMode;
-    ( void )pIdentifier;
-    ( void )pNetworkServerInfo;
-    ( void )pNetworkCredentialInfo;
-    ( void )pNetworkInterface;
+    ( void ) awsIotMqttMode;
+    ( void ) pIdentifier;
+    ( void ) pNetworkServerInfo;
+    ( void ) pNetworkCredentialInfo;
+    ( void ) pNetworkInterface;
 
     /* Create the echo client tasks. */
     for( xX = 0; xX < echoNUM_ECHO_CLIENTS; xX++ )
     {
-        snprintf( cNameBuffer, echoMAX_TASK_NAME_LENGTH, "Echo%ld", (long int)xX );
-        xTaskCreate( prvEchoClientTask,                               /* The function that implements the task. */
-                     cNameBuffer,                                     /* Just a text name for the task to aid debugging. */
+        snprintf( cNameBuffer, echoMAX_TASK_NAME_LENGTH, "Echo%ld", ( long int ) xX );
+        xTaskCreate( prvEchoClientTask,        /* The function that implements the task. */
+                     cNameBuffer,              /* Just a text name for the task to aid debugging. */
                      democonfigDEMO_STACKSIZE, /* The stack size is defined in FreeRTOSIPConfig.h. */
-                     ( void * ) xX,                                   /* The task parameter, not used in this case. */
-                     democonfigDEMO_PRIORITY,   /* The priority assigned to the task is defined in FreeRTOSConfig.h. */
-                     NULL );                                          /* The task handle is not used. */
+                     ( void * ) xX,            /* The task parameter, not used in this case. */
+                     democonfigDEMO_PRIORITY,  /* The priority assigned to the task is defined in FreeRTOSConfig.h. */
+                     NULL );                   /* The task handle is not used. */
     }
 
     return 0;

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -162,12 +162,12 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     BaseType_t xX;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
 
-	/* Unused parameters */
-	( void )awsIotMqttMode;
-	( void )pIdentifier;
-	( void )pNetworkServerInfo;
-	( void )pNetworkCredentialInfo;
-	( void )pNetworkInterface;
+    /* Unused parameters */
+    ( void )awsIotMqttMode;
+    ( void )pIdentifier;
+    ( void )pNetworkServerInfo;
+    ( void )pNetworkCredentialInfo;
+    ( void )pNetworkInterface;
 
     /* Create the echo client tasks. */
     for( xX = 0; xX < echoNUM_ECHO_CLIENTS; xX++ )
@@ -323,7 +323,7 @@ static void prvEchoClientTask( void * pvParameters )
                 /* If an error occurred it will be latched in xReceivedBytes,
                  * otherwise xReceived bytes will be just that - the number of
                  * bytes received from the echo server. */
-                if( xReceivedBytes > 0 )
+                if( xReceivedBytes == xTransmitted )
                 {
                     /* Compare the transmitted string to the received string. */
                     configASSERT( strncmp( pcReceivedString, pcTransmittedString, xTransmitted ) == 0 );
@@ -350,6 +350,11 @@ static void prvEchoClientTask( void * pvParameters )
                 }
                 else
                 {
+                    /* The received length did not match the transmitted
+                     * length. */
+                    ulTxRxFailures[ xInstance ]++;
+                    configPRINTF( ( "ERROR: xTransmitted %d xReceivedBytes %d \r\n",
+                                    ( int ) xTransmitted, ( int ) xReceivedBytes ) );
                     /* Timed out without receiving anything? */
                     break;
                 }


### PR DESCRIPTION
<!--- Title -->

aws_tcp_echo_client_single_task.c : a time-out is not fatal (second version)

Description
-----------

The earlier PR #354 had too many conflicts, this one will replace it.

When the reception of data times out, and at least 1 byte has been received, an ASSERT will be thrown because the contents does not match.
When the number of bytes received is less than expected, it would be nicer to just consider this as a failure. The link may have failed, the remote party is too slow, etc.

Only when the expected number of bytes was received, but the received string does not match, this should be a fatal error ( calling configASSERT() ).

Also I replaced a few tabs with spaces, to make it confirm Crustify.cfg.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.