### PR TITLE
Add CBMC proof for TaskDelay

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskDelay/Configurations.json
+++ b/tools/cbmc/proofs/TaskPool/TaskDelay/Configurations.json
@@ -1,0 +1,40 @@
+{
+  "ENTRY": "TaskDelay",
+  "DEF":
+  [
+    { "default" :
+      [
+        "FREERTOS_MODULE_TEST",
+        "PENDED_TICKS=1",
+        "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+        "configUSE_TRACE_FACILITY=0",
+        "configGENERATE_RUN_TIME_STATS=0"
+      ]
+    },
+    { "vTaskSuspend0" :
+      [
+        "FREERTOS_MODULE_TEST",
+        "PENDED_TICKS=1",
+        "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+        "configUSE_TRACE_FACILITY=0",
+        "configGENERATE_RUN_TIME_STATS=0",
+        "INCLUDE_vTaskSuspend=0"
+      ]
+    }
+  ],
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:4"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskDelay/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskDelay/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskDelay/README.md
@@ -1,0 +1,11 @@
+This proof demonstrates the memory safety of the TaskDelay function.  We assume
+that `pxCurrentTCB` is initialized and inserted in one of the ready tasks lists
+(with and without another task in the same list). We abstract function
+`xTaskResumeAll` by assuming that `xPendingReadyList` is empty and
+`uxPendedTicks` is `0`. Finally, we assume nondeterministic values for global
+variables `xTickCount` and `xNextTaskUnblockTime`, and `pdFALSE` for
+`uxSchedulerSuspended` (to avoid assertion failure).
+
+Configurations available:
+ * `default`: The default configuration.  `useTickHook1`: The default
+ * configuration with `INCLUDE_vTaskSuspend=0`

--- a/tools/cbmc/proofs/TaskPool/TaskDelay/TaskDelay_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskDelay/TaskDelay_harness.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vSetGlobalVariables( void );
+BaseType_t xPrepareTaskLists( void );
+BaseType_t xTaskResumeAllStub( void );
+
+/*
+ * This is a trick to overcome the "redefined twice" error
+ * when stubbing out the `xTaskResumeAll` function in the header
+ */
+BaseType_t xTaskResumeAll( void ) {
+	return xTaskResumeAllStub();
+}
+
+/*
+ * The harness test first calls two functions included in the tasks.c file
+ * that initialize the task lists and other global variables
+ */
+void harness()
+{
+	TickType_t xTicksToDelay;
+	BaseType_t xTasksPrepared;
+
+	vSetGlobalVariables();
+	xTasksPrepared = xPrepareTaskLists();
+
+	if ( xTasksPrepared != pdFAIL )
+	{
+		vTaskDelay( xTicksToDelay );
+	}
+}
+
+

--- a/tools/cbmc/proofs/TaskPool/TaskDelay/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskDelay/tasks_test_access_functions.h
@@ -1,0 +1,117 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	__CPROVER_assume( pxTCB->uxPriority < configMAX_PRIORITIES );
+
+	vListInitialiseItem( &( pxTCB->xStateListItem ) );
+	vListInitialiseItem( &( pxTCB->xEventListItem ) );
+
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xStateListItem ), pxTCB );
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xEventListItem ), pxTCB );
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), portMAX_DELAY );
+	}
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), portMAX_DELAY );
+	}
+	return pxTCB;
+}
+
+/*
+ * We set the values of relevant global variables to
+ * nondeterministic values, except for `uxSchedulerSuspended`
+ * which is set to 0 (to pass through the assertion)
+ */
+ 
+void vSetGlobalVariables( void )
+{
+	uxSchedulerSuspended = pdFALSE;
+	xTickCount = nondet();
+	xNextTaskUnblockTime = nondet();
+}
+
+/*
+ * We initialise and fill the task lists so coverage is optimal.
+ * This initialization is not guaranteed to be minimal, but it
+ * is quite efficient and it serves the same purpose
+ */
+BaseType_t xPrepareTaskLists( void )
+{
+	TCB_t * pxTCB = NULL;
+
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	/* The current task will be moved to the delayed list */
+	pxCurrentTCB = xUnconstrainedTCB();
+	if ( pxCurrentTCB == NULL )
+	{
+		return pdFAIL;
+	}
+	vListInsert( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ], &( pxCurrentTCB->xStateListItem ) );
+
+	/*
+	 * Nondeterministic insertion of a task in the ready tasks list
+	 * guarantees coverage in line 5104 (tasks.c)
+	 */
+	if ( nondet_bool() )
+	{
+		pxTCB = xUnconstrainedTCB();
+		if ( pxTCB == NULL )
+		{
+			return pdFAIL;
+		}
+		vListInsert( &pxReadyTasksLists[ pxTCB->uxPriority ], &( pxTCB->xStateListItem ) );
+		
+		/* Use of this macro ensures coverage on line 185 (list.c) */
+		listGET_OWNER_OF_NEXT_ENTRY( pxTCB , &pxReadyTasksLists[ pxTCB->uxPriority ] );
+	}
+	
+
+	return pdPASS;
+}
+
+/*
+ * We stub out `xTaskResumeAll` including the assertion and change on
+ * variables `uxSchedulerSuspended`. We assume that `xPendingReadyList`
+ * is empty to avoid the first loop, and uxPendedTicks to avoid the second
+ * one. Finally, we return a nondeterministic value (overapproximation)
+ */
+BaseType_t xTaskResumeAllStub( void )
+{
+	BaseType_t xAlreadyYielded;
+
+	configASSERT( uxSchedulerSuspended );
+
+	taskENTER_CRITICAL();
+	{
+		--uxSchedulerSuspended;
+		__CPROVER_assert( listLIST_IS_EMPTY( &xPendingReadyList ), "Pending ready tasks list not empty." );
+		__CPROVER_assert( uxPendedTicks == 0 , "uxPendedTicks is not equal to zero.");
+	}
+	taskEXIT_CRITICAL();
+
+	return xAlreadyYielded;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskDelay.

This proof depends on #774 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.