### PR TITLE
Add CBMC proof for TaskDelete

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskDelete/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskDelete/Makefile.json
@@ -1,0 +1,28 @@
+{
+  "ENTRY": "TaskDelete",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+    "'configASSERT(X)=__CPROVER_assert(X, \"Assertion Error\")'",
+    "STACK_DEPTH=10",
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:3"
+
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskDelete/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskDelete/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskDelete/README.md
@@ -1,0 +1,8 @@
+This proof demonstrates the memory safety of the TaskDelete function.  The
+initialization for the task to be delete and `pxCurrentTCB` is quite similar
+(since the task handle may be NULL, and in that case `pxCurrentTCB` is used).
+The task to be deleted requires the stack in the task control block to be
+allocated, and the flag for static allocation to be properly set (i.e., valid
+values as defined by the macros) Task lists are initialized with these tasks
+and nondet. filled with a few more items.  We assume a nondet. value for
+`xSchedulerRunning`.

--- a/tools/cbmc/proofs/TaskPool/TaskDelete/TaskDelete_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskDelete/TaskDelete_harness.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vSetGlobalVariables();
+BaseType_t xPrepareTaskLists( TaskHandle_t * xTask );
+
+/*
+ * The harness test first calls two functions included in the tasks.c file
+ * that initialize the task lists and other global variables
+ */
+void harness()
+{
+	TaskHandle_t xTaskToDelete;
+	BaseType_t xTasksPrepared;
+
+	vSetGlobalVariables();
+	xTasksPrepared = xPrepareTaskLists( &xTaskToDelete );
+
+	if ( xTasksPrepared != pdFAIL )
+	{
+		vTaskDelete( xTaskToDelete );
+	}
+}

--- a/tools/cbmc/proofs/TaskPool/TaskDelete/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskDelete/tasks_test_access_functions.h
@@ -1,0 +1,149 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+	uint8_t ucStaticAllocationFlag;
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	__CPROVER_assume( pxTCB->uxPriority < configMAX_PRIORITIES );
+
+	vListInitialiseItem( &( pxTCB->xStateListItem ) );
+	vListInitialiseItem( &( pxTCB->xEventListItem ) );
+
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xStateListItem ), pxTCB );
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xEventListItem ), pxTCB );
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), portMAX_DELAY );
+	}
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), portMAX_DELAY );
+	}
+
+	pxTCB->pxStack = ( StackType_t * ) pvPortMalloc( ( ( ( size_t ) STACK_DEPTH ) * sizeof( StackType_t ) ) );
+	if ( pxTCB->pxStack == NULL )
+	{
+		vPortFree( pxTCB );
+		return NULL;
+	}
+
+	__CPROVER_assume( ucStaticAllocationFlag <= tskSTATICALLY_ALLOCATED_STACK_AND_TCB );
+	__CPROVER_assume( ucStaticAllocationFlag >= tskDYNAMICALLY_ALLOCATED_STACK_AND_TCB );
+	pxTCB->ucStaticallyAllocated = ucStaticAllocationFlag;
+
+	return pxTCB;
+}
+
+/*
+ * We set the values of relevant global
+ * variables to nondeterministic values
+ */
+void vSetGlobalVariables()
+{
+	xSchedulerRunning = nondet();
+}
+
+/*
+ * We initialise and fill the task lists so coverage is optimal.
+ * This initialization is not guaranteed to be minimal, but it
+ * is quite efficient and it serves the same purpose
+ */
+BaseType_t xPrepareTaskLists( TaskHandle_t * xTask )
+{
+	TCB_t * pxTCB = NULL;
+
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	/*
+	 * The task handle passed to TaskDelete can be NULL. In that case, the
+	 * task to delete is the one in `pxCurrentTCB`, see the macro `prvGetTCBFromHandle`
+	 * in line 1165 (tasks.c) for reference. For that reason, we provide a similar
+	 * initialization for an arbitrary task `pxTCB` and `pxCurrentTCB`.
+	 */
+
+	pxTCB = xUnconstrainedTCB();
+	if ( pxTCB != NULL )
+	{
+		/* 
+		 * The `return pdFAIL` statement that follows can be uncommented
+		 * to test coverage when the task handle passed to TaskDelete is NULL
+		 */
+		// return pdFAIL;
+		if ( nondet_bool() )
+		{
+			TCB_t * pxOtherTCB;
+			pxOtherTCB = xUnconstrainedTCB();
+			/*
+			 * Nondeterministic insertion of another TCB in the same list
+			 * to guarantee coverage in line 1174 (tasks.c)
+			 */
+			if ( pxOtherTCB != NULL )
+			{
+				vListInsert( &xPendingReadyList, &( pxOtherTCB->xStateListItem ) );
+			}
+		}
+		vListInsert( &xPendingReadyList, &( pxTCB->xStateListItem ) );
+
+		/*
+		 * Nondeterministic insertion of an event list item to guarantee
+		 * coverage in lines 1180-1184 (tasks.c)
+		 */
+		if ( nondet_bool() )
+		{
+			vListInsert( pxDelayedTaskList, &( pxTCB->xEventListItem ) );
+		}
+	}
+
+	/* Note that `*xTask = NULL` can happen here, but this is fine -- `pxCurrentTCB` will be used instead */
+	*xTask = pxTCB;
+
+	/*
+	 * `pxCurrentTCB` must be initialized the same way as the previous task, but an
+	 * allocation failure cannot happen in this case (i.e., if the previous task is NULL)
+	 */
+	pxCurrentTCB = xUnconstrainedTCB();
+	if ( pxCurrentTCB == NULL )
+	{
+		return pdFAIL;
+	}
+
+	if ( nondet_bool() )
+	{
+		TCB_t * pxOtherTCB;
+		pxOtherTCB = xUnconstrainedTCB();
+		if ( pxOtherTCB != NULL )
+		{
+			vListInsert( &pxReadyTasksLists[ pxOtherTCB->uxPriority ], &( pxOtherTCB->xStateListItem ) );
+		}
+	}
+	vListInsert( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ], &( pxCurrentTCB->xStateListItem ) );
+	
+	/* Use of this macro ensures coverage on line 185 (list.c) */
+	listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB , &pxReadyTasksLists[ pxCurrentTCB->uxPriority ] );
+
+	if ( nondet_bool() )
+	{
+		vListInsert( pxDelayedTaskList, &( pxCurrentTCB->xEventListItem ) );
+	}
+
+	return pdPASS;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskDelay.

This proof depends on #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.