### PR TITLE
Add CBMC proof for TaskStartScheduler

### DIFF
--- a/freertos_kernel/queue.c
+++ b/freertos_kernel/queue.c
@@ -521,6 +521,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength, const UBaseT
 	QueueHandle_t xNewQueue;
 	const UBaseType_t uxMutexLength = ( UBaseType_t ) 1, uxMutexSize = ( UBaseType_t ) 0;
 
+		configASSERT( pxStaticQueue );
+
 		/* Prevent compiler warnings about unused parameters if
 		configUSE_TRACE_FACILITY does not equal 1. */
 		( void ) ucQueueType;

--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/patches/0003-Replace-MiniListItem_t-with-ListItem_t.patch
+++ b/tools/cbmc/patches/0003-Replace-MiniListItem_t-with-ListItem_t.patch
@@ -1,21 +1,18 @@
-From a81bec40a58ce45101adcea98239964da5826ec1 Mon Sep 17 00:00:00 2001
-From: Kareem Khazem <karkhaz@amazon.com>
-Date: Thu, 31 Jan 2019 15:15:43 -0800
-Subject: [PATCH 3/4] Replace MiniListItem_t with ListItem_t
-
-MiniListItem_t is intended to be the last element of a linked list. It
-saves space by having a payload but no `next' pointer, since there is no
-next element. CBMC gets confused when it sees a list of ListItem_ts with
-a smaller MiniListItem_t at the end, so this commit makes the last
-element of lists a ListItem_t instead.
-
-This patch should be removed soon: It is for a CBMC issue being fixed now.
----
- freertos_kernel/include/list.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
+diff --git a/freertos_kernel/include/FreeRTOS.h b/freertos_kernel/include/FreeRTOS.h
+index 84559a14..bf2211e7 100644
+--- a/freertos_kernel/include/FreeRTOS.h
++++ b/freertos_kernel/include/FreeRTOS.h
+@@ -1072,7 +1072,7 @@ typedef struct xSTATIC_LIST
+ 	#endif
+ 	UBaseType_t uxDummy2;
+ 	void *pvDummy3;
+-	StaticMiniListItem_t xDummy4;
++	StaticListItem_t xDummy4;
+ 	#if( configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES == 1 )
+ 		TickType_t xDummy5;
+ 	#endif
 diff --git a/freertos_kernel/include/list.h b/freertos_kernel/include/list.h
-index 43e0ffffb..f6c6b6636 100644
+index 48ad64df..016350a6 100644
 --- a/freertos_kernel/include/list.h
 +++ b/freertos_kernel/include/list.h
 @@ -166,7 +166,7 @@ typedef struct xLIST
@@ -26,7 +23,7 @@ index 43e0ffffb..f6c6b6636 100644
 +	ListItem_t xListEnd;
  	listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
  } List_t;
- 
--- 
+
+--
 2.21.0
 

--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -72,7 +72,10 @@ unpatch:
 #
 # Rules for building the CBMC harness
 
-$(ENTRY)_harness.goto: $(ENTRY)_harness.c
+queue_datastructure.h: $(filter-out $(ENTRY)_harness.goto, $(OBJS))
+	python3 @TYPE_HEADER_SCRIPT@ $(FREERTOS)/freertos_kernel/queue.goto $(FREERTOS)/freertos_kernel/queue.c
+
+$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(filter-out $(ENTRY)_harness.goto, $(OBJS)) $(H_GENERATE_HEADER)
 	$(GOTO_CC) @COMPILE_ONLY@ @RULE_OUTPUT@ $(INC) $(CFLAGS) @RULE_INPUT@
 
 $(ENTRY)1.goto: $(OBJS)
@@ -139,6 +142,7 @@ clean:
 	@RM@ $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
 	@RM@ cbmc.txt property.xml coverage.xml TAGS
 	@RM@ *~ \#*
+	@RM@ queue_datastructure.h
 
 
 veryclean: clean

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -40,6 +40,10 @@
 	"--32",
 	"--bounds-check",
 	"--pointer-check"
+    ],
+
+    "TYPE_HEADERS": [
+        "$(FREERTOS)/freertos_kernel/queue.c"
     ]
 }
 

--- a/tools/cbmc/proofs/MakefileLinux.json
+++ b/tools/cbmc/proofs/MakefileLinux.json
@@ -29,5 +29,8 @@
     ],
     "CP": [
 	"cp"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)/make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/MakefileWindows.json
+++ b/tools/cbmc/proofs/MakefileWindows.json
@@ -37,5 +37,8 @@
     ],
     "CP": [
 	"copy"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)\\make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/Makefile.json
+++ b/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "QueueCreateCountingSemaphoreStatic",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "GENERATE_HEADER": [
+    "queue_datastructure.h"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/QueueCreateCountingSemaphoreStatic_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/QueueCreateCountingSemaphoreStatic_harness.c
@@ -1,0 +1,17 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "cbmc.h"
+
+
+void harness(){
+    UBaseType_t uxMaxCount;
+    UBaseType_t uxInitialCount;
+
+    //xStaticQueue is required to be not null
+    StaticQueue_t xStaticQueue;
+
+    //Checked invariant
+    __CPROVER_assume(uxMaxCount != 0);
+    __CPROVER_assume(uxInitialCount <= uxMaxCount);
+    xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, &xStaticQueue );
+}

--- a/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/README.md
+++ b/tools/cbmc/proofs/Queue/QueueCreateCountingSemaphoreStatic/README.md
@@ -1,0 +1,3 @@
+Assuming uxMaxCount > 0, uxInitialCount <= uxMaxCount and the reference
+to the storage area is not null,
+this harness proves the memory saftey of QueueCreateCountingSemphoreStatic.

--- a/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/Makefile.json
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "QueueCreateMutexStatic",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "GENERATE_HEADER": [
+    "queue_datastructure.h"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/QueueCreateMutexStatic_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/QueueCreateMutexStatic_harness.c
@@ -1,0 +1,13 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "cbmc.h"
+
+
+void harness(){
+    uint8_t ucQueueType;
+
+    //The mutex storage is assumed to be not null.
+    StaticQueue_t xStaticQueue;
+
+    xQueueCreateMutexStatic( ucQueueType, &xStaticQueue );
+}

--- a/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/README.md
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutexStatic/README.md
@@ -1,0 +1,4 @@
+Given that the passed mutex storage area is not null, the QueueCreateMutexStatic
+function is memory safe.
+
+Otherwise an assertion violation is triggered.

--- a/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/Configurations.json
+++ b/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/Configurations.json
@@ -1,0 +1,36 @@
+{
+  "ENTRY": "QueueGenericCreateStatic",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    {
+      "QeueuGenericCreateStatic_DynamicAllocation": [
+        "configUSE_TRACE_FACILITY=0",
+        "configGENERATE_RUN_TIME_STATS=0",
+        "configSUPPORT_STATIC_ALLOCATION=1",
+        "configSUPPORT_DYNAMIC_ALLOCATION=1"
+      ]
+    },
+    {
+      "QeueuGenericCreateStatic_NoDynamicAllocation": [
+        "configUSE_TRACE_FACILITY=0",
+        "configGENERATE_RUN_TIME_STATS=0",
+        "configSUPPORT_STATIC_ALLOCATION=1",
+        "configSUPPORT_DYNAMIC_ALLOCATION=0"
+      ]
+    }
+  ],
+  "GENERATE_HEADER": [
+    "queue_datastructure.h"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/QueueGenericCreateStatic_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/QueueGenericCreateStatic_harness.c
@@ -1,0 +1,30 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "queue_datastructure.h"
+#include "cbmc.h"
+
+
+void harness(){
+    UBaseType_t uxQueueLength;
+    UBaseType_t uxItemSize;
+    uint8_t *ucQueueStorage = (uint8_t *) pvPortMalloc(sizeof(uint8_t));
+
+    //The queue storage space is explicitly assumed to be not null.
+    StaticQueue_t xStaticQueue;
+    uint8_t ucQueueType;
+
+    /* The QueueGenericReset method called during static queue creation
+       implicitly that there are no overflows in the computation
+       and the inputs are safe. There is no check for this in the code base. */
+    UBaseType_t upper_bound = portMAX_DELAY - sizeof(Queue_t);
+    __CPROVER_assume(uxItemSize < (upper_bound)/uxQueueLength);
+    __CPROVER_assume(uxQueueLength > ( UBaseType_t ) 0);
+    if(!ucQueueStorage){
+        uxItemSize = 0;
+    }else{
+        __CPROVER_assume(uxItemSize > 0);
+    }
+
+    xQueueGenericCreateStatic( uxQueueLength, uxItemSize, ucQueueStorage, &xStaticQueue, ucQueueType );
+}
+

--- a/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/README.md
+++ b/tools/cbmc/proofs/Queue/QueueGenericCreateStatic/README.md
@@ -1,0 +1,8 @@
+The harness proves memory safety of
+QueueGenericCreateStatic under the assumption made in the harness.
+
+The principal assumption is that (uxItemSize * uxQueueLength) + sizeof(Queue_t)
+does not overflow. Further, ucQueueStorage must only be null iff uxItemSize is null.
+In addition, the passed queue storage is assumed to be allocated to the right size.
+
+The configurations for configSUPPORT_DYNAMIC_ALLOCATION set to 0 and 1 are checked.

--- a/tools/cbmc/proofs/TaskPool/TaskStartScheduler/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskStartScheduler/Makefile.json
@@ -1,0 +1,27 @@
+{
+  "ENTRY": "TaskStartScheduler",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1",
+      "--unwindset prvInitialiseTaskLists.0:8,prvInitialiseNewTask.0:16,prvInitialiseNewTask.1:4"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto",
+    "$(FREERTOS)/freertos_kernel/timers.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskStartScheduler/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskStartScheduler/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskStartScheduler/README.md
@@ -1,0 +1,7 @@
+This proof demonstrates the memory safety of the TaskStartScheduler function.
+We assume that buffers for `pxIdleTaskTCB` and `pxTimerTaskTCB` (and their
+associated stacks `pxIdleTaskStack` and `pxTimerTaskStack`) have been
+previously allocated. The arguments passed by reference to
+`vApplicationGetIdleTaskMemory` and `vApplicationGetTimerTaskMemory` are
+assigned to these pointers since both functions expect statically-allocated
+buffers to be passed.

--- a/tools/cbmc/proofs/TaskPool/TaskStartScheduler/TaskStartScheduler_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskStartScheduler/TaskStartScheduler_harness.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+BaseType_t xPrepareTasks( void );
+
+/*
+ * We prepare `pxCurrentTCB` and the idle/timer task buffers
+ * (TCB + stack), then we call the function if allocation was ok
+ */
+void harness()
+{
+	BaseType_t xTasksPrepared;
+
+    xTasksPrepared = xPrepareTasks();
+
+    if ( xTasksPrepared != pdFAIL )
+    {
+	   vTaskStartScheduler();
+    }
+}

--- a/tools/cbmc/proofs/TaskPool/TaskStartScheduler/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskStartScheduler/tasks_test_access_functions.h
@@ -1,0 +1,82 @@
+#include "cbmc.h"
+
+/*
+ * We allocate an unconstrained TCB or return NULL if it fails
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	return pxTCB;
+}
+
+StaticTask_t *pxIdleTaskTCB;
+StaticTask_t *pxTimerTaskTCB;
+StackType_t  *pxIdleTaskStack;
+StackType_t  *pxTimerTaskStack;
+
+/*
+ * `pxCurrentTCB` allocation is allowed to fail. The global variables above
+ * this comment are used in the stubbed functions `vApplicationGetIdleTaskMemory`
+ * and `vApplicationGetTimerTaskMemory` (at the end of this file) and buffer allocation
+ * must be succesful for the proof to have no errors
+ */
+BaseType_t xPrepareTasks( void )
+{
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	pxCurrentTCB = xUnconstrainedTCB();
+
+	pxIdleTaskTCB = pvPortMalloc(sizeof(StaticTask_t));
+	if (pxIdleTaskTCB == NULL )
+	{
+		return pdFAIL;
+	}
+
+	pxIdleTaskStack = pvPortMalloc( sizeof(StackType_t) * configMINIMAL_STACK_SIZE );
+	if ( pxIdleTaskStack == NULL )
+	{
+		return pdFAIL;
+	}
+
+	pxTimerTaskTCB = pvPortMalloc( sizeof(StaticTask_t) );
+	if ( pxTimerTaskTCB == NULL )
+	{
+		return pdFAIL;
+	}
+
+	pxTimerTaskStack = pvPortMalloc( sizeof(StackType_t) * configTIMER_TASK_STACK_DEPTH );
+	if ( pxTimerTaskStack == NULL )
+	{
+		return pdFAIL;
+	}
+
+	return pdPASS;
+}
+
+/*
+ * The buffers used here have been succesfully allocated before (global variables)
+ */
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
+{
+	*ppxIdleTaskTCBBuffer = pxIdleTaskTCB;
+	*ppxIdleTaskStackBuffer = pxIdleTaskStack;
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+/*
+ * The buffers used here have been succesfully allocated before (global variables)
+ */
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize )
+{
+	*ppxTimerTaskTCBBuffer = pxTimerTaskTCB;
+	*ppxTimerTaskStackBuffer = pxTimerTaskStack;
+	*pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}

--- a/tools/cbmc/proofs/make_type_header_files.py
+++ b/tools/cbmc/proofs/make_type_header_files.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Compute type header files for c modules
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from tempfile import TemporaryDirectory
+
+DEFINE_REGEX_HEADER = re.compile(r"\s*#\s*define\s*([\w]+)")
+
+def get_module_name(file):
+    base = os.path.basename(file)
+    return base.split(".")[0]
+
+def collect_defines(file):
+    collector_result = ""
+    with open(file, "r") as in_file:
+        continue_define = False
+        in_potential_def_scope = ""
+        potential_define = False
+        potential_define_confirmed = False
+        for line in in_file:
+            matched = DEFINE_REGEX_HEADER.match(line)
+            if line.strip().startswith("#if"):
+                potential_define = True
+                in_potential_def_scope += line
+            elif line.strip().startswith("#endif") and potential_define:
+                if potential_define_confirmed:
+                    in_potential_def_scope += line
+                    collector_result += in_potential_def_scope
+                in_potential_def_scope = ""
+                potential_define = False
+                potential_define_confirmed = False
+            elif matched and potential_define:
+                potential_define_confirmed = True
+                in_potential_def_scope += line
+            elif matched or continue_define:
+                continue_define = line.strip("\n").endswith("\\")
+                collector_result += line
+            elif potential_define:
+                in_potential_def_scope += line
+    return collector_result
+
+
+def make_header_file(goto_binary, file, target_folder):
+    file = os.path.normpath(file)
+    with TemporaryDirectory() as tmpdir:
+        module = get_module_name(file)
+        header_file = "{}_datastructure.h".format(module)
+
+        drop_header_cmd = ["goto-instrument",
+                           "--dump-c-type-header",
+                           module,
+                           goto_binary,
+                           header_file]
+        res = subprocess.run(drop_header_cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             check=False,
+                             universal_newlines=True,
+                             cwd=tmpdir,
+                             shell=False)
+        if res.returncode:
+            logging.basicConfig(
+                format="{script}: %(levelname)s %(message)s".format(
+                    script=os.path.basename(__file__)))
+            logging.error("Processing for file: %s failed", file)
+            logging.error("The command %s resulted with: %s",
+                          drop_header_cmd,
+                          res.stdout)
+            logging.error("The returncode is: %s", res.returncode)
+            sys.exit(1)
+
+        header = os.path.normpath(os.path.join(tmpdir, header_file))
+        with open(header, "a") as out:
+            print(collect_defines(file), file=out)
+
+        target_file = os.path.normpath(os.path.join(target_folder, header_file))
+        shutil.move(header, target_file)
+
+
+if __name__ == '__main__':
+    if(len(sys.argv) == 3 or len(sys.argv) == 4):
+        ARG_BINARY = os.path.abspath(os.path.normpath(sys.argv[1]))
+        ARG_C_FILE = os.path.abspath(os.path.normpath(sys.argv[2]))
+        ARG_TARGET_FOLDER = os.path.abspath(os.getcwd())
+        if len(sys.argv) == 4:
+            ARG_TARGET_FOLDER = sys.argv[3]
+        make_header_file(ARG_BINARY, ARG_C_FILE, ARG_TARGET_FOLDER)
+    else:
+        print(textwrap.dedent("""\
+            Expected invocation:
+                make_type_header_files.py binary c-file [target_folder]"""))


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskStartScheduler.

This proofs depends on #774 #879 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.