### PR TITLE
Add CBMC proof for TaskGetSchedulerState

### DIFF
--- a/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TaskGetSchedulerState",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of the TaskGetSchedulerState function.
+We assume `xSchedulerRunning` and `uxSchedulerSuspended` to be nondeterministic values.

--- a/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/TaskGetSchedulerState_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/TaskGetSchedulerState_harness.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vSetGlobalVariables( void );
+
+/*
+ * We just require scheduler flags to be nondeterministic
+ * values before calling `xTaskGetSchedulerState`
+ */
+void harness()
+{
+	BaseType_t xResult;
+
+	vSetGlobalVariables();
+
+	xResult = xTaskGetSchedulerState();
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskGetSchedulerState/tasks_test_access_functions.h
@@ -1,0 +1,9 @@
+/*
+ * We set the values of relevant global
+ * variables to nondeterministic values
+ */
+void vSetGlobalVariables( void )
+{
+	xSchedulerRunning = nondet();
+	uxSchedulerSuspended = nondet();
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskGetSchedulerState.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.