### PR TITLE
Add CBMC proof for TaskGetTaskNumber

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TaskGetTaskNumber",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'"
+  ],
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/README.md
@@ -1,0 +1,2 @@
+This proof demonstrates the memory safety of the TaskGetTaskNumber function.
+No assumption is required since the function accepts a NULL value for the task handle.

--- a/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/TaskGetTaskNumber_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/TaskGetTaskNumber_harness.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+void vPrepareTask( TaskHandle_t * xTask );
+
+/* 
+ * We prepare an unconstrained task (possibly NULL)
+ * and then call `uxTaskGetTaskNumber`
+ */
+void harness()
+{
+	TaskHandle_t xTask;
+	UBaseType_t uxTaskNumber;
+
+	vPrepareTask( &xTask );
+
+	uxTaskNumber = uxTaskGetTaskNumber( xTask );
+}

--- a/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskGetTaskNumber/tasks_test_access_functions.h
@@ -1,0 +1,25 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+  TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+
+  if ( pxTCB == NULL )
+    return NULL;
+
+  return pxTCB;
+}
+
+/*
+ * We try to allocate an unconstrained TCB but do not
+ * check for NULL errors here (the function does it)
+ */
+void vPrepareTask( TaskHandle_t * xTask )
+{
+  __CPROVER_assert_zero_allocation();
+
+  *xTask = xUnconstrainedTCB();
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskGetTaskNumber.

Depends on #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.