### PR TITLE
DNS calculates protocol checksum with wrong length

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1308,6 +1308,9 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 		pxUDPHeader->usLength			   = FreeRTOS_htons( lNetLength + ipSIZE_OF_UDP_HEADER );
 		vFlip_16( pxUDPPacket->xUDPHeader.usSourcePort, pxUDPPacket->xUDPHeader.usDestinationPort );
 
+		/* Important: tell NIC driver how many bytes must be sent */
+		pxNetworkBuffer->xDataLength = ( size_t ) ( lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
+
 		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
 		{
 			/* calculate the IP header checksum */
@@ -1316,12 +1319,9 @@ TickType_t xTimeoutTime = pdMS_TO_TICKS( 200 );
 			pxIPHeader->usHeaderChecksum	   = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
 			/* calculate the UDP checksum for outgoing package */
-			usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, lNetLength, pdTRUE );
+			usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
 		}
 		#endif
-
-		/* Important: tell NIC driver how many bytes must be sent */
-		pxNetworkBuffer->xDataLength = ( size_t ) ( lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
 
 		/* This function will fill in the eth addresses and send the packet */
 		vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );


### PR DESCRIPTION
<!--- Title -->
DNS calculates protocol-checksum with wrong length
-----------
<!--- Describe your changes in detail -->

When the IP-task must calculate checksums:

    #define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM   0

the function `prvReplyDNSMessage()` passes the length of the UDP-payload, in stead of the length of the entire Ethernet packet to `usGenerateProtocolChecksum()`.

    -	usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, lNetLength, pdTRUE );
    +	usGenerateProtocolChecksum( ( uint8_t* ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );

As a result, the unit was not able to reply to LLMNR or NBNS requests.

I tested it by doing a ping to my device, by name. Ping uses the LLMNR protocol to find the IP-address.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.