### PR TITLE
cmake : Add mbedtls port files from IDF to 3rdparty/mbedtls library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ set(PROJECT_VERSION_MINOR "00")
 # Import global configurations.
 include("tools/cmake/afr.cmake")
 
+# Add 3rdparty modules.
+add_subdirectory("libraries/3rdparty")
+
 # -------------------------------------------------------------------------------------------------
 # Configure target board
 # -------------------------------------------------------------------------------------------------

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -48,6 +48,3 @@ foreach(module IN LISTS afr_modules_csdk afr_modules_freertos_plus afr_modules_a
         afr_add_subdirectory("${module}")
     endif()
 endforeach()
-
-# Add 3rdparty modules.
-add_subdirectory("${AFR_MODULES_DIR}/3rdparty")

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/CMakeLists.txt
@@ -1,21 +1,43 @@
-set(AMAZON_FREERTOS_ABSTRACTIONS_DIR "${AFR_MODULES_ABSTRACTIONS_DIR}")
-set(AMAZON_FREERTOS_3RDPARTY_DIR "${AFR_3RDPARTY_DIR}")
-
-set(
-    COMPONENT_ADD_INCLUDEDIRS
-    port/include
-    ${AMAZON_FREERTOS_ABSTRACTIONS_DIR}/pkcs11/mbedtls
-    ${AMAZON_FREERTOS_3RDPARTY_DIR}/mbedtls/include
-)
-
-# Edit following two lines to set component requirements (see docs)
-set(COMPONENT_REQUIRES )
-set(COMPONENT_PRIV_REQUIRES )
-
-set(COMPONENT_SRCDIRS ${AMAZON_FREERTOS_3RDPARTY_DIR}/mbedtls/library port)
-
 register_component()
 
-target_compile_definitions(${COMPONENT_TARGET} PUBLIC
-    -DMBEDTLS_CONFIG_FILE="mbedtls/esp_config.h"
+target_compile_options(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    ${IDF_COMPILE_OPTIONS}
+    $<$<COMPILE_LANGUAGE:C>:${IDF_C_COMPILE_OPTIONS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${IDF_CXX_COMPILE_OPTIONS}>
+)
+
+target_include_directories(
+    afr_3rdparty_mbedtls
+    PRIVATE
+    "${AFR_VENDORS_DIR}/espressif/esp-idf/components/vfs/include"
+    PUBLIC
+    ${IDF_INCLUDE_DIRECTORIES}
+    ${CMAKE_CURRENT_LIST_DIR}/port/include
+)
+
+target_sources(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_bignum.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_mem.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha256.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_hardware.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha1.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha512.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/mbedtls_debug.c"
+)
+
+target_compile_definitions(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    ${IDF_COMPILE_DEFINITIONS}
+    -DMBEDTLS_CONFIG_FILE="${CMAKE_CURRENT_LIST_DIR}/port/include/mbedtls/esp_config.h"
+)
+
+target_link_libraries(
+    ${COMPONENT_TARGET}
+    INTERFACE
+    afr_3rdparty_mbedtls
 )

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/CMakeLists.txt
@@ -1,21 +1,43 @@
-set(AMAZON_FREERTOS_ABSTRACTIONS_DIR "${AFR_MODULES_ABSTRACTIONS_DIR}")
-set(AMAZON_FREERTOS_3RDPARTY_DIR "${AFR_3RDPARTY_DIR}")
-
-set(
-    COMPONENT_ADD_INCLUDEDIRS
-    port/include
-    ${AMAZON_FREERTOS_ABSTRACTIONS_DIR}/pkcs11/mbedtls
-    ${AMAZON_FREERTOS_3RDPARTY_DIR}/mbedtls/include
-)
-
-# Edit following two lines to set component requirements (see docs)
-set(COMPONENT_REQUIRES )
-set(COMPONENT_PRIV_REQUIRES )
-
-set(COMPONENT_SRCDIRS ${AMAZON_FREERTOS_3RDPARTY_DIR}/mbedtls/library port)
-
 register_component()
 
-target_compile_definitions(${COMPONENT_TARGET} PUBLIC
-    -DMBEDTLS_CONFIG_FILE="mbedtls/esp_config.h"
+target_compile_options(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    ${IDF_COMPILE_OPTIONS}
+    $<$<COMPILE_LANGUAGE:C>:${IDF_C_COMPILE_OPTIONS}>
+    $<$<COMPILE_LANGUAGE:CXX>:${IDF_CXX_COMPILE_OPTIONS}>
+)
+
+target_include_directories(
+    afr_3rdparty_mbedtls
+    PRIVATE
+    "${AFR_VENDORS_DIR}/espressif/esp-idf/components/vfs/include"
+    PUBLIC
+    ${IDF_INCLUDE_DIRECTORIES}
+    ${CMAKE_CURRENT_LIST_DIR}/port/include
+)
+
+target_sources(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_bignum.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_mem.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha256.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_hardware.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha1.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/esp_sha512.c"
+    "${CMAKE_CURRENT_LIST_DIR}/port/mbedtls_debug.c"
+)
+
+target_compile_definitions(
+    afr_3rdparty_mbedtls
+    PUBLIC
+    ${IDF_COMPILE_DEFINITIONS}
+    -DMBEDTLS_CONFIG_FILE="${CMAKE_CURRENT_LIST_DIR}/port/include/mbedtls/esp_config.h"
+)
+
+target_link_libraries(
+    ${COMPONENT_TARGET}
+    INTERFACE
+    afr_3rdparty_mbedtls
 )


### PR DESCRIPTION
There are multiple changes in this PR. Apart from the correction in vendor/espressif specific cmake files, there are small changes in AFR library cmake files to have the 3rdparty libraries added prior to adding the vendor specific files. This allows adding vendor specific port sources and include files to be added to 3rdparty library targets.

List of changes:
* add 3rdparty libraries before adding vendor specific subdirectory
* IDF's mbedtls port files now added directly to the 3rdparty library

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.