### PR TITLE
Set delta callback in Shadow test

### DIFF
--- a/libraries/c_sdk/aws/shadow/test/aws_test_shadow.c
+++ b/libraries/c_sdk/aws/shadow/test/aws_test_shadow.c
@@ -477,6 +477,7 @@ TEST( Full_Shadow, UpdateCallback )
         /*Register update callback.*/
         xCallbackParams.pcThingName = shadowTHING_NAME;
         xCallbackParams.xShadowUpdatedCallback = prvTestUpdatedCallback;
+        xCallbackParams.xShadowDeltaCallback = prvTestDeltaCallback;
         xReturn = SHADOW_RegisterCallbacks( xShadowClientHandle,
                                             &xCallbackParams,
                                             shadowTIMEOUT );


### PR DESCRIPTION
In response to #825 

Adds a (different) delta callback in the update callback test; this will ensure that the correct function is being set.