### PR TITLE
Added timer for the initial message to be sent to Amazon

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1408,7 +1408,7 @@ static void prvOTAUpdateTask( void * pvUnused )
             ( void ) OTA_CheckForUpdate();
 
             if ((job_start_timer = OTA_InitJobStartTimer()) != pdTRUE) {
-				          // Timer doesn't exist, time to reset
+				          /* Fail out if timer doesn't exist */
 			            DEFINE_OTA_METHOD_NAME("OTA_InitJobStartTimer");
 				          OTA_LOG_L1("[%s] Job Start timer failed to initialize. Resetting\r\n", OTA_METHOD_NAME);
 				          (void)prvPAL_ResetDevice();
@@ -1756,7 +1756,7 @@ static void prvJobStartTimer_Callback(TimerHandle_t T)
 
 	}
 	else {
-		//Reset timer and poke amazon
+	  /* Restart timer and try again */
 		OTA_LOG_L1("[%s] Job Start failed to connect to Amazon.  Retrying\r\n", OTA_METHOD_NAME);
 		if ((job_start_timer = OTA_InitJobStartTimer()) != pdTRUE) {
 			OTA_LOG_L1("[%s] Timer failed to restart.  Exiting\r\n", OTA_METHOD_NAME);

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
@@ -54,6 +54,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
@@ -54,6 +54,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
@@ -49,6 +49,11 @@
 #define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
 
 /**
+* @brief Milliseconds to wait for initial message to make it to amazon
+*/
+#define otaconfigJOB_START_RESPONSE_WAIT_MS 16000U
+
+/**
  * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
  *
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send


### PR DESCRIPTION
This change creates a timer that exits when the initial message (post MQTT initialization) is successfully queued.  Addresses issue #875

Description
-----------
The function `OTA_InitJobStartTimer` is called before the main function loop within `prvOTAUpdateTask`.  This starts the timer that is then stopped in `prvOTAPublishCallback` when the first message to AWS is successfully queued (using `prvStopJobStartTimer`).  If there is timeout (handled within `prvJobStartTimer_Callback`) the timer either resets and triggers the sending of another message, or the OTA update is terminated, resetting the system.  These changes ensure that the initial dropped message problem is properly handled.  The timer is disabled for all subsequent OTA messages in the update.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.