### PR TITLE
Add CBMC harness for QueueCreateMutex

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/Queue/QueueCreateMutex/Makefile.json
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutex/Makefile.json
@@ -1,0 +1,19 @@
+{
+  "ENTRY": "QueueCreateMutex",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueCreateMutex/QueueCreateMutex_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutex/QueueCreateMutex_harness.c
@@ -1,0 +1,10 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+
+#include "cbmc.h"
+
+void harness() {
+  uint8_t ucQueueType;
+
+  xQueueCreateMutex(ucQueueType);
+}

--- a/tools/cbmc/proofs/Queue/QueueCreateMutex/README.md
+++ b/tools/cbmc/proofs/Queue/QueueCreateMutex/README.md
@@ -1,0 +1,2 @@
+This harness proves the memory safety of QueueCreateMutex
+for totally unconstrained input.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Add a CBMC harness for QueueCreateMutex. The single input variable is completely unrestricted.

Depends on #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.