### PR TITLE
Add CBMC harness for QueueGetMutexHolder

### DIFF
--- a/freertos_kernel/queue.c
+++ b/freertos_kernel/queue.c
@@ -541,6 +541,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength, const UBaseT
 	TaskHandle_t pxReturn;
 	Queue_t * const pxSemaphore = ( Queue_t * ) xSemaphore;
 
+		configASSERT( xSemaphore );
 		/* This function is called by xSemaphoreGetMutexHolder(), and should not
 		be called directly.  Note:  This is a good way of determining if the
 		calling task is the mutex holder, but not a good way of determining the

--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/include/queue_init.h
+++ b/tools/cbmc/include/queue_init.h
@@ -1,0 +1,129 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "queue_datastructure.h"
+
+/* Using prvCopyDataToQueue together with prvNotifyQueueSetContainer
+   leads to a problem space explosion. Therefore, we use this stub
+   and a sepearted proof on prvCopyDataToQueue to deal with it.
+   As prvNotifyQueueSetContainer is disabled if configUSE_QUEUE_SETS != 1,
+   in other cases the original implementation should be used. */
+#if( configUSE_QUEUE_SETS == 1 )
+	BaseType_t prvCopyDataToQueue( Queue_t * const pxQueue, const void *pvItemToQueue, const BaseType_t xPosition )
+	{
+		if(pxQueue->uxItemSize > ( UBaseType_t ) 0)
+		{
+			__CPROVER_assert(__CPROVER_r_ok(pvItemToQueue, ( size_t ) pxQueue->uxItemSize), "pvItemToQueue region must be readable");
+			if(xPosition == queueSEND_TO_BACK){
+				__CPROVER_assert(__CPROVER_w_ok(( void * ) pxQueue->pcWriteTo, ( size_t ) pxQueue->uxItemSize), "pxQueue->pcWriteTo region must be writable");
+			}else{
+				__CPROVER_assert(__CPROVER_w_ok(( void * ) pxQueue->u.xQueue.pcReadFrom, ( size_t ) pxQueue->uxItemSize), "pxQueue->u.xQueue.pcReadFrom region must be writable");
+			}
+			return pdFALSE;
+		}else
+		{
+			return nondet_BaseType_t();
+		}
+	}
+#endif
+
+/* xQueueCreateSet is compiled out if configUSE_QUEUE_SETS != 1.*/
+#if( configUSE_QUEUE_SETS == 1 )
+	QueueSetHandle_t xUnconstrainedQueueSet()
+	{
+		UBaseType_t uxEventQueueLength = 2;
+		QueueSetHandle_t xSet = xQueueCreateSet(uxEventQueueLength);
+		if( xSet )
+		{
+			xSet->cTxLock = nondet_int8_t();
+			xSet->cRxLock = nondet_int8_t();
+			xSet->uxMessagesWaiting = nondet_UBaseType_t();
+			xSet->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+			/* This is an invariant checked with a couple of asserts in the code base.
+			   If it is false from the beginning, the CBMC proofs are not able to succeed*/
+			__CPROVER_assume(xSet->uxMessagesWaiting < xSet->uxLength);
+			xSet->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+		}
+		return xSet;
+	}
+#endif
+
+/* Create a mostly unconstrained Queue but bound the max item size.
+   This is required for performance reasons in CBMC at the moment. */
+QueueHandle_t xUnconstrainedQueueBoundedItemSize( UBaseType_t uxItemSizeBound ) {
+	UBaseType_t uxQueueLength;
+	UBaseType_t uxItemSize;
+	uint8_t ucQueueType;
+	__CPROVER_assume(uxQueueLength > 0);
+	__CPROVER_assume(uxItemSize < uxItemSizeBound);
+	/* The implicit assumption for the QueueGenericCreate method is,
+	   that there are no overflows in the computation and the inputs are safe.
+	   There is no check for this in the code base */
+	UBaseType_t upper_bound = portMAX_DELAY - sizeof(Queue_t);
+	__CPROVER_assume(uxItemSize < (upper_bound)/uxQueueLength);
+	QueueHandle_t xQueue =
+		xQueueGenericCreate(uxQueueLength, uxItemSize, ucQueueType);
+	if(xQueue){
+		xQueue->cTxLock = nondet_int8_t();
+		xQueue->cRxLock = nondet_int8_t();
+		xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+		/* This is an invariant checked with a couple of asserts in the code base.
+		   If it is false from the beginning, the CBMC proofs are not able to succeed*/
+		__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
+		xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+		xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+		#if( configUSE_QUEUE_SETS == 1)
+			xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
+		#endif
+	}
+	return xQueue;
+}
+
+/* Create a mostly unconstrained Queue */
+QueueHandle_t xUnconstrainedQueue( void ) {
+	UBaseType_t uxQueueLength;
+	UBaseType_t uxItemSize;
+	uint8_t ucQueueType;
+	__CPROVER_assume(uxQueueLength > 0);
+	/* The implicit assumption for the QueueGenericCreate method is,
+	   that there are no overflows in the computation and the inputs are safe.
+	   There is no check for this in the code base */
+	UBaseType_t upper_bound = portMAX_DELAY - sizeof(Queue_t);
+	__CPROVER_assume(uxItemSize < (upper_bound)/uxQueueLength);
+	QueueHandle_t xQueue =
+		xQueueGenericCreate(uxQueueLength, uxItemSize, ucQueueType);
+	if(xQueue){
+		xQueue->cTxLock = nondet_int8_t();
+		xQueue->cRxLock = nondet_int8_t();
+		xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+		/* This is an invariant checked with a couple of asserts in the code base.
+		   If it is false from the beginning, the CBMC proofs are not able to succeed*/
+		__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
+		xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+		xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+		#if( configUSE_QUEUE_SETS == 1)
+			xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
+		#endif
+	}
+	return xQueue;
+}
+
+/* Create a mostly unconstrained Mutex */
+QueueHandle_t xUnconstrainedMutex( void ) {
+	uint8_t ucQueueType;
+	QueueHandle_t xQueue =
+		xQueueCreateMutex(ucQueueType);
+	if(xQueue){
+		xQueue->cTxLock = nondet_int8_t();
+		xQueue->cRxLock = nondet_int8_t();
+		xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+		/* This is an invariant checked with a couple of asserts in the code base.
+		   If it is false from the beginning, the CBMC proofs are not able to succeed*/
+		__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
+		xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+		xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+		#if( configUSE_QUEUE_SETS == 1)
+			xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
+		#endif
+	}
+	return xQueue;
+}

--- a/tools/cbmc/include/tasksStubs.h
+++ b/tools/cbmc/include/tasksStubs.h
@@ -1,0 +1,10 @@
+#ifndef INC_TASK_STUBS_H
+#define INC_TASK_STUBS_H
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+BaseType_t xState;
+void vInitTaskCheckForTimeOut(BaseType_t maxCounter, BaseType_t maxCounter_limit);
+
+#endif /* INC_TASK_STUBS_H */

--- a/tools/cbmc/proofs/CBMCStubLibrary/tasksStubs.c
+++ b/tools/cbmc/proofs/CBMCStubLibrary/tasksStubs.c
@@ -1,0 +1,47 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "tasksStubs.h"
+
+#ifndef TASK_STUB_COUNTER
+	#define TASK_STUB_COUNTER 0;
+#endif
+
+/* 5 is a magic number, but we need some number here as a default value.
+   This value is used to bound any loop depending on xTaskCheckForTimeOut
+   as a loop bound. It should be overwritten in the Makefile.json adapting
+   to the performance requirements of the harness. */
+#ifndef TASK_STUB_COUNTER_LIMIT
+	#define TASK_STUB_COUNTER_LIMIT 5;
+#endif
+
+
+static BaseType_t xCounter = TASK_STUB_COUNTER;
+static BaseType_t xCounterLimit = TASK_STUB_COUNTER_LIMIT;
+
+BaseType_t xTaskGetSchedulerState( void )
+{
+	return xState;
+}
+
+/* This function is another method apart from overwritting the defines to init the max
+   loop bound. */
+void vInitTaskCheckForTimeOut(BaseType_t maxCounter, BaseType_t maxCounter_limit)
+{
+	xCounter = maxCounter;
+	xCounterLimit = maxCounter_limit;
+}
+
+/* This is mostly called in a loop. For CBMC, we have to bound the loop
+   to a max limits of calls. Therefore this Stub models a nondet timeout in
+   max TASK_STUB_COUNTER_LIMIT iterations.*/
+BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) {
+	++xCounter;
+	if(xCounter == xCounterLimit)
+	{
+		return pdTRUE;
+	}
+	else
+	{
+		return nondet();
+	}
+}

--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -72,7 +72,10 @@ unpatch:
 #
 # Rules for building the CBMC harness
 
-$(ENTRY)_harness.goto: $(ENTRY)_harness.c
+queue_datastructure.h: $(filter-out $(ENTRY)_harness.goto, $(OBJS))
+	python3 @TYPE_HEADER_SCRIPT@ $(FREERTOS)/freertos_kernel/queue.goto $(FREERTOS)/freertos_kernel/queue.c
+
+$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(filter-out $(ENTRY)_harness.goto, $(OBJS)) $(H_GENERATE_HEADER)
 	$(GOTO_CC) @COMPILE_ONLY@ @RULE_OUTPUT@ $(INC) $(CFLAGS) @RULE_INPUT@
 
 $(ENTRY)1.goto: $(OBJS)
@@ -139,6 +142,7 @@ clean:
 	@RM@ $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
 	@RM@ cbmc.txt property.xml coverage.xml TAGS
 	@RM@ *~ \#*
+	@RM@ queue_datastructure.h
 
 
 veryclean: clean

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -40,6 +40,10 @@
 	"--32",
 	"--bounds-check",
 	"--pointer-check"
+    ],
+
+    "TYPE_HEADERS": [
+        "$(FREERTOS)/freertos_kernel/queue.c"
     ]
 }
 

--- a/tools/cbmc/proofs/MakefileLinux.json
+++ b/tools/cbmc/proofs/MakefileLinux.json
@@ -29,5 +29,8 @@
     ],
     "CP": [
 	"cp"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)/make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/MakefileWindows.json
+++ b/tools/cbmc/proofs/MakefileWindows.json
@@ -37,5 +37,8 @@
     ],
     "CP": [
 	"copy"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)\\make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolder/Makefile.json
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolder/Makefile.json
@@ -1,0 +1,25 @@
+{
+  "ENTRY": "QueueGetMutexHolder",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "INC": [
+    "."
+  ],
+  "GENERATE_HEADER": [
+    "queue_datastructure.h"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolder/QueueGetMutexHolder_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolder/QueueGetMutexHolder_harness.c
@@ -1,0 +1,14 @@
+#include "FreeRTOS.h"
+#include "queue_init.h"
+#include "queue.h"
+
+#include "cbmc.h"
+
+void harness() {
+  QueueHandle_t xSemaphore =
+      xUnconstrainedQueue();
+  if (xSemaphore) {
+    xSemaphore->uxQueueType = nondet();
+    xQueueGetMutexHolder(xSemaphore);
+  }
+}

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolder/README.md
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolder/README.md
@@ -1,0 +1,2 @@
+This harness proves the memory safety of QueueGetMutexHolder assuming the passed
+semaphore is not null.

--- a/tools/cbmc/proofs/make_type_header_files.py
+++ b/tools/cbmc/proofs/make_type_header_files.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Compute type header files for c modules
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from tempfile import TemporaryDirectory
+
+DEFINE_REGEX_HEADER = re.compile(r"\s*#\s*define\s*([\w]+)")
+
+def get_module_name(file):
+    base = os.path.basename(file)
+    return base.split(".")[0]
+
+def collect_defines(file):
+    collector_result = ""
+    with open(file, "r") as in_file:
+        continue_define = False
+        in_potential_def_scope = ""
+        potential_define = False
+        potential_define_confirmed = False
+        for line in in_file:
+            matched = DEFINE_REGEX_HEADER.match(line)
+            if line.strip().startswith("#if"):
+                potential_define = True
+                in_potential_def_scope += line
+            elif line.strip().startswith("#endif") and potential_define:
+                if potential_define_confirmed:
+                    in_potential_def_scope += line
+                    collector_result += in_potential_def_scope
+                in_potential_def_scope = ""
+                potential_define = False
+                potential_define_confirmed = False
+            elif matched and potential_define:
+                potential_define_confirmed = True
+                in_potential_def_scope += line
+            elif matched or continue_define:
+                continue_define = line.strip("\n").endswith("\\")
+                collector_result += line
+            elif potential_define:
+                in_potential_def_scope += line
+    return collector_result
+
+
+def make_header_file(goto_binary, file, target_folder):
+    file = os.path.normpath(file)
+    with TemporaryDirectory() as tmpdir:
+        module = get_module_name(file)
+        header_file = "{}_datastructure.h".format(module)
+
+        drop_header_cmd = ["goto-instrument",
+                           "--dump-c-type-header",
+                           module,
+                           goto_binary,
+                           header_file]
+        res = subprocess.run(drop_header_cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             check=False,
+                             universal_newlines=True,
+                             cwd=tmpdir,
+                             shell=False)
+        if res.returncode:
+            logging.basicConfig(
+                format="{script}: %(levelname)s %(message)s".format(
+                    script=os.path.basename(__file__)))
+            logging.error("Processing for file: %s failed", file)
+            logging.error("The command %s resulted with: %s",
+                          drop_header_cmd,
+                          res.stdout)
+            logging.error("The returncode is: %s", res.returncode)
+            sys.exit(1)
+
+        header = os.path.normpath(os.path.join(tmpdir, header_file))
+        with open(header, "a") as out:
+            print(collect_defines(file), file=out)
+
+        target_file = os.path.normpath(os.path.join(target_folder, header_file))
+        shutil.move(header, target_file)
+
+
+if __name__ == '__main__':
+    if(len(sys.argv) == 3 or len(sys.argv) == 4):
+        ARG_BINARY = os.path.abspath(os.path.normpath(sys.argv[1]))
+        ARG_C_FILE = os.path.abspath(os.path.normpath(sys.argv[2]))
+        ARG_TARGET_FOLDER = os.path.abspath(os.getcwd())
+        if len(sys.argv) == 4:
+            ARG_TARGET_FOLDER = sys.argv[3]
+        make_header_file(ARG_BINARY, ARG_C_FILE, ARG_TARGET_FOLDER)
+    else:
+        print(textwrap.dedent("""\
+            Expected invocation:
+                make_type_header_files.py binary c-file [target_folder]"""))


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Add CBMC Harness for QueueGetMutexHolder. It is assumed that the passed semaphore is not null plus the assumption implied by the stubs in #688.

Depends on #774, #697, #688

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.