### PR TITLE
Add CBMC harness for QueueGetMutexFromISR

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -72,7 +72,10 @@ unpatch:
 #
 # Rules for building the CBMC harness
 
-$(ENTRY)_harness.goto: $(ENTRY)_harness.c
+queue_datastructure.h: $(filter-out $(ENTRY)_harness.goto, $(OBJS))
+	python3 @TYPE_HEADER_SCRIPT@ $(FREERTOS)/freertos_kernel/queue.goto $(FREERTOS)/freertos_kernel/queue.c
+
+$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(filter-out $(ENTRY)_harness.goto, $(OBJS)) $(H_GENERATE_HEADER)
 	$(GOTO_CC) @COMPILE_ONLY@ @RULE_OUTPUT@ $(INC) $(CFLAGS) @RULE_INPUT@
 
 $(ENTRY)1.goto: $(OBJS)
@@ -139,6 +142,7 @@ clean:
 	@RM@ $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
 	@RM@ cbmc.txt property.xml coverage.xml TAGS
 	@RM@ *~ \#*
+	@RM@ queue_datastructure.h
 
 
 veryclean: clean

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -40,6 +40,10 @@
 	"--32",
 	"--bounds-check",
 	"--pointer-check"
+    ],
+
+    "TYPE_HEADERS": [
+        "$(FREERTOS)/freertos_kernel/queue.c"
     ]
 }
 

--- a/tools/cbmc/proofs/MakefileLinux.json
+++ b/tools/cbmc/proofs/MakefileLinux.json
@@ -29,5 +29,8 @@
     ],
     "CP": [
 	"cp"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)/make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/MakefileWindows.json
+++ b/tools/cbmc/proofs/MakefileWindows.json
@@ -37,5 +37,8 @@
     ],
     "CP": [
 	"copy"
+    ],
+    "TYPE_HEADER_SCRIPT": [
+    "$(PROOFS)\\make_type_header_files.py"
     ]
 }

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/Makefile.json
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/Makefile.json
@@ -1,0 +1,27 @@
+{
+  "ENTRY": "QueueGetMutexHolderFromISR",
+  "CBMCFLAGS": [
+    "--unwind 1",
+    "--signed-overflow-check",
+    "--pointer-overflow-check",
+    "--unsigned-overflow-check"
+  ],
+  "OBJS": [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/queue.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "DEF": [
+    "'configASSERT(X)=__CPROVER_assert(X, \"Assertion Error\")'",
+    "'configPRECONDITION(X)=__CPROVER_assume(X)'",
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "INC": [
+    "."
+  ],
+  "GENERATE_HEADER": [
+    "queue_datastructure.h"
+  ]
+}
+

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/QueueGetMutexHolderFromISR_harness.c
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/QueueGetMutexHolderFromISR_harness.c
@@ -1,0 +1,13 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "queue_datastructure.h"
+
+#include "cbmc.h"
+
+void harness(){
+	QueueHandle_t xSemaphore = pvPortMalloc(sizeof(Queue_t));
+	if (xSemaphore) {
+		xQueueGetMutexHolderFromISR( xSemaphore );
+	}
+}
+

--- a/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/README.md
+++ b/tools/cbmc/proofs/Queue/QueueGetMutexHolderFromISR/README.md
@@ -1,0 +1,2 @@
+Assuming that xSemaphore is a pointer to an allocated Queue_t instance,
+this harness proves the memory safety of QueueGetMutexHolderFromISR.

--- a/tools/cbmc/proofs/make_type_header_files.py
+++ b/tools/cbmc/proofs/make_type_header_files.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Compute type header files for c modules
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from tempfile import TemporaryDirectory
+
+DEFINE_REGEX_HEADER = re.compile(r"\s*#\s*define\s*([\w]+)")
+
+def get_module_name(file):
+    base = os.path.basename(file)
+    return base.split(".")[0]
+
+def collect_defines(file):
+    collector_result = ""
+    with open(file, "r") as in_file:
+        continue_define = False
+        in_potential_def_scope = ""
+        potential_define = False
+        potential_define_confirmed = False
+        for line in in_file:
+            matched = DEFINE_REGEX_HEADER.match(line)
+            if line.strip().startswith("#if"):
+                potential_define = True
+                in_potential_def_scope += line
+            elif line.strip().startswith("#endif") and potential_define:
+                if potential_define_confirmed:
+                    in_potential_def_scope += line
+                    collector_result += in_potential_def_scope
+                in_potential_def_scope = ""
+                potential_define = False
+                potential_define_confirmed = False
+            elif matched and potential_define:
+                potential_define_confirmed = True
+                in_potential_def_scope += line
+            elif matched or continue_define:
+                continue_define = line.strip("\n").endswith("\\")
+                collector_result += line
+            elif potential_define:
+                in_potential_def_scope += line
+    return collector_result
+
+
+def make_header_file(goto_binary, file, target_folder):
+    file = os.path.normpath(file)
+    with TemporaryDirectory() as tmpdir:
+        module = get_module_name(file)
+        header_file = "{}_datastructure.h".format(module)
+
+        drop_header_cmd = ["goto-instrument",
+                           "--dump-c-type-header",
+                           module,
+                           goto_binary,
+                           header_file]
+        res = subprocess.run(drop_header_cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             check=False,
+                             universal_newlines=True,
+                             cwd=tmpdir,
+                             shell=False)
+        if res.returncode:
+            logging.basicConfig(
+                format="{script}: %(levelname)s %(message)s".format(
+                    script=os.path.basename(__file__)))
+            logging.error("Processing for file: %s failed", file)
+            logging.error("The command %s resulted with: %s",
+                          drop_header_cmd,
+                          res.stdout)
+            logging.error("The returncode is: %s", res.returncode)
+            sys.exit(1)
+
+        header = os.path.normpath(os.path.join(tmpdir, header_file))
+        with open(header, "a") as out:
+            print(collect_defines(file), file=out)
+
+        target_file = os.path.normpath(os.path.join(target_folder, header_file))
+        shutil.move(header, target_file)
+
+
+if __name__ == '__main__':
+    if(len(sys.argv) == 3 or len(sys.argv) == 4):
+        ARG_BINARY = os.path.abspath(os.path.normpath(sys.argv[1]))
+        ARG_C_FILE = os.path.abspath(os.path.normpath(sys.argv[2]))
+        ARG_TARGET_FOLDER = os.path.abspath(os.getcwd())
+        if len(sys.argv) == 4:
+            ARG_TARGET_FOLDER = sys.argv[3]
+        make_header_file(ARG_BINARY, ARG_C_FILE, ARG_TARGET_FOLDER)
+    else:
+        print(textwrap.dedent("""\
+            Expected invocation:
+                make_type_header_files.py binary c-file [target_folder]"""))


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add CBMC harness for QueueGetMutexFromISR. The assumption is that the argument is allocated to a valid size.

Depends on #697 and #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.