### PR TITLE
cmake : Allow projects outside AFR source tree to link IDF component libs

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -255,13 +255,28 @@ set(IDF_BUILD_ARTIFACTS_DIR ${CMAKE_BINARY_DIR})
 
 set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
 
+# If external project is set do not link IDF components to aws target
+if (NOT IDF_PROJECT_EXECUTABLE)
+    set(IDF_PROJECT_EXECUTABLE ${exe_target})
+endif()
+
+set_property(GLOBAL PROPERTY IDF_PROJECT_EXECUTABLE ${IDF_PROJECT_EXECUTABLE})
+
+get_filename_component(
+    ABS_EXTRA_COMPONENT_DIRS
+    "${board_dir}/application_code/espressif_code" ABSOLUTE
+)
+
+list(APPEND IDF_EXTRA_COMPONENT_DIRS ${ABS_EXTRA_COMPONENT_DIRS})
+
 # This is a hack to have IDF build system use PRIVATE keyword when
 # calling target_link_libraries() on aws_demos target. This is necessary
 # as CMake doesn't allow mixing target_link_libraries() call signature
 # for the same target.
 function(target_link_libraries)
     set(_args ARGV)
-    if ((${ARGV0} STREQUAL aws_tests) OR (${ARGV0} STREQUAL aws_demos))
+    get_property(exe_target GLOBAL PROPERTY IDF_PROJECT_EXECUTABLE)
+    if (${ARGV0} STREQUAL ${exe_target})
         list(INSERT ${_args} 1 PRIVATE)
     endif()
     _target_link_libraries(${${_args}})
@@ -273,27 +288,18 @@ set(IDF_TOOLCHAIN_FILE ${CMAKE_TOOLCHAIN_FILE})
 # Provides idf_import_components and idf_link_components
 include(${esp_idf_dir}/tools/cmake/idf_functions.cmake)
 
-get_filename_component(
-    ABS_EXTRA_COMPONENT_DIRS
-    "${board_dir}/application_code/espressif_code" ABSOLUTE
-)
-
-set(IDF_EXTRA_COMPONENT_DIRS ${ABS_EXTRA_COMPONENT_DIRS})
-set(IDF_PROJECT_EXECUTABLE ${exe_target})
-
-
 # Wraps add_subdirectory() to create library targets for components, and then `return` them using the given variable.
 # In this case the variable is named `component`
 idf_import_components(components ${esp_idf_dir} esp-idf)
 
 # Wraps target_link_libraries() to link processed components by idf_import_components to target
-idf_link_components(${exe_target} "${components}")
+idf_link_components(${IDF_PROJECT_EXECUTABLE} "${components}")
 
 # Monitor target for running idf_monitor.py
 add_custom_target(monitor
     DEPENDS "${IDF_PROJECT_EXECUTABLE}"
     COMMAND ${CMAKE_COMMAND}
-    -D IDF_PATH="${espressif_dir}"
+    -D IDF_PATH="${esp_idf_dir}"
     -D PROJECT_ELF="${IDF_PROJECT_EXECUTABLE}"
     -D ELF_DIR="${CMAKE_BINARY_DIR}"
     -P run_idf_monitor.cmake


### PR DESCRIPTION
This should also fix support for adding extra components by setting IDF_EXTRA_COMPONENT_DIRS
Also corrected IDF_PATH supplied to `monitor` target

Here is a reference CMakeLists.txt of an external project outside the AFR source tree. Note that it is assumed the `amazon_freertos` root is a subdirectory of this project.

```
cmake_minimum_required(VERSION 3.13)

project(my_app)

add_executable(my_app main.c)

# Tell IDF build to link against this target
set(IDF_PROJECT_EXECUTABLE my_app)

get_filename_component(EXTRA_COMPONENT_DIRS
    "components/hello_world" ABSOLUTE
)

# Add some external components to the project
set(IDF_EXTRA_COMPONENT_DIRS ${EXTRA_COMPONENT_DIRS})

# AFR_BOARD tells which board we need to target.
set(AFR_BOARD espressif.esp32_devkitc CACHE INTERNAL "")

add_subdirectory(amazon-freertos)

target_link_libraries(my_app PRIVATE AFR::mqtt)
```

To build, flash an start the serial monitor, we need to call the following:

```
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=amazon-freertos/tools/cmake/toolchains/xtensa-esp32.cmake
cd build
make -j8 my_app flash
make monitor
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.