### PR TITLE
Fix for issue#897.

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1257,17 +1257,25 @@ static OTA_Err_t prvPublishGetStreamMessage( OTA_FileContext_t * C )
 
                     if( eResult != IOT_MQTT_SUCCESS )
                     {
+                        /* Don't return an error. Let max momentum catch it since this may be intermittent. */
                         OTA_LOG_L1( "[%s] Failed: %s\r\n", OTA_METHOD_NAME, pcTopicBuffer );
-                        /* Don't return an error. Let max momentum catch it since this may be intermittent.
-                           Restart the timer so that we will come back through here and try again */
-                        prvStartRequestTimer( C );
                     }
                     else
                     {
                         OTA_LOG_L1( "[%s] OK: %s\r\n", OTA_METHOD_NAME, pcTopicBuffer );
-                        /* Restart the request timer to retry if we don't complete the update. */
-                        prvStartRequestTimer( C );
                     }
+                    /* Restart the timer regardless if we published the Get Stream Request message
+                       or not.
+
+                       If we published the message, then the timer will be used to time
+                       out the OTA not continuing again.
+
+                       If we failed to publish the message, then
+                       the timer will be used to retry publishing the message again later.
+
+                       In both cases the max momentum, if reached, will be used to stop publishing
+                       the Get Stream Request message. */
+                    prvStartRequestTimer( C );
                 }
                 else
                 {

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1258,7 +1258,9 @@ static OTA_Err_t prvPublishGetStreamMessage( OTA_FileContext_t * C )
                     if( eResult != IOT_MQTT_SUCCESS )
                     {
                         OTA_LOG_L1( "[%s] Failed: %s\r\n", OTA_METHOD_NAME, pcTopicBuffer );
-                        /* Don't return an error. Let max momentum catch it since this may be intermittent. */
+                        /* Don't return an error. Let max momentum catch it since this may be intermittent.
+                           Restart the timer so that we will come back through here and try again */
+                        prvStartRequestTimer( C );
                     }
                     else
                     {


### PR DESCRIPTION
Added starting of the request timer even when the prvPublishMmessage returns a failure.

This is a fix for [Issue#897](https://github.com/aws/amazon-freertos/issues/897)

Description
-----------
Added the starting of the request timer even if the "prvPublishMessage" returns a failure.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.