### PR TITLE
Add CBMC proof for TaskPrioritySet

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -25,3 +25,26 @@ enum CBMC_LOOP_CONDITION { CBMC_LOOP_BREAK, CBMC_LOOP_CONTINUE, CBMC_LOOP_RETURN
 
 #define __CPROVER_printf_ptr(var) { uint8_t *ValueOf_ ## var = (uint8_t *) var; }
 #define __CPROVER_printf2_ptr(str,exp) { uint8_t *ValueOf_ ## str = (uint8_t *) (exp); }
+
+/* CBMC assert to test pvPortMalloc result when xWantedSize is 0. Mostly used to report
+ * full coverage on pvPortMalloc, but use with caution as it might complicate debugging
+ */
+#define __CPROVER_assert_zero_allocation() __CPROVER_assert( pvPortMalloc(0) == NULL, "pvPortMalloc allows zero-allocated memory.")
+
+/* xWantedSize is not bounded in this function, but there might be a need to bound it in the future.
+ * In theory, CBMC malloc allows to allocate an arbitrary amount of data. This will not be true for
+ * embedded devices.
+ */
+void *pvPortMalloc( size_t xWantedSize )
+{
+	if ( xWantedSize == 0 )
+	{
+		return NULL;
+	}
+	return nondet_bool() ? malloc( xWantedSize ) : NULL;
+}
+
+void vPortFree( void *pv )
+{
+	free(pv);
+}

--- a/tools/cbmc/proofs/TaskPool/TaskPrioritySet/Makefile.json
+++ b/tools/cbmc/proofs/TaskPool/TaskPrioritySet/Makefile.json
@@ -1,0 +1,26 @@
+{
+  "ENTRY": "TaskPrioritySet",
+  "DEF":
+  [
+    "FREERTOS_MODULE_TEST",
+    "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+    "configUSE_TRACE_FACILITY=0",
+    "configGENERATE_RUN_TIME_STATS=0"
+  ],
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:3"
+
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto",
+    "$(FREERTOS)/freertos_kernel/list.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/proofs/TaskPool/TaskPrioritySet/"
+  ]
+}

--- a/tools/cbmc/proofs/TaskPool/TaskPrioritySet/README.md
+++ b/tools/cbmc/proofs/TaskPool/TaskPrioritySet/README.md
@@ -1,0 +1,5 @@
+This proof demonstrates the memory safety of the TaskPrioritySet function.  The
+initialization for the task to be set and `pxCurrentTCB` is quite similar
+(since the task handle may be NULL, and in that case `pxCurrentTCB` is used).
+Task lists are initialized with these tasks and nondet. filled with a few more
+items. 

--- a/tools/cbmc/proofs/TaskPool/TaskPrioritySet/TaskPrioritySet_harness.c
+++ b/tools/cbmc/proofs/TaskPool/TaskPrioritySet/TaskPrioritySet_harness.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+BaseType_t xPrepareTaskLists( TaskHandle_t * xTask );
+
+/*
+ * We assume `uxNewPriority` to be a valid priority (avoids failed assert).
+ * The harness test first calls two functions included in the tasks.c file
+ * that initialize the task lists and other global variables
+ */
+void harness()
+{
+	TaskHandle_t xTask;
+	UBaseType_t uxNewPriority;
+	BaseType_t xTasksPrepared;
+
+	__CPROVER_assume( uxNewPriority < configMAX_PRIORITIES );
+
+	xTasksPrepared = xPrepareTaskLists( &xTask );
+
+	if ( xPrepareTaskLists( &xTask ) != pdFAIL )
+	{
+		vTaskPrioritySet( xTask, uxNewPriority );
+	}
+}

--- a/tools/cbmc/proofs/TaskPool/TaskPrioritySet/tasks_test_access_functions.h
+++ b/tools/cbmc/proofs/TaskPool/TaskPrioritySet/tasks_test_access_functions.h
@@ -1,0 +1,102 @@
+#include "cbmc.h"
+
+/*
+ * We allocate a TCB and set some members to basic values
+ */
+TaskHandle_t xUnconstrainedTCB( void )
+{
+	TCB_t * pxTCB = pvPortMalloc(sizeof(TCB_t));
+	uint8_t ucStaticAllocationFlag;
+
+	if ( pxTCB == NULL )
+		return NULL;
+
+	__CPROVER_assume( pxTCB->uxPriority < configMAX_PRIORITIES );
+
+	vListInitialiseItem( &( pxTCB->xStateListItem ) );
+	vListInitialiseItem( &( pxTCB->xEventListItem ) );
+
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xStateListItem ), pxTCB );
+	listSET_LIST_ITEM_OWNER( &( pxTCB->xEventListItem ), pxTCB );
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xStateListItem ), portMAX_DELAY );
+	}
+
+	if ( nondet_bool() )
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority );
+	}
+	else
+	{
+		listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), portMAX_DELAY );
+	}
+
+	return pxTCB;
+}
+
+/*
+ * We initialise and fill the task lists so coverage is optimal.
+ * This initialization is not guaranteed to be minimal, but it
+ * is quite efficient and it serves the same purpose
+ */
+BaseType_t xPrepareTaskLists( TaskHandle_t * xTask )
+{
+	TCB_t * pxTCB = NULL;
+
+	__CPROVER_assert_zero_allocation();
+
+	prvInitialiseTaskLists();
+
+	pxTCB = xUnconstrainedTCB();
+
+	/* Nondet. insertion of another task in the same list to allow both cases in line 1656 (tasks.c) */
+	if ( nondet_bool() )
+	{
+		TCB_t * pxOtherTCB;
+		pxOtherTCB = xUnconstrainedTCB();
+		if ( pxOtherTCB != NULL )
+		{
+			vListInsert( &pxReadyTasksLists[ pxOtherTCB->uxPriority ], &( pxOtherTCB->xStateListItem ) );
+		}
+	}
+
+	if ( pxTCB != NULL )
+	{
+		/* 
+		 * The `return pdFAIL` statement that follows can be uncommented
+		 * to test coverage when the task handle passed to TaskPrioritySet is NULL
+		 */
+		// return pdFAIL;
+		if ( nondet_bool() )
+		{
+			/* Nondet. insertion of this task in ready tasks list to allow both cases in line 1651 (tasks.c) */
+			vListInsert( &pxReadyTasksLists[ pxTCB->uxPriority ], &( pxTCB->xStateListItem ) );
+		}
+	}
+
+	/* Note that `*xTask = NULL` can happen here, but this is fine -- `pxCurrentTCB` will be used instead */
+	*xTask = pxTCB;
+
+	pxCurrentTCB = xUnconstrainedTCB();
+	if ( pxCurrentTCB == NULL )
+	{
+		return pdFAIL;
+	}
+
+	/* Nondet. insertion of this task in ready tasks list to allow both cases in line 1651 (tasks.c) */
+	if ( nondet_bool() )
+	{
+		vListInsert( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ], &( pxCurrentTCB->xStateListItem ) );
+
+		/* Use of this macro ensures coverage on line 185 (list.c) */
+		listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB , &pxReadyTasksLists[ pxCurrentTCB->uxPriority ] );
+	}
+
+	return pdPASS;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the CBMC memory-safety proof for TaskPrioritySet.

Depends on #774

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.