### PR TITLE
Change references from v4 to v2

### DIFF
--- a/libraries/c_sdk/aws/shadow/src/aws_shadow.c
+++ b/libraries/c_sdk/aws/shadow/src/aws_shadow.c
@@ -107,7 +107,7 @@ static void prvUpdatedCallbackWrapper( void * pvArgument,
                                        AwsIotShadowCallbackParam_t * const pxUpdatedDocument );
 
 /* Retrieves the MQTT v2 connection from the MQTT v1 connection handle. */
-extern IotMqttConnection_t MQTT_AGENT_Getv4Connection( MQTTAgentHandle_t xMQTTHandle );
+extern IotMqttConnection_t MQTT_AGENT_Getv2Connection( MQTTAgentHandle_t xMQTTHandle );
 
 /*-----------------------------------------------------------*/
 
@@ -475,7 +475,7 @@ ShadowReturnCode_t SHADOW_Update( ShadowClientHandle_t xShadowClientHandle,
     }
 
     /* Call the MQTT v2 blocking Shadow update function. */
-    xShadowError = AwsIotShadow_TimedUpdate( MQTT_AGENT_Getv4Connection( pxShadowClient->xMqttConnection ),
+    xShadowError = AwsIotShadow_TimedUpdate( MQTT_AGENT_Getv2Connection( pxShadowClient->xMqttConnection ),
                                              &xUpdateDocument,
                                              xFlags,
                                              shadowTICKS_TO_MS( xTimeoutTicks ) );
@@ -508,7 +508,7 @@ ShadowReturnCode_t SHADOW_Get( ShadowClientHandle_t xShadowClientHandle,
     }
 
     /* Call the MQTT v2 blocking Shadow get function. */
-    xShadowError = AwsIotShadow_TimedGet( MQTT_AGENT_Getv4Connection( pxShadowClient->xMqttConnection ),
+    xShadowError = AwsIotShadow_TimedGet( MQTT_AGENT_Getv2Connection( pxShadowClient->xMqttConnection ),
                                           &xGetDocument,
                                           xFlags,
                                           shadowTICKS_TO_MS( xTimeoutTicks ),
@@ -596,7 +596,7 @@ ShadowReturnCode_t SHADOW_RegisterCallbacks( ShadowClientHandle_t xShadowClientH
             pCallbackInfo = NULL;
         }
 
-        xShadowError = AwsIotShadow_SetDeltaCallback( MQTT_AGENT_Getv4Connection( pxShadowClient->xMqttConnection ),
+        xShadowError = AwsIotShadow_SetDeltaCallback( MQTT_AGENT_Getv2Connection( pxShadowClient->xMqttConnection ),
                                                       pxCallbackParams->pcThingName,
                                                       thingNameLength,
                                                       0,
@@ -616,7 +616,7 @@ ShadowReturnCode_t SHADOW_RegisterCallbacks( ShadowClientHandle_t xShadowClientH
             pCallbackInfo = NULL;
         }
 
-        xShadowError = AwsIotShadow_SetUpdatedCallback( MQTT_AGENT_Getv4Connection( pxShadowClient->xMqttConnection ),
+        xShadowError = AwsIotShadow_SetUpdatedCallback( MQTT_AGENT_Getv2Connection( pxShadowClient->xMqttConnection ),
                                                         pxCallbackParams->pcThingName,
                                                         thingNameLength,
                                                         0,

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
@@ -435,7 +435,7 @@ static void prvDisconnectCallbackWrapper( void * pvParameter,
 
 /*-----------------------------------------------------------*/
 
-IotMqttConnection_t MQTT_AGENT_Getv4Connection( MQTTAgentHandle_t xMQTTHandle )
+IotMqttConnection_t MQTT_AGENT_Getv2Connection( MQTTAgentHandle_t xMQTTHandle )
 {
     MQTTConnection_t * pxConnection = ( MQTTConnection_t * ) xMQTTHandle;
 


### PR DESCRIPTION
The C-SDK refers to upcoming MQTT API as v4, but for Amazon FreeRTOS they are v2 of these libraries.
Fixing comment references between v4 and v2 in Amazon FreeRTOS-only files to use Amazon FreeRTOS
versioning syntax.

https://amazon-freertos-ci.corp.amazon.com/view/3-Nightly/job/dsl_nightly_cmake/71/

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.