### PR TITLE
Update Microchip PIC32MZEF to use the Ethernet

### DIFF
--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -275,6 +275,7 @@
 									<logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
 										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
 										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
 									</logicalFolder>
 								</logicalFolder>
 							</logicalFolder>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -289,6 +289,7 @@
 									<logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
 										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
 										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
+										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
 									</logicalFolder>
 								</logicalFolder>
 							</logicalFolder>

--- a/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
+++ b/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
@@ -360,7 +360,7 @@ add_custom_command(
     COMMAND "${hexmate_path}" ${output_hex_file}  ${bl_hex_file} -O${exe_target}.production.unified.hex
 )
 if(NOT AFR_IS_TESTING)
-    set(ota_image_generator "${AFR_DEMOS_DIR}/ota/bootloader/utility/ota_image_generator.py")
+    set(ota_image_generator "${CMAKE_CURRENT_LIST_DIR}/bootloader/bootloader/utility/ota_image_generator.py")
     add_custom_command(
         TARGET ${exe_target} POST_BUILD
         COMMAND "echo" "Running xc32-objcopy"

--- a/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
+++ b/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
@@ -209,6 +209,7 @@ target_sources(
     INTERFACE
         "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c"
         "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c"
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c"
 )
 
 target_include_directories(

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -26,49 +26,49 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
-
-#define CONFIG_MQTT_DEMO_ENABLED 
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI|AWSIOT_NETWORK_TYPE_ETH )
+#define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                        ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                        ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_ETH )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
+#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS      ( 0 )
 /* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
+#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS        ( 1 )
 
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY + 5 )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY + 5 )
 
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 3000 )
+#define democonfigMQTT_TIMEOUT                pdMS_TO_TICKS( 3000 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS    ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -44,7 +44,7 @@
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
 #define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI|AWSIOT_NETWORK_TYPE_ETH )
 
 #define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
 #define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h
@@ -55,9 +55,9 @@
  *
  */
 #ifdef PIC32_USE_ETHERNET
-    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_ETH )
+    #define configENABLED_NETWORKS    ( AWSIOT_NETWORK_TYPE_ETH )
 #else
-    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+    #define configENABLED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
 #endif
 
 #endif /* CONFIG_FILES_AWS_IOT_NETWORK_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h
@@ -39,8 +39,11 @@
  * each network types supported. Flags for all supported network types can be found
  * in "aws_iot_network.h"
  */
-
-#define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
+#ifdef PIC32_USE_ETHERNET
+    #define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_ETH )
+#else
+    #define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
+#endif
 
 /**
  * @brief Configuration flag which is used to enable one or more network interfaces for a board.
@@ -51,7 +54,10 @@
  * in "aws_iot_network.h"
  *
  */
-
-#define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+#ifdef PIC32_USE_ETHERNET
+    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_ETH )
+#else
+    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+#endif
 
 #endif /* CONFIG_FILES_AWS_IOT_NETWORK_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -240,9 +240,13 @@ extern uint32_t ulRand();
  * generate replies to incoming ICMP echo (ping) requests. */
 #define ipconfigREPLY_TO_INCOMING_PINGS                1
 
-/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
- * FreeRTOS_SendPingRequest() API function is available. */
-#define ipconfigSUPPORT_OUTGOING_PINGS                 1
+/* vApplicationPingReplyHook() is called when ipconfigSUPPORT_OUTGOING_PINGS is enabled.
+ * In the Micorchip PIC32MZEF this hook is defined only in the AWS Wi-Fi port. */
+#ifndef PIC32_USE_ETHERNET
+    /* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+    * FreeRTOS_SendPingRequest() API function is available. */
+    #define ipconfigSUPPORT_OUTGOING_PINGS                 1
+#endif
 
 /* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
  * (and associated) API function is available. */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -113,7 +113,7 @@ extern uint32_t ulRand();
  * is not set to 1 then the network event hook will never be called.  See
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml
  */
-#define ipconfigUSE_NETWORK_EVENT_HOOK                 1
+#define ipconfigUSE_NETWORK_EVENT_HOOK            1
 
 /* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
  * a network buffer cannot be obtained then the calling task is held in the Blocked
@@ -127,7 +127,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS     ( 5000 / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If
@@ -136,14 +136,14 @@ extern uint32_t ulRand();
  * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
  * reason.  The static configuration used is that passed into the stack by the
  * FreeRTOS_IPInit() function call. */
-#define ipconfigUSE_DHCP                               1
-#define ipconfigDHCP_REGISTER_HOSTNAME                 1
-#define ipconfigDHCP_USES_UNICAST                      1
+#define ipconfigUSE_DHCP                          1
+#define ipconfigDHCP_REGISTER_HOSTNAME            1
+#define ipconfigDHCP_USES_UNICAST                 1
 
 /* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
  * provide an implementation of the DHCP callback function,
  * xApplicationDHCPUserHook(). */
-#define ipconfigUSE_DHCP_HOOK                          0
+#define ipconfigUSE_DHCP_HOOK                     0
 
 /* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
  * increasing time intervals until either a reply is received from a DHCP server
@@ -152,7 +152,7 @@ extern uint32_t ulRand();
  * static IP address passed as a parameter to FreeRTOS_IPInit() if the
  * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
  * a DHCP reply being received. */
-#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD             ( 120000 / portTICK_PERIOD_MS )
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD        ( 120000 / portTICK_PERIOD_MS )
 
 /* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
  * stack can only send a UDP message to a remove IP address if it knowns the MAC
@@ -163,19 +163,19 @@ extern uint32_t ulRand();
  * cache then the UDP message is replaced by a ARP message that solicits the
  * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
  * number of entries that can exist in the ARP table at any one time. */
-#define ipconfigARP_CACHE_ENTRIES                      6
+#define ipconfigARP_CACHE_ENTRIES                 6
 
 /* ARP requests that do not result in an ARP response will be re-transmitted a
  * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
  * aborted. */
-#define ipconfigMAX_ARP_RETRANSMISSIONS                ( 5 )
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
 
 /* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
  * table being created or refreshed and the entry being removed because it is stale.
  * New ARP requests are sent for ARP cache entries that are nearing their maximum
  * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
  * equal to 1500 seconds (or 25 minutes). */
-#define ipconfigMAX_ARP_AGE                            150
+#define ipconfigMAX_ARP_AGE                       150
 
 /* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
  * routines, which are relatively large.  To save code space the full
@@ -187,19 +187,19 @@ extern uint32_t ulRand();
  * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
  * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
  * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
-#define ipconfigINCLUDE_FULL_INET_ADDR                 1
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
 
 /* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         60
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
  * be queued for processing at any one time.  The event queue must be a minimum of
  * 5 greater than the total number of network buffers. */
-#define ipconfigEVENT_QUEUE_LENGTH                     ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+#define ipconfigEVENT_QUEUE_LENGTH                ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
 
 /* The address of a socket is the combination of its IP address and its port
  * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
@@ -213,39 +213,40 @@ extern uint32_t ulRand();
  * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
  * on a socket that has not yet been bound will result in the send operation being
  * aborted. */
-#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND    1
 
 /* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
-#define ipconfigUDP_TIME_TO_LIVE                       128
-#define ipconfigTCP_TIME_TO_LIVE                       128 /* also defined in FreeRTOSIPConfigDefaults.h */
+#define ipconfigUDP_TIME_TO_LIVE                  128
+#define ipconfigTCP_TIME_TO_LIVE                  128      /* also defined in FreeRTOSIPConfigDefaults.h */
 
 /* USE_TCP: Use TCP and all its features */
-#define ipconfigUSE_TCP                                ( 1 )
+#define ipconfigUSE_TCP                           ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                            ( 0 )
+#define ipconfigUSE_TCP_WIN                       ( 0 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1500
+#define ipconfigNETWORK_MTU                       1500
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */
-#define ipconfigUSE_DNS                                1
+#define ipconfigUSE_DNS                           1
 
 /* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
  * generate replies to incoming ICMP echo (ping) requests. */
-#define ipconfigREPLY_TO_INCOMING_PINGS                1
+#define ipconfigREPLY_TO_INCOMING_PINGS           1
 
 /* vApplicationPingReplyHook() is called when ipconfigSUPPORT_OUTGOING_PINGS is enabled.
  * In the Micorchip PIC32MZEF this hook is defined only in the AWS Wi-Fi port. */
 #ifndef PIC32_USE_ETHERNET
-    /* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
-    * FreeRTOS_SendPingRequest() API function is available. */
-    #define ipconfigSUPPORT_OUTGOING_PINGS                 1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+    #define ipconfigSUPPORT_OUTGOING_PINGS    1
 #endif
 
 /* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h
@@ -55,9 +55,9 @@
  *
  */
 #ifdef PIC32_USE_ETHERNET
-    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_ETH )
+    #define configENABLED_NETWORKS    ( AWSIOT_NETWORK_TYPE_ETH )
 #else
-    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+    #define configENABLED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
 #endif
 
 #endif /* CONFIG_FILES_AWS_IOT_NETWORK_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h
@@ -39,8 +39,11 @@
  * each network types supported. Flags for all supported network types can be found
  * in "aws_iot_network.h"
  */
-
-#define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
+#ifdef PIC32_USE_ETHERNET
+    #define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_ETH )
+#else
+    #define configSUPPORTED_NETWORKS    ( AWSIOT_NETWORK_TYPE_WIFI )
+#endif
 
 /**
  * @brief Configuration flag which is used to enable one or more network interfaces for a board.
@@ -51,7 +54,10 @@
  * in "aws_iot_network.h"
  *
  */
-
-#define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+#ifdef PIC32_USE_ETHERNET
+    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_ETH )
+#else
+    #define configENABLED_NETWORKS      ( AWSIOT_NETWORK_TYPE_WIFI )
+#endif
 
 #endif /* CONFIG_FILES_AWS_IOT_NETWORK_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c
@@ -405,7 +405,7 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
     WDRV_IsDisconnectRequestedSet( pdFALSE );
     WDRV_ConnectionStateSet( WDRV_CONNECTION_STATE_IN_PROGRESS );
 
-    WDRV_DBG_INFORM_MESSAGE( ( "Start Wi-Fi Connection...\r\n" ) );
+    WDRV_DBG_INFORM_MESSAGE( ( "Start Wi-Fi Connection to SSID %.*s...\r\n", pxNetworkParams->ucSSIDLength, pxNetworkParams->pcSSID ) );
 
     /* Read MAC address from the chip and set it in FreeRTOS network stack. */
     WDRV_EXT_CmdMacAddressGet( ucMACAddress );


### PR DESCRIPTION
Update Microchip PIC32MZEF to use the Ethernet

Description
-----------
The heart of this PR is this commit: https://github.com/aws/amazon-freertos/pull/907/commits/0244112dc709505ba24e88a5302d0539a41c0ce8
- Added PIC32_USE_ETHERNET where it was missing in Microchip.
- Added NetworkInterface_eth.c to be compiled in CMAKE, and the MPLABX IDE projects.
- Updated the network manager configuration files to support Ethernet .
- Fixed a path to some OTA utility python scripts that was incorrect in vendors\microchip\boards\curiosity_pic32mzef\CMakeLists.txt

This addresses issue: https://github.com/aws/amazon-freertos/issues/831

To use Ethernet you define this preprocessor macro at the project level: PIC32_USE_ETHERNET

We are still working on integrating this into the internal testing framework. Please look at this PR as step 1.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
   - Ran TCP Tests for both Wi-Fi and Ethernet. No regressions.
   - Ran Greengrass discovery demo for both Wi-Fi and Ethernet. Passed.
[ether_mchp_test_results.txt](https://github.com/aws/amazon-freertos/files/3364989/ether_mchp_test_results.txt)

- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.