### PR TITLE
CBMC memory-safety proof for DNSgetHostByName

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -420,7 +420,6 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
-if(pcHostName) {
 
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
@@ -482,8 +481,9 @@ if(pcHostName) {
 	{
 		ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
 	}
+
 	return ulIPAddress;
-  }
+
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -420,7 +420,7 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
-configASSERT(pcHostName);
+if(pcHostName) {
 
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
@@ -482,8 +482,8 @@ configASSERT(pcHostName);
 	{
 		ulIPAddress = prvGetHostByName( pcHostName, xIdentifier, xReadTimeOut_ms );
 	}
-
 	return ulIPAddress;
+  }
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -420,6 +420,8 @@ uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback
 uint32_t ulIPAddress = 0UL;
 TickType_t xReadTimeOut_ms = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
 TickType_t xIdentifier = 0;
+configASSERT(pcHostName);
+
 
 	/* If the supplied hostname is IP address, convert it to uint32_t
 	and return. */

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
@@ -1,0 +1,47 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_Sockets.h"
+
+/* This assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by 
+MAX_REQ_SIZE. */ 
+
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Abstraction of FreeRTOS_GetUDPPayloadBuffer. This should be checked later. For now we are allocating a fixed sized memory of size MAX_REQ_SIZE. */
+void * FreeRTOS_GetUDPPayloadBuffer(size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ) {
+	void *pvReturn = safeMalloc(MAX_REQ_SIZE); 
+	return pvReturn;
+}
+
+/* Abstraction of FreeRTOS_socket. This abstraction allocates a memory of size Socket_t. */
+Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol ) {
+	Socket_t xSocket = safeMalloc(sizeof(Socket_t)); /* Replaced malloc by safeMalloc */
+	return xSocket;
+}
+
+/* This function only uses the return value of prvParseDNSReply. Hence it returns an unconstrained uint32 value */
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+
+void harness() {
+	size_t len;
+	__CPROVER_assume(len >= 0 && len <= MAX_HOSTNAME_LEN);
+	char *pcHostName = safeMalloc(len); /* Replaced malloc by safeMalloc */
+	if (len && pcHostName) {
+		pcHostName[len-1] = NULL;
+	}
+	if (pcHostName) { /* Guarding against NULL pointer */
+		FreeRTOS_gethostbyname(pcHostName);
+	}
+}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/Makefile.json
@@ -1,0 +1,29 @@
+{
+  "ENTRY": "DNSgetHostByName",
+  ################################################################
+	# This configuration sets callback to 0. It also sets MAX_HOSTNAME_LEN to 10 and MAX_REQ_SIZE to 50 for performance issues.
+  # According to the specification MAX_HOST_NAME is upto 255.
+  "callback": 0,
+  "MAX_HOSTNAME_LEN": 10,
+  "MAX_REQ_SIZE": 50,
+  "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvProcessDNSCache.0:5,prvGetHostByName.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.1:{HOSTNAME_UNWIND},strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},strcmp.0:{HOSTNAME_UNWIND},strcpy.0:{HOSTNAME_UNWIND}",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigDNS_USE_CALLBACKS={callback}",
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
+  ],
+  "OPT" : "-m32"
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the DNSgetHostByName function, which prepares and sends a message to a DNS server.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.