### PR TITLE
Added two new precor test cases for OTA E2E.

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_project.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_project.py
@@ -241,7 +241,7 @@ class OtaAfrProject:
                 prefix = next(prefix for prefix in prefixToValue.keys() if line.startswith(prefix))
                 if prefixToValue[prefix] != None:
                     line = '{} {}\n'.format(prefix, prefixToValue[prefix])
-            # print(line) will place an extra newline character in the file.
+            # print(line) # will place an extra newline character in the file.
             sys.stdout.write(line)
 
     def setMqttLogsOn(self):
@@ -293,6 +293,14 @@ class OtaAfrProject:
                 '#define APP_VERSION_BUILD': bugfix
             },
             os.path.join(self._projectRootDir, OtaAfrProject.APPLICATION_VERSION_PATH)
+        )
+
+    def setOtaBlockSize(self, blockSize):
+        """Set aws_application_version.h with the input version.
+        """
+        self.__setIdentifierInFile(
+            {' #define otaconfigMAX_NUM_BLOCKS_REQUEST': str(blockSize) + 'U'},
+            os.path.join(self._projectRootDir, self._boardProjectPath, 'config_files', 'aws_ota_agent_config.h')
         )
 
     def setCodesignerCertificate(self, certificate):

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case.py
@@ -71,6 +71,13 @@ class OtaTestCase( object ):
         All the necessary setup. Optional method, but do call super setup if implementation is provided in sub-class.
         """
         self._otaProject.setApplicationVersion(0, 9, 0)
+
+        # Setting the block size for specific test case if required
+        if self._name == "OtaTestGreaterVersionMinBlockConfig":
+            self._otaProject.setOtaBlockSize(1)
+        elif self._name == "OtaTestGreaterVersionMaxBlockConfig":
+            self._otaProject.setOtaBlockSize(128)
+
         buildReturnCode = self._otaProject.buildProject()
         flashReturnCode = self._flashComm.flashAndRead()
 

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_factory.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_factory.py
@@ -36,7 +36,11 @@ from .aws_ota_test_case_missing_filename import OtaTestMissingFilename
 from .aws_ota_test_case_incorrect_platform import OtaTestIncorrectPlatform
 from .aws_ota_test_case_back_to_back_downloads import OtaTestBackToBackDownloads
 from .aws_ota_test_case_incorrect_wifi_password import OtaTestIncorrectWifiPassword
+from .aws_ota_test_case_greater_version_min_block_config import OtaTestGreaterVersionMinBlockConfig
+from .aws_ota_test_case_greater_version_max_block_config import OtaTestGreaterVersionMaxBlockConfig
 from .aws_ota_test_case_dummy_test import OtaTestDummyTest
+
+import pprint
 
 """
 All OTA test cases in the system.
@@ -55,7 +59,9 @@ AllOtaTestCases = {
     OtaTestMissingFilename.NAME : OtaTestMissingFilename,
     OtaTestBackToBackDownloads.NAME : OtaTestBackToBackDownloads,
     OtaTestIncorrectWifiPassword.NAME : OtaTestIncorrectWifiPassword,
-    OtaTestDummyTest.NAME : OtaTestDummyTest
+    OtaTestDummyTest.NAME : OtaTestDummyTest,
+    OtaTestGreaterVersionMinBlockConfig.NAME : OtaTestGreaterVersionMinBlockConfig,
+    OtaTestGreaterVersionMaxBlockConfig.NAME : OtaTestGreaterVersionMaxBlockConfig
 }
 
 class OtaTestCaseFactory( object ):

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version_max_block_config.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version_max_block_config.py
@@ -1,0 +1,50 @@
+"""
+Amazon FreeRTOS
+Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+http://aws.amazon.com/freertos
+http://www.FreeRTOS.org
+
+"""
+from .aws_ota_test_case import *
+from .aws_ota_aws_agent import *
+
+class OtaTestGreaterVersionMaxBlockConfig( OtaTestCase ):
+    NAME = 'OtaTestGreaterVersionMaxBlockConfig'
+    def __init__(self, boardConfig, otaProject, otaAwsAgent, flashComm):
+        super(OtaTestGreaterVersionMaxBlockConfig, self).__init__(
+            OtaTestGreaterVersionMaxBlockConfig.NAME,
+            True,
+            boardConfig,
+            otaProject,
+            otaAwsAgent,
+            flashComm
+        )
+
+    def run(self):
+        # Increase the version of the OTA image.
+        self._otaProject.setApplicationVersion(0, 9, 1)
+        # Set the block sice to minimum value
+        self._otaProject.setOtaBlockSize(128)
+        # Build the OTA image.
+        self._otaProject.buildProject()
+        # Start an OTA Update.
+        otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig)
+        return self.getTestResultAfterOtaUpdateCompletion(otaUpdateId)

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version_min_block_config.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_greater_version_min_block_config.py
@@ -1,0 +1,50 @@
+"""
+Amazon FreeRTOS
+Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+http://aws.amazon.com/freertos
+http://www.FreeRTOS.org
+
+"""
+from .aws_ota_test_case import *
+from .aws_ota_aws_agent import *
+
+class OtaTestGreaterVersionMinBlockConfig( OtaTestCase ):
+    NAME = 'OtaTestGreaterVersionMinBlockConfig'
+    def __init__(self, boardConfig, otaProject, otaAwsAgent, flashComm):
+        super(OtaTestGreaterVersionMinBlockConfig, self).__init__(
+            OtaTestGreaterVersionMinBlockConfig.NAME,
+            True,
+            boardConfig,
+            otaProject,
+            otaAwsAgent,
+            flashComm
+        )
+
+    def run(self):
+        # Increase the version of the OTA image.
+        self._otaProject.setApplicationVersion(0, 9, 1)
+        # Set the block sice to minimum value
+        self._otaProject.setOtaBlockSize(1)
+        # Build the OTA image.
+        self._otaProject.buildProject()
+        # Start an OTA Update.
+        otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig)
+        return self.getTestResultAfterOtaUpdateCompletion(otaUpdateId)


### PR DESCRIPTION
Added two new precor test cases for OTA E2E.

Description
-----------
Added two new precor test cases for OTA E2E. One with min block size of 1U and one with max block size of 128U.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.