### PR TITLE
Update aws_tests mbedtls on ESP32 to match aws_demos

### DIFF
--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_mem.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_mem.c
@@ -1,0 +1,38 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <esp_attr.h>
+#include <esp_heap_caps.h>
+#include <sdkconfig.h>
+#include "esp_mem.h"
+
+#ifndef CONFIG_MBEDTLS_CUSTOM_MEM_ALLOC
+
+IRAM_ATTR void *esp_mbedtls_mem_calloc(size_t n, size_t size)
+{
+#ifdef CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC
+    return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+#elif CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC
+    return heap_caps_calloc(n, size, MALLOC_CAP_SPIRAM|MALLOC_CAP_8BIT);
+#else
+    return calloc(n, size);
+#endif
+}
+
+IRAM_ATTR void esp_mbedtls_mem_free(void *ptr)
+{
+    return heap_caps_free(ptr);
+}
+
+#endif /* !CONFIG_MBEDTLS_CUSTOM_MEM_ALLOC */

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/include/esp_mem.h
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/include/esp_mem.h
@@ -1,0 +1,20 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdlib.h>
+
+void *esp_mbedtls_mem_calloc(size_t n, size_t size);
+void esp_mbedtls_mem_free(void *ptr);

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/include/mbedtls/esp_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/include/mbedtls/esp_config.h
@@ -116,6 +116,13 @@
  */
 #define MBEDTLS_PLATFORM_MEMORY
 
+/** Override calloc(), free() except for case where memory allocation scheme is not set to custom */
+#ifndef CONFIG_MBEDTLS_CUSTOM_MEM_ALLOC
+#include "esp_mem.h"
+#define MBEDTLS_PLATFORM_STD_CALLOC		esp_mbedtls_mem_calloc
+#define MBEDTLS_PLATFORM_STD_FREE		esp_mbedtls_mem_free
+#endif
+
 /**
  * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
  *
@@ -2616,8 +2623,46 @@
 //#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
 
 /* SSL options */
+#ifndef CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN             CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN /**< Maxium fragment length in bytes, determines the size of each of the two internal I/O buffers */
+
+#else
+
+/** \def MBEDTLS_SSL_IN_CONTENT_LEN
+ *
+ * Maximum incoming fragment length in bytes.
+ *
+ * Uncomment to set the size of the inward TLS buffer independently of the
+ * outward buffer.
+ */
+#define MBEDTLS_SSL_IN_CONTENT_LEN              CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN
+
+/** \def MBEDTLS_SSL_OUT_CONTENT_LEN
+ *
+ * Maximum outgoing fragment length in bytes.
+ *
+ * Uncomment to set the size of the outward TLS buffer independently of the
+ * inward buffer.
+ *
+ * It is possible to save RAM by setting a smaller outward buffer, while keeping
+ * the default inward 16384 byte buffer to conform to the TLS specification.
+ *
+ * The minimum required outward buffer size is determined by the handshake
+ * protocol's usage. Handshaking will fail if the outward buffer is too small.
+ * The specific size requirement depends on the configured ciphers and any
+ * certificate data which is sent during the handshake.
+ *
+ * For absolute minimum RAM usage, it's best to enable
+ * MBEDTLS_SSL_MAX_FRAGMENT_LENGTH and reduce MBEDTLS_SSL_MAX_CONTENT_LEN. This
+ * reduces both incoming and outgoing buffer sizes. However this is only
+ * guaranteed if the other end of the connection also supports the TLS
+ * max_fragment_len extension. Otherwise the connection may fail.
+ */
+#define MBEDTLS_SSL_OUT_CONTENT_LEN             CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN
+
+#endif /* !CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN */
+
 //#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 //#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
 //#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Commit 2eb5960 references mbedtls port files on ESP32 and cmake won't configure with `-D AFR_IS_TESTING=1`
- I resolved the issue by copying the relevant files from *aws_demos* to *aws_tests*
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.