### PR TITLE
FreeRTOS_IP.c three small changes

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h
@@ -47,7 +47,7 @@ UBaseType_t uxGetMinimumFreeNetworkBuffers( void );
 
 /* Copy a network buffer into a bigger buffer. */
 NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-	BaseType_t xNewLength);
+	size_t uxNewLength);
 
 /* Increase the size of a Network Buffer.
 In case BufferAllocation_2.c is used, the new space must be allocated. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -65,7 +65,9 @@ a constant. */
 
 
 /* Time delay between repeated attempts to initialise the network hardware. */
-#define ipINITIALISATION_RETRY_DELAY	( pdMS_TO_TICKS( 3000 ) )
+#ifndef ipINITIALISATION_RETRY_DELAY
+	#define ipINITIALISATION_RETRY_DELAY	( pdMS_TO_TICKS( 3000 ) )
+#endif
 
 /* Defines how often the ARP timer callback function is executed.  The time is
 shorted in the Windows simulator as simulated time is not real time. */
@@ -820,20 +822,20 @@ void *pvReturn;
 /*-----------------------------------------------------------*/
 
 NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-	BaseType_t xNewLength )
+	size_t uxNewLength )
 {
 NetworkBufferDescriptor_t * pxNewBuffer;
 
 	/* This function is only used when 'ipconfigZERO_COPY_TX_DRIVER' is set to 1.
 	The transmit routine wants to have ownership of the network buffer
 	descriptor, because it will pass the buffer straight to DMA. */
-	pxNewBuffer = pxGetNetworkBufferWithDescriptor( ( size_t ) xNewLength, ( TickType_t ) 0 );
+	pxNewBuffer = pxGetNetworkBufferWithDescriptor( uxNewLength, ( TickType_t ) 0 );
 
 	if( pxNewBuffer != NULL )
 	{
 		/* Set the actual packet size in case a bigger buffer than requested
 		was returned. */
-		pxNewBuffer->xDataLength = xNewLength;
+		pxNewBuffer->xDataLength = uxNewLength;
 
 		/* Copy the original packet information. */
 		pxNewBuffer->ulIPAddress = pxNetworkBuffer->ulIPAddress;
@@ -986,7 +988,10 @@ BaseType_t xReturn = pdFALSE;
 
 				/* Added to prevent ARP flood to gateway.  Ensure the
 				gateway is on the same subnet as the IP	address. */
-				configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) == ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask ) );
+				if( xNetworkAddressing.ulGatewayAddress != 0ul )
+				{
+					configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) == ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask ) );
+				}
 			}
 			#endif /* ipconfigUSE_DHCP == 1 */
 


### PR DESCRIPTION
<!--- Title -->
FreeRTOS_IP.c three small changes
-----------

In order to save time and energy, I would like to combine 3 small changes to `FreeRTOS_IP.c` in a single PR:

1. Check if `ipINITIALISATION_RETRY_DELAY` is already defined from outside
2. In function `pxDuplicateNetworkBufferWithDescriptor()`: give length parameter `size_t` type
3. Only check the validity of the gateway address if it is defined ( i.e. non-zero ).


Ad 1.
the function `xNetworkInterfaceInitialise()` is called repeatedly until it returns `pdPASS`. It shall return `pdPASS` once the PHY Link Status is high ( or once WiFi is connected ). The time between these calls ( polls ) is now fixed at 3 seconds.

FreeRTOS+TCP has a few macro's that are not exactly public, but that may be defined from outside. I would like to do the same here:

    /* Time delay between repeated attempts to initialise the network hardware. */
    #ifndef ipINITIALISATION_RETRY_DELAY
        #define ipINITIALISATION_RETRY_DELAY    ( pdMS_TO_TICKS( 3000 ) )
    #endif

In some cases, this will allow to start-up a device much quicker, e.g. 1 in stead of 3 seconds.


Ad 2.
There is often ambiguity about the use of `int` ( `BaseType_t` ), and `size_t` ( and [long stories](https://stackoverflow.com/questions/20388790/c-signed-or-unsigned-array-indexing) have been written about this subject ).
For array indexing I would prefer a signed variable. At the other hand, it is guaranteed that `size_t` can hold the length of the accessible memory. And also, the length of a buffer shall never be negative, so why use signed?
Within FreeRTOS+TCP, lengths are mostly stored in a `size_t`, so I propose :

    -    BaseType_t xNewLength )
    +    size_t uxNewLength )

The above change will avoid a few pc-lint errors.

Ad 3.
An IPv4 gateway address must have the same network address as the unit that uses it. This is tested in `FreeRTOS_IP.c : 989` in this assert:

    configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) ==
                 ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask )    );

In some LAN-only projects, there is no need for a gateway address.  This should not trigger an assert, so:

    if( xNetworkAddressing.ulGatewayAddress != 0ul )
    {
        configASSERT( xxx );
    }

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

In fact, I had the above changes already for a long time in all of my projects.

- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.