### PR TITLE
Name change in ProcessIPHeader proof

### DIFF
--- a/tools/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
+++ b/tools/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
@@ -12,7 +12,7 @@
   ],
   "DEF":
   [
-    "AMAZON_FREERTOS_ENABLE_UNIT_TESTS"
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
   ],
   "INC":
   [

--- a/tools/cbmc/proofs/parsing/ProcessIPPacket/ProcessIPPacket_harness.c
+++ b/tools/cbmc/proofs/parsing/ProcessIPPacket/ProcessIPPacket_harness.c
@@ -21,7 +21,7 @@ void harness() {
 
 	NetworkBufferDescriptor_t * const pxNetworkBuffer = malloc(sizeof(NetworkBufferDescriptor_t));
 	/* Pointer to the start of the Ethernet frame. It should be able to access the whole Ethernet frame.*/
-	pxNetworkBuffer->pucEthernetBuffer = malloc(ipTOTAL_ETHERNET_FRAME_SIZE); 
+	pxNetworkBuffer->pucEthernetBuffer = malloc(ipTOTAL_ETHERNET_FRAME_SIZE);
 	/* Minimum length of the pxNetworkBuffer->xDataLength is at least the size of the IPPacket_t. */
 	__CPROVER_assume(pxNetworkBuffer->xDataLength >= sizeof(IPPacket_t)  && pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE);
 	IPPacket_t * const pxIPPacket = malloc(sizeof(IPPacket_t));


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR changes the name of the flag in the proof for ProcessIPHeader in order to access the verification headers.
<!--- Describe your changes in detail -->
--------
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.