### PR TITLE
Adding CBMC proof for TCPHandleState

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -2665,6 +2665,8 @@ int32_t lRxSpace;
  */
 static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer )
 {
+configASSERT(pxSocket);
+configASSERT(ppxNetworkBuffer);
 TCPPacket_t *pxTCPPacket = ( TCPPacket_t * ) ( (*ppxNetworkBuffer)->pucEthernetBuffer );
 TCPHeader_t *pxTCPHeader = &( pxTCPPacket->xTCPHeader );
 BaseType_t xSendLength = 0;

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -1,0 +1,31 @@
+{
+  "ENTRY": "TCPHandleState",
+  "TX_DRIVER":1,
+  "RX_MESSAGES":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvWinScaleFactor.0:2",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigZERO_COPY_TX_DRIVER={TX_DRIVER}",
+    "ipconfigUSE_LINKED_RX_MESSAGES={RX_MESSAGES}",
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body prvTCPPrepareSend",
+    "--remove-function-body prvTCPReturnPacket"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -1,0 +1,45 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that prvTCPPrepareSend and prvTCPReturnPacket are correct.
+These functions are proved to be correct separately. */
+
+BaseType_t publicTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer );
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	size_t socketSize = sizeof(FreeRTOS_Socket_t);
+	if (ensure_memory_is_valid(pxSocket, socketSize)) {
+		/* ucOptionLength is the number of valid bytes in ulOptionsData[].
+		ulOptionsData[] is initialized as uint32_t ulOptionsData[ipSIZE_TCP_OPTIONS/sizeof(uint32_t)].
+		This assumption is required for a memcpy function that copies uxOptionsLength
+		data from pxTCPHeader->ucOptdata to pxTCPWindow->ulOptionsData.*/
+		__CPROVER_assume(pxSocket->u.xTCP.xTCPWindow.ucOptionLength == sizeof(uint32_t) * ipSIZE_TCP_OPTIONS/sizeof(uint32_t));
+		/* uxRxWinSize is initialized as size_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
+		__CPROVER_assume(pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof(size_t));
+		/* uxRxWinSize is initialized as uint16_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
+		__CPROVER_assume(pxSocket->u.xTCP.usInitMSS == sizeof(uint16_t));
+	}
+
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	size_t bufferSize = sizeof(NetworkBufferDescriptor_t);
+	if(ensure_memory_is_valid(pxNetworkBuffer, bufferSize)) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+	}
+	if (ensure_memory_is_valid(pxSocket, socketSize) &&
+		ensure_memory_is_valid(pxNetworkBuffer, bufferSize) &&
+		ensure_memory_is_valid(pxNetworkBuffer->pucEthernetBuffer, sizeof(TCPPacket_t)) &&
+		ensure_memory_is_valid(pxSocket->u.xTCP.pxPeerSocket, socketSize)) {
+
+			publicTCPHandleState(pxSocket, &pxNetworkBuffer);
+
+	}
+}

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,28 @@
+#define ensure_memory_is_valid( px, length ) (px != NULL) && __CPROVER_w_ok((px), length)
+
+/* Implementation of safe malloc which returns NULL if the requested size is 0.
+ Warning: The behavior of malloc(0) is platform dependent.
+ It is possible for malloc(0) to return an address without allocating memory.*/
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	FreeRTOS_Socket_t *pxSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	if (ensure_memory_is_valid(pxSocket, sizeof(FreeRTOS_Socket_t))) {
+		pxSocket->u.xTCP.rxStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.txStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.pxPeerSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	}
+	return pxSocket;
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvTCPHandleState function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.