### PR TITLE
Adding CBMC proof for TCP prepare

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1684,6 +1684,7 @@ BaseType_t xResize;
  */
 static int32_t prvTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength )
 {
+configASSERT(pxSocket);
 int32_t lDataLen;
 uint8_t *pucEthernetBuffer, *pucSendData;
 TCPPacket_t *pxTCPPacket;
@@ -2665,6 +2666,8 @@ int32_t lRxSpace;
  */
 static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer )
 {
+configASSERT(pxSocket);
+configASSERT(ppxNetworkBuffer);
 TCPPacket_t *pxTCPPacket = ( TCPPacket_t * ) ( (*ppxNetworkBuffer)->pucEthernetBuffer );
 TCPHeader_t *pxTCPHeader = &( pxTCPPacket->xTCPHeader );
 BaseType_t xSendLength = 0;

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TCPPrepareSend",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
@@ -1,0 +1,44 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_Stream_Buffer.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that pxGetNetworkBufferWithDescriptor is implemented correctly. */
+int32_t publicTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength );
+
+/* Abstraction of pxGetNetworkBufferWithDescriptor. It creates a buffer. */
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	NetworkBufferDescriptor_t *pxBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated ();
+	size_t bufferSize = sizeof(NetworkBufferDescriptor_t);
+	if (ensure_memory_is_valid(pxBuffer, bufferSize)) {
+		/* The code does not expect pucEthernetBuffer to be equal to NULL if
+		pxBuffer is not NULL. */
+		pxBuffer->pucEthernetBuffer = malloc(xRequestedSizeBytes);
+		pxBuffer->xDataLength = xRequestedSizeBytes;
+	}
+	return pxBuffer;
+}
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	size_t socketSize = sizeof(FreeRTOS_Socket_t);
+	size_t bufferSize = sizeof(NetworkBufferDescriptor_t);
+	if (ensure_memory_is_valid(pxNetworkBuffer, sizeof(*pxNetworkBuffer))) {
+		pxNetworkBuffer->xDataLength = bufferSize;
+		/* The code does not expect pucEthernetBuffer to be equal to NULL if
+		pxNetworkBuffer is not NULL. */
+		pxNetworkBuffer->pucEthernetBuffer = malloc(bufferSize);
+	}
+	UBaseType_t uxOptionsLength;
+	if(pxSocket) {
+		publicTCPPrepareSend(pxSocket, &pxNetworkBuffer, uxOptionsLength );
+	}
+}

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,28 @@
+#define ensure_memory_is_valid( px, length ) (px != NULL) && __CPROVER_w_ok((px), length)
+
+/* Implementation of safe malloc which returns NULL if the requested size is 0.
+ Warning: The behavior of malloc(0) is platform dependent.
+ It is possible for malloc(0) to return an address without allocating memory.*/
+void *safeMalloc(size_t xWantedSize) {
+	if(xWantedSize == 0) {
+		return NULL;
+	}
+	uint8_t byte;
+	return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	FreeRTOS_Socket_t *pxSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	if (ensure_memory_is_valid(pxSocket, sizeof(FreeRTOS_Socket_t))) {
+		pxSocket->u.xTCP.rxStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.txStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.pxPeerSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	}
+	return pxSocket;
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR includes the CBMC proof for memory safety of the prvTCPPrepareSend function.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.