### PR TITLE
Flush MQTT packets on receive malloc failure

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c
@@ -89,6 +89,22 @@ static IotMqttError_t _deserializeIncomingPacket( _mqttConnection_t * pMqttConne
 static void _sendPuback( _mqttConnection_t * pMqttConnection,
                          uint16_t packetIdentifier );
 
+/**
+ * @brief Flush a packet from the stream of incoming data.
+ *
+ * This function is called when memory for a packet cannot be allocated. The
+ * packet is flushed from the stream of incoming data so that the next packet
+ * may be read.
+ *
+ * @param[in] pNetworkConnection Network connection to use for receive, which
+ * may be different from the network connection associated with the MQTT connection.
+ * @param[in] pMqttConnection The associated MQTT connection.
+ * @param[in] length The length of the packet to flush.
+ */
+static void _flushPacket( void * pNetworkConnection,
+                          const _mqttConnection_t * pMqttConnection,
+                          size_t length );
+
 /*-----------------------------------------------------------*/
 
 static bool _incomingPacketValid( uint8_t packetType )
@@ -201,6 +217,14 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
 
         if( pIncomingPacket->pRemainingData == NULL )
         {
+            IotLogError( "(MQTT connection %p) Failed to allocate buffer of length "
+                         "%lu for incoming packet type %lu.",
+                         pMqttConnection,
+                         ( unsigned long ) pIncomingPacket->remainingLength,
+                         ( unsigned long ) pIncomingPacket->type );
+
+            _flushPacket( pNetworkConnection, pMqttConnection, pIncomingPacket->remainingLength );
+
             IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
         }
         else
@@ -720,6 +744,23 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
         }
 
         freePacket( pPuback );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void _flushPacket( void * pNetworkConnection,
+                          const _mqttConnection_t * pMqttConnection,
+                          size_t length )
+{
+    size_t bytesFlushed = 0;
+    uint8_t receivedByte = 0;
+
+    for( bytesFlushed = 0; bytesFlushed < length; bytesFlushed++ )
+    {
+        ( void ) _IotMqtt_GetNextByte( pNetworkConnection,
+                                       pMqttConnection->pNetworkInterface,
+                                       &receivedByte );
     }
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In response to #940
- Adds a log message on malloc failure (note that this log message may not print because logging requires malloc too).
- Flush a partial MQTT packet from the incoming data stream on malloc failure.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.