### PR TITLE
Fix TI CMake response file syntax

### DIFF
--- a/tools/cmake/toolchains/arm-ti.cmake
+++ b/tools/cmake/toolchains/arm-ti.cmake
@@ -40,5 +40,5 @@ link_libraries(-llibc.a)
 # Overwrite CMake archiver command for TI's compiler.
 set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> a <TARGET> <LINK_FLAGS> <OBJECTS>")
 
-# Overwrite response file flag for TI's compiler.
-set(CMAKE_C_RESPONSE_FILE_LINK_FLAG "-cmd_file=")
+# Default response file flag is "@".  TI's compiler doesn't require that.
+set(CMAKE_C_RESPONSE_FILE_LINK_FLAG "")


### PR DESCRIPTION
Corrects the syntax for specifying a response file to the TI
toolchain.

This resolves an issue when CMake attempted to build aws_tests.out on
Windows where, due to command line length limits, a response file was
being created and referenced incorrectly.

Signed-off-by: Chris Ring <cring@ti.com>

<!--- Title -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.