### PR TITLE
Enable/disable BLE gatt services through config

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
@@ -193,13 +193,92 @@
 #endif
 
 /**
+ * @brief Maximum number of device this device can be bonded with.
+ */
+#ifndef IOT_BLE_MAX_BONDED_DEVICES
+    #define IOT_BLE_MAX_BONDED_DEVICES    ( 5 )
+#endif
+
+#if ( IOT_BLE_ENCRYPTION_REQUIRED == 1 )
+    #if ( IOT_BLE_ENABLE_NUMERIC_COMPARISON == 1 )
+        #define IOT_BLE_CHAR_READ_PERM     eBTPermReadEncryptedMitm
+        #define IOT_BLE_CHAR_WRITE_PERM    eBTPermWriteEncryptedMitm
+    #else
+        #define IOT_BLE_CHAR_READ_PERM     eBTPermReadEncrypted
+        #define IOT_BLE_CHAR_WRITE_PERM    eBTPermWriteEncrypted
+    #endif
+#else
+    #define IOT_BLE_CHAR_READ_PERM         eBTPermRead
+    #define IOT_BLE_CHAR_WRITE_PERM        eBTPermWrite
+#endif
+
+/**
+ * @brief This configuration flag can be used to enable or disable all Amazon FreeRTOS GATT services.
+ * Configuration is useful if a custom GATT service is used instead of the default GATT services.
+ */
+#ifndef IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES
+    #define IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES  ( 1 )
+#endif
+
+/**
+ * @brief Set to true if user wants to add its own custom GATT services.
+ */
+#ifndef IOT_BLE_ADD_CUSTOM_SERVICES
+    #define IOT_BLE_ADD_CUSTOM_SERVICES    ( 0 )
+#endif
+
+
+/**
+ * @brief Flag to enable Amazon FreeRTOS Device Information Service. 
+ *
+ * Device Information service is used by the Amazon FreeRTOS mobile SDK to fetch device related information.
+ */
+#if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
+    #ifndef IOT_BLE_ENABLE_DEVICE_INFO_SERVICE
+        #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE  ( 1 )
+    #endif
+#else
+    #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE  ( 0 )
+#endif
+
+
+/**
  * @brief Enable WIFI provisioning GATT service.
  *
  * By default WIFI provisioning will be disabled.
  */
-#ifndef IOT_BLE_ENABLE_WIFI_PROVISIONING
-    #define IOT_BLE_ENABLE_WIFI_PROVISIONING    ( 0 )
+#if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
+    #ifndef IOT_BLE_ENABLE_WIFI_PROVISIONING
+        #define IOT_BLE_ENABLE_WIFI_PROVISIONING    ( 0 )
+    #endif
+#else
+   #define IOT_BLE_ENABLE_WIFI_PROVISIONING  ( 0 )
 #endif
+
+/**
+ * @brief Flag to enable MQTT over BLE using Amazon FreeRTOS Mobile SDK.
+ */
+#if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
+    #ifndef IOT_BLE_ENABLE_MQTT 
+        #define IOT_BLE_ENABLE_MQTT  ( 1 )
+    #endif
+#else
+    #define IOT_BLE_ENABLE_MQTT ( 0 )
+#endif
+
+
+/**
+ * @brief Flag to enable data transfer service.
+ * Data transfer service can be used to exchange raw data between  Amazon FreeRTOS device and Amazon FreeRTOS Mobile SDK.
+ */
+#if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
+    #ifndef IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE
+        #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE   ( 1 )
+    #endif
+#else
+    #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE   ( 0 )
+#endif
+
 
 /**
  * @brief Controls the number of network that can be discovered for WIFI provisioning.
@@ -221,36 +300,6 @@
 #endif
 
 /**
- * @brief Set to true if user wants to add its own custom services.
- */
-#ifndef IOT_BLE_ADD_CUSTOM_SERVICES
-    #define IOT_BLE_ADD_CUSTOM_SERVICES    ( 0 )
-#endif
-
-/**
- * @brief Maximum number of device this device can be bonded with.
- */
-#ifndef IOT_BLE_MAX_BONDED_DEVICES
-    #define IOT_BLE_MAX_BONDED_DEVICES    ( 5 )
-#endif
-
-#if ( IOT_BLE_ENCRYPTION_REQUIRED == 1 )
-    #if ( IOT_BLE_ENABLE_NUMERIC_COMPARISON == 1 )
-        #define IOT_BLE_CHAR_READ_PERM     eBTPermReadEncryptedMitm
-        #define IOT_BLE_CHAR_WRITE_PERM    eBTPermWriteEncryptedMitm
-    #else
-        #define IOT_BLE_CHAR_READ_PERM     eBTPermReadEncrypted
-        #define IOT_BLE_CHAR_WRITE_PERM    eBTPermWriteEncrypted
-    #endif
-#else
-    #define IOT_BLE_CHAR_READ_PERM         eBTPermRead
-    #define IOT_BLE_CHAR_WRITE_PERM        eBTPermWrite
-#endif
-
-#define IOT_BLE_MESG_ENCODER               ( _IotSerializerCborEncoder )
-#define IOT_BLE_MESG_DECODER               ( _IotSerializerCborDecoder )
-
-/**
  * @brief Waiting time between checks for connection established.
  */
 #ifndef IOT_BLE_MQTT_CREATE_CONNECTION_WAIT_MS
@@ -263,6 +312,7 @@
 #ifndef IOT_BLE_MQTT_CREATE_CONNECTION_RETRY
     #define IOT_BLE_MQTT_CREATE_CONNECTION_RETRY    ( 60 )
 #endif
+
 
 /*
  * @brief UUID mask for data transfer services.
@@ -280,17 +330,6 @@
  * Type will be part of the service UUID.
  */
 #define IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING    0x01
-
-/**
- * @brief Number of data transfer services.
- * User should change this when adding a new data transfer service type  or
- * removing the existing ones.
- */
-#if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
-    #define  IOT_BLE_NUM_DATA_TRANSFER_SERVICES    ( 2 )
-#else
-    #define IOT_BLE_NUM_DATA_TRANSFER_SERVICES     ( 1 )
-#endif
 
 /**
  *@brief Size of the buffer to store pending bytes to be sent out through data transfer service.
@@ -313,6 +352,10 @@
 #ifndef IOT_BLE_DATA_TRANSFER_TIMEOUT_MS
     #define IOT_BLE_DATA_TRANSFER_TIMEOUT_MS    ( 2000 )
 #endif
+
+
+#define IOT_BLE_MESG_ENCODER               ( _IotSerializerCborEncoder )
+#define IOT_BLE_MESG_DECODER               ( _IotSerializerCborDecoder )
 
 /**
  * @brief Default configuration for memory allocation of data transfer service buffers.

--- a/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
@@ -217,7 +217,7 @@
  * Configuration is useful if a custom GATT service is used instead of the default GATT services.
  */
 #ifndef IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES
-    #define IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES  ( 1 )
+    #define IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES    ( 1 )
 #endif
 
 /**
@@ -229,16 +229,16 @@
 
 
 /**
- * @brief Flag to enable Amazon FreeRTOS Device Information Service. 
+ * @brief Flag to enable Amazon FreeRTOS Device Information Service.
  *
  * Device Information service is used by the Amazon FreeRTOS mobile SDK to fetch device related information.
  */
 #if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
     #ifndef IOT_BLE_ENABLE_DEVICE_INFO_SERVICE
-        #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE  ( 1 )
+        #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE    ( 1 )
     #endif
 #else
-    #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE  ( 0 )
+    #define IOT_BLE_ENABLE_DEVICE_INFO_SERVICE        ( 0 )
 #endif
 
 
@@ -252,18 +252,18 @@
         #define IOT_BLE_ENABLE_WIFI_PROVISIONING    ( 0 )
     #endif
 #else
-   #define IOT_BLE_ENABLE_WIFI_PROVISIONING  ( 0 )
+    #define IOT_BLE_ENABLE_WIFI_PROVISIONING        ( 0 )
 #endif
 
 /**
  * @brief Flag to enable MQTT over BLE using Amazon FreeRTOS Mobile SDK.
  */
 #if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
-    #ifndef IOT_BLE_ENABLE_MQTT 
-        #define IOT_BLE_ENABLE_MQTT  ( 1 )
+    #ifndef IOT_BLE_ENABLE_MQTT
+        #define IOT_BLE_ENABLE_MQTT    ( 1 )
     #endif
 #else
-    #define IOT_BLE_ENABLE_MQTT ( 0 )
+    #define IOT_BLE_ENABLE_MQTT        ( 0 )
 #endif
 
 
@@ -273,10 +273,10 @@
  */
 #if ( IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES == 1 )
     #ifndef IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE
-        #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE   ( 1 )
+        #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE    ( 1 )
     #endif
 #else
-    #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE   ( 0 )
+    #define IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE        ( 0 )
 #endif
 
 
@@ -354,8 +354,8 @@
 #endif
 
 
-#define IOT_BLE_MESG_ENCODER               ( _IotSerializerCborEncoder )
-#define IOT_BLE_MESG_DECODER               ( _IotSerializerCborDecoder )
+#define IOT_BLE_MESG_ENCODER    ( _IotSerializerCborEncoder )
+#define IOT_BLE_MESG_DECODER    ( _IotSerializerCborDecoder )
 
 /**
  * @brief Default configuration for memory allocation of data transfer service buffers.

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -339,22 +339,22 @@ BTStatus_t _startAllServices()
     BTStatus_t status = eBTStatusSuccess;
     BaseType_t error = pdPASS;
 
-#if( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
-    if( error == pdPASS )
-    {
-        error = IotBleDeviceInfo_Init();
-    }
-#endif
-
-#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
-    if( error == pdPASS )
-    {
-        if( IotBleDataTransfer_Init() == false )
+    #if ( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
+        if( error == pdPASS )
         {
-            error = pdFAIL;
+            error = IotBleDeviceInfo_Init();
         }
-    }
-#endif
+    #endif
+
+    #if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
+        if( error == pdPASS )
+        {
+            if( IotBleDataTransfer_Init() == false )
+            {
+                error = pdFAIL;
+            }
+        }
+    #endif
 
     if( error != pdPASS )
     {

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -336,36 +336,30 @@ void _bondedCb( BTStatus_t status,
 
 BTStatus_t _startAllServices()
 {
-    BTStatus_t status = eBTStatusSuccess;
-    BaseType_t error = pdPASS;
+    BTStatus_t ret = eBTStatusSuccess;
+    bool status = true;
 
     #if ( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
-        if( error == pdPASS )
-        {
-            error = IotBleDeviceInfo_Init();
-        }
+        status = IotBleDeviceInfo_Init();
     #endif
 
     #if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
-        if( error == pdPASS )
+        if( status == true )
         {
-            if( IotBleDataTransfer_Init() == false )
-            {
-                error = pdFAIL;
-            }
+            status = IotBleDataTransfer_Init();
         }
     #endif
 
-    if( error != pdPASS )
+    if( status == false )
     {
-        status = eBTStatusFail;
+        ret = eBTStatusFail;
     }
 
     #if ( IOT_BLE_ADD_CUSTOM_SERVICES == 1 )
         IotBle_AddCustomServicesCb();
     #endif
 
-    return status;
+    return ret;
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -337,10 +337,16 @@ void _bondedCb( BTStatus_t status,
 BTStatus_t _startAllServices()
 {
     BTStatus_t status = eBTStatusSuccess;
-    BaseType_t error;
+    BaseType_t error = pdPASS;
 
-    error = IotBleDeviceInfo_Init();
+#if( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
+    if( error == pdPASS )
+    {
+        error = IotBleDeviceInfo_Init();
+    }
+#endif
 
+#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
     if( error == pdPASS )
     {
         if( IotBleDataTransfer_Init() == false )
@@ -348,6 +354,7 @@ BTStatus_t _startAllServices()
             error = pdFAIL;
         }
     }
+#endif
 
     if( error != pdPASS )
     {

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -150,6 +150,11 @@
  */
 #define _TRANSMIT_LENGTH( mtu )                      ( ( mtu ) - 3 )
 
+/**
+ * @brief Number of data transfer services is determined by number of rows of attribute table.
+ */
+ #define _NUM_DATA_TRANSFER_SERVICES                 ( sizeof( _attributeTable ) / sizeof(_attributeTable[0]) )
+
 /*-------------------------------------------------------------------------------------------------------------------------*/
 
 /**
@@ -313,22 +318,32 @@ extern int snprintf( char *,
 
 /*----------------------------------------------------------------------------------------------------------*/
 
-
-static const BTAttribute_t _attributeTable[ IOT_BLE_NUM_DATA_TRANSFER_SERVICES ][ IOT_BLE_DATA_TRANSFER_MAX_ATTRIBUTES ] =
+static const BTAttribute_t _attributeTable[][ IOT_BLE_DATA_TRANSFER_MAX_ATTRIBUTES ] =
 {
+#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
     #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
         _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
     #endif
-    _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+    #if ( IOT_BLE_ENABLE_MQTT == 1 )
+        _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+    #endif
+#endif
 };
 
-static IotBleDataTransferService_t _services[ IOT_BLE_NUM_DATA_TRANSFER_SERVICES ] =
+static IotBleDataTransferService_t _services[] =
 {
+#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
     #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
         _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
     #endif
-    _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+    #if ( IOT_BLE_ENABLE_MQTT == 1 )
+        _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+    #endif
+#endif
 };
+
+static const uint16_t _numDataTransferServices = _NUM_DATA_TRANSFER_SERVICES;
+
 
 static const IotBleAttributeEventCallback_t _callbacks[ IOT_BLE_DATA_TRANSFER_MAX_ATTRIBUTES ] =
 {
@@ -360,7 +375,7 @@ static IotBleDataTransferService_t * _getServiceFromHandle( uint16_t handle )
     uint8_t id;
     IotBleDataTransferService_t * pService = NULL;
 
-    for( id = 0; id < IOT_BLE_NUM_DATA_TRANSFER_SERVICES; id++ )
+    for( id = 0; id < _numDataTransferServices; id++ )
     {
         /* Check that the handle is included in the service. */
         if( ( handle > _services[ id ].handles[ 0 ] ) &&
@@ -823,7 +838,7 @@ static void _connectionCallback( BTStatus_t status,
         }
         else
         {
-            for( index = 0; index < IOT_BLE_NUM_DATA_TRANSFER_SERVICES; index++ )
+            for( index = 0; index < _numDataTransferServices; index++ )
             {
                 IotBleDataTransfer_Close( &_services[ index ].channel );
                 _services[ index ].isReady = false;
@@ -941,7 +956,7 @@ bool IotBleDataTransfer_Init( void )
     /* Initialize all data transfer services */
     if( ret == true )
     {
-        for( index = 0; index < IOT_BLE_NUM_DATA_TRANSFER_SERVICES; index++ )
+        for( index = 0; index < _numDataTransferServices; index++ )
         {
             ret = _initializeChannel( &_services[ index ].channel );
 
@@ -974,7 +989,7 @@ IotBleDataTransferChannel_t * IotBleDataTransfer_Open( uint8_t serviceIdentifier
     uint8_t index;
     IotBleDataTransferChannel_t * pChannel = NULL;
 
-    for( index = 0; index < IOT_BLE_NUM_DATA_TRANSFER_SERVICES; index++ )
+    for( index = 0; index < _numDataTransferServices; index++ )
     {
         if( _services[ index ].identifier == serviceIdentifier )
         {

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -153,7 +153,7 @@
 /**
  * @brief Number of data transfer services is determined by number of rows of attribute table.
  */
- #define _NUM_DATA_TRANSFER_SERVICES                 ( sizeof( _attributeTable ) / sizeof(_attributeTable[0]) )
+#define _NUM_DATA_TRANSFER_SERVICES    ( sizeof( _attributeTable ) / sizeof( _attributeTable[ 0 ] ) )
 
 /*-------------------------------------------------------------------------------------------------------------------------*/
 
@@ -320,26 +320,26 @@ extern int snprintf( char *,
 
 static const BTAttribute_t _attributeTable[][ IOT_BLE_DATA_TRANSFER_MAX_ATTRIBUTES ] =
 {
-#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
-    #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
-        _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
+    #if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
+        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
+            _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
+        #endif
+        #if ( IOT_BLE_ENABLE_MQTT == 1 )
+            _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+        #endif
     #endif
-    #if ( IOT_BLE_ENABLE_MQTT == 1 )
-        _ATTRIBUTE_TABLE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
-    #endif
-#endif
 };
 
 static IotBleDataTransferService_t _services[] =
 {
-#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
-    #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
-        _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
+    #if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
+        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
+            _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING ),
+        #endif
+        #if ( IOT_BLE_ENABLE_MQTT == 1 )
+            _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
+        #endif
     #endif
-    #if ( IOT_BLE_ENABLE_MQTT == 1 )
-        _SERVICE_INITIALIZER( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT )
-    #endif
-#endif
 };
 
 static const uint16_t _numDataTransferServices = _NUM_DATA_TRANSFER_SERVICES;


### PR DESCRIPTION
In response to https://github.com/aws/amazon-freertos/issues/950

Description
-----------

The PR adds config to enable or disable all FreeRTOS GATT services or selectively enable/disable each  of them.

By default, Device Information Service and Data Transfer Services are enabled by in FreeRTOS. 
To disable them, set :
``` #define IOT_BLE_ENABLE_FREERTOS_GATT_SERVICES ( 0 ) ``` in ```iot_ble_config.h```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

Tested all configurations against Nordic and ESP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.