### PR TITLE
Adding CBMC proof for HTTP

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -1,0 +1,20 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+/* We prove memory safety of IotHttpsClient_Disconnect separately. */
+IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHandle) {}
+
+
+void harness() {
+  	IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
+  	IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
+  	IotHttpsClient_Connect(&pConnHandle, pConnConfig);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -14,7 +14,7 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHa
 
 
 void harness() {
-  	IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
-  	IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
-  	IotHttpsClient_Connect(&pConnHandle, pConnConfig);
+  IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
+  IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
+  IotHttpsClient_Connect(&pConnHandle, pConnConfig);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -16,5 +16,15 @@
     "--remove-function-body _httpParserOnMessageBeginCallback",
     "--remove-function-body _httpParserOnMessageCompleteCallback",
     "--remove-function-body IotNetworkInterfaceDestroy"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -1,0 +1,20 @@
+{
+  "ENTRY": "IotHttpsClient_Connect",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset strlen.0:5"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body _httpParserOnHeadersCompleteCallback",
+    "--remove-function-body _httpParserOnMessageBeginCallback",
+    "--remove-function-body _httpParserOnMessageCompleteCallback",
+    "--remove-function-body IotNetworkInterfaceDestroy"
+  ]
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -1,0 +1,16 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+void harness() {
+	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  	uint32_t * pContentLength = malloc(sizeof(uint32_t));
+  	IotHttpsClient_ReadContentLength(respHandle, pContentLength);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
-  	uint32_t * pContentLength = malloc(sizeof(uint32_t));
-  	IotHttpsClient_ReadContentLength(respHandle, pContentLength);
+  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  uint32_t pContentLength;
+  IotHttpsClient_ReadContentLength(respHandle, &pContentLength);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -1,0 +1,13 @@
+{
+  "ENTRY": "IotHttpsClient_ReadContentLength",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ]
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -9,5 +9,15 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -1,0 +1,25 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+void harness() {
+	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  size_t pName_len;
+  __CPROVER_assume(pName_len >= 0 && pName_len <= IOT_HTTPS_MAX_HOST_NAME_LENGTH);
+  char *pName = safeMalloc(pName_len);
+  uint32_t len;
+  __CPROVER_assume(len >= 0 && len <= MAX_ACCEPTED_SIZE);
+  char  *pValue = safeMalloc(len);
+  if (respHandle) {
+    /* We need to bound respHandle->readHeaderValueLength in order to terminate strncpy */
+    __CPROVER_assume(respHandle->readHeaderValueLength >= 0 && respHandle->readHeaderValueLength <= MAX_ACCEPTED_SIZE + 1);
+  }
+  IotHttpsClient_ReadHeader(respHandle, pName, pValue, len);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -1,0 +1,23 @@
+{
+  "ENTRY": "IotHttpsClient_ReadHeader",
+  ################################################################
+  # This configuration sets MAX_ACCEPTED_SIZE to 20.
+  "MAX_ACCEPTED_SIZE": 20,
+  "STRNCPY_UNWIND": "__eval {MAX_ACCEPTED_SIZE} + 1",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset __builtin___strncpy_chk.0:{STRNCPY_UNWIND},strncpy.0:{STRNCPY_UNWIND}",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "DEF":
+  [
+    "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}"
+  ]
+}
+

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -18,6 +18,16 @@
   "DEF":
   [
     "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
   ]
 }
 

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
@@ -1,0 +1,16 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+void harness() {
+	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  	uint16_t *pStatus = safeMalloc(sizeof(uint16_t));
+  	IotHttpsClient_ReadResponseStatus(respHandle, pStatus);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
-  	uint16_t *pStatus = safeMalloc(sizeof(uint16_t));
-  	IotHttpsClient_ReadResponseStatus(respHandle, pStatus);
+  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  uint16_t pStatus;
+  IotHttpsClient_ReadResponseStatus(respHandle, &pStatus);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -1,0 +1,13 @@
+{
+  "ENTRY": "IotHttpsClient_ReadResponseStatus",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ]
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -9,5 +9,15 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -16,6 +16,7 @@ struct with two members: the first member is the header struct and the
 second member is the user data. This is faster than just allocating a
 sequence of bytes large enough to hold the header struct and the user data.
 We modeled responseHandle, requestHandle and connectionHandle similarly. */
+
 typedef struct _responseHandle
 {
   struct _httpsResponse RespHandle;
@@ -50,7 +51,8 @@ size_t http_parser_execute (http_parser *parser,
 IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
                void * pCredentialInfo,
                void * pConnection ) {
-  *(char **)pConnection = malloc(1); /* network connection is opaque */
+  /* This connection created is only used by the send, receive, close, and destroy functions*/
+  *(char **)pConnection = malloc(1); /* network connection is opaque.  */
   IotNetworkError_t error;
   return error;
 }
@@ -133,13 +135,12 @@ IotHttpsConnectionInfo_t * newConnectionInfo() {
 IotHttpsConnectionHandle_t newIotConnectionHandle () {
   IotHttpsConnectionHandle_t pConnectionHandle = safeMalloc(sizeof(_connHandle_t));
   if(pConnectionHandle) {
-    pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(uint32_t));
+    pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(_connHandle_t));
     pConnectionHandle->pNetworkInterface = newNetworkInterface();
-    pConnectionHandle->reqQ.pPrevious = NULL;
-    pConnectionHandle->reqQ.pNext = NULL;
-    pConnectionHandle->respQ.pPrevious = NULL;
-    pConnectionHandle->respQ.pNext = NULL;
-    //pConnectionHandle->taskPoolJob = malloc(sizeof(struct _taskPoolJob));
+    pConnectionHandle->reqQ.pPrevious = &(pConnectionHandle->reqQ);
+    pConnectionHandle->reqQ.pNext = &(pConnectionHandle->reqQ);
+    pConnectionHandle->respQ.pPrevious = &(pConnectionHandle->respQ);
+    pConnectionHandle->respQ.pNext = &(pConnectionHandle->respQ);
   }
   return pConnectionHandle;
 }
@@ -148,18 +149,19 @@ IotHttpsConnectionHandle_t newIotConnectionHandle () {
 IotHttpsResponseHandle_t newIotResponseHandle() {
   IotHttpsResponseHandle_t pResponseHandle = safeMalloc(sizeof(_resHandle_t));
   if(pResponseHandle) {
-    pResponseHandle->pBody = malloc(sizeof(uint32_t));
+    uint32_t len;
+    pResponseHandle->pBody = malloc(len);
     pResponseHandle->pHttpsConnection = newIotConnectionHandle();
     pResponseHandle->pHttpsRequest = safeMalloc(sizeof(_reqHandle_t));
     if(pResponseHandle->pHttpsRequest) {
       pResponseHandle->pHttpsRequest->pHttpsResponse = pResponseHandle;
     }
-    pResponseHandle->pHeaders = safeMalloc(sizeof(pResponseHandle) + sizeof(struct _httpResponse));
+    pResponseHandle->pHeaders = ((_resHandle_t*)pResponseHandle)->data;
     pResponseHandle->pHeadersCur = pResponseHandle->pHeaders;
+    pResponseHandle->pHeadersEnd = pResponseHandle->pHeaders + sizeof(((_resHandle_t*)pResponseHandle)->data);
     pResponseHandle->httpParserInfo.readHeaderParser.data = pResponseHandle;
     pResponseHandle->httpParserInfo.parseFunc = http_parser_execute;
     pResponseHandle->pReadHeaderValue = safeMalloc(sizeof(uint32_t));
-    pResponseHandle->pHeadersEnd = safeMalloc(sizeof(pResponseHandle) + sizeof(_resHandle_t)); ;
     __CPROVER_assume(pResponseHandle->readHeaderValueLength >= 0 &&
     pResponseHandle->readHeaderValueLength <= (pResponseHandle->pHeadersEnd - pResponseHandle->pHeaders));
     pResponseHandle->pReadHeaderValue = malloc(pResponseHandle->readHeaderValueLength);
@@ -175,14 +177,13 @@ IotHttpsRequestHandle_t newIotRequestHandle() {
     pRequestHandle->pHttpsResponse = newIotResponseHandle();
     pRequestHandle->pHttpsConnection = newIotConnectionHandle();
     pRequestHandle->pBody = malloc(len);
-    pRequestHandle->pHeaders = safeMalloc(sizeof(pRequestHandle) + sizeof(struct _httpRequest));
+    pRequestHandle->pHeaders = ((_reqHandle_t*)pRequestHandle)->data;
     pRequestHandle->pHeadersCur = pRequestHandle->pHeaders;
-    pRequestHandle->pHeadersEnd = safeMalloc(sizeof(pRequestHandle) + sizeof(_reqHandle_t));
+    pRequestHandle->pHeadersEnd = pRequestHandle->pHeaders + sizeof(((_reqHandle_t*)pRequestHandle)->data);
     pRequestHandle->pConnInfo = newConnectionInfo();
   }
   return pRequestHandle;
 }
-
 /* Creates a Request Info and assigns memory accordingly. */
 IotHttpsRequestInfo_t * newIotRequestInfo() {
   IotHttpsRequestInfo_t * pReqInfo = safeMalloc(sizeof(IotHttpsRequestInfo_t));
@@ -204,7 +205,6 @@ IotHttpsResponseInfo_t * newIotResponseInfo() {
   if(pRespInfo) {
     uint32_t bufferSize;
     uint32_t bodySize;
-    __CPROVER_assume(bufferSize > 0 && bufferSize <= responseUserBufferMinimumSize);
     pRespInfo->userBuffer.bufferLen = bufferSize;
     pRespInfo->userBuffer.pBuffer = malloc(bufferSize);
     pRespInfo->pSyncInfo = malloc(sizeof(IotHttpsSyncInfo_t));

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -124,7 +124,7 @@ IotHttpsConnectionInfo_t * newConnectionInfo() {
 IotHttpsConnectionHandle_t newIotConnectionHandle () {
   IotHttpsConnectionHandle_t pConnectionHandle = safeMalloc(sizeof(_connHandle_t));
   if(pConnectionHandle) {
-    pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(_connHandle_t));
+    pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(uint32_t));
     pConnectionHandle->pNetworkInterface = newNetworkInterface();
     pConnectionHandle->reqQ.pPrevious = safeMalloc(sizeof(IotLink_t));
     pConnectionHandle->reqQ.pNext = safeMalloc(sizeof(IotLink_t));
@@ -143,12 +143,12 @@ IotHttpsResponseHandle_t newIotResponseHandle() {
     if(pResponseHandle->pHttpsRequest) {
       pResponseHandle->pHttpsRequest->pHttpsResponse = pResponseHandle;
     }
-    pResponseHandle->pHeaders = (uint8_t *)pResponseHandle;
+    pResponseHandle->pHeaders = safeMalloc(sizeof(pResponseHandle) + sizeof(struct _httpResponse));
     pResponseHandle->pHeadersCur = pResponseHandle->pHeaders;
-    pResponseHandle->httpParserInfo.readHeaderParser.data = pResponseHandle; //???
+    pResponseHandle->httpParserInfo.readHeaderParser.data = pResponseHandle;
     pResponseHandle->httpParserInfo.parseFunc = http_parser_execute;
     pResponseHandle->pReadHeaderValue = safeMalloc(sizeof(uint32_t));
-    pResponseHandle->pHeadersEnd = pResponseHandle->pHeaders + sizeof(_resHandle_t) ;
+    pResponseHandle->pHeadersEnd = safeMalloc(sizeof(pResponseHandle) + sizeof(_resHandle_t)); ;
     __CPROVER_assume(pResponseHandle->readHeaderValueLength >= 0 &&
     pResponseHandle->readHeaderValueLength <= (pResponseHandle->pHeadersEnd - pResponseHandle->pHeaders));
     pResponseHandle->pReadHeaderValue = malloc(pResponseHandle->readHeaderValueLength);
@@ -158,17 +158,17 @@ IotHttpsResponseHandle_t newIotResponseHandle() {
 
 /* Creates a Request Handle and assigns memory accordingly. */
 IotHttpsRequestHandle_t newIotRequestHandle() {
-  IotHttpsRequestHandle_t requestHandle = safeMalloc(sizeof(_reqHandle_t));
-  if (requestHandle) {
-    requestHandle->pHttpsResponse = newIotResponseHandle();
-    requestHandle->pHttpsConnection = newIotConnectionHandle();
-    requestHandle->pBody = malloc(sizeof(uint32_t));
-    requestHandle->pHeaders = (uint8_t *)requestHandle;
-    requestHandle->pHeadersCur = requestHandle->pHeaders;
-    requestHandle->pHeadersEnd = requestHandle->pHeaders  + sizeof(_resHandle_t) ;
-    requestHandle->pConnInfo = newConnectionInfo();
+  IotHttpsRequestHandle_t pRequestHandle = safeMalloc(sizeof(_reqHandle_t));
+  if (pRequestHandle) {
+    pRequestHandle->pHttpsResponse = newIotResponseHandle();
+    pRequestHandle->pHttpsConnection = newIotConnectionHandle();
+    pRequestHandle->pBody = malloc(sizeof(uint32_t));
+    pRequestHandle->pHeaders = safeMalloc(sizeof(pRequestHandle) + sizeof(struct _httpRequest));
+    pRequestHandle->pHeadersCur = pRequestHandle->pHeaders;
+    pRequestHandle->pHeadersEnd = safeMalloc(sizeof(pRequestHandle) + sizeof(_reqHandle_t));
+    pRequestHandle->pConnInfo = newConnectionInfo();
   }
-  return requestHandle;
+  return pRequestHandle;
 }
 
 /* Creates a Request Info and assigns memory accordingly. */

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -1,6 +1,7 @@
 #define MAX_DATA_SIZE 1000
 
-/* Implementation of safe malloc which returns NULL if the reuested size is 0.*/
+/* Implementation of safe malloc which returns NULL if the requested size is 0.
+ Depending on the platform the malloc may return either NULL or an address. */
 void *safeMalloc(size_t xWantedSize) {
   if(xWantedSize == 0) {
     return NULL;
@@ -9,24 +10,28 @@ void *safeMalloc(size_t xWantedSize) {
   return byte ? malloc(xWantedSize) : NULL;
 }
 
-/* This modeling is required because otherwise CBMC takes
-too much time if assigned to minimumBufferSizes. */
+/* It is common for a buffer to contain a header struct followed by user data.
+We optimize CBMC performance by allocating space for the buffer using a
+struct with two members: the first member is the header struct and the
+second member is the user data. This is faster than just allocating a
+sequence of bytes large enough to hold the header struct and the user data.
+We modeled responseHandle, requestHandle and connectionHandle similarly. */
 typedef struct _responseHandle
 {
-    struct _httpsResponse RespHandle;
-    char data[MAX_DATA_SIZE];
+  struct _httpsResponse RespHandle;
+  char data[MAX_DATA_SIZE];
 } _resHandle_t;
 
 typedef struct _requestHandle
 {
-    struct _httpsRequest ReqHandle;
-    char data[MAX_DATA_SIZE];
+  struct _httpsRequest ReqHandle;
+  char data[MAX_DATA_SIZE];
 } _reqHandle_t;
 
 typedef struct _connectionHandle
 {
-    struct _httpsConnection pConnHandle;
-    char data[MAX_DATA_SIZE];
+  struct _httpsConnection pConnHandle;
+  char data[MAX_DATA_SIZE];
 } _connHandle_t;
 
 /* Models the third party HTTP Parser. */
@@ -45,41 +50,43 @@ size_t http_parser_execute (http_parser *parser,
 IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
                void * pCredentialInfo,
                void * pConnection ) {
-    *(char **)pConnection = malloc(1); /* network connection is opaque */
-    IotNetworkError_t error;
-    return error;
+  *(char **)pConnection = malloc(1); /* network connection is opaque */
+  IotNetworkError_t error;
+  return error;
 }
 
 size_t IotNetworkInterfaceSend( void * pConnection,
            const uint8_t * pMessage,
            size_t messageLength ) {
-    size_t size;
-    __CPROVER_assume(size <= messageLength);
-    return size;
+  size_t size;
+  __CPROVER_assume(size <= messageLength);
+  return size;
 }
 
 IotNetworkError_t IotNetworkInterfaceClose( void * pConnection ) {
-    IotNetworkError_t error;
-    return error;
+  IotNetworkError_t error;
+  return error;
 }
 
 size_t IotNetworkInterfaceReceive( void * pConnection,
         uint8_t * pBuffer,
         size_t bytesRequested ) {
-    uint8_t byte;
-    __CPROVER_array_copy(pBuffer,&byte);
+  uint8_t byte;
+  /* This intrinsic copies a source to a destination, and fills the
+  remainder of the destination with unconstrained data.*/
+  __CPROVER_array_copy(pBuffer,&byte);
 
-    size_t size;
-    __CPROVER_assume(size <= bytesRequested);
-    return size;
+  size_t size;
+  __CPROVER_assume(size <= bytesRequested);
+  return size;
 }
 
 IotNetworkError_t IotNetworkInterfaceCallback( void * pConnection,
                  IotNetworkReceiveCallback_t
                  receiveCallback,
                  void * pContext ) {
-    IotNetworkError_t error;
-    return error;
+  IotNetworkError_t error;
+  return error;
 }
 
 IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection ) {
@@ -106,10 +113,12 @@ IotHttpsConnectionInfo_t * newConnectionInfo() {
   IotHttpsConnectionInfo_t * pConnInfo = safeMalloc(sizeof(IotHttpsConnectionInfo_t));
   if(pConnInfo) {
     pConnInfo->pNetworkInterface = newNetworkInterface();
-    /* The +1 is required for coverage */
+    /* Function _createHttpsConnection checks if pConnInfo->addressLen is less than
+    IOT_HTTPS_MAX_HOST_NAME_LENGTH. The +1 is added to cover all cases. */
     __CPROVER_assume(pConnInfo->addressLen >= 0 && pConnInfo->addressLen <= IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
     pConnInfo->pAddress = safeMalloc(pConnInfo->addressLen);
-    /* The +1 is required for coverage */
+    /* Function _createHttpsConnection checks if pConnInfo->alpnProtocolsLen is less than
+    IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH. The +1 is added to cover all cases. */
     __CPROVER_assume(pConnInfo->alpnProtocolsLen >= 0 && pConnInfo->alpnProtocolsLen <= IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH + 1);
     pConnInfo->pAlpnProtocols = safeMalloc(pConnInfo->alpnProtocolsLen);
     pConnInfo->pCaCert = malloc(sizeof(uint32_t));
@@ -126,9 +135,11 @@ IotHttpsConnectionHandle_t newIotConnectionHandle () {
   if(pConnectionHandle) {
     pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(uint32_t));
     pConnectionHandle->pNetworkInterface = newNetworkInterface();
-    pConnectionHandle->reqQ.pPrevious = safeMalloc(sizeof(IotLink_t));
-    pConnectionHandle->reqQ.pNext = safeMalloc(sizeof(IotLink_t));
-    pConnectionHandle->taskPoolJob = malloc(sizeof(struct _taskPoolJob));
+    pConnectionHandle->reqQ.pPrevious = NULL;
+    pConnectionHandle->reqQ.pNext = NULL;
+    pConnectionHandle->respQ.pPrevious = NULL;
+    pConnectionHandle->respQ.pNext = NULL;
+    //pConnectionHandle->taskPoolJob = malloc(sizeof(struct _taskPoolJob));
   }
   return pConnectionHandle;
 }
@@ -160,9 +171,10 @@ IotHttpsResponseHandle_t newIotResponseHandle() {
 IotHttpsRequestHandle_t newIotRequestHandle() {
   IotHttpsRequestHandle_t pRequestHandle = safeMalloc(sizeof(_reqHandle_t));
   if (pRequestHandle) {
+    uint32_t len;
     pRequestHandle->pHttpsResponse = newIotResponseHandle();
     pRequestHandle->pHttpsConnection = newIotConnectionHandle();
-    pRequestHandle->pBody = malloc(sizeof(uint32_t));
+    pRequestHandle->pBody = malloc(len);
     pRequestHandle->pHeaders = safeMalloc(sizeof(pRequestHandle) + sizeof(struct _httpRequest));
     pRequestHandle->pHeadersCur = pRequestHandle->pHeaders;
     pRequestHandle->pHeadersEnd = safeMalloc(sizeof(pRequestHandle) + sizeof(_reqHandle_t));
@@ -174,11 +186,14 @@ IotHttpsRequestHandle_t newIotRequestHandle() {
 /* Creates a Request Info and assigns memory accordingly. */
 IotHttpsRequestInfo_t * newIotRequestInfo() {
   IotHttpsRequestInfo_t * pReqInfo = safeMalloc(sizeof(IotHttpsRequestInfo_t));
-  uint32_t bufferSize;
   if(pReqInfo) {
+    uint32_t bufferSize;
+    uint32_t hostNameLen;
     __CPROVER_assume(bufferSize >=0 && bufferSize <= requestUserBufferMinimumSize);
     pReqInfo->userBuffer.bufferLen = bufferSize;
     pReqInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
+    __CPROVER_assume(hostNameLen >= 0 && hostNameLen <= IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
+    pReqInfo->pHost = safeMalloc(hostNameLen);
   }
   return pReqInfo;
 }
@@ -186,15 +201,14 @@ IotHttpsRequestInfo_t * newIotRequestInfo() {
 /* Creates a Response Info and assigns memory accordingly. */
 IotHttpsResponseInfo_t * newIotResponseInfo() {
   IotHttpsResponseInfo_t * pRespInfo = safeMalloc(sizeof(IotHttpsResponseInfo_t));
-  uint32_t bufferSize;
-  uint32_t bodySize;
   if(pRespInfo) {
-    __CPROVER_assume(bufferSize >= 0 && bufferSize <= responseUserBufferMinimumSize);
+    uint32_t bufferSize;
+    uint32_t bodySize;
+    __CPROVER_assume(bufferSize > 0 && bufferSize <= responseUserBufferMinimumSize);
     pRespInfo->userBuffer.bufferLen = bufferSize;
-    pRespInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
+    pRespInfo->userBuffer.pBuffer = malloc(bufferSize);
     pRespInfo->pSyncInfo = malloc(sizeof(IotHttpsSyncInfo_t));
-    __CPROVER_assume(bodySize >= responseUserBufferMinimumSize);
-    pRespInfo->pSyncInfo->pBody = safeMalloc(bodySize);
+    pRespInfo->pSyncInfo->pBody = malloc(bodySize);
     pRespInfo->pSyncInfo->bodyLen = bodySize;
   }
   return pRespInfo;

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -1,0 +1,201 @@
+#define MAX_DATA_SIZE 1000
+
+/* Implementation of safe malloc which returns NULL if the reuested size is 0.*/
+void *safeMalloc(size_t xWantedSize) {
+  if(xWantedSize == 0) {
+    return NULL;
+  }
+  uint8_t byte;
+  return byte ? malloc(xWantedSize) : NULL;
+}
+
+/* This modeling is required because otherwise CBMC takes
+too much time if assigned to minimumBufferSizes. */
+typedef struct _responseHandle
+{
+    struct _httpsResponse RespHandle;
+    char data[MAX_DATA_SIZE];
+} _resHandle_t;
+
+typedef struct _requestHandle
+{
+    struct _httpsRequest ReqHandle;
+    char data[MAX_DATA_SIZE];
+} _reqHandle_t;
+
+typedef struct _connectionHandle
+{
+    struct _httpsConnection pConnHandle;
+    char data[MAX_DATA_SIZE];
+} _connHandle_t;
+
+/* Models the third party HTTP Parser. */
+size_t http_parser_execute (http_parser *parser,
+                            const http_parser_settings *settings,
+                            const char *data,
+                            size_t len) {
+  size_t ret;
+  _httpsResponse_t *_httpsResponse = (_httpsResponse_t *)(parser->data);
+  /* nondet_bool is required to get coverage. */
+  _httpsResponse->foundHeaderField = nondet_bool();
+  _httpsResponse->parserState = PARSER_STATE_BODY_COMPLETE;
+  return ret;
+}
+
+IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
+               void * pCredentialInfo,
+               void * pConnection ) {
+    *(char **)pConnection = malloc(1); /* network connection is opaque */
+    IotNetworkError_t error;
+    return error;
+}
+
+size_t IotNetworkInterfaceSend( void * pConnection,
+           const uint8_t * pMessage,
+           size_t messageLength ) {
+    size_t size;
+    __CPROVER_assume(size <= messageLength);
+    return size;
+}
+
+IotNetworkError_t IotNetworkInterfaceClose( void * pConnection ) {
+    IotNetworkError_t error;
+    return error;
+}
+
+size_t IotNetworkInterfaceReceive( void * pConnection,
+        uint8_t * pBuffer,
+        size_t bytesRequested ) {
+    uint8_t byte;
+    __CPROVER_array_copy(pBuffer,&byte);
+
+    size_t size;
+    __CPROVER_assume(size <= bytesRequested);
+    return size;
+}
+
+IotNetworkError_t IotNetworkInterfaceCallback( void * pConnection,
+                 IotNetworkReceiveCallback_t
+                 receiveCallback,
+                 void * pContext ) {
+    IotNetworkError_t error;
+    return error;
+}
+
+IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection ) {
+  IotNetworkError_t error;
+  return error;
+}
+
+IotNetworkInterface_t IOTNI = {
+  .create = IotNetworkInterfaceCreate,
+  .close = IotNetworkInterfaceClose,
+  .send = IotNetworkInterfaceSend,
+  .receive = IotNetworkInterfaceReceive,
+  .setReceiveCallback = IotNetworkInterfaceCallback,
+  .destroy = IotNetworkInterfaceDestroy
+};
+
+/* Models the Network Interface. */
+IotNetworkInterface_t *newNetworkInterface() {
+  return &IOTNI;
+}
+
+/* Creates a Connection Info and assigns memory accordingly. */
+IotHttpsConnectionInfo_t * newConnectionInfo() {
+  IotHttpsConnectionInfo_t * pConnInfo = safeMalloc(sizeof(IotHttpsConnectionInfo_t));
+  if(pConnInfo) {
+    pConnInfo->pNetworkInterface = newNetworkInterface();
+    /* The +1 is required for coverage */
+    __CPROVER_assume(pConnInfo->addressLen >= 0 && pConnInfo->addressLen <= IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
+    pConnInfo->pAddress = safeMalloc(pConnInfo->addressLen);
+    /* The +1 is required for coverage */
+    __CPROVER_assume(pConnInfo->alpnProtocolsLen >= 0 && pConnInfo->alpnProtocolsLen <= IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH + 1);
+    pConnInfo->pAlpnProtocols = safeMalloc(pConnInfo->alpnProtocolsLen);
+    pConnInfo->pCaCert = malloc(sizeof(uint32_t));
+    pConnInfo->pClientCert = malloc(sizeof(uint32_t));
+    pConnInfo->pPrivateKey = malloc(sizeof(uint32_t));
+    pConnInfo->userBuffer.pBuffer = safeMalloc(sizeof(_connHandle_t));
+  }
+  return pConnInfo;
+}
+
+/* Creates a Connection Handle and assigns memory accordingly. */
+IotHttpsConnectionHandle_t newIotConnectionHandle () {
+  IotHttpsConnectionHandle_t pConnectionHandle = safeMalloc(sizeof(_connHandle_t));
+  if(pConnectionHandle) {
+    pConnectionHandle->pNetworkConnection = safeMalloc(sizeof(_connHandle_t));
+    pConnectionHandle->pNetworkInterface = newNetworkInterface();
+    pConnectionHandle->reqQ.pPrevious = safeMalloc(sizeof(IotLink_t));
+    pConnectionHandle->reqQ.pNext = safeMalloc(sizeof(IotLink_t));
+    pConnectionHandle->taskPoolJob = malloc(sizeof(struct _taskPoolJob));
+  }
+  return pConnectionHandle;
+}
+
+/* Creates a Response Handle and assigns memory accordingly. */
+IotHttpsResponseHandle_t newIotResponseHandle() {
+  IotHttpsResponseHandle_t pResponseHandle = safeMalloc(sizeof(_resHandle_t));
+  if(pResponseHandle) {
+    pResponseHandle->pBody = malloc(sizeof(uint32_t));
+    pResponseHandle->pHttpsConnection = newIotConnectionHandle();
+    pResponseHandle->pHttpsRequest = safeMalloc(sizeof(_reqHandle_t));
+    if(pResponseHandle->pHttpsRequest) {
+      pResponseHandle->pHttpsRequest->pHttpsResponse = pResponseHandle;
+    }
+    pResponseHandle->pHeaders = (uint8_t *)pResponseHandle;
+    pResponseHandle->pHeadersCur = pResponseHandle->pHeaders;
+    pResponseHandle->httpParserInfo.readHeaderParser.data = pResponseHandle; //???
+    pResponseHandle->httpParserInfo.parseFunc = http_parser_execute;
+    pResponseHandle->pReadHeaderValue = safeMalloc(sizeof(uint32_t));
+    pResponseHandle->pHeadersEnd = pResponseHandle->pHeaders + sizeof(_resHandle_t) ;
+    __CPROVER_assume(pResponseHandle->readHeaderValueLength >= 0 &&
+    pResponseHandle->readHeaderValueLength <= (pResponseHandle->pHeadersEnd - pResponseHandle->pHeaders));
+    pResponseHandle->pReadHeaderValue = malloc(pResponseHandle->readHeaderValueLength);
+  }
+  return pResponseHandle;
+}
+
+/* Creates a Request Handle and assigns memory accordingly. */
+IotHttpsRequestHandle_t newIotRequestHandle() {
+  IotHttpsRequestHandle_t requestHandle = safeMalloc(sizeof(_reqHandle_t));
+  if (requestHandle) {
+    requestHandle->pHttpsResponse = newIotResponseHandle();
+    requestHandle->pHttpsConnection = newIotConnectionHandle();
+    requestHandle->pBody = malloc(sizeof(uint32_t));
+    requestHandle->pHeaders = (uint8_t *)requestHandle;
+    requestHandle->pHeadersCur = requestHandle->pHeaders;
+    requestHandle->pHeadersEnd = requestHandle->pHeaders  + sizeof(_resHandle_t) ;
+    requestHandle->pConnInfo = newConnectionInfo();
+  }
+  return requestHandle;
+}
+
+/* Creates a Request Info and assigns memory accordingly. */
+IotHttpsRequestInfo_t * newIotRequestInfo() {
+  IotHttpsRequestInfo_t * pReqInfo = safeMalloc(sizeof(IotHttpsRequestInfo_t));
+  uint32_t bufferSize;
+  if(pReqInfo) {
+    __CPROVER_assume(bufferSize >=0 && bufferSize <= requestUserBufferMinimumSize);
+    pReqInfo->userBuffer.bufferLen = bufferSize;
+    pReqInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
+  }
+  return pReqInfo;
+}
+
+/* Creates a Response Info and assigns memory accordingly. */
+IotHttpsResponseInfo_t * newIotResponseInfo() {
+  IotHttpsResponseInfo_t * pRespInfo = safeMalloc(sizeof(IotHttpsResponseInfo_t));
+  uint32_t bufferSize;
+  uint32_t bodySize;
+  if(pRespInfo) {
+    __CPROVER_assume(bufferSize >= 0 && bufferSize <= responseUserBufferMinimumSize);
+    pRespInfo->userBuffer.bufferLen = bufferSize;
+    pRespInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
+    pRespInfo->pSyncInfo = malloc(sizeof(IotHttpsSyncInfo_t));
+    __CPROVER_assume(bodySize >= responseUserBufferMinimumSize);
+    pRespInfo->pSyncInfo->pBody = safeMalloc(bodySize);
+    pRespInfo->pSyncInfo->bodyLen = bodySize;
+  }
+  return pRespInfo;
+}

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -1,7 +1,8 @@
 #define MAX_DATA_SIZE 1000
 
 /* Implementation of safe malloc which returns NULL if the requested size is 0.
- Depending on the platform the malloc may return either NULL or an address. */
+ Warning: The behavior of malloc(0) is platform dependent.
+ It is possible for malloc(0) to return an address without allocating memory.*/
 void *safeMalloc(size_t xWantedSize) {
   if(xWantedSize == 0) {
     return NULL;
@@ -206,7 +207,8 @@ IotHttpsResponseInfo_t * newIotResponseInfo() {
     uint32_t bufferSize;
     uint32_t bodySize;
     pRespInfo->userBuffer.bufferLen = bufferSize;
-    pRespInfo->userBuffer.pBuffer = malloc(bufferSize);
+    pRespInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
+    /* We assume that these two pointers can not be NULL.*/
     pRespInfo->pSyncInfo = malloc(sizeof(IotHttpsSyncInfo_t));
     pRespInfo->pSyncInfo->pBody = malloc(bodySize);
     pRespInfo->pSyncInfo->bodyLen = bodySize;

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -23,6 +23,8 @@
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/include",
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement",
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MSVC",
+	"$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+	"$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
 	"$(FREERTOS)/libraries/freertos_plus/aws/ota/include",
 	"$(FREERTOS)/libraries/3rdparty/mbedtls/include/mbedtls",
 	"$(FREERTOS)/libraries/3rdparty/tracealyzer_recorder/Include",
@@ -30,9 +32,14 @@
 	"$(FREERTOS)/libraries/3rdparty/pkcs11",
 	"$(FREERTOS)/libraries/3rdparty/tinycbor",
 	"$(FREERTOS)/libraries/3rdparty/win_pcap",
+	"$(FREERTOS)/libraries/3rdparty/http-parser",
 	"$(FREERTOS)/libraries/c_sdk/standard/serializer/src/cbor",
 	"$(FREERTOS)/libraries/c_sdk/aws/defender/include",
-	"$(FREERTOS)/tools/cbmc/include"
+	"$(FREERTOS)/tools/cbmc/include",
+	"$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+	"$(FREERTOS)/libraries/abstractions/platform/include/",
+	"$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+	"../../include"
     ],
 
     "CBMCFLAGS ": [

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -23,8 +23,6 @@
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/include",
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement",
 	"$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MSVC",
-	"$(FREERTOS)/libraries/freertos_plus/standard/https/include",
-	"$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
 	"$(FREERTOS)/libraries/freertos_plus/aws/ota/include",
 	"$(FREERTOS)/libraries/3rdparty/mbedtls/include/mbedtls",
 	"$(FREERTOS)/libraries/3rdparty/tracealyzer_recorder/Include",
@@ -32,14 +30,9 @@
 	"$(FREERTOS)/libraries/3rdparty/pkcs11",
 	"$(FREERTOS)/libraries/3rdparty/tinycbor",
 	"$(FREERTOS)/libraries/3rdparty/win_pcap",
-	"$(FREERTOS)/libraries/3rdparty/http-parser",
 	"$(FREERTOS)/libraries/c_sdk/standard/serializer/src/cbor",
 	"$(FREERTOS)/libraries/c_sdk/aws/defender/include",
-	"$(FREERTOS)/tools/cbmc/include",
-	"$(FREERTOS)/libraries/c_sdk/standard/common/include/",
-	"$(FREERTOS)/libraries/abstractions/platform/include/",
-	"$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
-	"../../include"
+	"$(FREERTOS)/tools/cbmc/include"
     ],
 
     "CBMCFLAGS ": [


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR contains CBMC proof for IotHttpsClient_Connect, IotHttpsClient_ReadContentLength, IotHttpsClient_ReadHeader, IotHttpsClient_ReadResponseStatus. The initialization of global data structures and memory allocation for pointers are done in global_state_HTTP.c.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.