### PR TITLE
Add ltorg to port for gcc arm cm3+4f+7

### DIFF
--- a/freertos_kernel/portable/GCC/ARM_CM3/port.c
+++ b/freertos_kernel/portable/GCC/ARM_CM3/port.c
@@ -247,6 +247,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/

--- a/freertos_kernel/portable/GCC/ARM_CM4F/port.c
+++ b/freertos_kernel/portable/GCC/ARM_CM4F/port.c
@@ -277,6 +277,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -707,7 +708,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"   .ltorg 						\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */		
 	);
 }
 /*-----------------------------------------------------------*/

--- a/freertos_kernel/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/freertos_kernel/portable/GCC/ARM_CM7/r0p1/port.c
@@ -271,6 +271,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -697,7 +698,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"   .ltorg 						\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 	);
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
- Add LTORG to `prvPortStartFirstTask` and `vPortEnableVFP` to enable compile with GCC and LTO optimization.

This was spotted when migrating the CI toolchain of [nanoFramework NXP port](https://github.com/nanoframework/nf-interpreter/pull/1411) to compile with GCC 8 2019 Q3 update. The optimization includes `-Os -flto -fuse-linker-plugin -fno-fat-lto-objects`. 

The build failed with:
```text
(…)
ccw7TTqT.s:154: Error: offset out of range
(…)
arm-none-eabi/bin/ld.exe: error: lto-wrapper failed
``` 
Removing LTO optimization options above allow the build to pass. Not the best option.

The problem seems to be related to the ldr generating a too long jump to the literal pool. A simple solution is to add a .ltorg at the end of each of `prvPortStartFirstTask` and `vPortEnableVFP` functions to ensure that the pool gets placed there.

See [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0041c/Chedgddh.html) about LTORG directive. 
And [here](https://bugs.launchpad.net/gcc-arm-embedded/+bug/1763050) about the proposed fix.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.