### PR TITLE
CBMC proof for IotHttpsClient_SendSync (depends on PR #966)

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -1,0 +1,28 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+#define HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH    ( 26 )
+
+/* stubbing library functions */
+int snprintf( char * contentLengthHeaderStr, size_t len, const char * data,  const char * content, uint32_t contentLength) {
+  int ret;
+  __CPROVER_assume(ret >= 0 && ret <= HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH);
+  return ret;
+}
+
+void harness() {
+  IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
+  IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
+  IotHttpsResponseHandle_t pRespHandle = newIotResponseHandle();
+  IotHttpsResponseInfo_t *pRespInfo = newIotResponseInfo();
+  uint32_t timeoutMs;
+  IotHttpsClient_SendSync(pConnHandle, reqHandle, &pRespHandle, pRespInfo, timeoutMs);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -1,0 +1,29 @@
+{
+  "ENTRY": "HttpsClient_SendSync",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset strlen.0:25,_flushHttpsNetworkData.0:5,_receiveHttpsMessage.0:2"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body _httpParserOnHeadersCompleteCallback",
+    "--remove-function-body _httpParserOnMessageBeginCallback",
+    "--remove-function-body _httpParserOnMessageCompleteCallback"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
+  ]
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR contains cbmc proof for IotHttpsClient_SendSync. The proof uses global_state_HTTP.c file added in PR #966.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.