### PR TITLE
CBMC proof for IotHttpsClient_Disconnect (depends on PR #966)

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -12,11 +12,14 @@
 void harness() {
   IotHttpsConnectionHandle_t connHandle = newIotConnectionHandle();
   if(connHandle) {
-  /* This is done to insert an element in reqQ and get coverage in IotHttpsClient_Disconnect. */
-  	_httpsRequest_t * pReq = malloc(sizeof(_httpsRequest_t));
-  	pReq->pHttpsResponse = malloc(sizeof(_httpsResponse_t));
-  /* This function inserts the element in the reqQ.*/
-  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), &(pReq->link));
+  /* This is done to insert two elements in reqQ and get coverage in IotHttpsClient_Disconnect. */
+  	_httpsRequest_t * p1Req = malloc(sizeof(_httpsRequest_t));
+  	p1Req->pHttpsResponse = malloc(sizeof(_httpsResponse_t));
+  	_httpsRequest_t * p2Req = malloc(sizeof(_httpsRequest_t));
+  	p2Req->pHttpsResponse = malloc(sizeof(_httpsResponse_t));
+  /* This function inserts an element in the reqQ.*/
+  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), &(p1Req->link));
+  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), &(p2Req->link));
   }
   IotHttpsClient_Disconnect(connHandle);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -15,9 +15,8 @@ void harness() {
   /* This is done to insert an element in reqQ and get coverage in IotHttpsClient_Disconnect. */
   	_httpsRequest_t * pReq = malloc(sizeof(_httpsRequest_t));
   	pReq->pHttpsResponse = malloc(sizeof(_httpsResponse_t));
-  	IotLink_t * pLink = pReq;
   /* This function inserts the element in the reqQ.*/
-  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), pLink);
+  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), &(pReq->link));
   }
   IotHttpsClient_Disconnect(connHandle);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -1,0 +1,23 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+void harness() {
+  IotHttpsConnectionHandle_t connHandle = newIotConnectionHandle();
+  if(connHandle) {
+  /* This is done to insert an element in reqQ and get coverage in IotHttpsClient_Disconnect. */
+  	_httpsRequest_t * pReq = malloc(sizeof(_httpsRequest_t));
+  	pReq->pHttpsResponse = malloc(sizeof(_httpsResponse_t));
+  	IotLink_t * pLink = pReq;
+  /* This function inserts the element in the reqQ.*/
+  	IotDeQueue_EnqueueTail(&(connHandle->reqQ), pLink);
+  }
+  IotHttpsClient_Disconnect(connHandle);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -1,0 +1,30 @@
+{
+  "ENTRY": "IotHttpsClient_Disconnect",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset strlen.0:5,IotListDouble_RemoveAll.0:2"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/iot_https_client.goto"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body _httpParserOnHeadersCompleteCallback",
+    "--remove-function-body _httpParserOnMessageBeginCallback",
+    "--remove-function-body _httpParserOnMessageCompleteCallback",
+    "--remove-function-body IotNetworkInterfaceDestroy"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/include",
+    "$(FREERTOS)/libraries/freertos_plus/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
+  ]
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR contains cbmc proof for IotHttpsClient_Disconnect. The proof uses global_state_HTTP.c file added in PR #966.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.