### PR TITLE
Qiutongs/tinycbor iar support

### DIFF
--- a/libraries/3rdparty/tinycbor/README.md
+++ b/libraries/3rdparty/tinycbor/README.md
@@ -34,6 +34,30 @@ Three files are excluded: cborjson.h, cbortojson.c, open_memstream.c.
 define ntohll(x)       ((cbor_ntohl((uint32_t)(x)) * UINT64_C(0x100000000)) + (cbor_ntohl((x) >> 32)))
 ```
 
+4. Add IAR compiler support.
+
+This code is copied from [ARMmbed/tinycbor](https://github.com/ARMmbed/tinycbor/blob/master/src/compilersupport_p.h)
+
+```
+#elif defined(__ICCARM__)
+#  if __LITTLE_ENDIAN__ == 1
+#    include <intrinsics.h>
+#    define ntohll(x)       ((__REV((uint32_t)(x)) * UINT64_C(0x100000000)) + (__REV((x) >> 32)))
+#    define htonll          ntohll
+#    define cbor_ntohl     __REV
+#    define cbor_htonl     __REV
+#    define cbor_ntohs     __REVSH
+#    define cbor_htons     __REVSH
+#  else
+#    define cbor_ntohll
+#    define cbor_htonll
+#    define cbor_ntohl
+#    define cbor_htonl
+#    define cbor_ntohs
+#    define cbor_htons
+#  endif
+```
+
 ## Modified "cborvalidation.c"
 
 Initialize local variable in function validate_floating_point; otherwise it is a may-not-be-initialized error when compiling with "make" on ESP.

--- a/libraries/3rdparty/tinycbor/compilersupport_p.h
+++ b/libraries/3rdparty/tinycbor/compilersupport_p.h
@@ -132,6 +132,23 @@ with these intrinsics. */
 #  define cbor_htonl        _byteswap_ulong
 #  define cbor_ntohs        _byteswap_ushort
 #  define cbor_htons        _byteswap_ushort
+#elif defined(__ICCARM__)
+#  if __LITTLE_ENDIAN__ == 1
+#    include <intrinsics.h>
+#    define ntohll(x)       ((__REV((uint32_t)(x)) * UINT64_C(0x100000000)) + (__REV((x) >> 32)))
+#    define htonll          ntohll
+#    define cbor_ntohl     __REV
+#    define cbor_htonl     __REV
+#    define cbor_ntohs     __REVSH
+#    define cbor_htons     __REVSH
+#  else
+#    define cbor_ntohll
+#    define cbor_htonll
+#    define cbor_ntohl
+#    define cbor_htonl
+#    define cbor_ntohs
+#    define cbor_htons
+#  endif
 #endif
 #endif
 #ifndef cbor_ntohs

--- a/projects/nxp/lpc54018iotmodule/iar/aws_demos/aws_demos.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/aws_demos/aws_demos.ewp
@@ -224,7 +224,6 @@
 					<state>FSL_RTOS_FREE_RTOS</state>
 					<state>A_LITTLE_ENDIAN</state>
 					<state>_DLIB_FILE_DESCRIPTOR=1</state>
-					<state>__little_endian__=1</state>
 				</option>
 				<option>
 					<name>CCPreprocFile</name>

--- a/projects/nxp/lpc54018iotmodule/iar/aws_tests/aws_tests.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/aws_tests/aws_tests.ewp
@@ -224,7 +224,6 @@
 					<state>AMAZON_FREERTOS_ENABLE_UNIT_TESTS</state>
 					<state>UNITY_INCLUDE_CONFIG_H</state>
 					<state>_DLIB_FILE_DESCRIPTOR=1</state>
-					<state>__little_endian__=1</state>
 				</option>
 				<option>
 					<name>CCPreprocFile</name>
@@ -2113,13 +2112,13 @@
 					<group>
 						<name>test</name>
 						<file>
-							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\serializer\test\iot_tests_deserializer_json.c</name>
-						</file>
-						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\serializer\test\iot_tests_serializer_cbor.c</name>
 						</file>
 						<file>
 							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\serializer\test\iot_tests_serializer_json.c</name>
+						</file>
+						<file>
+							<name>$PROJ_DIR$\..\..\..\..\..\libraries\c_sdk\standard\serializer\test\iot_tests_deserializer_json.c</name>
 						</file>
 					</group>
 				</group>

--- a/projects/ti/cc3220_launchpad/iar/aws_demos/aws_demos.ewp
+++ b/projects/ti/cc3220_launchpad/iar/aws_demos/aws_demos.ewp
@@ -221,7 +221,6 @@
 				<option>
 					<name>CCDefines</name>
 					<state>_DLIB_FILE_DESCRIPTOR</state>
-					<state>__little_endian__</state>
 				</option>
 				<option>
 					<name>CCPreprocFile</name>

--- a/vendors/nxp/boards/lpc54018iotmodule/iar.cmake
+++ b/vendors/nxp/boards/lpc54018iotmodule/iar.cmake
@@ -19,8 +19,6 @@ set(compiler_defined_symbols
     IMG_BAUDRATE=96000000
     # tinycbor cbor.h references "FILE"
     _DLIB_FILE_DESCRIPTOR=1
-    # tinycbor compilersupport.h needs this
-    __little_endian__=1
 )
 
 # Get the directory of compiler out of the full path

--- a/vendors/ti/boards/cc3220_launchpad/iar.cmake
+++ b/vendors/ti/boards/cc3220_launchpad/iar.cmake
@@ -4,7 +4,6 @@
 
 set(compiler_defined_symbols
     _DLIB_FILE_DESCRIPTOR
-    __little_endian__
 )
 
 set(assembler_defined_symbols


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Add IAR compiler support in tinycbor. This is to resolve issue https://github.com/aws/amazon-freertos/issues/820

The code is copied from https://github.com/ARMmbed/tinycbor/blob/master/src/compilersupport_p.h

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.

Tests:
- demo/test project builds successfully on NXP and TI
- TI demo runs successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.