### PR TITLE
Add option to run uncrustify to the pre-commit script

### DIFF
--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -5,25 +5,45 @@ import re
 import subprocess
 import sys
 import tempfile
+import argparse
 
 def main(): # pragma: no cover
-    files = sys.argv[1:]
-    failed_files = commit_is_ready(files)
-    if failed_files:
-        print("\nYou may run the following command to repeat the check:")
-        print("Hint: You may need to be at the repository's root directory.")
-        print("\n" + " \\\n".join([sys.argv[0]] + failed_files) + "\n")
-        print('Aborting Commit.')
-        sys.exit(1)
+    args = parse_args()
+
+    if args['uncrustify_all_files']:
+        file_names = get_all_files()
+        files_to_check = filter_checkable_files(file_names)
+        check_uncrustify(files_to_check, uncrustify=True)
+    elif args['uncrustify']:
+        file_names = get_modified_files()
+        files_to_check = filter_checkable_files(file_names)
+        check_uncrustify(files_to_check, uncrustify=True)
+    else:
+        failed_files = commit_is_ready()
+        if failed_files:
+            print("\nYou may run the following command to repeat the check: python tools/git/hooks/src/pre_commit.py")
+            print("\nYou may run the following command to uncrustify modified files: python tools/git/hooks/src/pre_commit.py --uncrustify")
+            print("\nYou may run the following command to uncrustify all files: python tools/git/hooks/src/pre_commit.py --uncrustify-all-files")
+            print("Hint: You may need to be at the repository's root directory.")
+            print('Aborting Commit.')
+            sys.exit(1)
     sys.exit(0)
 
 
-def commit_is_ready(file_names=""):
-    """Return False if not ready.  Return True if commit is ready"""
-    if not file_names:
-        file_names = get_modified_files()
+def parse_args():
+    parser = argparse.ArgumentParser(description='pre-commit checks')
 
-    files_to_check = [f for f in file_names if file_exists(f) and file_is_checkable(f)]
+    parser.add_argument('--uncrustify', default = False, action='store_true', help='Uncrustify modified files.')
+    parser.add_argument('--uncrustify-all-files', default = False, action='store_true', help='Uncrustify all files.')
+
+    args = parser.parse_args()
+    return vars(args)
+
+
+def commit_is_ready():
+    """Return False if not ready.  Return True if commit is ready"""
+    file_names = get_modified_files()
+    files_to_check = filter_checkable_files(file_names)
 
     checks = [
         check_secrets,
@@ -40,6 +60,19 @@ def commit_is_ready(file_names=""):
             if failed_files:
                 return failed_files
     return []
+
+
+def filter_checkable_files(file_names):
+    files_to_check = [f for f in file_names if file_exists(f) and file_is_checkable(f)]
+    return files_to_check
+
+
+def get_all_files():
+    file_names = []
+    for root, dirs, files in os.walk("."):
+        for f in files:
+            file_names.append(os.path.join(root, f))
+    return file_names
 
 
 def get_modified_files():
@@ -125,7 +158,7 @@ def check_hungarian_notation(changed_files):
     return failed_files
 
 
-def check_uncrustify(changed_files):
+def check_uncrustify(changed_files, uncrustify=False):
     """Return True if check failed.  Return False if check passed"""
     if "" == changed_files:
         return False
@@ -138,46 +171,18 @@ def check_uncrustify(changed_files):
             ), shell=True
         ):
             failed_files.append(changed_file)
-    if failed_files:
-        patch = patch_uncrustify(changed_files)
-        write_patch(patch)
+
+    if failed_files and uncrustify:
+        run_uncrustify(changed_files)
+
     return failed_files
 
-def patch_uncrustify(changed_files):
-    """Creates patch to fix formatting in a set of files"""
-    patch = ''
+
+def run_uncrustify(changed_files):
+    """Run uncrustify to fix formatting in a set of files"""
     for file in changed_files:
-        format_call = (
-            'uncrustify -q -c tools/uncrustify.cfg -f {}'.format(file)
-            + '| git --no-pager diff --color=always --no-index -- "{}" - '.format(file)
-            + '| tail -n+3'
-        )
-        diff_result = subprocess.check_output(format_call, shell=True)
-        if type(diff_result) is not str:
-            diff_result = diff_result.decode("utf-8")
-
-        diff_result = re.sub(r'---.*', '--- "a/{}"'.format(file), diff_result)
-        diff_result = re.sub(r'\+\+\+.*', '+++ "b/{}"'.format(file), diff_result)
-        patch += diff_result
-    return patch
-
-
-def write_patch(patch): # pragma: no cover
-    """Writes patch to temporary file and prints instructions to stdout"""
-    ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-    colorless_patch = ansi_escape.sub('', patch)
-    tmp_dir = tempfile.mkdtemp()
-    patch_file_name = os.path.join(tmp_dir, 'uncrustify_patch')
-    with open(patch_file_name, 'w') as patch_file:
-        patch_file.write(colorless_patch)
-    print("The staged files are not formatted correctly.")
-    # Todo: Default to print colored patch
-    # Use command line flag to print colorless
-    print(colorless_patch)
-    print("you may apply the patch using the following command:")
-    print("")
-    print("        git apply {}".format(patch_file_name))
-    print("")
+        format_call = ( 'uncrustify -q -c tools/uncrustify.cfg -f {} -o {}'.format(file, file) )
+        subprocess.check_output(format_call, shell=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -45,7 +45,7 @@ def parse_args():
     return vars(args)
 
 
-def commit_is_ready(file_names=[]):
+def commit_is_ready(file_names=None):
     """Return False if not ready.  Return True if commit is ready"""
     if not file_names:
         file_names = get_modified_files()

--- a/tools/git/hooks/src/pre_commit.py
+++ b/tools/git/hooks/src/pre_commit.py
@@ -15,14 +15,18 @@ def main(): # pragma: no cover
         files_to_check = filter_checkable_files(file_names)
         check_uncrustify(files_to_check, uncrustify=True)
     elif args['uncrustify']:
-        file_names = get_modified_files()
+        file_names = args['files']
+        if not file_names:
+            file_names = get_modified_files()
+
         files_to_check = filter_checkable_files(file_names)
         check_uncrustify(files_to_check, uncrustify=True)
     else:
-        failed_files = commit_is_ready()
+        failed_files = commit_is_ready(args['files'])
         if failed_files:
             print("\nYou may run the following command to repeat the check: python tools/git/hooks/src/pre_commit.py")
-            print("\nYou may run the following command to uncrustify modified files: python tools/git/hooks/src/pre_commit.py --uncrustify")
+            print("\nYou may run the following command to uncrustify staged files: python tools/git/hooks/src/pre_commit.py --uncrustify")
+            print("\nYou may run the following command to uncrustify a list of files: python tools/git/hooks/src/pre_commit.py --uncrustify <files>")
             print("\nYou may run the following command to uncrustify all files: python tools/git/hooks/src/pre_commit.py --uncrustify-all-files")
             print("Hint: You may need to be at the repository's root directory.")
             print('Aborting Commit.')
@@ -35,14 +39,17 @@ def parse_args():
 
     parser.add_argument('--uncrustify', default = False, action='store_true', help='Uncrustify modified files.')
     parser.add_argument('--uncrustify-all-files', default = False, action='store_true', help='Uncrustify all files.')
+    parser.add_argument('files', nargs='*', help='List of files to check.')
 
     args = parser.parse_args()
     return vars(args)
 
 
-def commit_is_ready():
+def commit_is_ready(file_names=[]):
     """Return False if not ready.  Return True if commit is ready"""
-    file_names = get_modified_files()
+    if not file_names:
+        file_names = get_modified_files()
+
     files_to_check = filter_checkable_files(file_names)
 
     checks = [


### PR DESCRIPTION
Description
-----------
pre-commit script runs some code style checks including uncrustify
before a commit is made. This commit adds 2 options to the script to
allow users to use the same script to uncrustify files:

1. ```python tools/git/hooks/src/pre_commit.py --uncrustify```
2. ```python tools/git/hooks/src/pre_commit.py --uncrustify-all-files```

The first one uncrustifies the modified files by the user while the
second one uncrustifies all the files in the repo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.