### PR TITLE
fix: demo stack sizes and priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for Amazon FreeRTOS
 
+### Updates
+### Demo specific stack size and priority
+- Make stack size and priority to be demo specific. In current release all demos have same stack size and priority. This change will make stack size and priority configurable for each demo. Demo can use default stack size/ priority or define its own.  
+
 ## 201906.00 Major 06/17/2019
 ### Release Versioning
 - Move Amazon FreeRTOS to a new versioning scheme (YYYYMM.NN [optional "Major" tag]), while retaining semantic versioning (x.y.z) used for individual libraries within Amazon FreeRTOS. This release contains multiple major version updates for individual libraries. See below for details.

--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -39,21 +39,61 @@
 
 /* Individual demo task entry definitions */
 #if defined( CONFIG_MQTT_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    RunMqttDemo
+    #define DEMO_entryFUNCTION              RunMqttDemo
+    #if defined( democonfigMQTT_ECHO_TASK_STACK_SIZE )
+        #undef democonfigDEMO_STACKSIZE
+        #define democonfigDEMO_STACKSIZE    democonfigMQTT_ECHO_TASK_STACK_SIZE
+    #endif
+    #if defined( democonfigMQTT_ECHO_TASK_PRIORITY )
+        #undef democonfigDEMO_PRIORITY
+        #define democonfigDEMO_PRIORITY     democonfigMQTT_ECHO_TASK_PRIORITY
+    #endif
 #elif defined( CONFIG_SHADOW_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    RunShadowDemo
+    #define DEMO_entryFUNCTION              RunShadowDemo
+    #if defined( democonfigSHADOW_DEMO_TASK_STACK_SIZE )
+        #undef democonfigDEMO_STACKSIZE
+        #define democonfigDEMO_STACKSIZE    democonfigSHADOW_DEMO_TASK_STACK_SIZE
+    #endif
+    #if defined( democonfigSHADOW_DEMO_TASK_PRIORITY )
+        #undef democonfigDEMO_PRIORITY
+        #define democonfigDEMO_PRIORITY     democonfigSHADOW_DEMO_TASK_PRIORITY
+    #endif
 #elif defined( CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vStartGreenGrassDiscoveryTask
+    #define DEMO_entryFUNCTION              vStartGreenGrassDiscoveryTask
+    #if defined( democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE )
+        #undef democonfigDEMO_STACKSIZE
+        #define democonfigDEMO_STACKSIZE    democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE
+    #endif
+    #if defined( democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY )
+        #undef democonfigDEMO_PRIORITY
+        #define democonfigDEMO_PRIORITY     democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY
+    #endif
 #elif defined( CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vStartTCPEchoClientTasks_SingleTasks
+    #define DEMO_entryFUNCTION              vStartTCPEchoClientTasks_SingleTasks
+    #if defined( democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE )
+        #undef democonfigDEMO_STACKSIZE
+        #define democonfigDEMO_STACKSIZE    democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE
+    #endif
+    #if defined( democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY )
+        #undef democonfigDEMO_PRIORITY
+        #define democonfigDEMO_PRIORITY     democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY
+    #endif
 #elif defined( CONFIG_DEFENDER_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vStartDefenderDemo
+    #define DEMO_entryFUNCTION              vStartDefenderDemo
 #elif defined( CONFIG_POSIX_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vStartPOSIXDemo
+    #define DEMO_entryFUNCTION              vStartPOSIXDemo
 #elif defined( CONFIG_OTA_UPDATE_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vStartOTAUpdateDemoTask
+    #define DEMO_entryFUNCTION              vStartOTAUpdateDemoTask
+    #if defined( democonfigOTA_UPDATE_TASK_STACK_SIZE )
+        #undef democonfigDEMO_STACKSIZE
+        #define democonfigDEMO_STACKSIZE    democonfigOTA_UPDATE_TASK_STACK_SIZE
+    #endif
+    #if defined( democonfigOTA_UPDATE_TASK_TASK_PRIORITY )
+        #undef democonfigDEMO_PRIORITY
+        #define democonfigDEMO_PRIORITY    democonfigOTA_UPDATE_TASK_TASK_PRIORITY
+    #endif
 #elif defined( CONFIG_BLE_GATT_SERVER_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION    vGattDemoSvcInit
+    #define DEMO_entryFUNCTION             vGattDemoSvcInit
 #else /* if defined( CONFIG_MQTT_DEMO_ENABLED ) */
 /* if no demo was defined there will be no entry point defined and we will not be able to run the demo */
     #error "No demo to run. One demo should be enabled"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -26,43 +26,34 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS      ( 1 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS        ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -26,43 +26,34 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS      ( 1 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS        ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -26,40 +26,37 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
-
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
 
 #if defined( CONFIG_MQTT_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES                          (  AWSIOT_NETWORK_TYPE_WIFI|AWSIOT_NETWORK_TYPE_BLE )
+    #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
 #endif
 
 #if defined( CONFIG_OTA_UPDATE_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES                          ( AWSIOT_NETWORK_TYPE_WIFI  )
+    #define democonfigNETWORK_TYPES                       ( AWSIOT_NETWORK_TYPE_WIFI )
 #endif
 
-#if defined( CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED )
-    #undef democonfigDEMO_STACKSIZE
-    #define democonfigDEMO_STACKSIZE          ( 9000)
-#endif
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 12 )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
@@ -26,45 +26,36 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_MQTT_BLE_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
-            CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED 
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_MQTT_BLE_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *          CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
+#define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                        ( tskIDLE_PRIORITY + 5 )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY + 5 )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -26,51 +26,43 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 2)
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 1 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY       ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 3000 )
+#define democonfigMQTT_TIMEOUT                            pdMS_TO_TICKS( 3000 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                ( mqttagentREQUIRE_TLS )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -26,76 +26,69 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
-
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS          ( 1 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS            ( 1 )
+#define democonfigDEMO_STACKSIZE                             ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                              ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                              ( AWSIOT_NETWORK_TYPE_WIFI )
 
 /* Timeout used when performing MQTT operations that do not need extra time
-to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                             pdMS_TO_TICKS( 2500 )
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 2500 )
 
 /* Timeout used when establishing a connection, which required TLS
-* negotiation. */
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT        pdMS_TO_TICKS( 12000 )
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 2 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY                  ( tskIDLE_PRIORITY + 5 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY + 5 )
 
 /* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY       ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE              ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY                ( tskIDLE_PRIORITY )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */
-#define democonfigSHADOW_DEMO_NUM_TASKS                    ( 1 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                      ( 1 )
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 1 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE               ( 4 * configMINIMAL_STACK_SIZE )
-#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 6 )
-#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE  ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY    ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS          	   ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_demo_config.h
@@ -26,56 +26,50 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS          ( 1 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS            ( 1 )
-
 /* Timeout used when performing MQTT operations that do not need extra time
-to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                             pdMS_TO_TICKS( 300 )
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 300 )
 
 /* Timeout used when establishing a connection, which required TLS
-* negotiation. */
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT        pdMS_TO_TICKS( 12000 )
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 2 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY )
 
 /* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY       ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE              ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY                ( tskIDLE_PRIORITY )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */
-#define democonfigSHADOW_DEMO_NUM_TASKS                    ( 2 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                      ( 2 )
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 1 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE               ( 4 * configMINIMAL_STACK_SIZE )
-#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 6 )
-#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE  ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY    ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS          	   ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -26,46 +26,35 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 1 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY + 1 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS         ( 0 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS           ( 1 )
-
-/* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY              ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 5 )
@@ -74,9 +63,9 @@
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                             pdMS_TO_TICKS( 2500 )
+#define democonfigMQTT_TIMEOUT                pdMS_TO_TICKS( 2500 )
 
 /* Send AWS IoT MQTT traffic encrypted. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS          	   ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS    ( mqttagentREQUIRE_TLS )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -55,20 +55,11 @@
 #define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS      ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS        ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY + 5 )
-
-
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                pdMS_TO_TICKS( 3000 )
+#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 3000 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS    ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
@@ -26,73 +26,67 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_BLE )
+#define democonfigDEMO_STACKSIZE                             ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                              ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                              ( AWSIOT_NETWORK_TYPE_BLE )
 
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS         ( 0 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS           ( 1 )
-
-#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 1 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                      ( 1 )
 
 /* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY              ( tskIDLE_PRIORITY + 5 )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY + 5 )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY + 5 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
 
 /* Shadow demo task parameters. */
 #define democonfigSHADOW_DEMO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 5 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 5 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE               ( 4 * configMINIMAL_STACK_SIZE )
-#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY + 5 )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5)
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY + 5 )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE  ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY    ( tskIDLE_PRIORITY + 5 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 5 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY                  ( tskIDLE_PRIORITY + 5 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY + 5 )
 
 /* Timeout used when establishing a connection, which required TLS
-negotiation. */
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT	       pdMS_TO_TICKS( 12000 )
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* Timeout used when performing MQTT operations that do not need extra time
-to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT						       pdMS_TO_TICKS( 3000 )
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 3000 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS                 ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -26,43 +26,34 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 15 )
-#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 1 )
-#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 15 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 1 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS                ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 1 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY + 1 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS      ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS        ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY + 1 )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 22 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -26,49 +26,40 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_ETH )
+#define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                        ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                        ( AWSIOT_NETWORK_TYPE_ETH )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 2 )
-
-/* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 300 )
+#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 300 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -26,59 +26,49 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_ETH )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_ETH )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 2500 )
+#define democonfigMQTT_TIMEOUT                            pdMS_TO_TICKS( 2500 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                ( mqttagentREQUIRE_TLS )
 
 /* Greengrass discovery example task parameters. */
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 16 )
 #define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* Workaround for the incompatibility between GNU/IAR C compilers and the CC-RX compiler. */
-#if defined(__CCRX__)
-#define __FUNCTION__    __func__
+#if defined( __CCRX__ )
+    #define __FUNCTION__    __func__
 #endif
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_demo_config.h
@@ -26,12 +26,6 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS         ( 0 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS           ( 1 )
-
 #define democonfigSHADOW_DEMO_NUM_TASKS                   ( 1 )
 
 /* IoT simple subscribe/publish example task parameters. */
@@ -48,39 +42,39 @@
 
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 1 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE               ( 4 * configMINIMAL_STACK_SIZE )
-#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 6 )
-#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE  ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY    ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE ( configMINIMAL_STACK_SIZE * 3 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 3 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY )
 
 /* Timeout used when establishing a connection, which required TLS
-negotiation. */
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT	pdMS_TO_TICKS( 12000 )
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* Timeout used when performing MQTT operations that do not need extra time
-to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT						pdMS_TO_TICKS( 2500 )
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 2500 )
 
 /* Send AWS IoT MQTT traffic encrypted. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS          	     ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS )
 
 /* Workaround for the incompatibility between GNU/IAR C compilers and the CC-RX compiler. */
-#if defined(__CCRX__)
-#define __FUNCTION__    __func__
+#if defined( __CCRX__ )
+    #define __FUNCTION__    __func__
 #endif
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -26,52 +26,44 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 3 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 3 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 2500 )
+#define democonfigMQTT_TIMEOUT                            pdMS_TO_TICKS( 2500 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                ( mqttagentREQUIRE_TLS )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 22 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 22 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -26,48 +26,39 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_WIFI )
+#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
 
 #if defined( democonfigBLE_MQTT_ECHO_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES                         ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
+    #define democonfigNETWORK_TYPES                    ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
 #endif
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 0 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY + 5 )
-
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
@@ -26,74 +26,68 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_MQTT_BLE_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
-            CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED 
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_MQTT_BLE_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *          CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS          ( 1 )
-
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS            ( 1 )
-
 /* Timeout used when performing MQTT operations that do not need extra time
-to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                             pdMS_TO_TICKS( 300 )
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 300 )
 
 /* Timeout used when establishing a connection, which required TLS
-* negotiation. */
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT        pdMS_TO_TICKS( 12000 )
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 2 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY )
 
 /* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY       ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE              ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY                ( tskIDLE_PRIORITY )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */
-#define democonfigSHADOW_DEMO_NUM_TASKS                    ( 2 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                      ( 2 )
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY      ( tskIDLE_PRIORITY + 1 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE               ( 4 * configMINIMAL_STACK_SIZE )
-#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 6 )
-#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY            ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE  ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY    ( tskIDLE_PRIORITY )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS          	   ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -26,52 +26,44 @@
 #ifndef _AWS_DEMO_CONFIG_H_
 #define _AWS_DEMO_CONFIG_H_
 
-/* To run a particular demo you need to define one of these. 
-   Only one demo can be configured at a time
-
-            CONFIG_MQTT_DEMO_ENABLED
-            CONFIG_SHADOW_DEMO_ENABLED
-            CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
-            CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
-            CONFIG_DEFENDER_DEMO_ENABLED
-            CONFIG_POSIX_DEMO_ENABLED
-            CONFIG_OTA_UPDATE_DEMO_ENABLED
-            
-    These defines are used in iot_demo_runner.h for demo selection */
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE               ( configMINIMAL_STACK_SIZE * 8 )
-#define democonfigDEMO_PRIORITY                ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES                ( AWSIOT_NETWORK_TYPE_ETH )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 5 )
+#define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_ETH )
 
-#define democonfigSHADOW_DEMO_NUM_TASKS             ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 4 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY         ( tskIDLE_PRIORITY )
-#define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 2 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
-/* Number of sub pub tasks that connect to a broker that is not using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_UNSECURE_TASKS            ( 1 )
-/* Number of sub pub tasks that connect to a broker that is using TLS. */
-#define democonfigMQTT_SUB_PUB_NUM_SECURE_TASKS              ( 1 )
-
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 5 )
-#define democonfigMQTT_SUB_PUB_TASK_PRIORITY        ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 300 )
+#define democonfigMQTT_TIMEOUT                            pdMS_TO_TICKS( 300 )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                ( mqttagentREQUIRE_TLS )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
-#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY       ( tskIDLE_PRIORITY )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 #endif /* _AWS_DEMO_CONFIG_H_ */


### PR DESCRIPTION
Updated stack sizes and priorities to be demo specific.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Release 1.5 changed demos to use  default stack size from aws_demo_config.h .  Some demos do need higher stack size. iot_demo_runner.h, defines entry function for each demo, the same file can be used define demo specific stack size if it is required. This change makes sure that if demo specific stack size and priority is defined, then it is used, otherwise default sizes are used. 

Other changes include cleaning up defines that are no longer used (related to SUB PUB demo) and uncrustify.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have tested my changes. No regression in existing tests.
- [X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.