### PR TITLE
fix bug in Nuvoton pkcs11 porting code

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -136,4 +136,9 @@
  */
 #define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
 
+/**
+ * Override default stack size for multi-task tests
+ */
+#define pkcs11testMULTI_TASK_STACK_SIZE                  ( 1024 )
+
 #endif /* _AWS_TEST_PKCS11_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
@@ -353,8 +353,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
     uint8_t usLength )
 {
-    uint8_t     **ppucData;
-    uint32_t    dataSize;  
+    uint8_t     *pucData = NULL;
+    uint32_t    dataSize = 0;  
     /* Avoid compiler warnings about unused variables. */
     ( void ) usLength;
   
@@ -370,7 +370,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
     {
         /* Check if object exists/has been created before returning. */
 
-        if( pdTRUE != prvFLASH_ReadFile( pcFileName, ppucData, &dataSize) )
+        if( pdTRUE != prvFLASH_ReadFile( pcFileName, &pucData, &dataSize) )
         {
             xHandle = eInvalidHandle;
         }


### PR DESCRIPTION

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
PKCS11 tests failed on Nuvoton due to memory corruption on stack. This is to fix the bug in Nuvoton pkcs11 porting code.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.