### PR TITLE
Remove call to vTaskDelete from runDemoTask

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -324,8 +324,6 @@ void runDemoTask( void * pArgument )
     {
         IotLogError( "Failed to initialize the demo. exiting..." );
     }
-
-    vTaskDelete( NULL );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION

Description
-----------

runDemoTask is created using Iot_CreateDetachedThread API and the
threads created using this API must not call vTaskDelete as it is
automatically called when the thread routine returns. Explicitly calling
vTaskDelete results in a memory leak as the internally allocated
threadInfo_t does not get freed.

This was reported here:
https://github.com/aws/amazon-freertos/issues/989

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.