### PR TITLE
Fix ESP cmakefile 

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -89,12 +89,20 @@ target_sources(
 set(BLE_SUPPORTED 1 CACHE INTERNAL "BLE is supported on this platform.")
 
 afr_mcu_port(ble_hal)
+
+# Include Bluedroid HAL files as header files.
+afr_glob_src( bluedroid_src DIRECTORY ${afr_ports_dir}/ble/bluedroid  RECURSE )
+set_source_files_properties( ${bluedroid_src} PROPERTIES HEADER_FILE_ONLY TRUE )
+
+# TODO: Include Nimble HAL files as header files.
+
 target_sources(
     AFR::ble_hal::mcu_port
     INTERFACE
         "${afr_ports_dir}/ble/iot_ble_hal_common_gap.c"
         "${afr_ports_dir}/ble/iot_ble_hal_gap.c"
         "${afr_ports_dir}/ble/iot_ble_hal_gatt_server.c"     
+        ${bluedroid_src}
 )
 target_include_directories(
     AFR::ble_hal::mcu_port


### PR DESCRIPTION
Fix ESP CMakefile to support multiple BLE stacks

Description
-----------
With recent changes for adding multiple BLE  HAL implementations, CMakefile also needs to be include them as header files instead of source. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

Ran successfully BLE tests on ESP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.