### PR TITLE
Update PEMfileToCString.html to add \ line joiners and remove semicolon

### DIFF
--- a/tools/certificate_configuration/PEMfileToCString.html
+++ b/tools/certificate_configuration/PEMfileToCString.html
@@ -24,10 +24,10 @@
             // Replace any CR/LF pairs with a newline character.
             credentialText = credentialText.replace(/\r\n/g, "\n");
 
-            // Add line endings (\n), string quote ("), and line continuation (\), as well as html line breaks.
+            // Add line endings, string quote, and line continuation, as well as html line breaks. (\n"\ <break>)
             credentialText = credentialText.replace(/\n/g, "\\n\"\\<br>\n\"");
 
-            // Format the end of the last line with " (but no .
+            // Format the end of the last line with " (but no line continuation).
             credentialText = credentialText + "\"\n";
 
             return credentialText;

--- a/tools/certificate_configuration/PEMfileToCString.html
+++ b/tools/certificate_configuration/PEMfileToCString.html
@@ -24,10 +24,10 @@
             // Replace any CR/LF pairs with a newline character.
             credentialText = credentialText.replace(/\r\n/g, "\n");
 
-            // Add line endings & html line break for C-language variable declaration.
+            // Add line endings (\n), string quote ("), and line continuation (\), as well as html line breaks.
             credentialText = credentialText.replace(/\n/g, "\\n\"\\<br>\n\"");
 
-            // Format the end of the last line with " and semicolon.
+            // Format the end of the last line with " (but no .
             credentialText = credentialText + "\"\n";
 
             return credentialText;

--- a/tools/certificate_configuration/PEMfileToCString.html
+++ b/tools/certificate_configuration/PEMfileToCString.html
@@ -25,10 +25,10 @@
             credentialText = credentialText.replace(/\r\n/g, "\n");
 
             // Add line endings & html line break for C-language variable declaration.
-            credentialText = credentialText.replace(/\n/g, "\\n\"<br>\n\"");
+            credentialText = credentialText.replace(/\n/g, "\\n\"\\<br>\n\"");
 
             // Format the end of the last line with " and semicolon.
-            credentialText = credentialText + "\";\n";
+            credentialText = credentialText + "\"\n";
 
             return credentialText;
         }


### PR DESCRIPTION
This matches the format now expected by aws_clientcredential_keys.h

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.