### PR TITLE
Retrieve the JITR/JITP certificate from PKCS11

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -562,12 +562,12 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     }
 
     /* Free certificate buffer since the parsing is complete */
-    if (NULL != pxCertificate)
+    if( NULL != pxCertificate )
     {
-        vPortFree(pxCertificate);
+        vPortFree( pxCertificate );
         pxCertificate = NULL;
     }
-    
+
     /*
      * Add a JITR device issuer certificate, if present.
      */
@@ -580,47 +580,47 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                 &xCertObj );
     }
 
-    if (xCertObj != CK_INVALID_HANDLE)
+    if( xCertObj != CK_INVALID_HANDLE )
     {
-        if (0 == xResult)
+        if( 0 == xResult )
         {
             /* Query the JITR certificate size. */
-            xTemplate[0].type = CKA_VALUE;
-            xTemplate[0].ulValueLen = 0;
-            xTemplate[0].pValue = NULL;
-            xResult = (BaseType_t)pxCtx->pxP11FunctionList->C_GetAttributeValue(pxCtx->xP11Session,
-                xCertObj,
-                xTemplate,
-                1);
+            xTemplate[ 0 ].type = CKA_VALUE;
+            xTemplate[ 0 ].ulValueLen = 0;
+            xTemplate[ 0 ].pValue = NULL;
+            xResult = ( BaseType_t ) pxCtx->pxP11FunctionList->C_GetAttributeValue( pxCtx->xP11Session,
+                                                                                    xCertObj,
+                                                                                    xTemplate,
+                                                                                    1 );
         }
 
-        if (0 == xResult)
+        if( 0 == xResult )
         {
             /* Create a buffer for the certificate. */
-            pxCertificate = (CK_BYTE_PTR)pvPortMalloc(xTemplate[0].ulValueLen); /*lint !e9079 Allow casting void* to other types. */
+            pxCertificate = ( CK_BYTE_PTR ) pvPortMalloc( xTemplate[ 0 ].ulValueLen ); /*lint !e9079 Allow casting void* to other types. */
 
-            if (NULL == pxCertificate)
+            if( NULL == pxCertificate )
             {
-                xResult = (BaseType_t)CKR_HOST_MEMORY;
+                xResult = ( BaseType_t ) CKR_HOST_MEMORY;
             }
         }
 
-        if (0 == xResult)
+        if( 0 == xResult )
         {
             /* Export the certificate. */
-            xTemplate[0].pValue = pxCertificate;
-            xResult = (BaseType_t)pxCtx->pxP11FunctionList->C_GetAttributeValue(pxCtx->xP11Session,
-                xCertObj,
-                xTemplate,
-                1);
+            xTemplate[ 0 ].pValue = pxCertificate;
+            xResult = ( BaseType_t ) pxCtx->pxP11FunctionList->C_GetAttributeValue( pxCtx->xP11Session,
+                                                                                    xCertObj,
+                                                                                    xTemplate,
+                                                                                    1 );
         }
 
-        if (0 == xResult)
+        if( 0 == xResult )
         {
             /* Decode the JITR certificate. */
-            xResult = mbedtls_x509_crt_parse(&pxCtx->xMbedX509Cli,
-                (const unsigned char*)pxCertificate,
-                xTemplate[0].ulValueLen);
+            xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509Cli,
+                                              ( const unsigned char * ) pxCertificate,
+                                              xTemplate[ 0 ].ulValueLen );
         }
     }
 


### PR DESCRIPTION
Update TLS implementation to retrieve the JITR/JITP certificate from PKCS11

Description
-----------
iot_tls.c uses keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM as a constant rather than retrieving the certificate from the PKCS11 interface where is was previously written (and where it would naturally reside permanently).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.