### PR TITLE
Bound name and value lengths so header length does not overflow.

### DIFF
--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2658,13 +2658,13 @@ IotHttpsReturnCode_t IotHttpsClient_AddHeader( IotHttpsRequestHandle_t reqHandle
     HTTPS_ON_NULL_ARG_GOTO_CLEANUP( reqHandle );
 
     /* Check for name long enough for header length calculation to overflow */
-    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(nameLen <= UINT32_MAX>>2,
+    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(nameLen <= ( UINT32_MAX>>2 ),
         IOT_HTTPS_INVALID_PARAMETER,
 	"Attempting to generate headers with name length %d > %d. This is not allowed.",
 	nameLen, UINT32_MAX>>2);
 
     /* Check for value long enough for header length calculation to overflow */
-    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(valueLen <= UINT32_MAX>>2,
+    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(valueLen <= ( UINT32_MAX>>2 ),
         IOT_HTTPS_INVALID_PARAMETER,
 	"Attempting to generate headers with value length %d > %d. This is not allowed.",
 	valueLen, UINT32_MAX>>2);

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2657,6 +2657,18 @@ IotHttpsReturnCode_t IotHttpsClient_AddHeader( IotHttpsRequestHandle_t reqHandle
     HTTPS_ON_NULL_ARG_GOTO_CLEANUP( pValue );
     HTTPS_ON_NULL_ARG_GOTO_CLEANUP( reqHandle );
 
+    /* Check for name long enough for header length calculation to overflow */
+    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(nameLen <= UINT32_MAX>>2,
+        IOT_HTTPS_INVALID_PARAMETER,
+	"Attempting to generate headers with name length %d > %d. This is not allowed.",
+	nameLen, UINT32_MAX>>2);
+
+    /* Check for value long enough for header length calculation to overflow */
+    HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(valueLen <= UINT32_MAX>>2,
+        IOT_HTTPS_INVALID_PARAMETER,
+	"Attempting to generate headers with value length %d > %d. This is not allowed.",
+	valueLen, UINT32_MAX>>2);
+
     /* Check for auto-generated header "Content-Length". This header is created and send automatically when right before
        request body is sent on the network. */
     HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP(strncmp(pName, HTTPS_CONTENT_LENGTH_HEADER, FAST_MACRO_STRLEN(HTTPS_CONTENT_LENGTH_HEADER)) != 0,


### PR DESCRIPTION
There is a buffer overflow in header generation if the lengths of
the header name or value are large enough to induce an integer overflow
in the header length calculation.  This patch bounds these lengths to
UINT32_MAX>>2.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.