### PR TITLE
Provide enough stack for the MQTT Echo Demo connection task (see #1024).

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,7 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 11 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */


### PR DESCRIPTION
Per #1024, this change increases the stack size for the above from 360 words to 990.