### PR TITLE
Update TLS_Recv to return bytes read immediately.

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -852,40 +852,39 @@ BaseType_t TLS_Recv( void * pvContext,
 
     if( ( NULL != pxCtx ) && ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) )
     {
-        while( xRead < xReadLength )
+        /* The secure sockets receive API does not guarantee that the bytes requested is the bytes 
+           that are returned as read into the buffer. This contract must flow down to TLS_Recv as
+           well. This routine will return how ever many bytes is returned from from mbedtls_ssl_read 
+           immediately; unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again.  */
+        do
         {
             xResult = mbedtls_ssl_read( &pxCtx->xMbedSslCtx,
                                         pucReadBuffer + xRead,
                                         xReadLength - xRead );
 
-            if( 0 < xResult )
+            if( xResult > 0 )
             {
                 /* Got data, so update the tally and keep looping. */
                 xRead += ( size_t ) xResult;
             }
-            else if( 0 == xResult )
-            {
-                /* No data received (and no error). The secure sockets
-                 * API supports non-blocking read, so stop the loop but don't
-                 * flag an error. */
-                break;
-            }
-            else if( MBEDTLS_ERR_SSL_WANT_READ != xResult )
-            {
-                /* Hard error: invalidate the context and stop. */
-                prvFreeContext( pxCtx );
-                break;
-            }
-        }
+            /* If xResult == 0, then no data was received (and there is no error). 
+             * The secure sockets API supports non-blocking read, so stop the loop, 
+             * but don't flag an error. */
+        } while( ( xResult == MBEDTLS_ERR_SSL_WANT_READ ) && ( xResult != 0) );
     }
     else
     {
         xResult = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
     }
 
-    if( 0 <= xResult )
+    if( xResult >= 0 )
     {
         xResult = ( BaseType_t ) xRead;
+    }
+    else
+    {
+        /* xResult < 0 is a hard error, so invalidate the context and stop. */
+        prvFreeContext( pxCtx );
     }
 
     return xResult;

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -852,10 +852,10 @@ BaseType_t TLS_Recv( void * pvContext,
 
     if( ( NULL != pxCtx ) && ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) )
     {
-        /* The secure sockets receive API does not guarantee that the bytes requested is the bytes 
-           that are returned as read into the buffer. This contract must flow down to TLS_Recv as
-           well. This routine will return how ever many bytes is returned from from mbedtls_ssl_read 
-           immediately; unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again.  */
+        /* The secure sockets receive API does not guarantee that the bytes requested is the bytes
+         *  that are returned as read into the buffer. This contract must flow down to TLS_Recv as
+         *  well. This routine will return how ever many bytes is returned from from mbedtls_ssl_read
+         *  immediately; unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again.  */
         do
         {
             xResult = mbedtls_ssl_read( &pxCtx->xMbedSslCtx,
@@ -867,10 +867,11 @@ BaseType_t TLS_Recv( void * pvContext,
                 /* Got data, so update the tally and keep looping. */
                 xRead += ( size_t ) xResult;
             }
-            /* If xResult == 0, then no data was received (and there is no error). 
-             * The secure sockets API supports non-blocking read, so stop the loop, 
+
+            /* If xResult == 0, then no data was received (and there is no error).
+             * The secure sockets API supports non-blocking read, so stop the loop,
              * but don't flag an error. */
-        } while( ( xResult == MBEDTLS_ERR_SSL_WANT_READ ) && ( xResult != 0) );
+        } while( ( xResult == MBEDTLS_ERR_SSL_WANT_READ ) && ( xResult != 0 ) );
     }
     else
     {

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -852,10 +852,8 @@ BaseType_t TLS_Recv( void * pvContext,
 
     if( ( NULL != pxCtx ) && ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) )
     {
-        /* The secure sockets receive API does not guarantee that the bytes requested is the bytes
-         *  that are returned as read into the buffer. This contract must flow down to TLS_Recv as
-         *  well. This routine will return how ever many bytes is returned from from mbedtls_ssl_read
-         *  immediately; unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again.  */
+        /* This routine will return however many bytes are returned from from mbedtls_ssl_read
+         * immediately unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again. */
         do
         {
             xResult = mbedtls_ssl_read( &pxCtx->xMbedSslCtx,
@@ -871,7 +869,7 @@ BaseType_t TLS_Recv( void * pvContext,
             /* If xResult == 0, then no data was received (and there is no error).
              * The secure sockets API supports non-blocking read, so stop the loop,
              * but don't flag an error. */
-        } while( ( xResult == MBEDTLS_ERR_SSL_WANT_READ ) && ( xResult != 0 ) );
+        } while( ( xResult == MBEDTLS_ERR_SSL_WANT_READ ) );
     }
     else
     {


### PR DESCRIPTION
TLS_Recv was returning an mbedtls error instead of the valid number of bytes read.

Description
-----------
Please consider the following scenario:
The server sends 300 valid bytes then immediately closes the connection. Such is the case with a non-persistent HTTP request.
My buffer to receive is 500 bytes. I cannot know large the HTTP response is so I ask the network receive function for 500 bytes.
In the original code mbedtls_ssl_read will return 300 bytes in the first iteration, but since that is less than the 500 bytes requested, the code loops again.
In the second iteration a negative error code is returned indicating that the server closed the connection. This error code would be returned replacing the 300 bytes read.

The correct way to handle this is to simply return the bytes read from mbedtls_ssl_read.
SOCKETS_Recv does not make any guarantees about the number of bytes returned being the number requests. TLS_Recv must also has the same contract.
So it is up to the calling application to call SOCKETS_Recv() multiple times until the full amount of data or a network error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.