### PR TITLE
Windows fixes for CBMC local runs

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -10,7 +10,7 @@
 	"WINVER=0x400",
 	"_CRT_SECURE_NO_WARNINGS",
 	"__PRETTY_FUNCTION__=__FUNCTION__",
-	"'configASSERT(X)=__CPROVER_assert(X, \"Assertion Error\")'",
+	"'configASSERT(X)=__CPROVER_assert(X,\"Assertion Error\")'",
     "'configPRECONDITION(X)=__CPROVER_assume(X)'"
     ],
 

--- a/tools/cbmc/proofs/make_cbmc_batch_files.py
+++ b/tools/cbmc/proofs/make_cbmc_batch_files.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 import os
+import platform
 import subprocess
 
 
@@ -35,6 +36,9 @@ def remove_cbmc_yaml_files():
 
 
 def create_cbmc_yaml_files():
+    # The YAML files are only used by CI and are not needed on Windows.
+    if platform.system() == "Windows":
+        return
     for dyr, _, files in os.walk("."):
         harness = [file for file in files if file.endswith("_harness.c")]
         if harness and "Makefile" in files:


### PR DESCRIPTION
CBMC proofs do not currently run on a Windows PC due to changes to the build infrastructure over summer. (CBMC proofs still run fine in CI). This patchset Windows proof run issues.