### PR TITLE
Http cleanup (depends on 1030)

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -1,0 +1,58 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "FreeRTOS_Sockets.h"
+
+/* FreeRTOS+TCP includes. */
+#include "iot_https_client.h"
+#include "iot_https_internal.h"
+
+#include "../global_state_HTTP.c"
+
+/****************************************************************
+* Stub out memcpy so that it copies nothing but simply checks that the
+* arguments are readable and writeable.
+*
+* A sequence of memcpy's in _addHeader causes cbmc to generate an
+* enormous formula with 229M+ clauses.  The values copies are never
+* used.
+*
+* MacOS header file /usr/include/secure/_string.h defines memcpy to
+* use a builtin function supported by CBMC, so we stub out the builtin
+* memcpy instead of the standard memcpy.
+****************************************************************/
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin___memcpy_chk)
+void *__builtin___memcpy_chk(void *dest, const void *src, size_t n, size_t m) {
+  __CPROVER_assert(__CPROVER_w_ok(dest, n), "write");
+  __CPROVER_assert(__CPROVER_r_ok(src, n), "read");
+  return dest;
+}
+#else
+void *memcpy(void *dest, const void *src, size_t n) {
+  __CPROVER_assert(__CPROVER_w_ok(dest, n), "write");
+  __CPROVER_assert(__CPROVER_r_ok(src, n), "read");
+  return dest;
+}
+#endif
+
+void harness() {
+  IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
+  uint32_t nameLen;
+  uint32_t valueLen;
+  __CPROVER_assume(nameLen < UINT32_MAX-1);
+  __CPROVER_assume(valueLen < UINT32_MAX-1);
+  char * pName = safeMalloc(nameLen+1);
+  char * pValue = safeMalloc(valueLen+1);
+  __CPROVER_assume(pName);
+  __CPROVER_assume(pValue);
+  if (pName)
+    pName[nameLen] = 0;
+  if (pValue)
+    pValue[valueLen] = 0;
+  IotHttpsClient_AddHeader(reqHandle, pName, nameLen, pValue, valueLen);
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
@@ -1,11 +1,26 @@
 {
   "ENTRY": "IotHttpsClient_AddHeader",
+
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
-      "--signed-overflow-check",
-      "--unsigned-overflow-check",
     "--unwind 1",
-    "--unwindset strlen.0:5,strncmp.0:20"
+    "--unwindset strlen.0:5,strncmp.0:20",
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [
@@ -25,5 +40,10 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
+
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
@@ -1,0 +1,29 @@
+{
+  "ENTRY": "IotHttpsClient_AddHeader",
+  "CBMCFLAGS":
+  [
+      "--signed-overflow-check",
+      "--unsigned-overflow-check",
+    "--unwind 1",
+    "--unwindset strlen.0:5,strncmp.0:20"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/c_sdk/standard/https/src/iot_https_client.goto"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body IotLogError"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/libraries/c_sdk/standard/https/include",
+    "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
+    "$(FREERTOS)/libraries/3rdparty/http-parser",
+    "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/include/",
+    "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
+    "../../include"
+  ]
+}

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -16,5 +16,7 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHa
 void harness() {
   IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
   IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
+  if (pConnConfig)
+    __CPROVER_assume(is_valid_NetworkInterface(pConnConfig->pNetworkInterface));
   IotHttpsClient_Connect(&pConnHandle, pConnConfig);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -3,7 +3,19 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset strlen.0:5"
+    "--unwindset strlen.0:5",
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -12,12 +12,13 @@
 void harness() {
   IotHttpsConnectionHandle_t connHandle = newIotConnectionHandle();
   if(connHandle) {
-  /* This is done to insert two elements in respQ and get coverage in IotHttpsClient_Disconnect. */
-  	_httpsResponse_t * p1Resp = malloc(sizeof(_httpsResponse_t));
-  	_httpsResponse_t * p2Resp = malloc(sizeof(_httpsResponse_t));
-  /* This function inserts an element in the respQ.*/
-  	IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p1Resp->link));
-  	IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p2Resp->link));
+    __CPROVER_assume(is_valid_NetworkInterface(connHandle->pNetworkInterface));
+
+    /* initialize connHandle->respQ to a list of two responses */
+    _httpsResponse_t * p1Resp = malloc(sizeof(_httpsResponse_t));
+    _httpsResponse_t * p2Resp = malloc(sizeof(_httpsResponse_t));
+    IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p1Resp->link));
+    IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p2Resp->link));
   }
   IotHttpsClient_Disconnect(connHandle);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -3,7 +3,19 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset strlen.0:5,IotListDouble_RemoveAll.0:2"
+    "--unwindset strlen.0:5,IotListDouble_RemoveAll.0:2",
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -3,7 +3,18 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--nondet-static"
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -1,14 +1,27 @@
 {
   "ENTRY": "IotHttpsClient_ReadHeader",
+
   ################################################################
   # This configuration sets MAX_ACCEPTED_SIZE to 20.
   "MAX_ACCEPTED_SIZE": 20,
   "STRNCPY_UNWIND": "__eval {MAX_ACCEPTED_SIZE} + 1",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
     "--unwindset __builtin___strncpy_chk.0:{STRNCPY_UNWIND},strncpy.0:{STRNCPY_UNWIND}",
-    "--nondet-static"
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -3,7 +3,18 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--nondet-static"
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -9,14 +9,45 @@
 
 #include "../global_state_HTTP.c"
 
+#ifndef HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH
 #define HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH    ( 26 )
+#endif
 
-/* stubbing library functions */
-int snprintf( char * contentLengthHeaderStr, size_t len, const char * data,  const char * content, uint32_t contentLength) {
+/****************************************************************
+* Stub out snprintf so that it writes nothing but simply checks that
+* the arguments are readable and writeable, and returns an
+* unconstrained length.
+*
+* MacOS header file /usr/include/secure/_stdio.h defines snprintf to
+* use a builtin function supported by CBMC, so we stub out the builtin
+* snprintf instead of the standard snprintf.
+****************************************************************/
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin___sprintf_chk)
+int __builtin___snprintf_chk (char *buf, size_t size, int flag, size_t os,
+			      const char *fmt, ...)
+{
   int ret;
+  __CPROVER_assert(__CPROVER_w_ok(buf, size), "sprintf output writeable");
+  __CPROVER_assert(fmt, "sprintf format nonnull");
   __CPROVER_assume(ret >= 0 && ret <= HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH);
   return ret;
 }
+
+#else
+int snprintf(char *buf, size_t size, const char *fmt, ...)
+{
+  int ret;
+  __CPROVER_assert(__CPROVER_w_ok(buf, size), "sprintf output writeable");
+  __CPROVER_assert(fmt, "sprintf format nonnull");
+  __CPROVER_assume(ret >= 0 && ret <= HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH);
+  return ret;
+}
+#endif
 
 void harness() {
   IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -1,9 +1,26 @@
 {
   "ENTRY": "HttpsClient_SendSync",
+
+  # This comes from libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+  # But can't this be removed by including this header in the test harness?
+  "HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH": "26",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset strlen.0:25,_flushHttpsNetworkData.0:5,_receiveHttpsMessage.0:2"
+    "--unwindset strlen.0:25,_flushHttpsNetworkData.0:5,_receiveHttpsMessage.0:2",
+
+    # uninitialized global variables have arbitrary values
+    "--nondet-static",
+
+    # interesting checks in addtion to memory safety
+    "--div-by-zero-check",
+    "--float-overflow-check",
+    "--nan-check",
+    "--pointer-overflow-check",
+    "--undefined-shift-check",
+    "--signed-overflow-check",
+    "--unsigned-overflow-check"
   ],
   "OBJS":
   [
@@ -25,5 +42,10 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH={HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH}"
   ]
+
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -1,4 +1,6 @@
-#define MAX_DATA_SIZE 1000
+#ifndef USER_DATA_SIZE
+#define USER_DATA_SIZE 1000
+#endif
 
 /* Implementation of safe malloc which returns NULL if the requested size is 0.
  Warning: The behavior of malloc(0) is platform dependent.
@@ -21,19 +23,19 @@ We modeled responseHandle, requestHandle and connectionHandle similarly. */
 typedef struct _responseHandle
 {
   struct _httpsResponse RespHandle;
-  char data[MAX_DATA_SIZE];
+  char data[USER_DATA_SIZE];
 } _resHandle_t;
 
 typedef struct _requestHandle
 {
   struct _httpsRequest ReqHandle;
-  char data[MAX_DATA_SIZE];
+  char data[USER_DATA_SIZE];
 } _reqHandle_t;
 
 typedef struct _connectionHandle
 {
   struct _httpsConnection pConnHandle;
-  char data[MAX_DATA_SIZE];
+  char data[USER_DATA_SIZE];
 } _connHandle_t;
 
 /* Models the third party HTTP Parser. */
@@ -109,6 +111,16 @@ IotNetworkInterface_t IOTNI = {
 /* Models the Network Interface. */
 IotNetworkInterface_t *newNetworkInterface() {
   return &IOTNI;
+}
+
+int is_valid_NetworkInterface(IotNetworkInterface_t *netif) {
+  return
+    netif->create == IotNetworkInterfaceCreate &&
+    netif->close == IotNetworkInterfaceClose &&
+    netif->send == IotNetworkInterfaceSend &&
+    netif->receive == IotNetworkInterfaceReceive &&
+    netif->setReceiveCallback == IotNetworkInterfaceCallback &&
+    netif->destroy == IotNetworkInterfaceDestroy;
 }
 
 /* Creates a Connection Info and assigns memory accordingly. */


### PR DESCRIPTION
    Strengthen HTTP proofs.
    
    Check for all built-in checks that come with cbmc:
    --bounds-check
    --pointer-check
    --div-by-zero-check
    --float-overflow-check
    --nan-check
    --pointer-overflow-check
    --undefined-shift-check
    --signed-overflow-check
    --unsigned-overflow-check
    
    Use --nondet-static to allow uninitialized global variable to start
    with arbitrary values.
    
    Clean up test harnesses (move defines from c files to makefiles)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.