### PR TITLE
fix: Use default stack size for MQTT demo.

### DIFF
--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
@@ -54,7 +54,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -51,7 +51,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 2 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -54,7 +54,6 @@
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 2 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY + 5 )
 
 /* IoT simple subscribe/publish example task parameters. */

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -53,7 +53,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY           ( tskIDLE_PRIORITY )
 
 

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_demo_config.h
@@ -58,7 +58,6 @@
 #define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 3 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY )
 
 /* Timeout used when establishing a connection, which required TLS

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 3 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -57,7 +57,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 2 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time


### PR DESCRIPTION
Make MQTT demo to use default stack size.

MQTT demo has been updated and updates to other components like PKCS may
require the demo to use larger stack size. Specific stack size defined
for MQTT was smaller than the default stack size. This PR removes specific
stack size #define for MQTT so that it will use the default stack size.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.