### PR TITLE
Fix cmake for OCW  and warnings

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -94,7 +94,9 @@ afr_mcu_port(ble_hal)
 afr_glob_src( bluedroid_src DIRECTORY ${afr_ports_dir}/ble/bluedroid  RECURSE )
 set_source_files_properties( ${bluedroid_src} PROPERTIES HEADER_FILE_ONLY TRUE )
 
-# TODO: Include Nimble HAL files as header files.
+# Include Nimble HAL files as header files.
+afr_glob_src( nimble_src DIRECTORY ${afr_ports_dir}/ble/nimble  RECURSE )
+set_source_files_properties( ${nimble_src} PROPERTIES HEADER_FILE_ONLY TRUE )
 
 target_sources(
     AFR::ble_hal::mcu_port

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -105,7 +105,9 @@ target_sources(
         "${afr_ports_dir}/ble/iot_ble_hal_gap.c"
         "${afr_ports_dir}/ble/iot_ble_hal_gatt_server.c"     
         ${bluedroid_src}
+        ${nimble_src}
 )
+
 target_include_directories(
     AFR::ble_hal::mcu_port
     INTERFACE

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -105,9 +105,9 @@ static BTStatus_t prvBTSetScanParameters( uint8_t ucAdapterIf,
                                           uint32_t ulScanInterval,
                                           uint32_t ulScanWindow );
 static BTStatus_t prvBTMultiAdvEnable( uint8_t ucAdapterIf,
-                                       BTGattAdvertismentParams_t xAdvParams );
+                                       BTGattAdvertismentParams_t * xAdvParams );
 static BTStatus_t prvBTMultiAdvUpdate( uint8_t ucAdapterIf,
-                                       BTGattAdvertismentParams_t advParams );
+                                       BTGattAdvertismentParams_t * advParams );
 static BTStatus_t prvBTMultiAdvSetInstData( uint8_t ucAdapterIf,
                                             bool bSetScanRsp,
                                             bool bIncludeName,
@@ -745,7 +745,7 @@ BTStatus_t prvBTSetScanParameters( uint8_t ucAdapterIf,
 /*-----------------------------------------------------------*/
 
 BTStatus_t prvBTMultiAdvEnable( uint8_t ucAdapterIf,
-                                BTGattAdvertismentParams_t xAdvParams )
+                                BTGattAdvertismentParams_t * xAdvParams )
 {
     BTStatus_t xStatus = eBTStatusUnsupported;
 
@@ -756,7 +756,7 @@ BTStatus_t prvBTMultiAdvEnable( uint8_t ucAdapterIf,
 /*-----------------------------------------------------------*/
 
 BTStatus_t prvBTMultiAdvUpdate( uint8_t ucAdapterIf,
-                                BTGattAdvertismentParams_t advParams )
+                                BTGattAdvertismentParams_t * advParams )
 {
     BTStatus_t xStatus = eBTStatusUnsupported;
 


### PR DESCRIPTION
Fix cmake for OCW

Description
-----------
Fix cmake for OCW: Added nimble port source files as include files in cmake so they get picked up by OCW.
Also fixed 2 warnings for functions stubs


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.