### PR TITLE
Escape configASSERT in FreeRTOSConfig.h for CBMC proof checking

### DIFF
--- a/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSConfig.h
@@ -124,7 +124,9 @@ void vConfigureTimerForRunTimeStats( void );
 /* Assert call defined for debug builds. */
 extern void vAssertCalled( const char * pcFile,
                            uint32_t ulLine );
+#ifndef configASSERT
 #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ )
+#endif
 
 /* The function that implements FreeRTOS printf style output, and the macro
  * that maps the configPRINTF() macros to that function. */


### PR DESCRIPTION
This is a two-line modification of a core FreeRTOS include file that makes it easy for us to test all configASSERTs in FreeRTOS (and HTTP) code.

This patch just encloses the definition of configASSERT within #ifndef ... #endif so
it can be redefined from the command line during CBMC proof checking
to invoke __CPROVER_assert to check the assertions with CBMC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.