### PR TITLE
Fix: OTA Agent prvParseJSONbyModel_Errors Tests

### DIFF
--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
@@ -325,7 +325,12 @@ TEST( Full_OTA_AGENT, prvParseJSONbyModel_Errors )
     JSON_DocModel_t xDocModel = { 0 };
     JSON_DocParam_t xDocParam = { 0 };
 
-
+    /* Initialize the OTA Agent for the following test. */
+    TEST_ASSERT_EQUAL_INT( eOTA_AgentState_Ready, OTA_AgentInit(
+                               xMQTTClientHandle,
+                               ( const uint8_t * ) clientcredentialIOT_THING_NAME,
+                               vOTACompleteCallback,
+                               pdMS_TO_TICKS( otatestAGENT_INIT_WAIT ) ) );
 
     /* Ensure that NULL parameters are rejected. */
     TEST_ASSERT_EQUAL( eDocParseErr_NullModelPointer,
@@ -362,13 +367,6 @@ TEST( Full_OTA_AGENT, prvParseJSONbyModel_Errors )
     /* Ensure that a JSON document containing a mismatched field is rejected. */
     TEST_ASSERT_EQUAL( NULL, TEST_OTA_prvParseJobDoc( otatestLASER_JSON_WITH_FIELD_MISMATCH,
                                                       sizeof( otatestLASER_JSON_WITH_FIELD_MISMATCH ) ) );
-
-    /* Initialize the OTA Agent for the following test. */
-    TEST_ASSERT_EQUAL_INT( eOTA_AgentState_Ready, OTA_AgentInit(
-                               xMQTTClientHandle,
-                               ( const uint8_t * ) clientcredentialIOT_THING_NAME,
-                               vOTACompleteCallback,
-                               pdMS_TO_TICKS( otatestAGENT_INIT_WAIT ) ) );
 
     /* The OTA Agent must be shut down if these tests fail, so a TEST_PROTECT is necessary. */
     if( TEST_PROTECT() )

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
@@ -325,7 +325,7 @@ TEST( Full_OTA_AGENT, prvParseJSONbyModel_Errors )
     JSON_DocModel_t xDocModel = { 0 };
     JSON_DocParam_t xDocParam = { 0 };
 
-    /* Initialize the OTA Agent for the following test. */
+    /* Initialize the OTA Agent for the following tests. */
     TEST_ASSERT_EQUAL_INT( eOTA_AgentState_Ready, OTA_AgentInit(
                                xMQTTClientHandle,
                                ( const uint8_t * ) clientcredentialIOT_THING_NAME,


### PR DESCRIPTION
This change fixes the OTA agent prvParseJSONbyModel_Errors test initialization.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.