### PR TITLE
CBMC HTTP proof cleanup (recreation)

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -43,15 +43,14 @@ void *memcpy(void *dest, const void *src, size_t n) {
 
 void harness() {
   IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
-  __CPROVER_assume(is_valid_IotRequestHandle(reqHandle));
+  if (reqHandle)
+    __CPROVER_assume(is_valid_IotRequestHandle(reqHandle));
   uint32_t nameLen;
   uint32_t valueLen;
   __CPROVER_assume(nameLen < UINT32_MAX-1);
   __CPROVER_assume(valueLen < UINT32_MAX-1);
   char * pName = safeMalloc(nameLen+1);
   char * pValue = safeMalloc(valueLen+1);
-  __CPROVER_assume(pName);
-  __CPROVER_assume(pValue);
   if (pName)
     pName[nameLen] = 0;
   if (pValue)

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -22,6 +22,7 @@
 * memcpy instead of the standard memcpy.
 ****************************************************************/
 
+/* This is a clang macro not available on linux */
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -43,6 +43,7 @@ void *memcpy(void *dest, const void *src, size_t n) {
 
 void harness() {
   IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
+  __CPROVER_assume(is_valid_IotRequestHandle(reqHandle));
   uint32_t nameLen;
   uint32_t valueLen;
   __CPROVER_assume(nameLen < UINT32_MAX-1);

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -42,7 +42,7 @@ void *memcpy(void *dest, const void *src, size_t n) {
 #endif
 
 void harness() {
-  IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
+  IotHttpsRequestHandle_t reqHandle = allocate_IotRequestHandle();
   if (reqHandle)
     __CPROVER_assume(is_valid_IotRequestHandle(reqHandle));
   uint32_t nameLen;

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -21,7 +21,7 @@ void harness() {
     __CPROVER_assume(is_stubbed_NetworkInterface(pConnHandle->pNetworkInterface));
   }
   if (pConnConfig) {
-    __CPROVER_assume(is_valid_NetworkInterface(pConnConfig->pNetworkInterface));
+    __CPROVER_assume(is_valid_ConnectionInfo(pConnConfig));
     __CPROVER_assume(is_stubbed_NetworkInterface(pConnConfig->pNetworkInterface));    
   }
   IotHttpsClient_Connect(&pConnHandle, pConnConfig);

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -14,15 +14,15 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHa
 
 
 void harness() {
-  IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
-  IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
+  IotHttpsConnectionHandle_t pConnHandle = allocate_IotConnectionHandle();
+  IotHttpsConnectionInfo_t *pConnConfig = allocate_IotConnectionInfo();
   if(pConnHandle) {
     __CPROVER_assume(is_valid_IotConnectionHandle(pConnHandle));
     __CPROVER_assume(is_stubbed_NetworkInterface(pConnHandle->pNetworkInterface));
   }
   if (pConnConfig) {
-    __CPROVER_assume(is_valid_ConnectionInfo(pConnConfig));
-    __CPROVER_assume(is_stubbed_NetworkInterface(pConnConfig->pNetworkInterface));    
+    __CPROVER_assume(is_valid_IotConnectionInfo(pConnConfig));
+    __CPROVER_assume(is_stubbed_NetworkInterface(pConnConfig->pNetworkInterface));
   }
   IotHttpsClient_Connect(&pConnHandle, pConnConfig);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -16,7 +16,13 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHa
 void harness() {
   IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
   IotHttpsConnectionInfo_t *pConnConfig = newConnectionInfo();
-  if (pConnConfig)
+  if(pConnHandle) {
+    __CPROVER_assume(is_valid_IotConnectionHandle(pConnHandle));
+    __CPROVER_assume(is_stubbed_NetworkInterface(pConnHandle->pNetworkInterface));
+  }
+  if (pConnConfig) {
     __CPROVER_assume(is_valid_NetworkInterface(pConnConfig->pNetworkInterface));
+    __CPROVER_assume(is_stubbed_NetworkInterface(pConnConfig->pNetworkInterface));    
+  }
   IotHttpsClient_Connect(&pConnHandle, pConnConfig);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/IotHttpsClient_Connect_harness.c
@@ -16,6 +16,7 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect(IotHttpsConnectionHandle_t connHa
 void harness() {
   IotHttpsConnectionHandle_t pConnHandle = allocate_IotConnectionHandle();
   IotHttpsConnectionInfo_t *pConnConfig = allocate_IotConnectionInfo();
+  initialize_IotConnectionHandle(pConnHandle);
   if(pConnHandle) {
     __CPROVER_assume(is_valid_IotConnectionHandle(pConnHandle));
     __CPROVER_assume(is_stubbed_NetworkInterface(pConnHandle->pNetworkInterface));

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -1,5 +1,10 @@
 {
   "ENTRY": "IotHttpsClient_Connect",
+
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -38,5 +43,9 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-  IotHttpsConnectionHandle_t connHandle = newIotConnectionHandle();
+  IotHttpsConnectionHandle_t connHandle = allocate_IotConnectionHandle();
   if(connHandle) {
     __CPROVER_assume(is_valid_IotConnectionHandle(connHandle));
     __CPROVER_assume(is_stubbed_NetworkInterface(connHandle->pNetworkInterface));

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -12,7 +12,8 @@
 void harness() {
   IotHttpsConnectionHandle_t connHandle = newIotConnectionHandle();
   if(connHandle) {
-    __CPROVER_assume(is_valid_NetworkInterface(connHandle->pNetworkInterface));
+    __CPROVER_assume(is_valid_IotConnectionHandle(connHandle));
+    __CPROVER_assume(is_stubbed_NetworkInterface(connHandle->pNetworkInterface));
 
     /* initialize connHandle->respQ to a list of two responses */
     _httpsResponse_t * p1Resp = malloc(sizeof(_httpsResponse_t));

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -11,6 +11,7 @@
 
 void harness() {
   IotHttpsConnectionHandle_t connHandle = allocate_IotConnectionHandle();
+  initialize_IotConnectionHandle(connHandle);
   if(connHandle) {
     __CPROVER_assume(is_valid_IotConnectionHandle(connHandle));
     __CPROVER_assume(is_stubbed_NetworkInterface(connHandle->pNetworkInterface));

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -1,5 +1,10 @@
 {
   "ENTRY": "IotHttpsClient_Disconnect",
+
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -38,5 +43,9 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -11,7 +11,8 @@
 
 void harness() {
   IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  if (respHandle)
+    __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   uint32_t pContentLength;
-  __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   IotHttpsClient_ReadContentLength(respHandle, &pContentLength);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -11,6 +11,7 @@
 
 void harness() {
   IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
+  initialize_IotResponseHandle(respHandle);
   if (respHandle)
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   uint32_t pContentLength;

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -12,6 +12,6 @@
 void harness() {
   IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
   uint32_t pContentLength;
-  __CPROVER_assume(is_valid_newIotResponseHandle(respHandle));
+  __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   IotHttpsClient_ReadContentLength(respHandle, &pContentLength);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
   if (respHandle)
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   uint32_t pContentLength;

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -12,5 +12,6 @@
 void harness() {
   IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
   uint32_t pContentLength;
+  __CPROVER_assume(is_valid_newIotResponseHandle(respHandle));
   IotHttpsClient_ReadContentLength(respHandle, &pContentLength);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -1,5 +1,10 @@
 {
   "ENTRY": "IotHttpsClient_ReadContentLength",
+
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -30,5 +35,9 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -10,16 +10,20 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-	IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
   size_t pName_len;
-  __CPROVER_assume(pName_len >= 0 && pName_len <= IOT_HTTPS_MAX_HOST_NAME_LENGTH);
+  __CPROVER_assume(pName_len >= 0 &&
+		   pName_len <= IOT_HTTPS_MAX_HOST_NAME_LENGTH);
   char *pName = safeMalloc(pName_len);
   uint32_t len;
   __CPROVER_assume(len >= 0 && len <= MAX_ACCEPTED_SIZE);
   char  *pValue = safeMalloc(len);
   if (respHandle) {
-    /* We need to bound respHandle->readHeaderValueLength in order to terminate strncpy */
-    __CPROVER_assume(respHandle->readHeaderValueLength >= 0 && respHandle->readHeaderValueLength <= MAX_ACCEPTED_SIZE + 1);
+    /* We need to bound respHandle->readHeaderValueLength in order to
+     * terminate strncpy */
+    __CPROVER_assume(respHandle->readHeaderValueLength >= 0 &&
+		     respHandle->readHeaderValueLength <= MAX_ACCEPTED_SIZE + 1);
+    __CPROVER_assume(is_valid_newIotResponseHandle(respHandle));
   }
   IotHttpsClient_ReadHeader(respHandle, pName, pName_len, pValue, len);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -15,6 +15,7 @@ void harness() {
   size_t valueLen;
   char *pName = safeMalloc(nameLen);
   char  *pValue = safeMalloc(valueLen);
+  initialize_IotResponseHandle(respHandle);
   if (respHandle) {
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -23,7 +23,7 @@ void harness() {
      * terminate strncpy */
     __CPROVER_assume(respHandle->readHeaderValueLength >= 0 &&
 		     respHandle->readHeaderValueLength <= MAX_ACCEPTED_SIZE + 1);
-    __CPROVER_assume(is_valid_newIotResponseHandle(respHandle));
+    __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   }
   IotHttpsClient_ReadHeader(respHandle, pName, pName_len, pValue, len);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -11,19 +11,12 @@
 
 void harness() {
   IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
-  size_t pName_len;
-  __CPROVER_assume(pName_len >= 0 &&
-		   pName_len <= IOT_HTTPS_MAX_HOST_NAME_LENGTH);
-  char *pName = safeMalloc(pName_len);
-  uint32_t len;
-  __CPROVER_assume(len >= 0 && len <= MAX_ACCEPTED_SIZE);
-  char  *pValue = safeMalloc(len);
+  size_t nameLen;
+  size_t valueLen;
+  char *pName = safeMalloc(nameLen);
+  char  *pValue = safeMalloc(valueLen);
   if (respHandle) {
-    /* We need to bound respHandle->readHeaderValueLength in order to
-     * terminate strncpy */
-    __CPROVER_assume(respHandle->readHeaderValueLength >= 0 &&
-		     respHandle->readHeaderValueLength <= MAX_ACCEPTED_SIZE + 1);
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
   }
-  IotHttpsClient_ReadHeader(respHandle, pName, pName_len, pValue, len);
+  IotHttpsClient_ReadHeader(respHandle, pName, nameLen, pValue, valueLen);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
   size_t pName_len;
   __CPROVER_assume(pName_len >= 0 &&
 		   pName_len <= IOT_HTTPS_MAX_HOST_NAME_LENGTH);

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -6,6 +6,10 @@
   "MAX_ACCEPTED_SIZE": 20,
   "STRNCPY_UNWIND": "__eval {MAX_ACCEPTED_SIZE} + 1",
 
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -28,10 +32,6 @@
     "$(ENTRY)_harness.goto",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/iot_https_client.goto"
   ],
-  "DEF":
-  [
-    "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}"
-  ],
   "INC":
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
@@ -41,6 +41,11 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}"
   ]
 }
 

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
@@ -12,5 +12,6 @@
 void harness() {
   IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
   uint16_t pStatus;
+  initialize_IotResponseHandle(respHandle);
   IotHttpsClient_ReadResponseStatus(respHandle, &pStatus);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/IotHttpsClient_ReadResponseStatus_harness.c
@@ -10,7 +10,7 @@
 #include "../global_state_HTTP.c"
 
 void harness() {
-  IotHttpsResponseHandle_t respHandle = newIotResponseHandle();
+  IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
   uint16_t pStatus;
   IotHttpsClient_ReadResponseStatus(respHandle, &pStatus);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -1,5 +1,10 @@
 {
   "ENTRY": "IotHttpsClient_ReadResponseStatus",
+  
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -30,5 +35,9 @@
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",
     "../../include"
+  ],
+  "DEF":
+  [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -58,6 +58,8 @@ void harness() {
   IotHttpsResponseInfo_t *pRespInfo = allocate_IotResponseInfo();
   uint32_t timeoutMs;
 
+  initialize_IotConnectionHandle(pConnHandle);
+  initialize_IotResponseHandle(pRespHandle);
   if (pRespInfo)
     __CPROVER_assume(is_valid_IotResponseInfo(pRespInfo));
   IotHttpsClient_SendSync(pConnHandle, reqHandle, &pRespHandle, pRespInfo, timeoutMs);

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -52,10 +52,10 @@ int snprintf(char *buf, size_t size, const char *fmt, ...)
 #endif
 
 void harness() {
-  IotHttpsConnectionHandle_t pConnHandle = newIotConnectionHandle();
-  IotHttpsRequestHandle_t reqHandle = newIotRequestHandle();
-  IotHttpsResponseHandle_t pRespHandle = newIotResponseHandle();
-  IotHttpsResponseInfo_t *pRespInfo = newIotResponseInfo();
+  IotHttpsConnectionHandle_t pConnHandle = allocate_IotConnectionHandle();
+  IotHttpsRequestHandle_t reqHandle = allocate_IotRequestHandle();
+  IotHttpsResponseHandle_t pRespHandle = allocate_IotResponseHandle();
+  IotHttpsResponseInfo_t *pRespInfo = allocate_IotResponseInfo();
   uint32_t timeoutMs;
 
   if (pRespInfo)

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -58,6 +58,7 @@ void harness() {
   IotHttpsResponseInfo_t *pRespInfo = newIotResponseInfo();
   uint32_t timeoutMs;
 
-  __CPROVER_assume(is_valid_IotResponseInfo(pRespInfo));
+  if (pRespInfo)
+    __CPROVER_assume(is_valid_IotResponseInfo(pRespInfo));
   IotHttpsClient_SendSync(pConnHandle, reqHandle, &pRespHandle, pRespInfo, timeoutMs);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -9,20 +9,22 @@
 
 #include "../global_state_HTTP.c"
 
-#ifndef HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH
-#define HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH    ( 26 )
-#endif
-
 /****************************************************************
 * Stub out snprintf so that it writes nothing but simply checks that
-* the arguments are readable and writeable, and returns an
-* unconstrained length.
+* the arguments are readable and writeable, and returns a length.
+*
+* The snprintf function is used by SendSync only to build a header
+* whose length is bounded by HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH,
+* so snprintf returns an unconstrained length between 0 and this 
+* bound.  This value is defined in iot_https_internal.h.
 *
 * MacOS header file /usr/include/secure/_stdio.h defines snprintf to
-* use a builtin function supported by CBMC, so we stub out the builtin
-* snprintf instead of the standard snprintf.
+* use a builtin function supported by CBMC, so when this builtin is
+* available, we stub out the builtin snprintf instead of the standard
+* snprintf.
 ****************************************************************/
 
+/* This is a clang macro not available on linux */
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/HttpsClient_SendSync_harness.c
@@ -15,7 +15,7 @@
 *
 * The snprintf function is used by SendSync only to build a header
 * whose length is bounded by HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH,
-* so snprintf returns an unconstrained length between 0 and this 
+* so snprintf returns an unconstrained length between 0 and this
 * bound.  This value is defined in iot_https_internal.h.
 *
 * MacOS header file /usr/include/secure/_stdio.h defines snprintf to
@@ -57,5 +57,7 @@ void harness() {
   IotHttpsResponseHandle_t pRespHandle = newIotResponseHandle();
   IotHttpsResponseInfo_t *pRespInfo = newIotResponseInfo();
   uint32_t timeoutMs;
+
+  __CPROVER_assume(is_valid_IotResponseInfo(pRespInfo));
   IotHttpsClient_SendSync(pConnHandle, reqHandle, &pRespHandle, pRespInfo, timeoutMs);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -1,10 +1,6 @@
 {
   "ENTRY": "HttpsClient_SendSync",
 
-  # This comes from libraries/c_sdk/standard/https/src/private/iot_https_internal.h
-  # But can't this be removed by including this header in the test harness?
-  "HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH": "26",
-
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -45,7 +41,6 @@
   ],
   "DEF":
   [
-    "HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH={HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH}"
   ]
 
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -1,6 +1,10 @@
 {
   "ENTRY": "HttpsClient_SendSync",
 
+  # This is the length of the user data after the header in a buffer.
+  # This can be set to any size.
+  "USER_DATA_SIZE": "1000",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -41,6 +45,6 @@
   ],
   "DEF":
   [
+    "USER_DATA_SIZE={USER_DATA_SIZE}"
   ]
-
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -153,7 +153,7 @@ IotNetworkInterface_t IOTNI = {
 };
 
 /* Models the Network Interface. */
-IotNetworkInterface_t *newNetworkInterface() {
+IotNetworkInterface_t *allocate_NetworkInterface() {
   return nondet_bool() ? &IOTNI : NULL;
 }
 
@@ -188,11 +188,11 @@ int is_stubbed_NetworkInterface(IotNetworkInterface_t *netif) {
  ****************************************************************/
 
 /* Creates a Connection Info and assigns memory accordingly. */
-IotHttpsConnectionInfo_t * newConnectionInfo() {
+IotHttpsConnectionInfo_t * allocate_IotConnectionInfo() {
   IotHttpsConnectionInfo_t * pConnInfo =
     safeMalloc(sizeof(IotHttpsConnectionInfo_t));
   if(pConnInfo) {
-    pConnInfo->pNetworkInterface = newNetworkInterface();
+    pConnInfo->pNetworkInterface = allocate_NetworkInterface();
     pConnInfo->pAddress = safeMalloc(pConnInfo->addressLen);
     pConnInfo->pAlpnProtocols = safeMalloc(pConnInfo->alpnProtocolsLen);
     pConnInfo->pCaCert = safeMalloc(sizeof(uint32_t));
@@ -203,7 +203,7 @@ IotHttpsConnectionInfo_t * newConnectionInfo() {
   return pConnInfo;
 }
 
-int is_valid_ConnectionInfo(IotHttpsConnectionInfo_t *pConnInfo) {
+int is_valid_IotConnectionInfo(IotHttpsConnectionInfo_t *pConnInfo) {
   return
     pConnInfo->pCaCert &&
     pConnInfo->pClientCert &&
@@ -218,13 +218,13 @@ int is_valid_ConnectionInfo(IotHttpsConnectionInfo_t *pConnInfo) {
  ****************************************************************/
 
 /* Creates a Connection Handle and assigns memory accordingly. */
-IotHttpsConnectionHandle_t newIotConnectionHandle () {
+IotHttpsConnectionHandle_t allocate_IotConnectionHandle () {
   IotHttpsConnectionHandle_t pConnectionHandle =
     safeMalloc(sizeof(_connHandle_t));
   if(pConnectionHandle) {
     // network connection just points to an allocated memory object
     pConnectionHandle->pNetworkConnection = safeMalloc(1);
-    pConnectionHandle->pNetworkInterface = newNetworkInterface();
+    pConnectionHandle->pNetworkInterface = allocate_NetworkInterface();
     // ???: Should reqQ initialization be an assumption?
     pConnectionHandle->reqQ.pPrevious = &(pConnectionHandle->reqQ);
     pConnectionHandle->reqQ.pNext = &(pConnectionHandle->reqQ);
@@ -247,7 +247,7 @@ int is_valid_IotConnectionHandle(IotHttpsConnectionHandle_t handle) {
  ****************************************************************/
 
 /* Creates a Response Handle and assigns memory accordingly. */
-IotHttpsResponseHandle_t newIotResponseHandle() {
+IotHttpsResponseHandle_t allocate_IotResponseHandle() {
   IotHttpsResponseHandle_t pResponseHandle = safeMalloc(sizeof(_resHandle_t));
   if(pResponseHandle) {
     uint32_t len;
@@ -255,7 +255,7 @@ IotHttpsResponseHandle_t newIotResponseHandle() {
     pResponseHandle->httpParserInfo.parseFunc = http_parser_execute;
 
     pResponseHandle->pBody = safeMalloc(len);
-    pResponseHandle->pHttpsConnection = newIotConnectionHandle();
+    pResponseHandle->pHttpsConnection = allocate_IotConnectionHandle();
     pResponseHandle->pReadHeaderField =
       safeMalloc(pResponseHandle->readHeaderFieldLength);
     pResponseHandle->pReadHeaderValue =
@@ -292,14 +292,14 @@ int is_valid_IotResponseHandle(IotHttpsResponseHandle_t pResponseHandle) {
  ****************************************************************/
 
 /* Creates a Request Handle and assigns memory accordingly. */
-IotHttpsRequestHandle_t newIotRequestHandle() {
+IotHttpsRequestHandle_t allocate_IotRequestHandle() {
   IotHttpsRequestHandle_t pRequestHandle = safeMalloc(sizeof(_reqHandle_t));
   if (pRequestHandle) {
     uint32_t len;
-    pRequestHandle->pHttpsResponse = newIotResponseHandle();
-    pRequestHandle->pHttpsConnection = newIotConnectionHandle();
+    pRequestHandle->pHttpsResponse = allocate_IotResponseHandle();
+    pRequestHandle->pHttpsConnection = allocate_IotConnectionHandle();
     pRequestHandle->pBody = safeMalloc(len);
-    pRequestHandle->pConnInfo = newConnectionInfo();
+    pRequestHandle->pConnInfo = allocate_IotConnectionInfo();
   }
   return pRequestHandle;
 }
@@ -334,7 +334,7 @@ int is_valid_IotRequestHandle(IotHttpsRequestHandle_t pRequestHandle) {
  ****************************************************************/
 
 /* Creates a Request Info and assigns memory accordingly. */
-IotHttpsRequestInfo_t * newIotRequestInfo() {
+IotHttpsRequestInfo_t * allocate_IotRequestInfo() {
   IotHttpsRequestInfo_t * pReqInfo
     = safeMalloc(sizeof(IotHttpsRequestInfo_t));
   if(pReqInfo) {
@@ -356,7 +356,7 @@ int is_valid_IotRequestInfo(IotHttpsRequestInfo_t * pReqInfo) {
  ****************************************************************/
 
 /* Creates a Response Info and assigns memory accordingly. */
-IotHttpsResponseInfo_t * newIotResponseInfo() {
+IotHttpsResponseInfo_t * allocate_IotResponseInfo() {
   IotHttpsResponseInfo_t * pRespInfo =
     safeMalloc(sizeof(IotHttpsResponseInfo_t));
   if(pRespInfo) {

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -9,8 +9,7 @@ void *safeMalloc(size_t xWantedSize) {
   if(xWantedSize == 0) {
     return NULL;
   }
-  uint8_t byte;
-  return byte ? malloc(xWantedSize) : NULL;
+  return nondet_bool() ? malloc(xWantedSize) : NULL;
 }
 
 /****************************************************************/
@@ -60,8 +59,7 @@ size_t http_parser_execute (http_parser *parser,
   _httpsResponse->foundHeaderField = nondet_bool();
   _httpsResponse->parserState = PARSER_STATE_BODY_COMPLETE;
 
-  size_t ret;
-  return ret;
+  return nondet_size_t();
 }
 
 /****************************************************************

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -333,6 +333,7 @@ int is_valid_IotRequestHandle(IotHttpsRequestHandle_t pRequestHandle) {
 
 /****************************************************************
  * IotHttpsRequestInfo constructor
+ * This is currently unusued and untested.
  ****************************************************************/
 
 /* Creates a Request Info and assigns memory accordingly. */
@@ -340,17 +341,17 @@ IotHttpsRequestInfo_t * newIotRequestInfo() {
   IotHttpsRequestInfo_t * pReqInfo
     = safeMalloc(sizeof(IotHttpsRequestInfo_t));
   if(pReqInfo) {
-    uint32_t bufferSize;
-    uint32_t hostNameLen;
-    __CPROVER_assume(bufferSize >=0 && bufferSize <=
-		     requestUserBufferMinimumSize);
-    pReqInfo->userBuffer.bufferLen = bufferSize;
-    pReqInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
-    __CPROVER_assume(hostNameLen >= 0 && hostNameLen <=
-		     IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
-    pReqInfo->pHost = safeMalloc(hostNameLen);
+    pReqInfo->userBuffer.pBuffer = safeMalloc(pReqInfo->userBuffer.bufferLen);
+    pReqInfo->pHost = safeMalloc(pReqInfo->hostLen);
   }
   return pReqInfo;
+}
+
+int is_valid_IotRequestInfo(IotHttpsRequestInfo_t * pReqInfo) {
+  return
+    // Should the global minimum size really be an upper bound?
+    pReqInfo->userBuffer.bufferLen <= requestUserBufferMinimumSize &&
+    pReqInfo->hostLen <= IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1;
 }
 
 /****************************************************************
@@ -362,14 +363,17 @@ IotHttpsResponseInfo_t * newIotResponseInfo() {
   IotHttpsResponseInfo_t * pRespInfo =
     safeMalloc(sizeof(IotHttpsResponseInfo_t));
   if(pRespInfo) {
-    uint32_t bufferSize;
-    uint32_t bodySize;
-    pRespInfo->userBuffer.bufferLen = bufferSize;
-    pRespInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
-    /* We assume that these two pointers can not be NULL.*/
-    pRespInfo->pSyncInfo = malloc(sizeof(IotHttpsSyncInfo_t));
-    pRespInfo->pSyncInfo->pBody = malloc(bodySize);
-    pRespInfo->pSyncInfo->bodyLen = bodySize;
+    pRespInfo->userBuffer.pBuffer = safeMalloc(pRespInfo->userBuffer.bufferLen);
+    pRespInfo->pSyncInfo = safeMalloc(sizeof(IotHttpsSyncInfo_t));
+    if (pRespInfo->pSyncInfo)
+      pRespInfo->pSyncInfo->pBody = safeMalloc(pRespInfo->pSyncInfo->bodyLen);
   }
   return pRespInfo;
+}
+
+int is_valid_IotResponseInfo(IotHttpsResponseInfo_t * pRespInfo){
+  return
+    pRespInfo &&
+    pRespInfo->pSyncInfo &&
+    pRespInfo->pSyncInfo->pBody;
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -257,7 +257,7 @@ IotHttpsResponseHandle_t newIotResponseHandle() {
 
     pResponseHandle->httpParserInfo.parseFunc = http_parser_execute;
 
-    pResponseHandle->pBody = saveMalloc(len);
+    pResponseHandle->pBody = safeMalloc(len);
     pResponseHandle->pHttpsConnection = newIotConnectionHandle();
     pResponseHandle->pReadHeaderValue =
       safeMalloc(pResponseHandle->readHeaderValueLength);
@@ -337,14 +337,17 @@ int is_valid_IotRequestHandle(IotHttpsRequestHandle_t pRequestHandle) {
 
 /* Creates a Request Info and assigns memory accordingly. */
 IotHttpsRequestInfo_t * newIotRequestInfo() {
-  IotHttpsRequestInfo_t * pReqInfo = safeMalloc(sizeof(IotHttpsRequestInfo_t));
+  IotHttpsRequestInfo_t * pReqInfo
+    = safeMalloc(sizeof(IotHttpsRequestInfo_t));
   if(pReqInfo) {
     uint32_t bufferSize;
     uint32_t hostNameLen;
-    __CPROVER_assume(bufferSize >=0 && bufferSize <= requestUserBufferMinimumSize);
+    __CPROVER_assume(bufferSize >=0 && bufferSize <=
+		     requestUserBufferMinimumSize);
     pReqInfo->userBuffer.bufferLen = bufferSize;
     pReqInfo->userBuffer.pBuffer = safeMalloc(bufferSize);
-    __CPROVER_assume(hostNameLen >= 0 && hostNameLen <= IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
+    __CPROVER_assume(hostNameLen >= 0 && hostNameLen <=
+		     IOT_HTTPS_MAX_HOST_NAME_LENGTH + 1);
     pReqInfo->pHost = safeMalloc(hostNameLen);
   }
   return pReqInfo;
@@ -356,7 +359,8 @@ IotHttpsRequestInfo_t * newIotRequestInfo() {
 
 /* Creates a Response Info and assigns memory accordingly. */
 IotHttpsResponseInfo_t * newIotResponseInfo() {
-  IotHttpsResponseInfo_t * pRespInfo = safeMalloc(sizeof(IotHttpsResponseInfo_t));
+  IotHttpsResponseInfo_t * pRespInfo =
+    safeMalloc(sizeof(IotHttpsResponseInfo_t));
   if(pRespInfo) {
     uint32_t bufferSize;
     uint32_t bodySize;


### PR DESCRIPTION
This is a recreation of PR 1040 that has been closed to produce this PR that should be cleaner to merge into the http branch.  https://github.com/aws/amazon-freertos/pull/1040 

This is a sequence of changes to the HTTP proofs intended to clean up the proofs in general, refactor the constructors in global_state_HTTP.c into allocators that do nothing but malloc memory and is_valid predicates that encode all of the assumptions we are making about the type (eg, that the malloc succeeded and the pointer is valid). This refactoring has the advantage of recording all assumptions explicitly in the test harness itself, but the process of writing the is_valid predicates and testing that each of the remaining conjuncts was necessary led to weakening the assumptions (and thus strengthening the proofs).

We are also now testing for the full set of CBMC code checks (eg, testing for arithmetic overflow; testing for correctness even with arbitrary values written to uninitialized global state), and checking all configASSERTs embedded in the code.

We have also modified the test harness (how things like memcpy and snprintf are stubbed out) so that the proofs now build and run on both Linux and MacOS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.