### PR TITLE
increase stack size of nxp demos

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -42,17 +42,17 @@
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 15 )
+#define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 20 )
 #define democonfigDEMO_PRIORITY                           ( tskIDLE_PRIORITY + 1 )
 #define democonfigNETWORK_TYPES                           ( AWSIOT_NETWORK_TYPE_WIFI )
 
 #define democonfigSHADOW_DEMO_NUM_TASKS                   ( 2 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 15 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY + 1 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 10 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 11 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 15 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,6 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 10 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 15 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Shadow, Defender, HTTPS_SYNC demos are stuck on TLS connection. Increasing stack size can fix the problem

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.