### PR TITLE
Add metadata for http demos for OCW

### DIFF
--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -1,6 +1,10 @@
 # AFR HTTPS demo
 afr_demo_module(https)
 
+afr_set_demo_metadata(ID "HTTPS_DEMO")
+afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
+afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client S3 download")
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE


### PR DESCRIPTION
Add metadata for http demos for OCW

Description
-----------
This change is to add metadata for OCW for http demos

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.