### PR TITLE
Improve CBMC coverage on HTTP synchronous proofs to all but one line.

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/IotHttpsClient_Disconnect_harness.c
@@ -15,12 +15,6 @@ void harness() {
   if(connHandle) {
     __CPROVER_assume(is_valid_IotConnectionHandle(connHandle));
     __CPROVER_assume(is_stubbed_NetworkInterface(connHandle->pNetworkInterface));
-
-    /* initialize connHandle->respQ to a list of two responses */
-    _httpsResponse_t * p1Resp = malloc(sizeof(_httpsResponse_t));
-    _httpsResponse_t * p2Resp = malloc(sizeof(_httpsResponse_t));
-    IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p1Resp->link));
-    IotDeQueue_EnqueueTail(&(connHandle->respQ), &(p2Resp->link));
   }
   IotHttpsClient_Disconnect(connHandle);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -12,8 +12,11 @@
 void harness() {
   IotHttpsResponseHandle_t respHandle = allocate_IotResponseHandle();
   initialize_IotResponseHandle(respHandle);
-  if (respHandle)
+  if (respHandle) {
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
+    // ???: replace assumption above with initialization
+    respHandle->httpParserInfo.readHeaderParser.data = respHandle;
+  }
   uint32_t pContentLength;
   IotHttpsClient_ReadContentLength(respHandle, &pContentLength);
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/IotHttpsClient_ReadContentLength_harness.c
@@ -14,7 +14,9 @@ void harness() {
   initialize_IotResponseHandle(respHandle);
   if (respHandle) {
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
-    // ???: replace assumption above with initialization
+    // Until a CBMC issue is addressed
+    // https://github.com/diffblue/cbmc/issues/5004
+    // copy an assumption from is_valid above as a simple assignment below.
     respHandle->httpParserInfo.readHeaderParser.data = respHandle;
   }
   uint32_t pContentLength;

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -18,7 +18,9 @@ void harness() {
   initialize_IotResponseHandle(respHandle);
   if (respHandle) {
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
-    // ???: replace assumption above with initialization
+    // Until a CBMC issue is addressed
+    // https://github.com/diffblue/cbmc/issues/5004
+    // copy an assumption from is_valid above as a simple assignment below.
     respHandle->httpParserInfo.readHeaderParser.data = respHandle;
   }
   __CPROVER_assume(0 < valueLen && valueLen < UINT32_MAX);

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/IotHttpsClient_ReadHeader_harness.c
@@ -18,6 +18,9 @@ void harness() {
   initialize_IotResponseHandle(respHandle);
   if (respHandle) {
     __CPROVER_assume(is_valid_IotResponseHandle(respHandle));
+    // ???: replace assumption above with initialization
+    respHandle->httpParserInfo.readHeaderParser.data = respHandle;
   }
+  __CPROVER_assume(0 < valueLen && valueLen < UINT32_MAX);
   IotHttpsClient_ReadHeader(respHandle, pName, nameLen, pValue, valueLen);
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -29,8 +29,9 @@ void *safeMalloc(size_t xWantedSize) {
  * responseHandle, requestHandle and connectionHandle similarly.
  */
 
-// TODO: Replace this with a model allowing unconstrained sizes,
-// or at least allowing a small set of differing sizes.
+// TODO: Replace this model of buffers with a model allowing
+// unconstrained sizes for the user data member, or at least
+// allowing a small set of differing sizes.
 
 typedef struct _responseHandle
 {
@@ -69,17 +70,16 @@ size_t http_parser_execute (http_parser *parser,
   _httpsResponse->parserState = PARSER_STATE_BODY_COMPLETE;
 
   // Generate the header value found
+  size_t valueLength;
   if (_httpsResponse->foundHeaderField) {
-    size_t valueLen;
-    __CPROVER_assume(valueLen <= len);
-    _httpsResponse->pReadHeaderValue = malloc(valueLen+1);
-    _httpsResponse->pReadHeaderValue[valueLen] = 0;
-    _httpsResponse->readHeaderValueLength = valueLen;
+    __CPROVER_assume(valueLength <= len);
+    _httpsResponse->pReadHeaderValue = malloc(valueLength+1);
+    _httpsResponse->pReadHeaderValue[valueLength] = 0;
+    _httpsResponse->readHeaderValueLength = valueLength;
   }
 
-  // ???: Should this be valueLen?
-  // ???: Does it suggest a problem that returning any length works?
-  return nondet_size_t();
+  // Return the number of characters in ReadHeaderValue
+  return _httpsResponse->foundHeaderField ? valueLength : 0;
 }
 
 /****************************************************************


### PR DESCRIPTION
The only uncovered lines are blocks of code guarded by a test for the
asynchronous case, plus one line in the cleanup code for SendSync.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.