### PR TITLE
iot_demo_mqtt.c: test if the client identifier points to a non-empty …

### DIFF
--- a/demos/mqtt/iot_demo_mqtt.c
+++ b/demos/mqtt/iot_demo_mqtt.c
@@ -431,7 +431,7 @@ static int _establishMqttConnection( bool awsIotMqttMode,
 
     /* Use the parameter client identifier if provided. Otherwise, generate a
      * unique client identifier. */
-    if( ( pIdentifier != NULL ) && ( pIdentifier[0] != '\0' ) )
+    if( ( pIdentifier != NULL ) && ( pIdentifier[ 0 ] != '\0' ) )
     {
         connectInfo.pClientIdentifier = pIdentifier;
         connectInfo.clientIdentifierLength = ( uint16_t ) strlen( pIdentifier );

--- a/demos/mqtt/iot_demo_mqtt.c
+++ b/demos/mqtt/iot_demo_mqtt.c
@@ -431,7 +431,7 @@ static int _establishMqttConnection( bool awsIotMqttMode,
 
     /* Use the parameter client identifier if provided. Otherwise, generate a
      * unique client identifier. */
-    if( pIdentifier != NULL )
+    if( ( pIdentifier != NULL ) && ( pIdentifier[0] != '\0' ) )
     {
         connectInfo.pClientIdentifier = pIdentifier;
         connectInfo.clientIdentifierLength = ( uint16_t ) strlen( pIdentifier );


### PR DESCRIPTION

iot_demo_mqtt.c: test if the client identifier points to a non-empty string

<!--- Title -->

Description
-----------
In `iot_demo_mqtt.c` : when a client identifier is not provided by the user, one will be created as e.g. `iotdemo123`:

~~~c
    /* Use the parameter client identifier if provided. Otherwise, generate a
     * unique client identifier. */
    if( pIdentifier != NULL )
    {
        /* Use it. */
    }
    else
    {
        /* Generate a client identifier. */
    }
~~~

Looking back where `pIdentifier` is set, I find the macro `clientcredentialIOT_THING_NAME` which, by default, is defined as an empty string:

~~~c
#define clientcredentialIOT_THING_NAME               ""
~~~

The demo will fail, and it is hard to find the cause of the error message.

To avoid this little annoyance, I would like to propose this small change:

~~~c
-    if( pIdentifier != NULL )
+    if( ( pIdentifier != NULL ) && ( pIdentifier[0] != '\0' ) )
~~~

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
i tested this together with PR #1055 on a Microchip board and in a Windows project.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.