### PR TITLE
Minor Doxygen Fixes

### DIFF
--- a/doc/config/common
+++ b/doc/config/common
@@ -88,7 +88,7 @@ ALIASES += constants_page{1}="@page \1_constants Constants"
 ALIASES += constants_brief{1}="@brief Defined constants of the \1.<br><br>Libraries may @c #`define` constants in their headers with special meanings. This page describes the meanings and uses of any constants defined by the \1. Related constants are shown in a single section on this page.<br>"
 
 # Alias for starting a functions page.
-ALIASES += functions_page{2}="@page \1_functions Functions"
+ALIASES += functions_page{1}="@page \1_functions Functions"
 ALIASES += functions_brief{1}="@brief Functions of the \1 library.<br><br>The \1 library consists of the following functions."
 
 # Alias for listing a single function on a functions page.

--- a/doc/guidance.md
+++ b/doc/guidance.md
@@ -7,7 +7,7 @@ This is about how to use Doxygen to maintain the API documents. There are three 
 
 # Setup Doxygen
 
-[Doxygen Manual](http://www.stack.nl/~dimitri/doxygen/manual/index.html)
+[Doxygen Manual](http://www.doxygen.nl/manual/index.html)
 
 - download and install Doxygen
 - install graphviz


### PR DESCRIPTION
Fixed broken Doxygen link. Fixed inconsistent custom command.

Description
-----------
Current Doxygen link in guidance.md 403's. An alias was using less arguments than the argument number specified.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.