### PR TITLE
Feat: Add support for sending number of blocks with OTA data request.

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1541,7 +1541,7 @@ static void prvOTAUpdateTask( void * pvUnused )
     OTA_FileContext_t * C = NULL;
     OTA_Err_t xErr;
     OTA_PubMsg_t * pxMsgMetaData;
-    uint32_t ulNumOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;	
+    uint32_t ulNumOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
 
     ( void ) pvUnused;
 
@@ -1662,9 +1662,8 @@ static void prvOTAUpdateTask( void * pvUnused )
                                          *
                                          * If there is a valid job id, then a job status update will be sent.
                                          */
-                                         (void)prvSetImageStateWithReason(eOTA_ImageState_Aborted, kOTA_Err_JobParserError);
+                                        ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, kOTA_Err_JobParserError );
                                     }
-
                                 }
                                 else
                                 {
@@ -1734,9 +1733,9 @@ static void prvOTAUpdateTask( void * pvUnused )
                                             /* First reset the momentum counter since we received a good block. */
                                             C->ulRequestMomentum = 0;
                                             prvUpdateJobStatus( C, eJobStatus_InProgress, ( int32_t ) eJobReason_Receiving, ( int32_t ) NULL );
-                                      
+
                                             /* Check if we have received expected number of blocks for the current request. */
-                                            if(ulNumOfBlocksToReceive > 1)
+                                            if( ulNumOfBlocksToReceive > 1 )
                                             {
                                                 ulNumOfBlocksToReceive--;
                                             }
@@ -1744,15 +1743,13 @@ static void prvOTAUpdateTask( void * pvUnused )
                                             {
                                                 /* Received number of data blocks requested so restart the request timer.*/
                                                 prvStartRequestTimer( C );
-                                                                                               
+
                                                 /* Send the event to request next set of data blocks.*/
                                                 if( xOTA_Agent.xOTA_EventFlags != NULL )
                                                 {
                                                     ( void ) xEventGroupSetBits( xOTA_Agent.xOTA_EventFlags, OTA_EVT_MASK_REQ_TIMEOUT );
-                                                }  
-                                            
+                                                }
                                             }
-                                            
                                         }
                                     }
                                 }

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1385,7 +1385,8 @@ static OTA_Err_t prvPublishGetStreamMessage( OTA_FileContext_t * C )
                     ( int32_t ) ( OTA_FILE_BLOCK_SIZE & 0x7fffffffUL ), /* Mask to keep lint happy. It's still a constant. */
                     0,
                     C->pucRxBlockBitmap,
-                    ulBitmapLen ) )
+                    ulBitmapLen,
+                    otaconfigMAX_NUM_BLOCKS_REQUEST ) )
             {
                 ulMsgSizeToPublish = ( uint32_t ) xMsgSizeFromStream;
 
@@ -1540,6 +1541,7 @@ static void prvOTAUpdateTask( void * pvUnused )
     OTA_FileContext_t * C = NULL;
     OTA_Err_t xErr;
     OTA_PubMsg_t * pxMsgMetaData;
+    uint32_t ulNumOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;	
 
     ( void ) pvUnused;
 
@@ -1592,6 +1594,8 @@ static void prvOTAUpdateTask( void * pvUnused )
                 {
                     if( C->ulBlocksRemaining > 0U )
                     {
+                        ulNumOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
+
                         xErr = prvPublishGetStreamMessage( C );
 
                         if( xErr != kOTA_Err_None )
@@ -1658,8 +1662,9 @@ static void prvOTAUpdateTask( void * pvUnused )
                                          *
                                          * If there is a valid job id, then a job status update will be sent.
                                          */
-                                        ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, kOTA_Err_JobParserError );
+                                         (void)prvSetImageStateWithReason(eOTA_ImageState_Aborted, kOTA_Err_JobParserError);
                                     }
+
                                 }
                                 else
                                 {
@@ -1729,6 +1734,25 @@ static void prvOTAUpdateTask( void * pvUnused )
                                             /* First reset the momentum counter since we received a good block. */
                                             C->ulRequestMomentum = 0;
                                             prvUpdateJobStatus( C, eJobStatus_InProgress, ( int32_t ) eJobReason_Receiving, ( int32_t ) NULL );
+                                      
+                                            /* Check if we have received expected number of blocks for the current request. */
+                                            if(ulNumOfBlocksToReceive > 1)
+                                            {
+                                                ulNumOfBlocksToReceive--;
+                                            }
+                                            else
+                                            {
+                                                /* Received number of data blocks requested so restart the request timer.*/
+                                                prvStartRequestTimer( C );
+                                                                                               
+                                                /* Send the event to request next set of data blocks.*/
+                                                if( xOTA_Agent.xOTA_EventFlags != NULL )
+                                                {
+                                                    ( void ) xEventGroupSetBits( xOTA_Agent.xOTA_EventFlags, OTA_EVT_MASK_REQ_TIMEOUT );
+                                                }  
+                                            
+                                            }
+                                            
                                         }
                                     }
                                 }

--- a/libraries/freertos_plus/aws/ota/src/aws_ota_cbor.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_ota_cbor.c
@@ -37,7 +37,7 @@
  * @brief Message field definitions, per the server specification.
  */
 
-#define OTA_CBOR_GETSTREAMREQUEST_ITEM_COUNT    5
+#define OTA_CBOR_GETSTREAMREQUEST_ITEM_COUNT    6
 
 /**
  * @brief Internal context structure for decoding CBOR arrays.
@@ -204,7 +204,8 @@ BaseType_t OTA_CBOR_Encode_GetStreamRequestMessage( uint8_t * pucMessageBuffer,
                                                     int32_t lBlockSize,
                                                     int32_t lBlockOffset,
                                                     uint8_t * pucBlockBitmap,
-                                                    size_t xBlockBitmapSize )
+                                                    size_t xBlockBitmapSize,
+                                                    int32_t lNumOfBlocksRequested )
 {
     CborError xCborResult = CborNoError;
     CborEncoder xCborEncoder, xCborMapEncoder;
@@ -282,6 +283,19 @@ BaseType_t OTA_CBOR_Encode_GetStreamRequestMessage( uint8_t * pucMessageBuffer,
         xCborResult = cbor_encode_byte_string( &xCborMapEncoder,
                                                pucBlockBitmap,
                                                xBlockBitmapSize );
+    }
+
+    /* Encode the number of blocks requested key and value. */
+    if( CborNoError == xCborResult )
+    {
+        xCborResult = cbor_encode_text_stringz( &xCborMapEncoder,
+                                                OTA_CBOR_NUMBEROFBLOCKS_KEY );
+    }
+
+    if( CborNoError == xCborResult )
+    {
+        xCborResult = cbor_encode_int( &xCborMapEncoder,
+                                       lNumOfBlocksRequested );
     }
 
     /* Done with the encoder. */

--- a/libraries/freertos_plus/aws/ota/src/aws_ota_cbor.h
+++ b/libraries/freertos_plus/aws/ota/src/aws_ota_cbor.h
@@ -49,6 +49,7 @@ BaseType_t OTA_CBOR_Encode_GetStreamRequestMessage( uint8_t * pucMessageBuffer,
                                                     int32_t lBlockSize,
                                                     int32_t lBlockOffset,
                                                     uint8_t * pucBlockBitmap,
-                                                    size_t xBlockBitmapSize );
+                                                    size_t xBlockBitmapSize,
+                                                    int32_t lNumOfBlocksRequested );
 
 #endif /* ifndef __AWS_OTACBOR__H__ */

--- a/libraries/freertos_plus/aws/ota/src/aws_ota_cbor_internal.h
+++ b/libraries/freertos_plus/aws/ota/src/aws_ota_cbor_internal.h
@@ -46,5 +46,6 @@
 #define OTA_CBOR_FILESIZE_KEY             "z"
 #define OTA_CBOR_BLOCKID_KEY              "i"
 #define OTA_CBOR_BLOCKPAYLOAD_KEY         "p"
+#define OTA_CBOR_NUMBEROFBLOCKS_KEY       "n"
 
 #endif /* ifndef _AWS_OTA_CBOR_INTERNAL_H_ */

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_cbor.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_cbor.c
@@ -528,10 +528,10 @@ TEST( Full_OTA_CBOR, CborOtaApi )
         OTA_FILE_BLOCK_SIZE,
         0,
         ( uint8_t * ) &ulBitmap,
-        ulBitmapLen,
-        otaconfigMAX_NUM_BLOCKS_REQUEST )
+        sizeof( ulBitmap ),
+        otaconfigMAX_NUM_BLOCKS_REQUEST );
 
-              TEST_ASSERT_TRUE( xResult );
+    TEST_ASSERT_TRUE( xResult );
 
     prvSaveCborTestFile( "tempGetStreamRequest.cbor", ucCborWork, xEncodedSize );
 

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_cbor.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_cbor.c
@@ -528,8 +528,10 @@ TEST( Full_OTA_CBOR, CborOtaApi )
         OTA_FILE_BLOCK_SIZE,
         0,
         ( uint8_t * ) &ulBitmap,
-        sizeof( ulBitmap ) );
-    TEST_ASSERT_TRUE( xResult );
+        ulBitmapLen,
+        otaconfigMAX_NUM_BLOCKS_REQUEST )
+
+              TEST_ASSERT_TRUE( xResult );
 
     prvSaveCborTestFile( "tempGetStreamRequest.cbor", ucCborWork, xEncodedSize );
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
@@ -70,4 +70,17 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
@@ -70,4 +70,19 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+ 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
@@ -70,4 +70,19 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+ 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
@@ -70,4 +70,19 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+ 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_OTA_UPDATE_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
@@ -75,4 +75,19 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        	128U
+ 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
@@ -75,4 +75,19 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+ 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,18 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ * 
+ *  This configuration parameter is sent with data requests and represents the maximum number of 
+ *  data blocks the service will send in response. The maximum limit for this must be calculated 
+ *  from the maximum data response limit (128 KB from service) divided by the block size. 
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on 
+ *  how many data blocks response is expected for each data requests. 
+ *  Please note that this must be set larger than zero.
+ *  
+ */
+ #define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */


### PR DESCRIPTION
<!--- Title -->
Add support in OTA agent for controlling number of data blocks requested from streaming service.

Description
-----------
<!--- Describe your changes in detail -->
This change adds support in OTA agent for controlling number of data blocks requested from streaming service. A new parameter representing number of data blocks is added as a config that is sent with every data block request. For example if this parameter is set as 16 then OTA streaming service will send 16 Data Blocks in response.
This change also restarts the timer as soon as the requested number of data blocks are received instead of waiting for the request timer timeout. This helps in speeding up the OTA process by avoiding unnecessary wait for timer to expire.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.