### PR TITLE
Limit Tx/Rx task pairs to 1 for MQTT_Agent_MultiTaskTest on Mediatek

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Hook function related definitions. */
 #define configUSE_TICK_HOOK                        0
 #define configUSE_IDLE_HOOK                        0
-#define configUSE_MALLOC_FAILED_HOOK               0
+#define configUSE_MALLOC_FAILED_HOOK               1
 #define configCHECK_FOR_STACK_OVERFLOW             2      /* Not applicable to the Win32 port. */
 
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    0

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_config.h
@@ -30,4 +30,10 @@
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"
 
+/* Limit the number of Tx and Rx tasks to 1 for MQTT_Agent_MultiTaskTest.
+ * The default value is 2 which results in test failure because of malloc failure
+ * as we do not have enough RAM to do two simultaneous TLS handshakes. */
+#define mqttagenttestMULTI_TASK_TEST_NUM_RX_TASKS   1
+#define mqttagenttestMULTI_TASK_TEST_NUM_TX_TASKS   1
+
 #endif /* ifndef IOT_CONFIG_H_ */


### PR DESCRIPTION
Description
-----------
The default number of Tx/Rx task pairs for ```MQTT_Agent_MultiTaskTest``` is 2
which means that we try to establish two simultaneous connections to the
AWS IoT broker. This results in test failure as we do not have enough
RAM to do two simultaneous TLS handshakes. This change limits the number
of Tx/Rx task pairs to 1 for Mediatek.

This change also sets ```configUSE_MALLOC_FAILED_HOOK``` to 1 which makes memory
failure debugging a lot easier.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.