### PR TITLE
Add http-parser submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "http-parser"]
+	path = libraries/3rdparty/http-parser
+	url = https://github.com/nodejs/http-parser.git
+	branch = v2.9.2


### PR DESCRIPTION
http-parser is a submodule used by the upcoming https library

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.