### PR TITLE
Fix IotNetworkAfr_ReceiveUpto() to return the number of bytes recieved.

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -607,6 +607,7 @@ size_t IotNetworkAfr_ReceiveUpto( void * pConnection,
     }
     else
     {
+        bytesReceived += ( size_t ) socketStatus;
         IotLogDebug( "Successfully received %lu bytes.",
                      ( unsigned long ) bytesReceived );
     }


### PR DESCRIPTION
Fix IotNetworkAfr_ReceiveUpto() to return the number of bytes recieved.

This has been tested with the HTTPS demo and tests that utilize the network.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.