### PR TITLE
Merge the HTTPS Client asynchronous and synchronous demos into one demo

### DIFF
--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -1,7 +1,7 @@
 # AFR HTTPS demo
 afr_demo_module(https)
 
-afr_set_demo_metadata(ID "HTTPS_DEMO")
+afr_set_demo_metadata(ID "HTTPS_S3_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
 afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client S3 download")
 

--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -1,9 +1,9 @@
 # AFR HTTPS demo
 afr_demo_module(https)
 
-afr_set_demo_metadata(ID "HTTPS_S3_DEMO")
+afr_set_demo_metadata(ID "HTTPS_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
-afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client S3 download")
+afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client S3 file download")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -60,6 +60,15 @@
 
 /*-----------------------------------------------------------*/
 
+/* Declaration of demo function. */
+int RunHttpsS3Demo( bool awsIotMqttMode,
+                    const char * pIdentifier,
+                    void * pNetworkServerInfo,
+                    void * pNetworkCredentialInfo,
+                    const IotNetworkInterface_t * pNetworkInterface );
+
+/*-----------------------------------------------------------*/
+
 int _IotHttpsDemo_GetS3ObjectFileSize( uint32_t * pFileSize,
                                        IotHttpsConnectionHandle_t connHandle,
                                        const char * pPath,
@@ -220,4 +229,39 @@ int _IotHttpsDemo_GetS3ObjectFileSize( uint32_t * pFileSize,
     }
 
     return EXIT_SUCCESS;
+}
+
+/*-----------------------------------------------------------*/
+
+int RunHttpsS3Demo( bool awsIotMqttMode,
+                    const char * pIdentifier,
+                    void * pNetworkServerInfo,
+                    void * pNetworkCredentialInfo,
+                    const IotNetworkInterface_t * pNetworkInterface )
+{
+    #if defined( IOT_DEMO_HTTPS_ASYNC )
+        IotLogInfo( "Running the HTTPS Client S3 asynchronous download demo." );
+        extern int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
+                                              const char * pIdentifier,
+                                              void * pNetworkServerInfo,
+                                              void * pNetworkCredentialInfo,
+                                              const IotNetworkInterface_t * pNetworkInterface );
+        return RunHttpsAsyncDownloadDemo( awsIotMqttMode,
+                                          pIdentifier,
+                                          pNetworkServerInfo,
+                                          pNetworkCredentialInfo,
+                                          pNetworkInterface );
+    #else /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
+        IotLogInfo( "Running the HTTPS Client S3 synchronous download demo." );
+        extern int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
+                                             const char * pIdentifier,
+                                             void * pNetworkServerInfo,
+                                             void * pNetworkCredentialInfo,
+                                             const IotNetworkInterface_t * pNetworkInterface );
+        return RunHttpsSyncDownloadDemo( awsIotMqttMode,
+                                         pIdentifier,
+                                         pNetworkServerInfo,
+                                         pNetworkCredentialInfo,
+                                         pNetworkInterface );
+    #endif /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
 }

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -60,20 +60,6 @@
 
 /*-----------------------------------------------------------*/
 
-extern int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
-                                      const char * pIdentifier,
-                                      void * pNetworkServerInfo,
-                                      void * pNetworkCredentialInfo,
-                                      const IotNetworkInterface_t * pNetworkInterface );
-
-extern int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
-                                     const char * pIdentifier,
-                                     void * pNetworkServerInfo,
-                                     void * pNetworkCredentialInfo,
-                                     const IotNetworkInterface_t * pNetworkInterface );
-
-/*-----------------------------------------------------------*/
-
 /* Declaration of demo function. */
 int RunHttpsDemo( bool awsIotMqttMode,
                   const char * pIdentifier,
@@ -253,24 +239,29 @@ int RunHttpsDemo( bool awsIotMqttMode,
                   void * pNetworkCredentialInfo,
                   const IotNetworkInterface_t * pNetworkInterface )
 {
-    int status = EXIT_SUCCESS;
-
-    IotLogInfo( "** Now running the HTTPS Client asynchronous download from S3 demo. **" );
-    status = RunHttpsAsyncDownloadDemo( awsIotMqttMode,
-                                        pIdentifier,
-                                        pNetworkServerInfo,
-                                        pNetworkCredentialInfo,
-                                        pNetworkInterface );
-
-    if( status == EXIT_SUCCESS )
-    {
-        IotLogInfo( "** Now running the HTTPS Client synchronous download from S3 demo. **" );
-        status = RunHttpsSyncDownloadDemo( awsIotMqttMode,
-                                           pIdentifier,
-                                           pNetworkServerInfo,
-                                           pNetworkCredentialInfo,
-                                           pNetworkInterface );
-    }
-
-    return status;
+    #if defined( IOT_DEMO_HTTPS_ASYNC )
+        IotLogInfo( "Running the HTTPS Client S3 asynchronous download demo." );
+        extern int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
+                                              const char * pIdentifier,
+                                              void * pNetworkServerInfo,
+                                              void * pNetworkCredentialInfo,
+                                              const IotNetworkInterface_t * pNetworkInterface );
+        return RunHttpsAsyncDownloadDemo( awsIotMqttMode,
+                                          pIdentifier,
+                                          pNetworkServerInfo,
+                                          pNetworkCredentialInfo,
+                                          pNetworkInterface );
+    #else /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
+        IotLogInfo( "Running the HTTPS Client S3 synchronous download demo." );
+        extern int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
+                                             const char * pIdentifier,
+                                             void * pNetworkServerInfo,
+                                             void * pNetworkCredentialInfo,
+                                             const IotNetworkInterface_t * pNetworkInterface );
+        return RunHttpsSyncDownloadDemo( awsIotMqttMode,
+                                         pIdentifier,
+                                         pNetworkServerInfo,
+                                         pNetworkCredentialInfo,
+                                         pNetworkInterface );
+    #endif /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
 }

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -62,10 +62,10 @@
 
 /* Declaration of demo function. */
 int RunHttpsDemo( bool awsIotMqttMode,
-                    const char * pIdentifier,
-                    void * pNetworkServerInfo,
-                    void * pNetworkCredentialInfo,
-                    const IotNetworkInterface_t * pNetworkInterface );
+                  const char * pIdentifier,
+                  void * pNetworkServerInfo,
+                  void * pNetworkCredentialInfo,
+                  const IotNetworkInterface_t * pNetworkInterface );
 
 /*-----------------------------------------------------------*/
 

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -60,6 +60,20 @@
 
 /*-----------------------------------------------------------*/
 
+extern int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
+                                      const char * pIdentifier,
+                                      void * pNetworkServerInfo,
+                                      void * pNetworkCredentialInfo,
+                                      const IotNetworkInterface_t * pNetworkInterface );
+
+extern int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
+                                     const char * pIdentifier,
+                                     void * pNetworkServerInfo,
+                                     void * pNetworkCredentialInfo,
+                                     const IotNetworkInterface_t * pNetworkInterface );
+
+/*-----------------------------------------------------------*/
+
 /* Declaration of demo function. */
 int RunHttpsDemo( bool awsIotMqttMode,
                   const char * pIdentifier,
@@ -239,29 +253,24 @@ int RunHttpsDemo( bool awsIotMqttMode,
                   void * pNetworkCredentialInfo,
                   const IotNetworkInterface_t * pNetworkInterface )
 {
-    #if defined( IOT_DEMO_HTTPS_ASYNC )
-        IotLogInfo( "Running the HTTPS Client S3 asynchronous download demo." );
-        extern int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
-                                              const char * pIdentifier,
-                                              void * pNetworkServerInfo,
-                                              void * pNetworkCredentialInfo,
-                                              const IotNetworkInterface_t * pNetworkInterface );
-        return RunHttpsAsyncDownloadDemo( awsIotMqttMode,
-                                          pIdentifier,
-                                          pNetworkServerInfo,
-                                          pNetworkCredentialInfo,
-                                          pNetworkInterface );
-    #else /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
-        IotLogInfo( "Running the HTTPS Client S3 synchronous download demo." );
-        extern int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
-                                             const char * pIdentifier,
-                                             void * pNetworkServerInfo,
-                                             void * pNetworkCredentialInfo,
-                                             const IotNetworkInterface_t * pNetworkInterface );
-        return RunHttpsSyncDownloadDemo( awsIotMqttMode,
-                                         pIdentifier,
-                                         pNetworkServerInfo,
-                                         pNetworkCredentialInfo,
-                                         pNetworkInterface );
-    #endif /* if defined( IOT_DEMO_HTTPS_ASYNC ) */
+    int status = EXIT_SUCCESS;
+
+    IotLogInfo( "** Now running the HTTPS Client asynchronous download from S3 demo. **" );
+    status = RunHttpsAsyncDownloadDemo( awsIotMqttMode,
+                                        pIdentifier,
+                                        pNetworkServerInfo,
+                                        pNetworkCredentialInfo,
+                                        pNetworkInterface );
+
+    if( status == EXIT_SUCCESS )
+    {
+        IotLogInfo( "** Now running the HTTPS Client synchronous download from S3 demo. **" );
+        status = RunHttpsSyncDownloadDemo( awsIotMqttMode,
+                                           pIdentifier,
+                                           pNetworkServerInfo,
+                                           pNetworkCredentialInfo,
+                                           pNetworkInterface );
+    }
+
+    return status;
 }

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -61,7 +61,7 @@
 /*-----------------------------------------------------------*/
 
 /* Declaration of demo function. */
-int RunHttpsS3Demo( bool awsIotMqttMode,
+int RunHttpsDemo( bool awsIotMqttMode,
                     const char * pIdentifier,
                     void * pNetworkServerInfo,
                     void * pNetworkCredentialInfo,
@@ -233,7 +233,7 @@ int _IotHttpsDemo_GetS3ObjectFileSize( uint32_t * pFileSize,
 
 /*-----------------------------------------------------------*/
 
-int RunHttpsS3Demo( bool awsIotMqttMode,
+int RunHttpsDemo( bool awsIotMqttMode,
                     const char * pIdentifier,
                     void * pNetworkServerInfo,
                     void * pNetworkCredentialInfo,

--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -234,10 +234,10 @@ int _IotHttpsDemo_GetS3ObjectFileSize( uint32_t * pFileSize,
 /*-----------------------------------------------------------*/
 
 int RunHttpsDemo( bool awsIotMqttMode,
-                    const char * pIdentifier,
-                    void * pNetworkServerInfo,
-                    void * pNetworkCredentialInfo,
-                    const IotNetworkInterface_t * pNetworkInterface )
+                  const char * pIdentifier,
+                  void * pNetworkServerInfo,
+                  void * pNetworkCredentialInfo,
+                  const IotNetworkInterface_t * pNetworkInterface )
 {
     #if defined( IOT_DEMO_HTTPS_ASYNC )
         IotLogInfo( "Running the HTTPS Client S3 asynchronous download demo." );

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -504,15 +504,11 @@ static void _errorCallback( void * pPrivData,
 /**
  * @brief The function that runs the HTTPS Asynchronous demo.
  *
- * @param[in] awsIotMqttMode Specify if this demo is running with the AWS IoT
- * MQTT server. Set this to `false` if using another MQTT server.
- * @param[in] pIdentifier NULL-terminated MQTT client identifier. The demo starting parameters are built for core MQTT.
- *  but this demo ignores these parameters.
- * @param[in] pNetworkServerInfo Passed to the MQTT connect function when
- * establishing the MQTT connection.
- * @param[in] pNetworkCredentialInfo Passed to the MQTT connect function when
- * establishing the MQTT connection.
- * @param[in] pNetworkInterface The network interface to use for this demo.
+ * @param[in] awsIotMqttMode Specify if this demo is running with the AWS IoT MQTT server. This is ignored in this demo.
+ * @param[in] pIdentifier NULL-terminated MQTT client identifier. This is ignored in this demo.
+ * @param[in] pNetworkServerInfo Contains network information specific for the MQTT demo. This is ignored in this demo.
+ * @param[in] pNetworkCredentialInfo Contains credential Info specific for the MQTT demo. This is ignored in this demo.
+ * @param[in] pNetworkInterface Contains the network interface interaction routines.
  *
  * @return `EXIT_SUCCESS` if the demo completes successfully; `EXIT_FAILURE` otherwise.
  */

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -167,10 +167,8 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
 /**
  * @brief The function that runs the HTTPS Synchronous Download demo.
  *
- * @param[in] awsIotMqttMode Specify if this demo is running with the AWS IoT MQTT server. Set this to `false` if using
- *      another MQTT server. This parameter is not used for this demo.
- * @param[in] pIdentifier NULL-terminated MQTT client identifier. The demo starting parameters are built for core MQTT.
- *      but this demo ignores these parameters.
+ * @param[in] awsIotMqttMode Specify if this demo is running with the AWS IoT MQTT server. This is ignored in this demo.
+ * @param[in] pIdentifier NULL-terminated MQTT client identifier. This is ignored in this demo.
  * @param[in] pNetworkServerInfo Contains network information specific for the MQTT demo. This is ignored in this demo.
  * @param[in] pNetworkCredentialInfo Contains credential Info specific for the MQTT demo. This is ignored in this demo.
  * @param[in] pNetworkInterface Contains the network interface interaction routines.

--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -94,10 +94,8 @@
     #endif
 #elif defined( CONFIG_BLE_GATT_SERVER_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             vGattDemoSvcInit
-#elif defined( CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION             RunHttpsSyncDownloadDemo
-#elif defined( CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION             RunHttpsAsyncDownloadDemo
+#elif defined( CONFIG_HTTPS_S3_DEMO_ENABLED )
+    #define DEMO_entryFUNCTION             RunHttpsS3Demo
 #else /* if defined( CONFIG_MQTT_DEMO_ENABLED ) */
 /* if no demo was defined there will be no entry point defined and we will not be able to run the demo */
     #error "No demo to run. One demo should be enabled"

--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -94,8 +94,8 @@
     #endif
 #elif defined( CONFIG_BLE_GATT_SERVER_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             vGattDemoSvcInit
-#elif defined( CONFIG_HTTPS_S3_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION             RunHttpsS3Demo
+#elif defined( CONFIG_HTTPS_DEMO_ENABLED )
+    #define DEMO_entryFUNCTION             RunHttpsDemo
 #else /* if defined( CONFIG_MQTT_DEMO_ENABLED ) */
 /* if no demo was defined there will be no entry point defined and we will not be able to run the demo */
     #error "No demo to run. One demo should be enabled"

--- a/doc/lib/https.txt
+++ b/doc/lib/https.txt
@@ -141,7 +141,7 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         Paste your RSA-2048 or ECC-P256 keys into [aws_clientcredential_keys.h](https://github.com/aws/amazon-freertos/blob/master/demos/include/aws_clientcredential_keys.h). This is needed to for the TLS handshake with the AWS S3 HTTP Server.  
     </li>
     <li>
-        Enable the <b>Synchronous download demo</b> by defining @ref CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED in aws_demo_config.h:
+        Enable the <b>Synchronous download demo</b> by defining @ref CONFIG_HTTPS_S3_DEMO_ENABLED in aws_demo_config.h:
         \code
         /* To run a particular demo you need to define one of these.
         * Only one demo can be configured at a time
@@ -153,12 +153,11 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         *          CONFIG_DEFENDER_DEMO_ENABLED
         *          CONFIG_POSIX_DEMO_ENABLED
         *          CONFIG_OTA_UPDATE_DEMO_ENABLED
-        *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
-        *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+        *          CONFIG_HTTPS_S3_DEMO_ENABLED
         *
         *  These defines are used in iot_demo_runner.h for demo selection */
 
-        #define CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
+        #define CONFIG_HTTPS_S3_DEMO_ENABLED
         \endcode
     </li>
     <li>
@@ -199,7 +198,7 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         \endcode
     </li>
     <li>
-        Enable the <b>Asynchronous download demo</b> by defining either @ref CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED in aws_demo_config.h:  
+        Enable the <b>Asynchronous download demo</b> by defining @ref CONFIG_HTTPS_S3_DEMO_ENABLED in aws_demo_config.h:  
         \code
         /* To run a particular demo you need to define one of these.
         * Only one demo can be configured at a time
@@ -211,13 +210,22 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         *          CONFIG_DEFENDER_DEMO_ENABLED
         *          CONFIG_POSIX_DEMO_ENABLED
         *          CONFIG_OTA_UPDATE_DEMO_ENABLED
-        *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
-        *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+        *          CONFIG_HTTPS_S3_DEMO_ENABLED
         *
         *  These defines are used in iot_demo_runner.h for demo selection */
 
-        #define CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+        #define CONFIG_HTTPS_S3_DEMO_ENABLED
         \endcode
+
+        Then defining @ref IOT_DEMO_HTTPS_ASYNC in iot_config.h:
+        \code
+        /* This file contains configuration settings for the demos. */
+
+        #ifndef IOT_CONFIG_H_
+        #define IOT_CONFIG_H_
+
+        #define IOT_DEMO_HTTPS_ASYNC
+        \endcode 
     </li>
     <li>
         See @ref building_demo for instructions on building the demo.  
@@ -275,6 +283,12 @@ Note:
 /**
 @config_page{https_demo,Demo}
 @config_brief{https_demo,HTTP Client demo,demos}
+
+@section IOT_DEMO_HTTPS_ASYNC
+@brief Run the asynchronous version of the HTTPS Client S3 demo.
+
+@configpossible Any. <br>
+@configdefault This configuration is undefined by default.
 
 @section IOT_DEMO_HTTPS_PRESIGNED_GET_URL
 @brief Presigned URL for AWS S3 GET Object access.

--- a/doc/lib/https.txt
+++ b/doc/lib/https.txt
@@ -141,7 +141,7 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         Paste your RSA-2048 or ECC-P256 keys into [aws_clientcredential_keys.h](https://github.com/aws/amazon-freertos/blob/master/demos/include/aws_clientcredential_keys.h). This is needed to for the TLS handshake with the AWS S3 HTTP Server.  
     </li>
     <li>
-        Enable the <b>Synchronous download demo</b> by defining @ref CONFIG_HTTPS_S3_DEMO_ENABLED in aws_demo_config.h:
+        Enable the <b>Synchronous download demo</b> by defining @ref CONFIG_HTTPS_DEMO_ENABLED in aws_demo_config.h:
         \code
         /* To run a particular demo you need to define one of these.
         * Only one demo can be configured at a time
@@ -153,11 +153,11 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         *          CONFIG_DEFENDER_DEMO_ENABLED
         *          CONFIG_POSIX_DEMO_ENABLED
         *          CONFIG_OTA_UPDATE_DEMO_ENABLED
-        *          CONFIG_HTTPS_S3_DEMO_ENABLED
+        *          CONFIG_HTTPS_DEMO_ENABLED
         *
         *  These defines are used in iot_demo_runner.h for demo selection */
 
-        #define CONFIG_HTTPS_S3_DEMO_ENABLED
+        #define CONFIG_HTTPS_DEMO_ENABLED
         \endcode
     </li>
     <li>
@@ -198,7 +198,7 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         \endcode
     </li>
     <li>
-        Enable the <b>Asynchronous download demo</b> by defining @ref CONFIG_HTTPS_S3_DEMO_ENABLED in aws_demo_config.h:  
+        Enable the <b>Asynchronous download demo</b> by defining @ref CONFIG_HTTPS_DEMO_ENABLED in aws_demo_config.h:  
         \code
         /* To run a particular demo you need to define one of these.
         * Only one demo can be configured at a time
@@ -210,11 +210,11 @@ This demo will use @ref https_client_function_sendasync to download the file spe
         *          CONFIG_DEFENDER_DEMO_ENABLED
         *          CONFIG_POSIX_DEMO_ENABLED
         *          CONFIG_OTA_UPDATE_DEMO_ENABLED
-        *          CONFIG_HTTPS_S3_DEMO_ENABLED
+        *          CONFIG_HTTPS_DEMO_ENABLED
         *
         *  These defines are used in iot_demo_runner.h for demo selection */
 
-        #define CONFIG_HTTPS_S3_DEMO_ENABLED
+        #define CONFIG_HTTPS_DEMO_ENABLED
         \endcode
 
         Then defining @ref IOT_DEMO_HTTPS_ASYNC in iot_config.h:

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/application_code/main.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/application_code/main.c
@@ -30,8 +30,6 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#define CONFIG_MQTT_DEMO_ENABLED
-
 /* AWS library includes. */
 #include "iot_system_init.h"
 #include "iot_logging_task.h"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
  *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
  *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
@@ -42,7 +42,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_demo_config.h
@@ -42,7 +42,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -35,7 +35,7 @@
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_demo_config.h
@@ -35,8 +35,7 @@
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                             ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -35,7 +35,7 @@
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                             ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -35,8 +35,7 @@
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 20 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -35,8 +35,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 20 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -35,7 +35,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 20 )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 20 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  * These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  * These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  * These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -36,10 +36,9 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
- *  These defines are used in iot_demo_runner.h for demo selection */
+ * These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_MQTT_DEMO_ENABLED
 

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_demo_config.h
@@ -42,7 +42,7 @@
             
     These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* OTA Update task example parameters. */
 #define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( configMINIMAL_STACK_SIZE * 4 )

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_demo_config.h
@@ -42,7 +42,7 @@
             
     These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* OTA Update task example parameters. */
 #define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( configMINIMAL_STACK_SIZE * 4 )

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -36,12 +36,11 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
@@ -39,7 +39,7 @@
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
  *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
  *          CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_demo_config.h
@@ -39,8 +39,7 @@
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
  *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
  *          CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -36,7 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_S3_DEMO_ENABLED
+ *          CONFIG_HTTPS_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -36,8 +36,7 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
- *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
- *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_S3_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/aws_demo_config.h
@@ -40,7 +40,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_HTTPS_DEMO_ENABLED /* Temporary commit to check the build in test/build system. */
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )


### PR DESCRIPTION
The HTTPS Client asynchronous and synchronous S3 download demos were merged into one demo.
A user configuration IOT_DEMO_HTTPS_ASYNC switches between the demos and CONFIG_HTTPS_S3_DEMO_ENABLED
was defined instead of two separate configs. This is done because the demos share similarities and an advanced user would know to which detail they desired.

This was also done to better support the Online Configuration download in AWS IoT.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.