### PR TITLE
Update the configuration metadata to enable the synchronous download demo

### DIFF
--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -1,9 +1,9 @@
 # AFR HTTPS demo
 afr_demo_module(https)
 
-afr_set_demo_metadata(ID "HTTPS_DEMO")
+afr_set_demo_metadata(ID "HTTPS_SYNC_DOWNLOAD_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
-afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client S3 download")
+afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client Download")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}

--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -3,7 +3,7 @@ afr_demo_module(https)
 
 afr_set_demo_metadata(ID "HTTPS_SYNC_DOWNLOAD_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
-afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client Download")
+afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client Demos")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -557,7 +557,7 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     bool inUseRequestMutexCreated = false;
     bool fileFinishedSemCreated = false;
 
-    IotLogInfo( "S3 Download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
+    IotLogInfo( "HTTPS Client Asynchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
     /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL, ( size_t ) strlen( IOT_DEMO_HTTPS_PRESIGNED_GET_URL ), &pPath, &pathLen );

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -237,7 +237,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     /* Buffer to write the Range: header value string. */
     char rangeValueStr[ RANGE_VALUE_MAX_LENGTH ] = { 0 };
 
-    IotLogInfo( "S3 Download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
+    IotLogInfo( "HTTPS Client Synchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
     /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL,


### PR DESCRIPTION
Update the configuration metadata to enable the HTTPS Client synchronous download demo

Users can read the HTTPS Client docs and enable the asynchronous download demo.
Update logging in demos to demote which type of demo is currently running.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.