### PR TITLE
Change log update for HTTPS Client V1.0.0 and doxygen update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log for Amazon FreeRTOS
 
 ### New Features
+#### New Board:Nuvoton NuMaker-IoT-M487
+- Nuvoton NuMaker-IoT-M487 are now qualified for Amazon FreeRTOS.
+- Disclaimer on RNG: The random number generation solution in this port is for demonstration purposes only. 
+
 #### FreeRTOS Kernel V10.2.1
 - Kernel version for Amazon FreeRTOS is updated to V10.2.1.
 - Add ARM Cortex-M23 (ARMv8-M) GCC/ARMclang and IAR ports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### HTTPS Client Library V1.0.0
 - The HTTPS Client library for Amazon FreeRTOS supports the HTTP/1.1 protocol over TLS. 
 - The current request methods supported are GET and HEAD.
-- Examples demonstrates for downloading a file using GET with a pre-signed URL for an S3 object.
+- Examples demonstrate downloading a file using GET with a pre-signed URL for an S3 object.
 
 ### Updates
 #### PKCS #11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### HTTPS Client Library V1.0.0
 - The HTTPS Client library for Amazon FreeRTOS supports the HTTP/1.1 protocol over TLS. 
 - The current request methods supported are GET and HEAD.
-- Examples demonstrate downloading a file using GET with a pre-signed URL for an S3 object.
+- Examples demonstrate downloading a file from S3 using GET with a pre-signed URL.
 
 ### Updates
 #### PKCS #11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Add ARM Cortex-M23 (ARMv8-M) GCC/ARMclang and IAR ports.
 - Add support to automatically switch between 32-bit and 64-bit cores to RISC-V port.
 
+#### HTTPS Client Library V1.0.0
+- The HTTPS Client library for Amazon FreeRTOS supports the HTTP/1.1 protocol over TLS. 
+- The current request methods supported are GET and HEAD.
+- Examples demonstrates for downloading a file using GET with a pre-signed URL for an S3 object.
+
 ### Updates
 #### PKCS #11
 - Update the Amazon FreeRTOS mbedTLS-based PKCS #11 implementation, tests, demos, and PKCS #11 consuming libraries for compliance with standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Features
 #### New Board:Nuvoton NuMaker-IoT-M487
-- Nuvoton NuMaker-IoT-M487 are now qualified for Amazon FreeRTOS.
+- Nuvoton NuMaker-IoT-M487 is now qualified for Amazon FreeRTOS.
 - Disclaimer on RNG: The random number generation solution in this port is for demonstration purposes only. 
 
 #### FreeRTOS Kernel V10.2.1

--- a/doc/lib/https.txt
+++ b/doc/lib/https.txt
@@ -79,7 +79,7 @@ The HTTPS Client library will invoke a task pool worker to send a request. It wi
 
 These demos shows downloading a file from S3 using a pre-signed URL using the Amazon FreeRTOS HTTP Client library. The HTTPS Client library is a generic HTTP/1.1 client library that be used to download files from other web servers as well.
 
-See @subpage https_demo_config for configuration settings that change the behavior of the demo.
+See @subpage https_demo_usage for information on how to get the demo up and running.
 
 The main HTTPS Client demo files are [iot_demo_https_s3_download_async.c](https://github.com/aws/amazon-freertos/tree/master/demos/https/iot_demo_https_s3_download_async.c) and [iot_demo_https_s3_download_sync.c](https://github.com/aws/amazon-freertos/tree/master/demos/https/iot_demo_https_s3_download_sync.c), which contain platform-independent code. See @ref building_demo for instructions on building the HTTPS Client demo.
 
@@ -93,7 +93,9 @@ This demo will use @ref https_client_function_sendsync to download the file spec
 
 This demo will use @ref https_client_function_sendasync to download the file specified in S3.
 
-<h1> Demo usage instructions </h1>
+See @subpage https_demo_config for configuration settings that change the behavior of the demo.
+
+@page https_demo_usage Demo Usage Instructions
 
 <ol>
     <li>


### PR DESCRIPTION
* Doxygen update for the HTTPS Client library moves the demo usage instructions to their own page. This supports linkage to page and easy finding from AWS Getting Started pages.
* Change Log update introduces the first version of the HTTPS Client library to Amazon FreeRTOS.
* Change log update for Nuvoton NuMaker-IoT-M487 release.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.