### PR TITLE
Add connection retries to the HTTPS Client demos.

### DIFF
--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -647,11 +647,12 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Connect to S3. */
-    for( connIndex = 0; connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
+    for( connIndex = 1; connIndex <= IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
     {
         httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
 
-        if( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR )
+        if( ( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR ) &&
+            ( connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY ) )
         {
             IotLogError( "Failed to connect to the S3 server, retrying after %d ms.",
                          IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -152,6 +152,20 @@
     #define IOT_HTTPS_DEMO_ASYNC_TIMEOUT_MS    ( ( uint32_t ) 300000 )   /* 5 minute timeout for this demo. */
 #endif
 
+/* Time to wait in milliseconds before retrying the HTTPS Connection. A connection is only attempted again if
+* IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This indicates an error in the network
+* layer. To view logging for network errors update IOT_LOG_LEVEL_NETWORK to IOT_LOG_ERROR in iot_config.h. */
+#ifndef IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS
+    #define IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS    ( ( uint32_t ) 3000 )
+#endif
+
+/* Number of times to retry the HTTPS connection. A connection is only attempted again if
+ * IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This indicates an error in the network
+ * layer. To view logging for network errors update IOT_LOG_LEVEL_NETWORK to IOT_LOG_ERROR in iot_config.h. */
+#ifndef IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY
+    #define IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY    ( ( uint32_t ) 3 )
+#endif
+
 /** @endcond */
 
 /**
@@ -552,6 +566,8 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     uint32_t numReqBytes = 0;
     /* curByte indicates which starting byte we want to download next. */
     uint32_t curByte = 0;
+    /* The current index in the number of connection tries. */
+    uint32_t connIndex = 0;
 
     /* Signal if the global semaphores were created for cleanup. */
     bool inUseRequestMutexCreated = false;
@@ -631,7 +647,22 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Connect to S3. */
-    httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
+    for( connIndex = 0; connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
+    {
+        httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
+
+        if( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR )
+        {
+            IotLogError( "Failed to connect to the S3 server, retrying after %d ms.",
+                         IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );
+            IotClock_SleepMs( IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
 
     if( httpsClientStatus != IOT_HTTPS_OK )
     {

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -339,11 +339,12 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Connect to S3. */
-    for( connIndex = 0; connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
+    for( connIndex = 1; connIndex <= IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
     {
         httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
 
-        if( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR )
+        if( ( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR ) &&
+            ( connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY ) )
         {
             IotLogError( "Failed to connect to the S3 server, retrying after %d ms.",
                          IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -45,6 +45,7 @@
 #include "platform/iot_network.h"
 #include "private/iot_error.h"
 #include "iot_demo_https_common.h"
+#include "platform/iot_clock.h"
 
 /**
  * This demonstates downloading a file from S3 using a pre-signed URL using the Amazon FreeRTOS HTTP Client library.
@@ -129,6 +130,20 @@
  * the size of the file we want to download.*/
 #ifndef IOT_DEMO_HTTPS_RESP_BODY_BUFFER_SIZE
     #define IOT_DEMO_HTTPS_RESP_BODY_BUFFER_SIZE    ( 512 )
+#endif
+
+/* Time to wait in milliseconds before retrying the HTTPS Connection. A connection is only attempted again if
+ * IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This indicates an error in the network
+ * layer. To view logging for network errors update IOT_LOG_LEVEL_NETWORK to IOT_LOG_ERROR in iot_config.h */
+#ifndef IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS
+    #define IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS    ( ( uint32_t ) 3000 )
+#endif
+
+/* Number of times to retry the HTTPS connection. A connection is only attempted again if
+ * IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This indicates an error in the network
+ * layer. To view logging for network errors update IOT_LOG_LEVEL_NETWORK to IOT_LOG_ERROR in iot_config.h */
+#ifndef IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY
+    #define IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY    ( ( uint32_t ) 3 )
 #endif
 
 /** @endcond */
@@ -236,6 +251,8 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     uint32_t curByte = 0;
     /* Buffer to write the Range: header value string. */
     char rangeValueStr[ RANGE_VALUE_MAX_LENGTH ] = { 0 };
+    /* The current index in the number of connection tries. */
+    uint32_t connIndex = 0;
 
     IotLogInfo( "HTTPS Client Synchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
@@ -322,7 +339,22 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Connect to S3. */
-    httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
+    for( connIndex = 0; connIndex < IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY; connIndex++ )
+    {
+        httpsClientStatus = IotHttpsClient_Connect( &connHandle, &connConfig );
+
+        if( httpsClientStatus == IOT_HTTPS_CONNECTION_ERROR )
+        {
+            IotLogError( "Failed to connect to the S3 server, retrying after %d ms.",
+                         IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );
+            IotClock_SleepMs( IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS );
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
 
     if( httpsClientStatus != IOT_HTTPS_OK )
     {

--- a/doc/lib/https.txt
+++ b/doc/lib/https.txt
@@ -341,6 +341,25 @@ Size in bytes of the buffer used to store the response body (parts of it). This 
 @configpossible Any positive integer. <br>
 @configdefault `512`
 
+@section IOT_DEMO_HTTPS_CONNECTION_RETRY_WAIT_MS
+@brief Time to wait in milliseconds before retrying the HTTPS Connection.
+
+A connection is only attempted again if @ref IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This 
+indicates an error in the network layer. To view network errors update @ref IOT_LOG_LEVEL_NETWORK to @ref IOT_LOG_ERROR 
+in iot_config.h.
+
+@configpossible Any positive integer.
+@configdefault `3000`
+
+@section IOT_DEMO_HTTPS_CONNECTION_NUM_RETRY
+@brief Number of times to retry the HTTPS connection.
+
+A connection is only attempted again if @ref IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This 
+indicates an error in the network layer. To view network errors update @ref IOT_LOG_LEVEL_NETWORK to @ref IOT_LOG_ERROR 
+in iot_config.h.
+
+@configpossible Any positive integer.
+@configdefault `3`
 
 <h1> Asynchronous Download Demo specific configurations:  </h1> 
 These configurations apply only to [iot_demo_https_s3_download_async.c](https://github.com/aws/amazon-freertos/tree/master/demos/https/iot_demo_https_s3_download_async.c).


### PR DESCRIPTION
Sometimes the boards experience transient network issues in connection to some servers. This reduces the likely-hood the demo fails for those errors.

A connection is only attempted again if IOT_HTTPS_CONNECTION_ERROR is returned from IotHttpsClient_Connect(). This indicates an error in the network layer. To view logging for network errors update IOT_LOG_LEVEL_NETWORK to IOT_LOG_ERROR in iot_config.h.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.