### PR TITLE
Fix parenthesis in default define for MCHP FreeRTOS_debug_printf

### DIFF
--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -45,7 +45,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * out the debugging messages. */
 #define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    #define FreeRTOS_debug_printf( X )    vLoggingPrintf( X )
+    #define FreeRTOS_debug_printf( X )    vLoggingPrintf X 
 #endif
 
 /* Set to 1 to print out non debugging messages, for example the output of the

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -45,7 +45,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * out the debugging messages. */
 #define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    #define FreeRTOS_debug_printf( X )    vLoggingPrintf( X )
+    #define FreeRTOS_debug_printf( X )    vLoggingPrintf X 
 #endif
 
 /* Set to 1 to print out non debugging messages, for example the output of the


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.