### PR TITLE
Fix Greengrass test and add debugging support

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/application_code/main.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/application_code/main.c
@@ -53,6 +53,9 @@
 
 #define WIFI_FW_DEBUG_LOG_PORT
 
+/* Set the following to 1 to enable debugging. */
+#define MTK_DEBUGGER  0
+
 /**
  * @brief Application task startup hook for applications using Wi-Fi. If you are not
  * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
@@ -94,6 +97,10 @@ static void prvMiscInitialization( void );
  */
 int main( void )
 {
+    #if ( MTK_DEBUGGER != 0 )
+        { volatile int wait_ice = 1 ; while ( wait_ice ) ; }
+    #endif
+
     /* Perform any hardware initialization that does not require the RTOS to be
      * running.  */
     prvMiscInitialization();

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/application_code/main.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/application_code/main.c
@@ -53,6 +53,9 @@
 
 #define WIFI_FW_DEBUG_LOG_PORT
 
+/* Set the following to 1 to enable debugging. */
+#define MTK_DEBUGGER  0
+
 /**
  * @brief Application task startup hook for applications using Wi-Fi. If you are not
  * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
@@ -92,6 +95,10 @@ static void prvMiscInitialization( void );
  */
 int main( void )
 {
+    #if ( MTK_DEBUGGER != 0 )
+        { volatile int wait_ice = 1 ; while ( wait_ice ) ; }
+    #endif
+
     /* Perform any hardware initialization that does not require the RTOS to be
      * running.  */
     prvMiscInitialization();
@@ -183,7 +190,7 @@ void vApplicationDaemonTaskStartupHook( void )
                      "RunTests_task",
                      mainTEST_RUNNER_TASK_STACK_SIZE,
                      NULL,
-                     tskIDLE_PRIORITY + 1,
+                     tskIDLE_PRIORITY,
                      NULL );
     }
 }


### PR DESCRIPTION
Description
-----------

Each of the Greengrass test calls ```IotSdk_Init``` in the setup and
```IotSdk_Cleanup``` in the teardown. ```IotSdk_Init``` creates the system task pool
which consists of 2 tasks of 2K stack size each. ```IotSdk_Cleanup``` deletes
those tasks by calling ```vTaskDelete```.``` vTaskDelete``` only marks a task for
deletion and the actual deletion happens in the idle task. The test
runner task for Mediatek was running at ```tskIDLE_PRIORITY + 1``` and was not
allowing the Idle task to run between test runs. As a result, the heap
space allocated for system pool tasks' stack and TCB was not getting
freed. This was resulting in memory allocation failures leading to test
failures. This change lowers the priority of the test runner task to
```tskIDLE_PRIORITY``` to ensure that the heap space is freed between test
runs. This fixes the Greengrass tests for Mediatek.

The debugging instruction on the getting started page for Mediatek
( https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_mediatek.html )
mention ```MTK_DEBUGGER``` macro and ```wait_ice``` variable. These are needed for
debugging this board but were missing from the code. This change adds
these macros and variables to enable debugging suopport.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.