### PR TITLE
Fix log message in ReceiveUpto

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -595,22 +595,26 @@ size_t IotNetworkAfr_ReceiveUpto( void * pConnection,
         pNetworkConnection->bufferedByteValid = false;
     }
 
-    /* Block and wait for incoming data. */
-    socketStatus = SOCKETS_Recv( pNetworkConnection->socket,
-                                 pBuffer + bytesReceived,
-                                 bufferSize - bytesReceived,
-                                 0 );
+    if( bufferSize - bytesReceived > 0 )
+    {
+        /* Block and wait for incoming data. */
+        socketStatus = SOCKETS_Recv( pNetworkConnection->socket,
+                                     pBuffer + bytesReceived,
+                                     bufferSize - bytesReceived,
+                                     0 );
 
-    if( socketStatus <= 0 )
-    {
-        IotLogError( "Error %ld while receiving data.", ( long int ) socketStatus );
+        if( socketStatus <= 0 )
+        {
+            IotLogError( "Error %ld while receiving data.", ( long int ) socketStatus );
+        }
+        else
+        {
+            bytesReceived += ( size_t ) socketStatus;
+        }
     }
-    else
-    {
-        bytesReceived += ( size_t ) socketStatus;
-        IotLogDebug( "Successfully received %lu bytes.",
-                     ( unsigned long ) bytesReceived );
-    }
+
+    IotLogDebug( "Received %lu bytes.",
+                 ( unsigned long ) bytesReceived );
 
     return bytesReceived;
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
An incorrect error log message would have been printed if bufferSize was 1.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.