### PR TITLE
Fix WiFi test failures/hangs for Mediatek

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
@@ -1249,32 +1249,24 @@ WIFIReturnCode_t WIFI_Disconnect( void )
     xSemaphoreTake( _g_state.critical_section, portMAX_DELAY );
 
     /*
+     * early exit if already disconnected
+     */
+    if( _g_state.connected == false )
+    {
+        LOG_I( wifi, "%s: Already disconnected.\n", __FUNCTION__ );
+        xSemaphoreGive( _g_state.critical_section );
+        return eWiFiSuccess;
+    }
+    else
+    {
+        LOG_I( wifi, "%s: Connected. Proceeding to disconnect.\n", __FUNCTION__ );
+    }
+
+    /*
      * stop ip stack
      */
 
     _mtk_sta_ip_down( &_g_state );
-
-    /*
-     * early exit if already disconnected
-     */
-
-    if( wifi_connection_get_link_status( &link_status ) >= 0 )
-    {
-        if( WIFI_STATUS_LINK_DISCONNECTED == link_status )
-        {
-            LOG_I( wifi, "%s: link down\n", __FUNCTION__ );
-            xSemaphoreGive( _g_state.critical_section );
-            return eWiFiSuccess;
-        }
-        else
-        {
-            LOG_I( wifi, "%s: link up\n", __FUNCTION__ );
-        }
-    }
-    else
-    {
-        LOG_I( wifi, "%s: unable to get link status\n", __FUNCTION__ );
-    }
 
     /*
      * disconnect AP

--- a/vendors/mediatek/sdk/middleware/MTK/dhcpd/src/dhcpd.c
+++ b/vendors/mediatek/sdk/middleware/MTK/dhcpd/src/dhcpd.c
@@ -1281,11 +1281,11 @@ void dhcpd_stop(void)
     dhcpd_mutex_lock();
     if (dhcpd_running == 1) {
         dhcpd_running = 0;
-        vTaskDelete(dhcpd_task_handle);
-        dhcpd_task_handle=0;
         wifi_connection_unregister_event_notifier(WIFI_EVENT_IOT_DISCONNECTED, dhcpd_wifi_api_rx_event_handler);
         close(dhcpd_socket);
         dhcpd_socket = -1;
+        vTaskDelete(dhcpd_task_handle);
+        dhcpd_task_handle=0;
 
 		dhcpd_release_alloc_info_lists();
 


### PR DESCRIPTION
Description
-----------

Mediatek DHCP code creates a DCHP task in ```dhcpd_start``` function which
creates a LWIP socket and listens on it. ```dhcpd_stop``` function deletes
the DHCP task and then closes the socket. When the socket is closed,
LWIP makes sure that if any task is waiting for the data to be received
on the socket, it gets unblocked. The following piece of code from LWIP
does that:

```c
while( xTask != NULL )
{
    xTaskAbortDelay( xTask );
    taskYIELD();
    xTask = pxMailBox->xTask;
}
```

```dhcpd_stop``` function first deletes the DHCP task and then closes the
LWIP socket. This creates a race condition –

 - DHCP task calls ```recv_from``` on the socket and gets blocked waiting for
   the data on the socket.
 - User task (test runner in our case) calls ```dhcpd_stop``` which deletes
   the DHCP task and then attempts to close the above socket. Since the
   DHCP task is still waiting for the data, the above mentioned while
   loop tries to unblock it - A deleted task cannot be unblocked/run
   and therefore the above while loop becomes an infinite loop.

This change fixes the ```dhcpd_stop``` function to first close the socket and
then delete the DHCP task.

```WIFI_Disconnect``` implementation incorrectly assumes that "link up" means
that the WiFi module is connected to an AP. This causes problem because
```AFQP_WIFI_ConnectAP_InvalidSecurityTypes``` test provides incorrect
security type WEP instead of WPA2 which results in auth error and leaves
the module in "link up" but disconnected state. The call to
```WIFI_Disconnect``` in the setup function then tries to disconnect the already
disconnected module and enters an infinite wait for a callback which
never gets invoked. This change fixes the ```WIFI_Disconnect``` implementation
to check the connected state variable (which is set in the connection
successful callback) to determine whether or not the module is already
connected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.