### PR TITLE
August 20, adapted and tested FreeRTOS_DNS to use IPv6

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOSIPConfigDefaults.h
@@ -545,6 +545,10 @@ from the FreeRTOSIPConfig.h configuration header file. */
 	#define ipconfigSOCKET_HAS_USER_SEMAPHORE 0
 #endif
 
+#ifndef ipconfigSOCKET_HAS_USER_WAKE_CALLBACK
+	#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK 0
+#endif
+
 #ifndef ipconfigSUPPORT_SELECT_FUNCTION
 	#define ipconfigSUPPORT_SELECT_FUNCTION 0
 #endif

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_DNS.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_DNS.h
@@ -152,7 +152,11 @@ uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer );
 	 * Users may define this type of function as a callback.
 	 * It will be called when a DNS reply is received or when a timeout has been reached.
 	 */
-	typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, uint32_t /* ulIPAddress */ );
+	#if( ipconfigUSE_IPv6 != 0 )
+		typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, struct freertos_sockaddr6 * /* pxAddress6 */ );
+	#else
+		typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, uint32_t /* ulIPAddress */ );
+	#endif
 
 	/*
 	 * Asynchronous version of gethostbyname()

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP.h
@@ -95,6 +95,7 @@ BaseType_t xRandom32( uint32_t *pulValue );
 #define ipIP_ADDRESS_LENGTH_BYTES ( 4 )
 
 /* IP protocol definitions. */
+#define ipPROTOCOL_EXT_HEADER	( 0 )	/* Exists in IPv6 */
 #define ipPROTOCOL_ICMP			( 1 )
 #define ipPROTOCOL_IGMP         ( 2 )
 #define ipPROTOCOL_TCP			( 6 )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP_Private.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP_Private.h
@@ -644,6 +644,11 @@ void vNetworkSocketsInit( void );
  */
 BaseType_t xIPIsNetworkTaskReady( void );
 
+#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+	struct xSOCKET;
+	typedef void (*SocketWakeupCallback_t)( struct xSOCKET * pxSocket );
+#endif
+
 #if( ipconfigUSE_TCP == 1 )
 
 	/*
@@ -831,6 +836,10 @@ typedef struct xSOCKET
 	#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
 		SemaphoreHandle_t pxUserSemaphore;
 	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+	#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+		SocketWakeupCallback_t pxUserWakeCallback;
+	#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+
 	#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 		struct xSOCKET_SET *pxSocketSet;
 		/* User may indicate which bits are interesting for this socket. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_Sockets.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_Sockets.h
@@ -148,6 +148,12 @@ FreeRTOS_setsockopt(). */
 	#define FREERTOS_SO_UDP_MAX_RX_PACKETS	( 16 )		/* This option helps to limit the maximum number of packets a UDP socket will buffer */
 #endif
 
+#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+	#define FREERTOS_SO_WAKEUP_CALLBACK	( 17 )
+#endif
+
+#define FREERTOS_SO_SET_LOW_HIGH_WATER	( 18 )
+
 #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET 	( 0x80 )  /* For internal use only, but also part of an 8-bit bitwise value. */
 #define FREERTOS_FRAGMENTED_PACKET				( 0x40 )  /* For internal use only, but also part of an 8-bit bitwise value. */
 
@@ -173,6 +179,12 @@ typedef struct xWIN_PROPS {
 	int32_t lRxBufSize;	/* Unit: bytes */
 	int32_t lRxWinSize;	/* Unit: MSS */
 } WinProperties_t;
+
+typedef struct xLOW_HIGH_WATER {
+	/* Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option */
+	size_t uxLittleSpace;	/* Send a STOP when buffer space drops below X bytes */
+	size_t uxEnoughSpace;	/* Send a GO when buffer space grows above X bytes */
+} LowHighWater_t;
 
 /* For compatibility with the expected Berkeley sockets naming. */
 #define socklen_t uint32_t
@@ -255,7 +267,11 @@ BaseType_t FreeRTOS_bind( Socket_t xSocket, struct freertos_sockaddr *pxAddress,
 
 /* function to get the local address and IP port */
 /* Note that when 'ipconfigUSE_IPv6 != 0', freertos_sockaddr can be intepreted as a freertos_sockaddr6. */
-size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+#if( ipconfigUSE_IPv6 != 0 )
+	size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr6 *pxAddress6 );
+#else
+	size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+#endif
 
 /* Made available when ipconfigETHERNET_DRIVER_FILTERS_PACKETS is set to 1. */
 BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
@@ -281,7 +297,11 @@ BaseType_t FreeRTOS_shutdown (Socket_t xSocket, BaseType_t xHow);
 /* Return the remote address and IP port. */
 
 /* Note that when 'ipconfigUSE_IPv6 != 0', freertos_sockaddr can be intepreted as a freertos_sockaddr6. */
-BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+#if( ipconfigUSE_IPv6 != 0 )
+	BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr6 *pxAddress6 );
+#else
+	BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+#endif
 
 #if( ipconfigUSE_IPv6 != 0 )
 	/* Get the type of IP: either 'ipTYPE_IPv4' or 'ipTYPE_IPv6'. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_ARP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_ARP.c
@@ -122,10 +122,13 @@ NetworkEndPoint_t *pxTargetEndPoint = pxNetworkBuffer->pxEndPoint;
 			case ipARP_REQUEST	:
 				if( ulSenderProtocolAddress != ulTargetProtocolAddress )
 				{
-					FreeRTOS_printf( ( "ipARP_REQUEST from %lxip to %lxip end-point %lxip\n",
-									   FreeRTOS_ntohl( ulSenderProtocolAddress ),
-									   FreeRTOS_ntohl( ulTargetProtocolAddress ),
-									   FreeRTOS_ntohl( pxTargetEndPoint ? pxTargetEndPoint->ipv4.ulIPAddress : 0uL ) ) );
+					if( pxTargetEndPoint != NULL )
+					{
+						FreeRTOS_printf( ( "ipARP_REQUEST from %lxip to %lxip end-point %lxip\n",
+										   FreeRTOS_ntohl( ulSenderProtocolAddress ),
+										   FreeRTOS_ntohl( ulTargetProtocolAddress ),
+										   FreeRTOS_ntohl( pxTargetEndPoint ? pxTargetEndPoint->ipv4.ulIPAddress : 0uL ) ) );
+					}
 				}
 				/* The packet contained an ARP request.  Was it for the IP
 				address of one of the end-points? */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_DNS.c
@@ -158,6 +158,12 @@ static uint32_t prvGetHostByName( const char *pcHostName,
 								  TickType_t uxReadTimeOut_ticks,
 								  struct freertos_sockaddr *pxAddress );
 
+#if( ipconfigUSE_IPv6 != 0 )
+	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier, BaseType_t xIsIPv6 );
+#else
+	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier );
+#endif
+
 /*
  * The NBNS and the LLMNR protocol share this reply function.
  */
@@ -211,11 +217,11 @@ static uint32_t prvGetHostByName( const char *pcHostName,
 	static DNSCacheRow_t xDNSCache[ ipconfigDNS_CACHE_ENTRIES ];
 	static BaseType_t xFreeEntry = 0;
 
-    void FreeRTOS_dnsclear()
-    {
-        memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
+	void FreeRTOS_dnsclear()
+	{
+		memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
 		xFreeEntry = 0;
-    }
+	}
 #endif /* ipconfigUSE_DNS_CACHE == 1 */
 
 #if( ipconfigUSE_LLMNR == 1 )
@@ -235,7 +241,7 @@ static uint32_t prvGetHostByName( const char *pcHostName,
 			0x00, 0x01,
 			0x00, 0x03,
 		}
-	};
+	};/*lint !e9018 declaration of symbol 'ipLLMNR_IP_ADDR_IPv6' with union based type 'const IPv6_Address_t' [MISRA 2012 Rule 19.2, advisory]. */
 
 	const MACAddress_t xLLMNR_MacAdressIPv6 = { { 0x33, 0x33, 0x00, 0x01, 0x00, 0x03 } };
 #endif /* ipconfigUSE_LLMNR && ipconfigUSE_IPv6 */
@@ -343,7 +349,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 		memset( &xIPv46_Address, '\0', sizeof xIPv46_Address );
 		/* Also the fields 'ucIs_IPv6' and 'ulIPAddress' have been cleared. */
-		prvProcessDNSCache( pcHostName, &xIPv46_Address, 0, pdTRUE );
+		( void ) prvProcessDNSCache( pcHostName, &xIPv46_Address, 0, pdTRUE );
 
 		return xIPv46_Address.u.ulIPAddress;
 	}
@@ -351,10 +357,11 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 /*-----------------------------------------------------------*/
 
 #if( ipconfigUSE_DNS_CACHE == 1 ) && ( ipconfigUSE_IPv6 != 0 )
-	uint32_t FreeRTOS_dnslookup6( const char *pcHostName, IPv6_Address_t *pxAddress_IPv6 )
+	uint32_t FreeRTOS_dnslookup6( const char *pcHostName, IPv6_Address_t *pxAddress_IPv6 )/*lint !e9018 declaration of symbol 'ipLLMNR_IP_ADDR_IPv6' with union based type 'const IPv6_Address_t' [MISRA 2012 Rule 19.2, advisory]. */
 	{
 	IPv46_Address_t xIPv46_Address;
 	BaseType_t xResult;
+	uint32_t ulReturn;
 
 		memset( &xIPv46_Address, '\0', sizeof xIPv46_Address );
 		/* Let prvProcessDNSCache only return IPv6 addresses. */
@@ -365,7 +372,15 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 			memcpy( pxAddress_IPv6, xIPv46_Address.u.xAddress_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 		}
 
-		return xResult;
+		if( xResult != pdFALSE )
+		{
+			ulReturn = 1uL;
+		}
+		else
+		{
+			ulReturn = 0uL;
+		}
+		return ulReturn;
 	}
 #endif /* ( ipconfigUSE_DNS_CACHE == 1 ) && ( ipconfigUSE_IPv6 != 0 ) */
 /*-----------------------------------------------------------*/
@@ -378,6 +393,10 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 		TimeOut_t xTimeoutState;
 		void *pvSearchID;
 		struct xLIST_ITEM xListItem;
+		#if( ipconfigUSE_IPv6 != 0 )
+			/* Remeber if this was a IPv6 lookup. */
+			BaseType_t xIsIPv6;
+		#endif
 		char pcName[ 1 ];
 	} DNSCallback_t;
 
@@ -425,7 +444,28 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 				}
 				else if( xTaskCheckForTimeOut( &pxCallback->xTimeoutState, &pxCallback->xRemaningTime ) != pdFALSE )
 				{
-					pxCallback->pCallbackFunction( pxCallback->pcName, pxCallback->pvSearchID, 0 );
+					/* A time-out occurred in the asynchronous search.
+					Cal the application hook with the proper information. */
+					#if( ipconfigUSE_IPv6 != 0 )
+					{
+						struct freertos_sockaddr6 xAddress6;
+						memset( &( xAddress6 ), '\0', sizeof xAddress6 );
+						xAddress6.sin_len = sizeof( xAddress6 );
+						if( pxCallback->xIsIPv6 != pdFALSE )
+						{
+							xAddress6.sin_family = FREERTOS_AF_INET6;
+						}
+						else
+						{
+							xAddress6.sin_family = FREERTOS_AF_INET4;
+						}
+						pxCallback->pCallbackFunction( pxCallback->pcName, pxCallback->pvSearchID, &( xAddress6 ) );
+					}
+					#else
+					{
+						pxCallback->pCallbackFunction( pxCallback->pcName, pxCallback->pvSearchID, 0uL );
+					}
+					#endif
 					( void )uxListRemove( &pxCallback->xListItem );
 					vPortFree( pxCallback );
 				}
@@ -453,8 +493,11 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 	/* FreeRTOS_gethostbyname_a() was called along with callback parameters.
 	Store them in a list for later reference. */
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier );
-	static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier )
+	#if( ipconfigUSE_IPv6 != 0 )
+		static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier, BaseType_t xIsIPv6 )
+	#else
+		static void vDNSSetCallBack( const char *pcHostName, void *pvSearchID, FOnDNSEvent pCallbackFunction, TickType_t xTimeout, TickType_t uxIdentifier )
+	#endif
 	{
 		size_t uxLength = strlen( pcHostName );
 		DNSCallback_t *pxCallback = ipPOINTER_CAST( DNSCallback_t *, pvPortMalloc( sizeof( *pxCallback ) + uxLength ) );
@@ -472,6 +515,11 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 			pxCallback->pCallbackFunction = pCallbackFunction;
 			pxCallback->pvSearchID = pvSearchID;
 			pxCallback->xRemaningTime = xTimeout;
+			#if( ipconfigUSE_IPv6 != 0 )
+			{
+				pxCallback->xIsIPv6 = xIsIPv6;
+			}
+			#endif
 			vTaskSetTimeOutState( &pxCallback->xTimeoutState );
 			listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ipPOINTER_CAST( void *, pxCallback ) );
 			listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), uxIdentifier );
@@ -487,8 +535,13 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
 	/* A DNS reply was received, see if there is any matching entry and
 	call the handler.  Returns pdTRUE if uxIdentifier was recognised. */
+#if( ipconfigUSE_IPv6 != 0 )
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, struct freertos_sockaddr6 *pxAddress );
+	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, struct freertos_sockaddr6 *pxAddress )
+#else
 	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress );
 	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier, const char *pcName, uint32_t ulIPAddress )
+#endif
 	{
 		BaseType_t xResult = pdFALSE;
 		const ListItem_t *pxIterator;
@@ -504,7 +557,11 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 				{
 					DNSCallback_t *pxCallback = ipPOINTER_CAST( DNSCallback_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
 					configPRINTF( ( "xDNSDoCallback (0x%04lX) for '%s'\n", uxIdentifier, pcName ) );
+					#if( ipconfigUSE_IPv6 != 0 )
+					pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, pxAddress );
+					#else
 					pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, ulIPAddress );
+					#endif
 					( void ) uxListRemove( &pxCallback->xListItem );
 					vPortFree( pxCallback );
 					if( listLIST_IS_EMPTY( &xCallbackList ) )
@@ -551,6 +608,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 									struct freertos_addrinfo **ppxResult)		/* An allocated struct, containing the results. */
 #endif	/* ipconfigDNS_USE_CALLBACKS == 1 */
 {
+BaseType_t xReturn = -pdFREERTOS_ERRNO_ENOENT;
 uint32_t ulResult;
 struct freertos_addrinfo *pxAddrInfo;
 #if( ipconfigUSE_IPv6 != 0 )
@@ -558,6 +616,9 @@ struct freertos_sockaddr6 xAddress;
 #else
 struct freertos_sockaddr xAddress;
 #endif
+
+	( void ) pcService;
+	( void ) pxHints;
 
 	*( ppxResult ) = NULL;
 	memset( &( xAddress ), '\0', sizeof( xAddress ) );
@@ -574,21 +635,21 @@ struct freertos_sockaddr xAddress;
 
 	#if( ipconfigDNS_USE_CALLBACKS == 1 )
 	{
-		ulResult = prvPrepareLookup( pcName, ( struct freertos_sockaddr * ) &( xAddress ), pCallback, pvSearchID, xTimeout );
+		ulResult = prvPrepareLookup( pcName, ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ), pCallback, pvSearchID, xTimeout );
 	}
 	#else
 	{
-		ulResult = prvPrepareLookup( pcName, ( struct freertos_sockaddr * ) &( xAddress ) );
+		ulResult = prvPrepareLookup( pcName, ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ) );
 	}
 	#endif
 	if( ulResult != 0uL )
 	{
-		pxAddrInfo = ( struct freertos_addrinfo * ) pvPortMalloc( sizeof( *pxAddrInfo ) );
+		pxAddrInfo = ipPOINTER_CAST( struct freertos_addrinfo *, pvPortMalloc( sizeof( *pxAddrInfo ) ) );
 		if( pxAddrInfo != NULL )
 		{
 			memset( pxAddrInfo, '\0', sizeof( *pxAddrInfo ) );
 			pxAddrInfo->ai_canonname = pxAddrInfo->xPrivateStorage.ucName;
-			snprintf( pxAddrInfo->xPrivateStorage.ucName, sizeof( pxAddrInfo->xPrivateStorage.ucName ), "%s", pcName );
+			strncpy( pxAddrInfo->xPrivateStorage.ucName, pcName, sizeof( pxAddrInfo->xPrivateStorage.ucName ) );
 
 			#if( ipconfigUSE_IPv6 != 0 )
 			{
@@ -615,20 +676,24 @@ struct freertos_sockaddr xAddress;
 				pxAddrInfo->ai_addrlen = ipSIZE_OF_IPv4_ADDRESS;
 			}
 			*( ppxResult ) = pxAddrInfo;
+			xReturn = 0;
 		}
 		else
 		{
 			/* The node was found but a malloc failed. */
-			ulResult = 0uL;
+			xReturn = -pdFREERTOS_ERRNO_ENOMEM;
 		}
 	}
-	return ulResult;
+	return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void FreeRTOS_freeaddrinfo(struct freertos_addrinfo *pxResult)
 {
-	vPortFree( pxResult );
+	if( pxResult != NULL )
+	{
+		vPortFree( pxResult );
+	}
 }
 /*-----------------------------------------------------------*/
 
@@ -682,7 +747,20 @@ TickType_t uxIdentifier = 0;
 	#if( ipconfigINCLUDE_FULL_INET_ADDR == 1 )
 	{
 		#if( ipconfigUSE_IPv6 != 0 )
-		if( xIsIPv6 == pdFALSE )
+		if( xIsIPv6 != pdFALSE )
+		{
+		IPv6_Address_t xAddress_IPv6;	/*lint !e9018 declaration of symbol 'xAddress_IPv6' with union based type 'const IPv6_Address_t' [MISRA 2012 Rule 19.2, advisory]. */
+
+			/* ulIPAddress does not represent an IPv4 address here. It becomes non-zero when the look-up succeeds. */
+			ulIPAddress = ( uint32_t ) FreeRTOS_inet_pton6( pcHostName, xAddress_IPv6.ucBytes );
+			if( ( ulIPAddress != 0uL ) && ( pxAddress != NULL ) )
+			{
+			struct freertos_sockaddr6 *pxAddress6 = ipPOINTER_CAST(struct freertos_sockaddr6 *, pxAddress );
+
+				memcpy( pxAddress6->sin_addrv6.ucBytes, xAddress_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+			}
+		}
+		else
 		#endif
 		{
 			ulIPAddress = FreeRTOS_inet_addr( pcHostName );
@@ -695,14 +773,26 @@ TickType_t uxIdentifier = 0;
 	#if( ipconfigUSE_DNS_CACHE == 1 )
 	{
 		#if( ipconfigUSE_IPv6 != 0 )
-		if( xIsIPv6 == pdFALSE )
+		if( xIsIPv6 != pdFALSE )
+		{
+			if( ( pxAddress != NULL ) && ( ulIPAddress == 0UL ) )
+			{
+			struct freertos_sockaddr6 *pxAddress6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
+
+				ulIPAddress = FreeRTOS_dnslookup6( pcHostName, &( pxAddress6->sin_addrv6 ) );
+				if( ulIPAddress != 0uL )
+				{
+				}
+			}
+		}
+		else
 		#endif
 		{
 			if( ulIPAddress == 0UL )
 			{
 				ulIPAddress = FreeRTOS_dnslookup( pcHostName );
 
-				if( ulIPAddress != 0 )
+				if( ulIPAddress != 0uL )
 				{
 					FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
 				}
@@ -733,13 +823,42 @@ TickType_t uxIdentifier = 0;
 				if( uxIdentifier != ( TickType_t ) 0u )
 				{
 					uxReadTimeOut_ticks = 0;
-					vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )uxIdentifier );
+					#if( ipconfigUSE_IPv6 != 0 )
+					{
+						vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )uxIdentifier, xIsIPv6 );
+					}
+					#else
+					{
+						vDNSSetCallBack( pcHostName, pvSearchID, pCallback, xTimeout, ( TickType_t )uxIdentifier );
+					}
+					#endif
 				}
 			}
 			else
 			{
 				/* The IP address is known, do the call-back now. */
-				pCallback( pcHostName, pvSearchID, ulIPAddress );
+				#if( ipconfigUSE_IPv6 != 0 )
+				if( xIsIPv6 != pdFALSE )
+				{
+					pCallback( pcHostName, pvSearchID, ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress ) );
+				}
+				else if( pxAddress != NULL )
+				{
+					pxAddress->sin_family = FREERTOS_AF_INET4;
+					pxAddress->sin_addr = ulIPAddress;
+					pCallback( pcHostName, pvSearchID, ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress ) );
+				}
+				else
+				{
+					/* No comment. */
+				}
+				#else
+				{
+					pxAddress->sin_family = FREERTOS_AF_INET4;
+					pxAddress->sin_addr = ulIPAddress;
+					pCallback( pcHostName, pvSearchID, ulIPAddress );
+				}
+				#endif
 			}
 		}
 	}
@@ -754,11 +873,6 @@ TickType_t uxIdentifier = 0;
 }
 /*-----------------------------------------------------------*/
 
-struct xNetworkCopy {
-	uint32_t values[ ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + 16 ) / 4 ];
-};
-volatile struct xNetworkCopy *pxNetworkCopy;
-
 static uint32_t prvGetHostByName( const char *pcHostName,
 								  TickType_t uxIdentifier,
 								  TickType_t uxReadTimeOut_ticks,
@@ -767,7 +881,7 @@ static uint32_t prvGetHostByName( const char *pcHostName,
 struct freertos_sockaddr xAddress;
 Socket_t xDNSSocket;
 uint32_t ulIPAddress = 0UL;
-uint8_t *pucUDPPayloadBuffer, *pucReceiveBuffer;
+uint8_t *pucUDPPayloadBuffer = NULL, *pucReceiveBuffer;
 uint32_t ulAddressLength = sizeof( struct freertos_sockaddr );
 BaseType_t xAttempt;
 int32_t lBytes;
@@ -836,8 +950,7 @@ UBaseType_t uxHostType;
 			if( pxNetworkBuffer != NULL )
 			{
 				pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ uxHeaderBytes ] );
-pxNetworkCopy = ( volatile struct xNetworkCopy * ) &( pxNetworkBuffer->pucEthernetBuffer[ -10 ] );
-				pucUDPPayloadBuffer[ -( ipUDP_PAYLOAD_IP_TYPE_OFFSET ) ] = ipTYPE_IPv4;
+				pucUDPPayloadBuffer[ - ( ( int ) ipUDP_PAYLOAD_IP_TYPE_OFFSET ) ] = ( uint8_t ) ipTYPE_IPv4;
 			}
 
 			if( pucUDPPayloadBuffer != NULL )
@@ -893,7 +1006,7 @@ pxNetworkCopy = ( volatile struct xNetworkCopy * ) &( pxNetworkBuffer->pucEthern
 					if( lBytes > 0 )
 					{
 					BaseType_t xExpected;
-					DNSMessage_t *pxDNSMessageHeader = ( DNSMessage_t * ) pucReceiveBuffer;
+					DNSMessage_t *pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucReceiveBuffer );
 
 						/* See if the identifiers match. */
 						if( uxIdentifier == ( TickType_t ) pxDNSMessageHeader->usIdentifier )
@@ -1021,6 +1134,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 	#ifdef _lint
 	( void ) pxTail;
+	( void ) uxHostType;
 	#else
 	vSetField16( pxTail, DNSTail_t, usType, ( uint16_t ) uxHostType );	/*lint !e78 !e830 !e40 !e835 !e572 !e778 !e530 !e830*/  /* Type A: host */
 	vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );		/*lint !e78 !e830 !e40 !e835 !e572 !e778 !e530 !e830*/  /* 1: Class IN */
@@ -1185,13 +1299,20 @@ static size_t prvSkipNameField( uint8_t *pucByte,
 
 		if( pxNetworkBuffer->xDataLength >= sizeof( DNSMessage_t ) )
 		{
+		#if( ipconfigUSE_IPv6 != 0 )
+		struct freertos_sockaddr6 xAddress;
+		#else
+		struct freertos_sockaddr xAddress;
+		#endif
+
 			configPRINTF( ( "ulDNSHandlePacket: received reply\n" ) );
+			memset( &xAddress, '\0', sizeof xAddress );
 			pxDNSMessageHeader =
 				ipPOINTER_CAST( DNSMessage_t *, &( pxNetworkBuffer->pucEthernetBuffer [ sizeof( UDPPacket_t ) ] ) );
 
 			( void ) prvParseDNSReply( ( uint8_t * )pxDNSMessageHeader,
 									   pxNetworkBuffer->xDataLength,
-									   NULL,
+									   ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ),
 									   pdFALSE );
 		}
 
@@ -1224,7 +1345,7 @@ static NetworkEndPoint_t *prvFindEndPointOnNetMask( NetworkBufferDescriptor_t *p
 NetworkEndPoint_t *pxEndPoint;
 
 #if( ipconfigUSE_IPv6 != 0 )
-	IPPacket_IPv6_t *xIPPacket_IPv6 = ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer;
+	IPPacket_IPv6_t *xIPPacket_IPv6 = ipPOINTER_CAST( IPPacket_IPv6_t *, pxNetworkBuffer->pucEthernetBuffer );
 
 	if( xIPPacket_IPv6->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
 	{
@@ -1400,7 +1521,8 @@ IPv46_Address_t xIP_Address;
 					pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
 
 					/* Sanity check the data length of an IPv4 answer. */
-					if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == uxAddressLength )
+					/* lint: uxAddressLength is defined because xDoAccept = true. */
+					if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == uxAddressLength )/*lint !e644 Variable 'uxAddressLength' (line 1380) may not have been initialized [MISRA 2012 Rule 9.1, mandatory]). */
 					{
 						/* Copy the IP address out of the record. */
 						#if( ipconfigUSE_IPv6 != 0 )
@@ -1411,7 +1533,7 @@ IPv46_Address_t xIP_Address;
 									ipSIZE_OF_IPv6_ADDRESS );
 							if( pxAddress != NULL )
 							{
-							struct freertos_sockaddr6 *pxSockaddr6 = ( struct freertos_sockaddr6 * ) pxAddress;
+							struct freertos_sockaddr6 *pxSockaddr6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
 
 								memcpy( pxSockaddr6->sin_addrv6.ucBytes,
 										&( pucByte [ sizeof( DNSAnswerRecord_t ) ] ),
@@ -1428,10 +1550,9 @@ IPv46_Address_t xIP_Address;
 									ipSIZE_OF_IPv4_ADDRESS );
 							if( pxAddress != NULL )
 							{
-								memcpy( &( pxAddress->sin_addr ),
-										&( pucByte [ sizeof( DNSAnswerRecord_t ) ] ),
-										ipSIZE_OF_IPv4_ADDRESS );
+								pxAddress->sin_addr = ulIPAddress;
 							}
+							xIP_Address.u.ulIPAddress = ulIPAddress;
 						#if( ipconfigUSE_IPv6 != 0 )
 							xIP_Address.ucIs_IPv6 = ( uint8_t ) 0u;
 						#endif
@@ -1439,8 +1560,18 @@ IPv46_Address_t xIP_Address;
 
 						#if( ipconfigDNS_USE_CALLBACKS == 1 )
 						{
+						BaseType_t xCallbackResult;
+							#if( ipconfigUSE_IPv6 != 0 )
+							{
+								xCallbackResult = xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress ) );
+							}
+							#else
+							{
+								xCallbackResult = xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress );
+							}
+							#endif
 							/* See if any asynchronous call was made to FreeRTOS_gethostbyname_a() */
-							if( xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress ) != pdFALSE )
+							if( xCallbackResult != pdFALSE )
 							{
 								/* This device has requested this DNS look-up.
 								The result may be stored in the DNS cache. */
@@ -1454,7 +1585,7 @@ IPv46_Address_t xIP_Address;
 							request was issued by this device. */
 							if( xDoStore != pdFALSE )
 							{
-								prvProcessDNSCache( pcName, &xIP_Address, pxDNSAnswerRecord->ulTTL, pdFALSE );
+								( void ) prvProcessDNSCache( pcName, &xIP_Address, pxDNSAnswerRecord->ulTTL, pdFALSE );
 							}
 							#if( ipconfigUSE_IPv6 != 0 )
 							if( usType == ( uint16_t ) dnsTYPE_AAAA_HOST )
@@ -1590,7 +1721,7 @@ IPv46_Address_t xIP_Address;
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( usType == dnsTYPE_AAAA_HOST )
 			{
-				xExtraLength = sizeof( LLMNRAnswer_t ) - sizeof( pxAnswer->ulIPAddress ) + ipSIZE_OF_IPv6_ADDRESS;
+				xExtraLength = sizeof( LLMNRAnswer_t ) + ipSIZE_OF_IPv6_ADDRESS - sizeof( pxAnswer->ulIPAddress );
 			}
 			else
 			#endif
@@ -1641,13 +1772,19 @@ IPv46_Address_t xIP_Address;
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( usType == dnsTYPE_AAAA_HOST )
 			{
+			size_t uxDistance;
+			NetworkEndPoint_t *pxReplyEndpoint = FreeRTOS_FirstEndPoint_IPv6( NULL );
+				if( pxReplyEndpoint == NULL )
+				{
+					break;
+				}
 				#ifndef _lint
 				vSetField16( pxAnswer, LLMNRAnswer_t, usDataLength, ipSIZE_OF_IPv6_ADDRESS );
 				#endif /* lint */
-				memcpy( &( pxAnswer->ulIPAddress ), pxEndPoint->ipv6.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-				FreeRTOS_printf( ( "LLMNR return IPv6 %pip\n", pxEndPoint->ipv6.xIPAddress.ucBytes ) );
-				usLength = ( int16_t ) ( sizeof( *pxAnswer ) + ( size_t ) ( pucByte - pucNewBuffer ) -
-						   sizeof( pxAnswer->ulIPAddress ) + ipSIZE_OF_IPv6_ADDRESS );
+				memcpy( &( pxAnswer->ulIPAddress ), pxReplyEndpoint->ipv6.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );/*lint !e419 Warning -- Apparent data overrun for function , argument 3 (size=16) exceeds argument 1 (size=4) [MISRA 2012 Rule 1.3, required]). */
+				FreeRTOS_printf( ( "LLMNR return IPv6 %pip\n", pxReplyEndpoint->ipv6.xIPAddress.ucBytes ) );
+				uxDistance = ( size_t ) ( pucByte - pucNewBuffer );/*lint !e946, !e947 */
+				usLength = ( int16_t ) ( sizeof( *pxAnswer ) + uxDistance + ipSIZE_OF_IPv6_ADDRESS - sizeof( pxAnswer->ulIPAddress ) );
 			}
 			else
 			#endif
@@ -1850,7 +1987,7 @@ IPv46_Address_t xIP_Address;
 
 static Socket_t prvCreateDNSSocket( void )
 {
-Socket_t xSocket = NULL;
+Socket_t xSocket;
 struct freertos_sockaddr xAddress;
 BaseType_t xReturn;
 
@@ -1897,11 +2034,11 @@ BaseType_t xReturn;
 		UDPPacket_IPv6_t *xUDPPacket_IPv6;
 		IPHeader_IPv6_t *pxIPHeader_IPv6;
 
-			xUDPPacket_IPv6 = ( UDPPacket_IPv6_t * )pxNetworkBuffer->pucEthernetBuffer;
+			xUDPPacket_IPv6 = ipPOINTER_CAST( UDPPacket_IPv6_t *,pxNetworkBuffer->pucEthernetBuffer );
 			pxIPHeader_IPv6 = &( xUDPPacket_IPv6->xIPHeader );
 			pxUDPHeader = &xUDPPacket_IPv6->xUDPHeader;
 
-			pxIPHeader_IPv6->usPayloadLength = FreeRTOS_htons( lNetLength + ipSIZE_OF_UDP_HEADER );
+			pxIPHeader_IPv6->usPayloadLength = FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
 
 			{
 				memcpy( pxIPHeader_IPv6->xDestinationIPv6Address.ucBytes, pxIPHeader_IPv6->xSourceIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
@@ -1910,23 +2047,23 @@ BaseType_t xReturn;
 
 			FreeRTOS_printf( ( "DNSreturn to %pip\n", pxEndPoint->ipv6.xIPAddress.ucBytes ) );
 
-			xUDPPacket_IPv6->xUDPHeader.usLength = FreeRTOS_htons( lNetLength + ipSIZE_OF_UDP_HEADER );
+			xUDPPacket_IPv6->xUDPHeader.usLength = FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
 			vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );
-			xDataLength = ( size_t ) ( lNetLength + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
+			xDataLength = ( size_t ) lNetLength + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER;
 		}
 		else
 	#endif /* ipconfigUSE_IPv6 */
 		{
 			pxUDPHeader = &pxUDPPacket->xUDPHeader;
 			/* HT: started using defines like 'ipSIZE_OF_xxx' */
-			pxIPHeader->usLength               = FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER );
+			pxIPHeader->usLength				= FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER );
 			/* HT:endian: should not be translated, copying from packet to packet */
-			pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
-			pxIPHeader->ulSourceIPAddress      = ( pxEndPoint != NULL ) ? pxEndPoint->ipv4.ulIPAddress : 0uL;
-			pxIPHeader->ucTimeToLive           = ipconfigUDP_TIME_TO_LIVE;
-			pxIPHeader->usIdentification       = FreeRTOS_htons( usPacketIdentifier );
+			pxIPHeader->ulDestinationIPAddress	= pxIPHeader->ulSourceIPAddress;
+			pxIPHeader->ulSourceIPAddress		= ( pxEndPoint != NULL ) ? pxEndPoint->ipv4.ulIPAddress : 0uL;
+			pxIPHeader->ucTimeToLive			= ipconfigUDP_TIME_TO_LIVE;
+			pxIPHeader->usIdentification		= FreeRTOS_htons( usPacketIdentifier );
 			usPacketIdentifier++;
-			pxUDPHeader->usLength              = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
+			pxUDPHeader->usLength				= FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
 			vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );	/*lint !e717  do ... while(0); */
 			xDataLength = ( size_t ) ( ( uint32_t ) lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER );
 		}
@@ -1939,9 +2076,9 @@ BaseType_t xReturn;
 			#endif
 			{
 				/* Calculate the IP header checksum. */
-				pxIPHeader->usHeaderChecksum       = 0x00;
-				pxIPHeader->usHeaderChecksum       = usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-				pxIPHeader->usHeaderChecksum       = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+				pxIPHeader->usHeaderChecksum	= 0x00;
+				pxIPHeader->usHeaderChecksum	= usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+				pxIPHeader->usHeaderChecksum	= ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 			}
 
 			/* calculate the UDP checksum for outgoing package */
@@ -1970,27 +2107,6 @@ BaseType_t xReturn;
 	BaseType_t xFound = pdFALSE;
 	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000UL;
 
-if( xLookUp )
-{
-	#if( ipconfigUSE_IPv6 != 0 )
-		FreeRTOS_printf( ( "prvProcessDNSCache: lookup-%d '%s'\n", pxIP->ucIs_IPv6 ? 6 : 4, pcName ) );
-	#else
-		FreeRTOS_printf( ( "prvProcessDNSCache: lookup-4 '%s'\n", pcName ) );
-	#endif
-}
-else
-{
-	#if( ipconfigUSE_IPv6 != 0 )
-	if( pxIP->ucIs_IPv6 )
-	{
-		FreeRTOS_printf( ( "prvProcessDNSCache: add-6 '%s': %pip\n", pcName, pxIP->u.xAddress_IPv6.ucBytes ) );
-	}
-	else
-	#endif
-	{
-		FreeRTOS_printf( ( "prvProcessDNSCache: add-4 '%s': %lxip\n", pcName, pxIP->u.ulIPAddress ) );
-	}
-}
 		/* For each entry in the DNS cache table. */
 		for( x = 0; x < ipconfigDNS_CACHE_ENTRIES; x++ )
 		{
@@ -2033,6 +2149,39 @@ FreeRTOS_printf( ( "prvProcessDNSCache: Delete old '%s' at %d\n", xDNSCache[ x ]
 			}
 		}
 
+		#warning This logging should be taken away later
+		if( xLookUp )
+		{
+			#if( ipconfigUSE_IPv6 != 0 )
+				FreeRTOS_printf( ( "prvProcessDNSCache: lookup-%d '%s': found = %d\n",
+								   pxIP->ucIs_IPv6 ? 6 : 4,
+								   pcName,
+								   ( int ) xFound ) );/*lint !e9027 Unpermitted operand to operator '?' [MISRA 2012 Rule 10.1, required]. */
+			#else
+				FreeRTOS_printf( ( "prvProcessDNSCache: lookup-4 '%s': found = %d\n",
+								   pcName,
+								   ( int ) xFound ) );
+			#endif
+		}
+		else
+		{
+			#if( ipconfigUSE_IPv6 != 0 )
+			if( pxIP->ucIs_IPv6 )
+			{
+				FreeRTOS_printf( ( "prvProcessDNSCache: add-6 '%s': %pip: found = %d\n",
+								   pcName,
+								   pxIP->u.xAddress_IPv6.ucBytes,
+								   ( int ) xFound ) );
+			}
+			else
+			#endif
+			{
+				FreeRTOS_printf( ( "prvProcessDNSCache: add-4 '%s': %lxip: found = %d\n",
+								   pcName,
+								   FreeRTOS_ntohl( pxIP->u.ulIPAddress ),
+								   ( int ) xFound ) );
+			}
+		}
 		if( xFound == pdFALSE )
 		{
 			if( xLookUp != pdFALSE )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_IP.c
@@ -1341,7 +1341,7 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t *pulIPAddress, const uint3
 			xEnoughSpace = xNumberOfBytesToSend < ( ( ipconfigNETWORK_MTU - sizeof( IPHeader_t ) ) - sizeof( ICMPHeader_t ) );
 			if( ( uxGetNumberOfFreeNetworkBuffers() >= 3 ) && ( xNumberOfBytesToSend >= 1 ) && ( xEnoughSpace != pdFALSE ) )
 			{
-				pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipIP_PAYLOAD_OFFSET ] ) );
+				pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
 				pxEthernetHeader->usFrameType = ipIPv4_FRAME_TYPE;
 				
 
@@ -1371,7 +1371,7 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t *pulIPAddress, const uint3
 				/* Send to the stack. */
 				xStackTxEvent.pvData = pxNetworkBuffer;
 
-				if( xSendEventStructToIPTask( &xStackTxEvent, xBlockTimeTicks) != pdPASS )
+				if( xSendEventStructToIPTask( &( xStackTxEvent ), xBlockTimeTicks) != pdPASS )
 				{
 					vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
 					iptraceSTACK_TX_EVENT_LOST( ipSTACK_TX_EVENT );
@@ -1604,7 +1604,7 @@ NetworkEndPoint_t *pxEndPoint;
 			 pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
 		{
 			#if ipconfigUSE_DHCP == 1
-			if( pxEndPoint->bits.bWantDHCP != pdFALSE_UNSIGNED )
+			if( ( pxEndPoint->bits.bWantDHCP != pdFALSE_UNSIGNED ) && ( ENDPOINT_IS_IPv6( pxEndPoint ) == pdFALSE ) )
 			{
 			IPStackEvent_t xEventMessage;
 			const TickType_t xDontBlock = 0;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Routing.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Routing.c
@@ -632,7 +632,7 @@ uint32_t ulIPSourceAddress = 0uL;
 				continue;
 			}
 		#endif /* ( ipconfigUSE_IPv6 != 0 ) */
-			if( pxEndPoint->ipv4.ulIPAddress == ulIPTargetAddress  )
+			if( ( pxEndPoint->ipv4.ulIPAddress == ulIPTargetAddress  ) || ( ulIPTargetAddress == ~0uL ) )
 			{
 /*				xDoLog = pdFALSE; */
 				xDone = pdTRUE;
@@ -720,16 +720,13 @@ NetworkEndPoint_t *FreeRTOS_FindGateWay( BaseType_t xIPType )
 	{
 	NetworkEndPoint_t *pxEndPoint = pxNetworkEndPoints;
 
-		if( pxInterface != NULL )
+		while( pxEndPoint != NULL )
 		{
-			while( pxEndPoint != NULL )
+			if( ( ( pxInterface == NULL ) || ( pxEndPoint->pxNetworkInterface == pxInterface ) ) && ( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED ) )
 			{
-				if( ( pxEndPoint->pxNetworkInterface == pxInterface ) && ( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED ) )
-				{
-					break;
-				}
-				pxEndPoint = pxEndPoint->pxNext;
+				break;
 			}
+			pxEndPoint = pxEndPoint->pxNext;
 		}
 
 		return pxEndPoint;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Sockets.c
@@ -599,7 +599,7 @@ EventBits_t xEventBits = ( EventBits_t ) 0;
 
 	if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_UDP, pdTRUE ) == pdFALSE )
 	{
-		return -pdFREERTOS_ERRNO_EINVAL;
+		return -pdFREERTOS_ERRNO_EINVAL;/*lint !e904: Return statement before end of function [MISRA 2012 Rule 15.5, advisory]) */
 	}
 
 	lPacketCount = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
@@ -886,7 +886,8 @@ size_t xPayloadOffset = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF
 				if( xIsIPV6 )
 				{
 					pxNetworkBuffer->ulIPAddress = 0uL;
-					memcpy( pxUDPPacket_IPv6->xIPHeader.xDestinationIPv6Address.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+					/* lint When xIsIPV6 it true, pxDestinationAddress_IPv6 is initialised. */
+					memcpy( pxUDPPacket_IPv6->xIPHeader.xDestinationIPv6Address.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );/*lint !e644 Variable 'pxDestinationAddress_IPv6' (line 797) may not have been initialized [MISRA 2012 Rule 9.1, mandatory]). */
 					memcpy( pxNetworkBuffer->xIPv6_Address.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 					pxUDPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 				}
@@ -1003,7 +1004,7 @@ BaseType_t xReturn = 0;
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( pxAddress->sin_family == FREERTOS_AF_INET6 )
 			{
-			struct freertos_sockaddr6 *pxAddress_IPv6 = ( struct freertos_sockaddr6 * )pxAddress;
+			struct freertos_sockaddr6 *pxAddress_IPv6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
 
 				memcpy( pxSocket->xLocalAddress_IPv6.ucBytes, pxAddress_IPv6->sin_addrv6.ucBytes, sizeof( pxSocket->xLocalAddress_IPv6.ucBytes ) );
 				pxSocket->bits.bIsIPv6 = pdTRUE_UNSIGNED;
@@ -1088,7 +1089,7 @@ struct freertos_sockaddr * pxAddress = pxBindAddress;	/* To void e9044 function 
 		if( pxAddress == NULL )
 		{
 			pxAddress = &xAddress;
-			/* For now, put it to zero, will be assigned later */
+			/* Put the port to zero to be assigned later. */
 			pxAddress->sin_port = 0u;
 		}
 	}
@@ -1131,7 +1132,7 @@ struct freertos_sockaddr * pxAddress = pxBindAddress;	/* To void e9044 function 
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( pxAddress->sin_family == FREERTOS_AF_INET6 )
 			{
-			struct freertos_sockaddr6 * pxAddress_IPv6 = ( struct freertos_sockaddr6 * )pxAddress;
+			struct freertos_sockaddr6 * pxAddress_IPv6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
 				pxSocket->ulLocalAddress = 0uL;
 				memcpy( pxSocket->xLocalAddress_IPv6.ucBytes, pxAddress_IPv6->sin_addrv6.ucBytes, sizeof( pxSocket->xLocalAddress_IPv6.ucBytes ) );
 			}
@@ -1347,7 +1348,7 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 
 	const char *prvSocketProps( FreeRTOS_Socket_t *pxSocket )
 	{
-	static char ucReturn[ 92 ];
+	static char pucReturn[ 92 ];
 
 		#if ipconfigUSE_TCP == 1
 		if( pxSocket->ucProtocol == FREERTOS_IPPROTO_TCP )
@@ -1355,7 +1356,7 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
 			{
-				( void ) snprintf( ucReturn, sizeof( ucReturn ), "%pip port %u to %pip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+				( void ) snprintf( pucReturn, sizeof( pucReturn ), "%pip port %u to %pip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
 					pxSocket->xLocalAddress_IPv6.ucBytes,
 					pxSocket->usLocalPort,
 					pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes,
@@ -1364,7 +1365,7 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 			else
 			#endif /* ipconfigUSE_IPv6 */
 			{
-				( void ) snprintf( ucReturn, sizeof( ucReturn ), "%lxip port %u to %lxip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+				( void ) snprintf( pucReturn, sizeof( pucReturn ), "%lxip port %u to %lxip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
 					pxSocket->ulLocalAddress,
 					pxSocket->usLocalPort,
 					pxSocket->u.xTCP.ulRemoteIP,
@@ -1378,14 +1379,14 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
 			{
-				( void ) snprintf( ucReturn, sizeof( ucReturn ), "%pip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+				( void ) snprintf( pucReturn, sizeof( pucReturn ), "%pip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
 					pxSocket->xLocalAddress_IPv6.ucBytes,
 					pxSocket->usLocalPort );
 			}
 			else
 			#endif /* ipconfigUSE_IPv6 */
 			{
-				( void ) snprintf( ucReturn, sizeof( ucReturn ), "%lxip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+				( void ) snprintf( pucReturn, sizeof( pucReturn ), "%lxip port %u",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
 					pxSocket->ulLocalAddress,
 					pxSocket->usLocalPort );
 			}
@@ -1394,7 +1395,7 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 		{
 			/* Protocol not handled. */
 		}
-		return ucReturn;
+		return pucReturn;
 	}
 #endif /* ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) ) */
 /*-----------------------------------------------------------*/
@@ -1437,6 +1438,8 @@ NetworkBufferDescriptor_t *pxNetworkBuffer;
 
 /*-----------------------------------------------------------*/
 
+/* FreeRTOS_setsockopt calls itself, but in a very limited way,
+only when FREERTOS_SO_WIN_PROPERTIES is being set. */
 /*lint -e9070 recursive function  [MISRA 2012 Rule 17.2, required]) */
 BaseType_t FreeRTOS_setsockopt( Socket_t xSocket, int32_t lLevel, int32_t lOptionName, const void *pvOptionValue, size_t xOptionLength )
 {
@@ -1583,6 +1586,44 @@ FreeRTOS_Socket_t *pxSocket;
 					xReturn = 0;
 					break;
 			#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+
+			#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
+				case FREERTOS_SO_WAKEUP_CALLBACK:
+				{
+					/* Each socket can have a callback function that is executed
+					when there is an event the socket's owner might want to
+					process. */
+					pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+					xReturn = 0;
+				}
+				break;
+			#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+
+			case FREERTOS_SO_SET_LOW_HIGH_WATER:
+				{
+				LowHighWater_t *pxLowHighWater = ipPOINTER_CAST( LowHighWater_t *, pvOptionValue );
+
+					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+					{
+						/* It is not allowed to access 'pxSocket->u.xTCP'. */
+						FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: wrong socket type\n" ) );
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+					if( ( pxLowHighWater->uxLittleSpace >= pxLowHighWater->uxEnoughSpace ) ||
+						( pxLowHighWater->uxEnoughSpace > pxSocket->u.xTCP.uxRxStreamSize ) )
+					{
+						/* Impossible values. */
+						FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: bad values\n" ) );
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+					/* Send a STOP when buffer space drops below 'uxLittleSpace' bytes. */
+					pxSocket->u.xTCP.uxLittleSpace = pxLowHighWater->uxLittleSpace;
+					/* Send a GO when buffer space grows above 'uxEnoughSpace' bytes. */
+					pxSocket->u.xTCP.uxEnoughSpace = pxLowHighWater->uxEnoughSpace;
+					xReturn = 0;
+				}
+				break;
+
 			case FREERTOS_SO_SNDBUF:	/* Set the size of the send buffer, in units of MSS (TCP only) */
 			case FREERTOS_SO_RCVBUF:	/* Set the size of the receive buffer, in units of MSS (TCP only) */
 				{
@@ -1636,8 +1677,17 @@ FreeRTOS_Socket_t *pxSocket;
 					}
 
 					pxProps = ipPOINTER_CAST( WinProperties_t *, pvOptionValue );
-					( void ) FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ), sizeof( pxProps->lTxBufSize ) );
-					( void ) FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ), sizeof( pxProps->lRxBufSize ) );
+
+					if ( FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ), sizeof( pxProps->lTxBufSize ) ) != 0 )
+					{
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+
+					if ( FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ), sizeof( pxProps->lRxBufSize ) ) != 0 )
+					{
+						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
+					}
+
 					#if( ipconfigUSE_TCP_WIN == 1 )
 					{
 						pxSocket->u.xTCP.uxRxWinSize = ( uint32_t )pxProps->lRxWinSize;	/* Fixed value: size of the TCP reception window */
@@ -1655,7 +1705,7 @@ FreeRTOS_Socket_t *pxSocket;
 					if( pxSocket->u.xTCP.xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
 					{
 						pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usInitMSS;
-						pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usInitMSS;
+						pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usInitMSS;
 					}
 				}
 
@@ -1889,12 +1939,15 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 	{
 	BaseType_t xResult;
 	uint32_t ulIPAddress = FreeRTOS_inet_addr( pcSource );
+
 		if( ulIPAddress == pdFAIL )
 		{
 			xResult = 0;
 		}
 		else
 		{
+			/* Translate "192.168.2.100" to an array of 4 uint8_t's,
+			network-endian. */
 			pucDest[ 0 ] = ulIPAddress >> 24;
 			pucDest[ 1 ] = ( ulIPAddress >> 16 ) & 0xff;
 			pucDest[ 2 ] = ( ulIPAddress >> 8 ) & 0xff;
@@ -1918,6 +1971,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 	UBaseType_t uxOctetNumber;
 	BaseType_t xResult = pdPASS;
 
+		/* Translate "192.168.2.100" to a 32-bit number, network-endian. */
 		for( uxOctetNumber = 0u; uxOctetNumber < socketMAX_IP_ADDRESS_OCTETS; uxOctetNumber++ )
 		{
 			ulValue = 0uL;
@@ -2005,7 +2059,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 	BaseType_t FreeRTOS_inet_pton6( const char *pcSource, uint8_t *pucDest )
 	{
 	uint8_t *pucTarget, *pucEnd, *pucColon;
-	const char *curtok;
+	//const char *curtok;
 	char ch;
 	uint32_t ulValue = 0uL;
 	uint8_t ucNew;
@@ -2014,7 +2068,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 
 		pucTarget = pucDest;
 		memset( pucTarget, '\0', ipSIZE_OF_IPv6_ADDRESS );
-		pucEnd = pucTarget + ipSIZE_OF_IPv6_ADDRESS;
+		pucEnd = &( pucTarget[ ipSIZE_OF_IPv6_ADDRESS ] );
 		pucColon = NULL;
 		xResult = 0;
 
@@ -2029,7 +2083,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 			{
 				pcSource++;
 			}
-			curtok = pcSource;
+			//curtok = pcSource;
 			xHadDigit = pdFALSE;
 			ulValue = 0;
 			for( ;; )
@@ -2040,12 +2094,12 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 					/* The string is parsed now.
 					Store the last short, if present. */
 					if( ( xHadDigit != pdFALSE ) &&
-						( pucTarget <= pucEnd - sizeof( uint16_t ) ) )
+						( pucTarget <= pucEnd - sizeof( uint16_t ) ) )	/*lint !e9050 !e946 dependence placed on C/C++ operator precedence; operators '<=' and '-' [MISRA 2012 Rule 12.1, advisory]. */
 					{
 						/* Add the last value seen, network byte order */
 						pucTarget[ 0 ] = ( uint8_t ) ( ulValue >> 8 ) & 0xff;
 						pucTarget[ 1 ] = ( uint8_t ) ulValue & 0xff;
-						pucTarget += 2;
+						pucTarget = &( pucTarget[ 2 ] );
 					}
 					break;
 				}
@@ -2053,15 +2107,15 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 
 				if( ( ch >= '0' ) && ( ch <= '9' ) )
 				{
-					ucNew = ch - '0';
+					ucNew = ( uint8_t ) ( ch - '0' );
 				}
 				else if( ( ch >= 'a' ) && ( ch <= 'f' ) )
 				{
-					ucNew = ch - 'a' + 10;
+					ucNew = ( uint8_t ) ( ch + 10 - 'a' );
 				}
 				else if( ( ch >= 'A' ) && ( ch <= 'F' ) )
 				{
-					ucNew = ch - 'A' + 10;
+					ucNew = ( uint8_t ) ( ch + 10 - 'A' );
 				}
 				else
 				{
@@ -2070,7 +2124,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 
 				if( ucNew != ( uint8_t ) 255 )
 				{
-					if( ( ulValue & 0xf000ul ) != 0uL )
+					if( ( ulValue & 0xf000uL ) != 0uL )
 					{
 						/* An overflow will occur. */
 						break;
@@ -2080,7 +2134,7 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 				}
 				else if( ch == ':' )
 				{
-					curtok = pcSource;
+					//curtok = pcSource;
 					if( xHadDigit == pdFALSE )
 					{
 						/* A sequence of "::" may only occur once. */
@@ -2091,33 +2145,25 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 						pucColon = pucTarget;
 						continue;
 					}
-					if( pucTarget > pucEnd - sizeof( uint16_t ) )
+					if( pucTarget > ( pucEnd - sizeof( uint16_t ) ) )	/*lint !e946 Relational or subtract operator applied to pointers [MISRA 2012 Rule 18.2, required], [MISRA 2012 Rule 18.3, required]. */
 					{
 						break;
 					}
 					pucTarget[ 0 ] = ( uint8_t ) ( ulValue >> 8 ) & 0xff;
 					pucTarget[ 1 ] = ( uint8_t ) ulValue & 0xff;
-					pucTarget += 2;
+					pucTarget = &( pucTarget[ 2 ] );
 					xHadDigit = pdFALSE;
 					ulValue = 0;
 				}
-				else if (ch == '.' &&
-					( ( pucTarget + sizeof( uint16_t ) ) <= pucEnd ) &&
-					FreeRTOS_inet_pton4( curtok, pucTarget ) > 0 )
-				{
-					pucTarget += sizeof( uint16_t );
-					xHadDigit = pdFALSE;
-					xResult = 1;
-					break;
-				}
 				else
 				{
+					/* When an IPv4 address is provided, this break will be reached. */
 					break;
 				}
-			}
+			}	/* for( ;; ) */
 			if( pucColon != NULL )
 			{
-			const BaseType_t xCount = ( int32_t ) ( pucTarget - pucColon );
+			const BaseType_t xCount = ( int32_t ) ( pucTarget - pucColon );/*lint !e946 !e947 Relational or subtract operator applied to pointers [MISRA 2012 Rule 18.2, required], [MISRA 2012 Rule 18.3, required]. */
 			BaseType_t xIndex;
 
 				/* Inserting 'xCount' zero's. */
@@ -2139,23 +2185,26 @@ FreeRTOS_Socket_t *pxSocket = NULL;
 /*-----------------------------------------------------------*/
 
 /* Function to get the local address and IP port */
-size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
+#if( ipconfigUSE_IPv6 != 0 )
+	size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr6 *pxAddress6 )
+#else
+	size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
+#endif
 {
 FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 #if( ipconfigUSE_IPv6 != 0 )
-	struct freertos_sockaddr6 *pxAddress_IPv6 = ( struct freertos_sockaddr6 * )pxAddress;
+	struct freertos_sockaddr *pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, pxAddress6 );
 #endif /* ipconfigUSE_IPv6 */
 
 	#if( ipconfigUSE_IPv6 != 0 )
 	if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
 	{
-		configASSERT( pxAddress_IPv6->sin_len == sizeof( *pxAddress_IPv6 ) );
 
-		pxAddress_IPv6->sin_family = FREERTOS_AF_INET6;
+		pxAddress6->sin_family = FREERTOS_AF_INET6;
 		/* IP address of local machine. */
-		memcpy( pxAddress_IPv6->sin_addrv6.ucBytes, pxSocket->xLocalAddress_IPv6.ucBytes, sizeof( pxAddress_IPv6->sin_addrv6.ucBytes ) );
+		memcpy( pxAddress6->sin_addrv6.ucBytes, pxSocket->xLocalAddress_IPv6.ucBytes, sizeof( pxAddress6->sin_addrv6.ucBytes ) );
 		/* Local port on this machine. */
-		pxAddress_IPv6->sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
+		pxAddress6->sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
 	}
 	else
 	#endif
@@ -2182,6 +2231,15 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		if( pxSocket->pxUserSemaphore != NULL )
 		{
 			( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
+		}
+	}
+	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+
+	#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+	{
+		if( pxSocket->pxUserWakeCallback != NULL )
+		{
+			pxSocket->pxUserWakeCallback( pxSocket );
 		}
 	}
 	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
@@ -2298,18 +2356,24 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 				pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE_UNSIGNED;
 				pxSocket->u.xTCP.ucRepCount = 0u;
 
-#if( ipconfigUSE_IPv6 != 0 )
+			#if( ipconfigUSE_IPv6 != 0 )
 				if( pxAddress->sin_family == FREERTOS_AF_INET6 )
 				{
-				struct freertos_sockaddr6 *pxAddress_IPv6 = ( struct freertos_sockaddr6 * ) pxAddress;
+				struct freertos_sockaddr6 *pxAddress_IPv6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
 
+					pxSocket->bits.bIsIPv6 = pdTRUE_UNSIGNED;
 					FreeRTOS_printf( ( "FreeRTOS_connect: %u to %pip port %u\n",
 						pxSocket->usLocalPort, pxAddress_IPv6->sin_addrv6.ucBytes, FreeRTOS_ntohs( pxAddress_IPv6->sin_port ) ) );
 					memcpy( pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes, pxAddress_IPv6->sin_addrv6.ucBytes, sizeof( pxSocket->xLocalAddress_IPv6.ucBytes ) );
 				}
 				else
-#endif /* ipconfigUSE_IPv6 */
+			#endif /* ipconfigUSE_IPv6 */
 				{
+					#if( ipconfigUSE_IPv6 != 0 )
+					{
+						pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
+					}
+					#endif	/* ( ipconfigUSE_IPv6 != 0 ) */
 					FreeRTOS_printf( ( "FreeRTOS_connect: %u to %lxip:%u\n",
 						pxSocket->usLocalPort, FreeRTOS_ntohl( pxAddress->sin_addr ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
 				}
@@ -2430,6 +2494,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 	TimeOut_t xTimeOut;
 	IPStackEvent_t xAskEvent;
 
+		#if( ipconfigUSE_IPv6 != 0 )
+		configASSERT( pxAddress->sin_len >= sizeof( struct freertos_sockaddr6 ) );
+		#endif
 		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
 		{
 			/* Not a valid socket or wrong type */
@@ -2476,17 +2543,32 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 
 				if( pxClientSocket != NULL )
 				{
-					if( pxAddress != NULL )
+					#if( ipconfigUSE_IPv6 != 0 )
+					if( pxClientSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
 					{
-						/* IP address of remote machine. */
-						pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.ulRemoteIP );
 
-						/* Port on remote machine. */
-						pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
+						*pxAddressLength = sizeof( struct freertos_sockaddr6 );
+						if( pxAddress != NULL )
+						{
+						struct freertos_sockaddr6 *pxAddress6 = ipPOINTER_CAST( struct freertos_sockaddr6 *, pxAddress );
+
+							pxAddress6->sin_family = FREERTOS_AF_INET6;
+							/* Copy IP-address and port number. */
+							memcpy( pxAddress6->sin_addrv6.ucBytes, pxClientSocket->u.xTCP.xRemoteIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+							pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
+						}
 					}
-					if( pxAddressLength != NULL )
+					else
+					#endif
 					{
-						*pxAddressLength = sizeof( *pxAddress );
+						*pxAddressLength = sizeof( struct freertos_sockaddr );
+						if( pxAddress != NULL )
+						{
+							pxAddress->sin_family = FREERTOS_AF_INET4;
+							/* Copy IP-address and port number. */
+							pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.ulRemoteIP );
+							pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
+						}
 					}
 
 					if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
@@ -2599,6 +2681,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 				{
 					break;
 				}
+
 				if( xTimed == pdFALSE )
 				{
 					/* Only in the first round, check for non-blocking. */
@@ -2727,7 +2810,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		{
 			xResult = -pdFREERTOS_ERRNO_ENOMEM;
 		}
-		else if( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCLOSED )
+		else if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) ||
+				 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) ||
+				 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSING ) )
 		{
 			xResult = -pdFREERTOS_ERRNO_ENOTCONN;
 		}
@@ -2770,24 +2855,26 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 	'*pxLength' will contain the number of bytes that may be written. */
 	uint8_t *FreeRTOS_get_tx_head( Socket_t xSocket, BaseType_t *pxLength )
 	{
-	uint8_t *pucReturn;
+    uint8_t *pucReturn = NULL;
 	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	StreamBuffer_t *pxBuffer = pxSocket->u.xTCP.txStream;
+	StreamBuffer_t *pxBuffer = NULL;
 
-		if( pxBuffer != NULL )
-		{
-		BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
-		BaseType_t xRemain = ( BaseType_t ) ( pxBuffer->LENGTH - pxBuffer->uxHead );
+        *pxLength = 0;
 
-			*pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
-			pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
+        /* Confirm that this is a TCP socket before dereferencing structure
+        member pointers. */
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdFALSE ) == pdTRUE )
+        {
+            pxBuffer = pxSocket->u.xTCP.txStream;
+			if( pxBuffer != NULL )
+			{
+			BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
+			BaseType_t xRemain = ( BaseType_t ) ( pxBuffer->LENGTH - pxBuffer->uxHead );
+
+				*pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
+				pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
+			}
 		}
-		else
-		{
-			*pxLength = 0;
-			pucReturn = NULL;
-		}
-
 		return pucReturn;
 	}
 #endif /* ipconfigUSE_TCP */
@@ -2952,7 +3039,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 
 			if( xByteCount == 0 )
 			{
-				if( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED )
+				if( pxSocket->u.xTCP.ucTCPState > ( uint8_t ) eESTABLISHED )
 				{
 					xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOTCONN;
 				}
@@ -2995,7 +3082,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		{
 			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
 		}
-		else if( ( pxSocket->u.xTCP.ucTCPState != ( EventBits_t ) eCLOSED ) && ( pxSocket->u.xTCP.ucTCPState != ( EventBits_t ) eCLOSE_WAIT ) )
+		else if( ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED ) && ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSE_WAIT ) )
 		{
 			/* Socket is in a wrong state. */
 			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
@@ -3052,7 +3139,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 			supports the listen() operation. */
 			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
 		}
-		else if ( pxSocket->u.xTCP.ucTCPState != ( EventBits_t ) eESTABLISHED )
+		else if ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
 		{
 			/*_RB_ Is this comment correct?  The socket is not of a type that
 			supports the listen() operation. */
@@ -3175,7 +3262,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		#if( ipconfigUSE_IPv6 != 0 )
 			, IPv6_Address_t *pxAddress_IPv6
 		#endif /* ipconfigUSE_IPv6 */
-		)
+		)/*lint !e9018 declaration of symbol 'pxAddress_IPv6' with union based type [MISRA 2012 Rule 19.2, advisory]. */
 	{
 	ListItem_t *pxIterator;
 	FreeRTOS_Socket_t *pxResult = NULL, *pxListenSocket = NULL;
@@ -3189,7 +3276,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 
 			if( pxSocket->usLocalPort == ( uint16_t ) uxLocalPort )
 			{
-				if( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eTCP_LISTEN )
+				if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
 				{
 					/* If this is a socket listening to uxLocalPort, remember it
 					in case there is no perfect match. */
@@ -3201,20 +3288,29 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 					{
 						if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED)
 						{
-							if( ( pxAddress_IPv6 != NULL ) && ( memcmp( pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes , pxAddress_IPv6->ucBytes, ipSIZE_OF_IPv6_ADDRESS ) == 0 ) )
+							if( pxAddress_IPv6 != NULL )
 							{
-								/* For sockets not in listening mode, find a match with
-								uxLocalPort, ulRemoteIP AND uxRemotePort. */
-								pxResult = pxSocket;
-								break;
+								if( memcmp( pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes , pxAddress_IPv6->ucBytes, ipSIZE_OF_IPv6_ADDRESS ) == 0 )
+								{
+									/* For sockets not in listening mode, find a match with
+									uxLocalPort, ulRemoteIP AND uxRemotePort. */
+									pxResult = pxSocket;
+									break;
+								}
 							}
 						}
-						else if( ( pxAddress_IPv6 == NULL ) && ( pxSocket->u.xTCP.ulRemoteIP == ulRemoteIP ) )
+						else
 						{
-							/* For sockets not in listening mode, find a match with
-							uxLocalPort, ulRemoteIP AND uxRemotePort. */
-							pxResult = pxSocket;
-							break;
+							if( pxAddress_IPv6 == NULL )
+							{
+								if( pxSocket->u.xTCP.ulRemoteIP == ulRemoteIP )
+								{
+									/* For sockets not in listening mode, find a match with
+									uxLocalPort, ulRemoteIP AND uxRemotePort. */
+									pxResult = pxSocket;
+									break;
+								}
+							}
 						}
 					}
 					#else
@@ -3466,13 +3562,17 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 #if( ipconfigUSE_TCP == 1 )
 
 	/* Function to get the remote address and IP port */
-	BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
+	#if( ipconfigUSE_IPv6 != 0 )
+		BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr6 *pxAddress6 )
+	#else
+		BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
+	#endif	/* ( ipconfigUSE_IPv6 != 0 ) */
 	{
 	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xResult;
 	#if( ipconfigUSE_IPv6 != 0 )
-		struct freertos_sockaddr6 *pxAddress_IPv6 = ( struct freertos_sockaddr6 * )pxAddress;
-	#endif /* ipconfigUSE_IPv6 */
+		struct freertos_sockaddr *pxAddress = ipPOINTER_CAST(struct freertos_sockaddr *, pxAddress6 );
+	#endif
+	BaseType_t xResult;
 
 		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
 		{
@@ -3486,15 +3586,15 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 			#if( ipconfigUSE_IPv6 != 0 )
 			if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
 			{
-				configASSERT( pxAddress_IPv6->sin_len == sizeof( *pxAddress_IPv6 ) );
+				configASSERT( pxAddress6->sin_len == sizeof( *pxAddress6 ) );
 
-				pxAddress_IPv6->sin_family = FREERTOS_AF_INET6;
+				pxAddress6->sin_family = FREERTOS_AF_INET6;
 
 				/* IP address of remote machine. */
-				memcpy( pxAddress_IPv6->sin_addrv6.ucBytes, pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes, sizeof( pxAddress_IPv6->sin_addrv6.ucBytes ) );
+				memcpy( pxAddress6->sin_addrv6.ucBytes, pxSocket->u.xTCP.xRemoteIP_IPv6.ucBytes, sizeof( pxAddress6->sin_addrv6.ucBytes ) );
 
 				/* Port of remote machine. */
-				pxAddress_IPv6->sin_port = FreeRTOS_htons ( pxSocket->u.xTCP.usRemotePort );
+				pxAddress6->sin_port = FreeRTOS_htons ( pxSocket->u.xTCP.usRemotePort );
 			}
 			else
 			#endif /* ipconfigUSE_IPv6 */
@@ -3524,7 +3624,14 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 	BaseType_t xResult;
 
-		xResult = pxSocket->bits.bIsIPv6 ? ipTYPE_IPv4 : ipTYPE_IPv6;
+		if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
+		{
+			xResult = ipTYPE_IPv6;
+		}
+		else
+		{
+			xResult = ipTYPE_IPv4;
+		}
 		return xResult;
 	}
 #endif
@@ -3543,9 +3650,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		{
 			xResult = -pdFREERTOS_ERRNO_EINVAL;
 		}
-		else if( pxSocket->u.xTCP.ucTCPState != ( EventBits_t ) eESTABLISHED )
+		else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
 		{
-			if( ( pxSocket->u.xTCP.ucTCPState < ( EventBits_t ) eCONNECT_SYN ) || ( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED ) )
+			if( ( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCONNECT_SYN ) || ( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED ) )
 			{
 				xResult = -1;
 			}
@@ -3641,9 +3748,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		}
 		else
 		{
-			if( pxSocket->u.xTCP.ucTCPState >= ( EventBits_t ) eESTABLISHED )
+			if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
 			{
-				if( pxSocket->u.xTCP.ucTCPState < ( EventBits_t ) eCLOSE_WAIT )
+				if( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCLOSE_WAIT )
 				{
 					xReturn = pdTRUE;
 				}
@@ -3746,7 +3853,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 		 */
 		xAskEvent.eEventType = eTCPNetStat;
 		xAskEvent.pvData = ( void * ) NULL;
-		( void ) xSendEventStructToIPTask( &xAskEvent, 1000u );
+		( void ) xSendEventStructToIPTask( &xAskEvent, pdMS_TO_TICKS( 1000u ) );
 	}
 
 #endif /* ipconfigUSE_TCP */
@@ -3759,6 +3866,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 	/* Show a simple listing of all created sockets and their connections */
 	ListItem_t *pxIterator;
 	BaseType_t count = 0;
+	size_t uxMinimum = uxGetMinimumFreeNetworkBuffers();
+	size_t uxCurrent = uxGetNumberOfFreeNetworkBuffers();
 
 		if( !listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) )
 		{
@@ -3800,7 +3909,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 					void *pxHandleReceive = NULL;
 				#endif
 				char ucChildText[16] = "";
-				if( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eTCP_LISTEN )
+				if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
 				{
 					( void ) snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",	/*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
 						pxSocket->u.xTCP.usChildCount,
@@ -3849,11 +3958,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 				count++;
 			}
 
-			FreeRTOS_printf( ( "FreeRTOS_netstat: %lu sockets %lu < %lu < %d buffers free\n",
-				count,
-				uxGetMinimumFreeNetworkBuffers( ),
-				uxGetNumberOfFreeNetworkBuffers( ),
-				ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
+			FreeRTOS_printf( ( "FreeRTOS_netstat: %u sockets %u < %u < %d buffers free\n",
+				( unsigned ) count,
+				( unsigned ) uxMinimum,
+				( unsigned ) uxCurrent,
+				( int ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
 		}
 	}
 
@@ -3921,7 +4030,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 					/* Is the set owner interested in READ events? */
 					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != 0 )
 					{
-						if( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eTCP_LISTEN )
+						if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
 						{
 							if( ( pxSocket->u.xTCP.pxPeerSocket != NULL ) && ( pxSocket->u.xTCP.pxPeerSocket->u.xTCP.bits.bPassAccept != 0 ) )
 							{
@@ -3946,7 +4055,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 					/* Is the set owner interested in EXCEPTION events? */
 					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0 )
 					{
-						if( ( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCLOSE_WAIT ) || ( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCLOSED ) )
+						if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) || ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) )
 						{
 							xSocketBits |= ( EventBits_t ) eSELECT_EXCEPT;
 						}
@@ -3968,7 +4077,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
 						if( bMatch == pdFALSE )
 						{
 							if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) &&
-								( pxSocket->u.xTCP.ucTCPState >= ( EventBits_t ) eESTABLISHED ) &&
+								( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
 								( pxSocket->u.xTCP.bits.bConnPassed == pdFALSE_UNSIGNED ) )
 							{
 								pxSocket->u.xTCP.bits.bConnPassed = pdTRUE_UNSIGNED;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/checksum.ipv6.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/checksum.ipv6.c
@@ -159,7 +159,7 @@ int location = 0;
 		#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
 	}
 #if( ipconfigUSE_IPv6 != 0 )
-	else if( ucProtocol == ipPROTOCOL_ICMP_IPv6 )
+	else if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
 	{
 	size_t xNeeded;
 		switch( pxProtocolHeaders->xICMPHeader_IPv6.ucTypeOfMessage )
@@ -260,7 +260,7 @@ int location = 0;
 		location = 12;
 		goto eror_exit;
 	}
-	if( ucProtocol <= ( uint8_t ) ipPROTOCOL_IGMP )
+	if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) || ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
 	{
 		/* ICMP/IGMP do not have a pseudo header for CRC-calculation. */
 		usChecksum = ( uint16_t )
@@ -268,7 +268,7 @@ int location = 0;
 				( uint8_t * ) &( pxProtocolHeaders->xICMPHeader ), ( size_t ) ulLength ) );
 	}
 	#if( ipconfigUSE_IPv6 != 0 )
-	else if( ucProtocol == ipPROTOCOL_ICMP_IPv6 )
+	else if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
 	{
 		usChecksum = ( uint16_t )
 			( ~usGenerateChecksum( usChecksum,

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -855,6 +855,9 @@ static BaseType_t xMayAcceptPacket( NetworkBufferDescriptor_t *pxDescriptor )
 {
 const ProtocolPacket_t *pxProtPacket = ( const ProtocolPacket_t * )pxDescriptor->pucEthernetBuffer;
 
+	pxDescriptor->pxInterface = pxMyInterface;
+	pxDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxDescriptor->pucEthernetBuffer );
+
 	#warning _HT_ This is temporarily for debugging
 	if( pxProtPacket->xTCPPacket.xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
 	{
@@ -1032,11 +1035,6 @@ uint8_t *pucBuffer;
 		{
 			/* See if this packet must be handled. */
 			xAccepted = xMayAcceptPacket( pxCurDescriptor );
-			if( xAccepted != pdFALSE )
-			{
-				pxCurDescriptor->pxInterface = pxMyInterface;
-				pxCurDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxCurDescriptor->pucEthernetBuffer );
-			}
 
 			pxCurDescriptor->xDataLength = xReceivedLength;
 			xRxEvent.pvData = ( void * ) pxCurDescriptor;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/protocols/FTP/FreeRTOS_FTP_server.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/protocols/FTP/FreeRTOS_FTP_server.c
@@ -1089,10 +1089,10 @@ BaseType_t xRxSize;
 					struct freertos_sockaddr xRemoteAddress, xLocalAddress;
 				#endif
 					xRemoteAddress.sin_len = sizeof( xRemoteAddress );
-					FreeRTOS_GetRemoteAddress( pxClient->xTransferSocket, ( struct freertos_sockaddr * )&xRemoteAddress );
+					FreeRTOS_GetRemoteAddress( pxClient->xTransferSocket, &xRemoteAddress );
 
 					xLocalAddress.sin_len = sizeof( xLocalAddress );
-					FreeRTOS_GetLocalAddress( pxClient->xTransferSocket, ( struct freertos_sockaddr * )&xLocalAddress );
+					FreeRTOS_GetLocalAddress( pxClient->xTransferSocket, &xLocalAddress );
 
 					FreeRTOS_printf( ( "%s Connected from %u to %u\n",
 						pxClient->bits1.bIsListen != pdFALSE_UNSIGNED ? "PASV" : "PORT",


### PR DESCRIPTION
<!--- Title -->
August 20, adapted and tested FreeRTOS_DNS to use IPv6

Description
-----------
FreeRTOS_DNS.c :

Applied PC-LINT.

Checked the asynchronous lookup ( `FreeRTOS_getaddrinfo_a()`, `FreeRTOS_gethostbyname_a()` ) with both IPv4/v6.

The declaration of the application-hook had to change:

~~~c
	#if( ipconfigUSE_IPv6 != 0 )
		typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, struct freertos_sockaddr6 * /* pxAddress6 */ );
	#else
		typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, uint32_t /* ulIPAddress */ );
	#endif
~~~

Further developed and tested the new `FreeRTOS_getaddrinfo()` functions.


FreeRTOS_Socket.c

Applied PC-LINT.

Added socket options for low- and high water. Merged from the existing IPv4-only release.

Merged 'ipconfigSOCKET_HAS_USER_WAKE_CALLBACK' from the existing IPv4-only release.

`FreeRTOS_accept()` : fill in the IPv6 address structure.

`prvTCPSendCheck()` : a more complete check of `ucTCPState` (merged from IPv4).

`FreeRTOS_get_tx_head()` : check if the socket is valid (merged from IPv4).


Tested and corrected outgoing connections for IPv6, mostly `prvTCPPrepareConnect()`.

`FreeRTOS_GetLocalAddress()` / `FreeRTOS_GetRemoteAddress()` can now also be used for IPv6 sockets.

All changes were tested on an STM32F4 board in a LAN with two separate routers: one for IPv4 and one IPv6 ).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.
Linting in this project will be a continuous process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.