### PR TITLE
New integration test, stress test and KPI test in Iot Tester

### DIFF
--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -39,6 +39,7 @@ typedef struct
     uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
 } response_t;
 
+void prvBLESetUp( void );
 static void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
                                       bool bNeedRsp,
                                       bool IsPrep,

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -33,137 +33,16 @@
 
 #include "iot_test_ble_hal_common.h"
 
-
-typedef enum
-{
-    bletestATTR_SRVCA_SERVICE,
-    bletestATTR_SRVCA_CHAR_A,
-    bletestATTR_SRVCA_NUMBER
-} bletestAttSrvA_t;
-
-
-typedef enum
-{
-    bletestATTR_SRVCB_SERVICE,
-    bletestATTR_SRVCB_CHAR_A,
-    bletestATTR_SRVCB_CHAR_B,
-    bletestATTR_SRVCB_CHAR_C,
-    bletestATTR_SRVCB_CHAR_D,
-    bletestATTR_SRVCB_CHAR_E,
-    bletestATTR_SRVCB_CCCD_E,
-    bletestATTR_SRVCB_CHAR_F,
-    bletestATTR_SRVCB_CCCD_F,
-    bletestATTR_SRVCB_CHARF_DESCR_A,
-    bletestATTR_SRVCB_CHARF_DESCR_B,
-    bletestATTR_SRVCB_CHARF_DESCR_C,
-    bletestATTR_SRVCB_CHARF_DESCR_D,
-    bletestATTR_INCLUDED_SERVICE,
-    bletestATTR_SRVCB_NUMBER
-} bletestAttSrvB_t;
-
 typedef struct
 {
     size_t xLength;
     uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
 } response_t;
 
-static void prvSetGetProperty( BTProperty_t * pxProperty,
-                               bool bIsSet );
-static void prvStartAdvertisement( void );
 static void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
                                       bool bNeedRsp,
                                       bool IsPrep,
                                       uint16_t usOffset );
 static void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
-static void prvDeviceStateChangedCb( BTState_t xState );
-static void prvRegisterBleAdapterCb( BTStatus_t xStatus,
-                                     uint8_t ucAdapterIf,
-                                     BTUuid_t * pxAppUuid );
-static void prvBTRegisterServerCb( BTStatus_t xStatus,
-                                   uint8_t ucServerIf,
-                                   BTUuid_t * pxAppUuid );
-static void prvBTUnregisterServerCb( BTStatus_t xStatus,
-                                     uint8_t ucServerIf );
-static void prvServiceAddedCb( BTStatus_t xStatus,
-                               uint8_t ucServerIf,
-                               BTGattSrvcId_t * pxSrvcId,
-                               uint16_t usServiceHandle );
-static void prvIncludedServiceAddedCb( BTStatus_t xStatus,
-                                       uint8_t ucServerIf,
-                                       uint16_t usServiceHandle,
-                                       uint16_t usInclSrvcHandle );
-static void prvServiceStartedCb( BTStatus_t xStatus,
-                                 uint8_t ucServerIf,
-                                 uint16_t usServiceHandle );
-void prvServiceStoppedCb( BTStatus_t xStatus,
-                          uint8_t ucServerIf,
-                          uint16_t usServiceHandle );
-void prvServiceDeletedCb( BTStatus_t xStatus,
-                          uint8_t ucServerIf,
-                          uint16_t usServiceHandle );
-void prvCharacteristicAddedCb( BTStatus_t xStatus,
-                               uint8_t ucServerIf,
-                               BTUuid_t * pxUuid,
-                               uint16_t usServiceHandle,
-                               uint16_t usCharHandle );
-void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
-                                    uint8_t ucServerIf,
-                                    BTUuid_t * pxUuid,
-                                    uint16_t usServiceHandle,
-                                    uint16_t usCharHandle );
-void prvAdapterPropertiesCb( BTStatus_t xStatus,
-                             uint32_t ulNumProperties,
-                             BTProperty_t * pxProperties );
-void prvSetAdvDataCb( BTStatus_t xStatus );
-void prvAdvStatusCb( BTStatus_t xStatus,
-                     uint32_t ulServerIf,
-                     bool bStart );
-void prvConnectionCb( uint16_t usConnId,
-                      uint8_t ucServerIf,
-                      bool bConnected,
-                      BTBdaddr_t * pxBda );
-void prvConnParameterUpdateCb( BTStatus_t xStatus,
-                               const BTBdaddr_t * pxBdAddr,
-                               uint32_t minInterval,
-                               uint32_t maxInterval,
-                               uint32_t latency,
-                               uint32_t usConnInterval,
-                               uint32_t timeout );
-void prvRequestReadCb( uint16_t usConnId,
-                       uint32_t ulTransId,
-                       BTBdaddr_t * pxBda,
-                       uint16_t usAttrHandle,
-                       uint16_t usOffset );
-void prvRequestWriteCb( uint16_t usConnId,
-                        uint32_t ulTransId,
-                        BTBdaddr_t * pxBda,
-                        uint16_t usAttrHandle,
-                        uint16_t usOffset,
-                        size_t xLength,
-                        bool bNeedRsp,
-                        bool bIsPrep,
-                        uint8_t * pucValue );
-void prvIndicationSentCb( uint16_t usConnId,
-                          BTStatus_t xStatus );
-void prvResponseConfirmationCb( BTStatus_t xStatus,
-                                uint16_t usHandle );
-void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
-                      BTBdname_t * pxRemoteBdName,
-                      uint32_t ulCod,
-                      BTSspVariant_t xPairingVariant,
-                      uint32_t ulPassKey );
-void prvPairingStateChangedCb( BTStatus_t xStatus,
-                               BTBdaddr_t * pxRemoteBdAddr,
-                               BTBondState_t xState,
-                               BTSecurityLevel_t xSecurityLevel,
-                               BTAuthFailureReason_t xReason );
-void prvRequestExecWriteCb( uint16_t usConnId,
-                            uint32_t ulTransId,
-                            BTBdaddr_t * pxBda,
-                            bool bExecWrite );
-void prvBondedCb( BTStatus_t xStatus,
-                  BTBdaddr_t * pxRemoteBdAddr,
-                  bool bIsBonded );
-void prvStartStopAdvCheck( bool start );
 
 #endif /* _IOT_TEST_BLE_HAL_AFQP_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -45,5 +45,15 @@
                                    bool IsPrep,
                                    uint16_t usOffset );
     void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
+    void pushToQueue( IotLink_t * pEventList );
+    void prvSetGetProperty( BTProperty_t * pxProperty,
+                            bool bIsSet );
+    void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
+                              uint16_t usServiceDataLen,
+                              char * pcServiceData,
+                              BTUuid_t * pxServiceUuid,
+                              size_t xNbServices );
+    void prvStartStopAdvCheck( bool start );
+    BTStatus_t bleStackInit( void );
 
 #endif /* _IOT_TEST_BLE_HAL_AFQP_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -33,27 +33,27 @@
 
 #include "iot_test_ble_hal_common.h"
 
-    typedef struct
-    {
-        size_t xLength;
-        uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
-    } response_t;
+typedef struct
+{
+    size_t xLength;
+    uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
+} response_t;
 
-    void prvBLESetUp( void );
-    void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
-                                   bool bNeedRsp,
-                                   bool IsPrep,
-                                   uint16_t usOffset );
-    void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
-    void pushToQueue( IotLink_t * pEventList );
-    void prvSetGetProperty( BTProperty_t * pxProperty,
-                            bool bIsSet );
-    void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
-                              uint16_t usServiceDataLen,
-                              char * pcServiceData,
-                              BTUuid_t * pxServiceUuid,
-                              size_t xNbServices );
-    void prvStartStopAdvCheck( bool start );
-    BTStatus_t bleStackInit( void );
+void prvBLESetUp( void );
+void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
+                               bool bNeedRsp,
+                               bool IsPrep,
+                               uint16_t usOffset );
+void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
+void pushToQueue( IotLink_t * pEventList );
+void prvSetGetProperty( BTProperty_t * pxProperty,
+                        bool bIsSet );
+void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
+                          uint16_t usServiceDataLen,
+                          char * pcServiceData,
+                          BTUuid_t * pxServiceUuid,
+                          size_t xNbServices );
+void prvStartStopAdvCheck( bool start );
+BTStatus_t bleStackInit( void );
 
 #endif /* _IOT_TEST_BLE_HAL_AFQP_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -33,17 +33,17 @@
 
 #include "iot_test_ble_hal_common.h"
 
-typedef struct
-{
-    size_t xLength;
-    uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
-} response_t;
+    typedef struct
+    {
+        size_t xLength;
+        uint8_t ucBuffer[ bletestsSTRINGYFIED_UUID_SIZE ];
+    } response_t;
 
-void prvBLESetUp( void );
-static void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
-                                      bool bNeedRsp,
-                                      bool IsPrep,
-                                      uint16_t usOffset );
-static void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
+    void prvBLESetUp( void );
+    static void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
+                                          bool bNeedRsp,
+                                          bool IsPrep,
+                                          uint16_t usOffset );
+    static void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
 
 #endif /* _IOT_TEST_BLE_HAL_AFQP_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_afqp.h
@@ -40,10 +40,10 @@
     } response_t;
 
     void prvBLESetUp( void );
-    static void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
-                                          bool bNeedRsp,
-                                          bool IsPrep,
-                                          uint16_t usOffset );
-    static void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
+    void prvWriteCheckAndResponse( bletestAttSrvB_t xAttribute,
+                                   bool bNeedRsp,
+                                   bool IsPrep,
+                                   uint16_t usOffset );
+    void prvReadCheckAndResponse( bletestAttSrvB_t xAttribute );
 
 #endif /* _IOT_TEST_BLE_HAL_AFQP_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -57,43 +57,9 @@ typedef struct
     uint32_t timeout;     /**< Connection timeout. */
 } IotBleConnectionParam_t;
 
-typedef enum
-{
-    eBLEHALEventServerRegisteredCb = 0,
-    eBLEHALEventEnableDisableCb = 1,
-    eBLEHALEventCharAddedCb = 2,
-    eBLEHALEventServiceAddedCb = 3,
-    eBLEHALEventServiceStartedCb = 4,
-    eBLEHALEventServiceStoppedCb = 5,
-    eBLEHALEventServiceDeletedCb = 6,
-    eBLEHALEventCharDescrAddedCb = 7,
-    eBLEHALEventIncludedServiceAdded = 8,
-    eBLEHALEventRegisterBleAdapterCb = 9,
-    eBLEHALEventAdapterPropertiesCb = 10,
-    eBLEHALEventRegisterUnregisterGattServerCb = 11,
-    eBLEHALEventPropertyCb = 12,
-    eBLEHALEventSetAdvCb = 13,
-    eBLEHALEventStartAdvCb = 14,
-    eBLEHALEventConnectionCb = 15,
-    eBLEHALEventConnectionUpdateCb = 16,
-    eBLEHALEventReadAttrCb = 17,
-    eBLEHALEventWriteAttrCb = 18,
-    eBLEHALEventIndicateCb = 19,
-    eBLEHALEventConfimCb = 20,
-    eBLEHALEventSSPrequestCb = 21,
-    eBLEHALEventSSPrequestConfirmationCb = 22,
-    eBLEHALEventPairingStateChangedCb = 23,
-    eBLEHALEventRequestExecWriteCb = 24,
-    eBLEHALEventBondedCb = 25,
-    eBLENbHALEvents,
-} BLEHALEventsTypes_t;
-
-typedef struct
-{
-    IotLink_t eventList;
-    BLEHALEventsTypes_t xEventTypes;
-    int32_t lHandle;
-} BLEHALEventsInternals_t;
+#define bletestsAPP_UUID                 { 0x11, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+#define bletestsSERVER_UUID              { 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+#define bletestsFREERTOS_SVC_UUID        { 0x5A, 0xDB, 0x32, 0xF9, 0x79, 0xE6, 0xB5, 0x83, 0xFB, 0x4E, 0xAF, 0x48, 0x68, 0x11, 0x7F, 0x8A }
 
 #define NO_HANDLE                        -1
 
@@ -103,11 +69,6 @@ typedef struct
 #define bletestsSTRINGYFIED_UUID_SIZE    36 /* like "8a7f1168-48af-4efb-83b5-e679f9320002" */
 #define bletestsFULL_PERMISSIONS         ( eBTPermRead | eBTPermWrite )
 #define bletestsNB_INCLUDEDSERVICES      1
-
-#define bletestsAPP_UUID                 { 0x11, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
-#define bletestsSERVER_UUID              { 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
-#define bletestsFREERTOS_SVC_UUID        { 0x5A, 0xDB, 0x32, 0xF9, 0x79, 0xE6, 0xB5, 0x83, 0xFB, 0x4E, 0xAF, 0x48, 0x68, 0x11, 0x7F, 0x8A }
-
 
 #define bletestsCCCD            \
     {                           \
@@ -203,19 +164,46 @@ typedef struct
 #define QUEUE_LENGTH                          20
 #define ITEM_SIZE                             sizeof( void * )
 
-extern IotListDouble_t g_eventQueueHead;
-extern IotMutex_t g_threadSafetyMutex;
-extern IotSemaphore_t g_eventSemaphore;
+#define BLE_TESTS_WAIT                        60000                 /* Wait 60s max */
+#define BLE_TESTS_SHORT_WAIT                  4000                  /* Wait 4s max */
 
-extern BTInterface_t * g_pxBTInterface;
-extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
-extern BTUuid_t g_xServerUUID;
-extern BTUuid_t g_xAppUUID;
-extern uint8_t g_ucBLEAdapterIf;
-extern uint8_t g_ucBLEServerIf;
-extern BTBdaddr_t g_xAddressConnectedDevice;
-extern BTGattServerInterface_t * g_pxGattServerInterface;
-extern uint16_t g_usBLEConnId;
+typedef enum
+{
+    eBLEHALEventServerRegisteredCb = 0,
+    eBLEHALEventEnableDisableCb = 1,
+    eBLEHALEventCharAddedCb = 2,
+    eBLEHALEventServiceAddedCb = 3,
+    eBLEHALEventServiceStartedCb = 4,
+    eBLEHALEventServiceStoppedCb = 5,
+    eBLEHALEventServiceDeletedCb = 6,
+    eBLEHALEventCharDescrAddedCb = 7,
+    eBLEHALEventIncludedServiceAdded = 8,
+    eBLEHALEventRegisterBleAdapterCb = 9,
+    eBLEHALEventAdapterPropertiesCb = 10,
+    eBLEHALEventRegisterUnregisterGattServerCb = 11,
+    eBLEHALEventPropertyCb = 12,
+    eBLEHALEventSetAdvCb = 13,
+    eBLEHALEventStartAdvCb = 14,
+    eBLEHALEventConnectionCb = 15,
+    eBLEHALEventConnectionUpdateCb = 16,
+    eBLEHALEventReadAttrCb = 17,
+    eBLEHALEventWriteAttrCb = 18,
+    eBLEHALEventIndicateCb = 19,
+    eBLEHALEventConfimCb = 20,
+    eBLEHALEventSSPrequestCb = 21,
+    eBLEHALEventSSPrequestConfirmationCb = 22,
+    eBLEHALEventPairingStateChangedCb = 23,
+    eBLEHALEventRequestExecWriteCb = 24,
+    eBLEHALEventBondedCb = 25,
+    eBLENbHALEvents,
+} BLEHALEventsTypes_t;
+
+typedef struct
+{
+    IotLink_t eventList;
+    BLEHALEventsTypes_t xEventTypes;
+    int32_t lHandle;
+} BLEHALEventsInternals_t;
 
 typedef struct
 {
@@ -349,18 +337,158 @@ typedef struct
     bool bIsBonded;
 } BLETESTBondedCallback_t;
 
-static const uint32_t bletestWAIT_MODE1_LEVEL2_QUERY = 10000; /* Wait 10s max */
-static const uint32_t BLE_TESTS_WAIT = 60000;                 /* Wait 60s max */
-static const uint32_t BLE_TESTS_SHORT_WAIT = 4000;            /* Wait 4s max */
 
+typedef enum
+{
+    bletestATTR_SRVCA_SERVICE,
+    bletestATTR_SRVCA_CHAR_A,
+    bletestATTR_SRVCA_NUMBER
+} bletestAttSrvA_t;
+
+typedef enum
+{
+    bletestATTR_SRVCB_SERVICE,
+    bletestATTR_SRVCB_CHAR_A,
+    bletestATTR_SRVCB_CHAR_B,
+    bletestATTR_SRVCB_CHAR_C,
+    bletestATTR_SRVCB_CHAR_D,
+    bletestATTR_SRVCB_CHAR_E,
+    bletestATTR_SRVCB_CCCD_E,
+    bletestATTR_SRVCB_CHAR_F,
+    bletestATTR_SRVCB_CCCD_F,
+    bletestATTR_SRVCB_CHARF_DESCR_A,
+    bletestATTR_SRVCB_CHARF_DESCR_B,
+    bletestATTR_SRVCB_CHARF_DESCR_C,
+    bletestATTR_SRVCB_CHARF_DESCR_D,
+    bletestATTR_INCLUDED_SERVICE,
+    bletestATTR_SRVCB_NUMBER
+} bletestAttSrvB_t;
+
+void pushToQueue( IotLink_t * pEventList );
+void prvSetGetProperty( BTProperty_t * pxProperty,
+                        bool bIsSet );
+void prvStartAdvertisement( void );
+void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
+                          uint16_t usServiceDataLen,
+                          char * pcServiceData,
+                          BTUuid_t * pxServiceUuid,
+                          size_t xNbServices );
+BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
+                                  int32_t lhandle,
+                                  void * pxMessage,
+                                  size_t xMessageLength,
+                                  uint32_t timeoutMs );
+void prvDeviceStateChangedCb( BTState_t xState );
+void prvRegisterBleAdapterCb( BTStatus_t xStatus,
+                              uint8_t ucAdapterIf,
+                              BTUuid_t * pxAppUuid );
+void prvBTRegisterServerCb( BTStatus_t xStatus,
+                            uint8_t ucServerIf,
+                            BTUuid_t * pxAppUuid );
+void prvBTUnregisterServerCb( BTStatus_t xStatus,
+                              uint8_t ucServerIf );
+void prvServiceAddedCb( BTStatus_t xStatus,
+                        uint8_t ucServerIf,
+                        BTGattSrvcId_t * pxSrvcId,
+                        uint16_t usServiceHandle );
+void prvIncludedServiceAddedCb( BTStatus_t xStatus,
+                                uint8_t ucServerIf,
+                                uint16_t usServiceHandle,
+                                uint16_t usInclSrvcHandle );
+void prvServiceStartedCb( BTStatus_t xStatus,
+                          uint8_t ucServerIf,
+                          uint16_t usServiceHandle );
+void prvServiceStoppedCb( BTStatus_t xStatus,
+                          uint8_t ucServerIf,
+                          uint16_t usServiceHandle );
+void prvServiceDeletedCb( BTStatus_t xStatus,
+                          uint8_t ucServerIf,
+                          uint16_t usServiceHandle );
+void prvCharacteristicAddedCb( BTStatus_t xStatus,
+                               uint8_t ucServerIf,
+                               BTUuid_t * pxUuid,
+                               uint16_t usServiceHandle,
+                               uint16_t usCharHandle );
+void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
+                                    uint8_t ucServerIf,
+                                    BTUuid_t * pxUuid,
+                                    uint16_t usServiceHandle,
+                                    uint16_t usCharHandle );
+void prvAdapterPropertiesCb( BTStatus_t xStatus,
+                             uint32_t ulNumProperties,
+                             BTProperty_t * pxProperties );
+void prvSetAdvDataCb( BTStatus_t xStatus );
+void prvAdvStatusCb( BTStatus_t xStatus,
+                     uint32_t ulServerIf,
+                     bool bStart );
+void prvConnectionCb( uint16_t usConnId,
+                      uint8_t ucServerIf,
+                      bool bConnected,
+                      BTBdaddr_t * pxBda );
+void prvConnParameterUpdateCb( BTStatus_t xStatus,
+                               const BTBdaddr_t * pxBdAddr,
+                               uint32_t minInterval,
+                               uint32_t maxInterval,
+                               uint32_t latency,
+                               uint32_t usConnInterval,
+                               uint32_t timeout );
+void prvRequestReadCb( uint16_t usConnId,
+                       uint32_t ulTransId,
+                       BTBdaddr_t * pxBda,
+                       uint16_t usAttrHandle,
+                       uint16_t usOffset );
+void prvRequestWriteCb( uint16_t usConnId,
+                        uint32_t ulTransId,
+                        BTBdaddr_t * pxBda,
+                        uint16_t usAttrHandle,
+                        uint16_t usOffset,
+                        size_t xLength,
+                        bool bNeedRsp,
+                        bool bIsPrep,
+                        uint8_t * pucValue );
+void prvIndicationSentCb( uint16_t usConnId,
+                          BTStatus_t xStatus );
+void prvResponseConfirmationCb( BTStatus_t xStatus,
+                                uint16_t usHandle );
+void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
+                      BTBdname_t * pxRemoteBdName,
+                      uint32_t ulCod,
+                      BTSspVariant_t xPairingVariant,
+                      uint32_t ulPassKey );
+void prvPairingStateChangedCb( BTStatus_t xStatus,
+                               BTBdaddr_t * pxRemoteBdAddr,
+                               BTBondState_t xState,
+                               BTSecurityLevel_t xSecurityLevel,
+                               BTAuthFailureReason_t xReason );
+void prvRequestExecWriteCb( uint16_t usConnId,
+                            uint32_t ulTransId,
+                            BTBdaddr_t * pxBda,
+                            bool bExecWrite );
+void prvBondedCb( BTStatus_t xStatus,
+                  BTBdaddr_t * pxRemoteBdAddr,
+                  bool bIsBonded );
+void prvStartStopAdvCheck( bool start );
 BTStatus_t bleStackInit( void );
-
-extern void pushToQueue( IotLink_t * pEventList );
-
-extern BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
-                                         int32_t lhandle,
-                                         void * pxMessage,
-                                         size_t xMessageLength,
-                                         uint32_t timeoutMs );
+void prvBLESetUp( void );
+void prvBLEManagerInit( void );
+void prvBLEEnable( bool bEnable );
+void prvStartService( BTService_t * xRefSrvc );
+/* void prvCreateService( BTService_t * xRefSrvc ); */
+void prvCreateServiceA( void );
+void prvCreateServiceB( void );
+void prvWaitConnection( bool bConnected );
+void prvStopService( BTService_t * xRefSrvc );
+void prvDeleteService( BTService_t * xRefSrvc );
+/* void prvCreateCharacteristic( BTService_t * xSrvc, */
+/*                               int xAttribute ); */
+/* void prvCreateCharacteristicDescriptor( BTService_t * xSrvc, */
+/*                                         int xAttribute ); */
+void checkNotificationIndication( bletestAttSrvB_t xAttribute,
+                                  bool enable );
+void prvBTUnregister( void );
+void prvBLEGAPInit( void );
+void prvBLEGATTInit( void );
+void prvSetAdvProperty( void );
+void prvSetAdvData( void );
 
 #endif /* _IOT_TEST_BLE_HAL_COMMON_H */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -364,20 +364,6 @@
         bletestATTR_SRVCB_NUMBER
     } bletestAttSrvB_t;
 
-    void pushToQueue( IotLink_t * pEventList );
-    void prvSetGetProperty( BTProperty_t * pxProperty,
-                            bool bIsSet );
-    void prvStartAdvertisement( void );
-    void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
-                              uint16_t usServiceDataLen,
-                              char * pcServiceData,
-                              BTUuid_t * pxServiceUuid,
-                              size_t xNbServices );
-    BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
-                                      int32_t lhandle,
-                                      void * pxMessage,
-                                      size_t xMessageLength,
-                                      uint32_t timeoutMs );
     void prvDeviceStateChangedCb( BTState_t xState );
     void prvRegisterBleAdapterCb( BTStatus_t xStatus,
                                   uint8_t ucAdapterIf,
@@ -467,8 +453,12 @@
     void prvBondedCb( BTStatus_t xStatus,
                       BTBdaddr_t * pxRemoteBdAddr,
                       bool bIsBonded );
-    void prvStartStopAdvCheck( bool start );
-    BTStatus_t bleStackInit( void );
+    void prvStartAdvertisement( void );
+    BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
+                                      int32_t lhandle,
+                                      void * pxMessage,
+                                      size_t xMessageLength,
+                                      uint32_t timeoutMs );
     void prvBLEManagerInit( void );
     void prvBLEEnable( bool bEnable );
     void prvStartService( BTService_t * xRefSrvc );

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -472,16 +472,11 @@
     void prvBLEManagerInit( void );
     void prvBLEEnable( bool bEnable );
     void prvStartService( BTService_t * xRefSrvc );
-/* void prvCreateService( BTService_t * xRefSrvc ); */
     void prvCreateServiceA( void );
     void prvCreateServiceB( void );
     void prvWaitConnection( bool bConnected );
     void prvStopService( BTService_t * xRefSrvc );
     void prvDeleteService( BTService_t * xRefSrvc );
-/* void prvCreateCharacteristic( BTService_t * xSrvc, */
-/*                               int xAttribute ); */
-/* void prvCreateCharacteristicDescriptor( BTService_t * xSrvc, */
-/*                                         int xAttribute ); */
     void checkNotificationIndication( bletestAttSrvB_t xAttribute,
                                       bool enable );
     void prvBTUnregister( void );

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -49,13 +49,13 @@
 /**
  * @brief Connection parameters.
  */
-    typedef struct
-    {
-        uint32_t minInterval; /**< Minimum connection interval. */
-        uint32_t maxInterval; /**< Maximum connection interval. */
-        uint32_t latency;     /**< Slave latency. */
-        uint32_t timeout;     /**< Connection timeout. */
-    } IotBleConnectionParam_t;
+typedef struct
+{
+    uint32_t minInterval; /**< Minimum connection interval. */
+    uint32_t maxInterval; /**< Maximum connection interval. */
+    uint32_t latency;     /**< Slave latency. */
+    uint32_t timeout;     /**< Connection timeout. */
+} IotBleConnectionParam_t;
 
 #define bletestsAPP_UUID                 { 0x11, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
 #define bletestsSERVER_UUID              { 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
@@ -167,312 +167,312 @@
 #define BLE_TESTS_WAIT                        60000                 /* Wait 60s max */
 #define BLE_TESTS_SHORT_WAIT                  4000                  /* Wait 4s max */
 
-    typedef enum
-    {
-        eBLEHALEventServerRegisteredCb = 0,
-        eBLEHALEventEnableDisableCb = 1,
-        eBLEHALEventCharAddedCb = 2,
-        eBLEHALEventServiceAddedCb = 3,
-        eBLEHALEventServiceStartedCb = 4,
-        eBLEHALEventServiceStoppedCb = 5,
-        eBLEHALEventServiceDeletedCb = 6,
-        eBLEHALEventCharDescrAddedCb = 7,
-        eBLEHALEventIncludedServiceAdded = 8,
-        eBLEHALEventRegisterBleAdapterCb = 9,
-        eBLEHALEventAdapterPropertiesCb = 10,
-        eBLEHALEventRegisterUnregisterGattServerCb = 11,
-        eBLEHALEventPropertyCb = 12,
-        eBLEHALEventSetAdvCb = 13,
-        eBLEHALEventStartAdvCb = 14,
-        eBLEHALEventConnectionCb = 15,
-        eBLEHALEventConnectionUpdateCb = 16,
-        eBLEHALEventReadAttrCb = 17,
-        eBLEHALEventWriteAttrCb = 18,
-        eBLEHALEventIndicateCb = 19,
-        eBLEHALEventConfimCb = 20,
-        eBLEHALEventSSPrequestCb = 21,
-        eBLEHALEventSSPrequestConfirmationCb = 22,
-        eBLEHALEventPairingStateChangedCb = 23,
-        eBLEHALEventRequestExecWriteCb = 24,
-        eBLEHALEventBondedCb = 25,
-        eBLENbHALEvents,
-    } BLEHALEventsTypes_t;
+typedef enum
+{
+    eBLEHALEventServerRegisteredCb = 0,
+    eBLEHALEventEnableDisableCb = 1,
+    eBLEHALEventCharAddedCb = 2,
+    eBLEHALEventServiceAddedCb = 3,
+    eBLEHALEventServiceStartedCb = 4,
+    eBLEHALEventServiceStoppedCb = 5,
+    eBLEHALEventServiceDeletedCb = 6,
+    eBLEHALEventCharDescrAddedCb = 7,
+    eBLEHALEventIncludedServiceAdded = 8,
+    eBLEHALEventRegisterBleAdapterCb = 9,
+    eBLEHALEventAdapterPropertiesCb = 10,
+    eBLEHALEventRegisterUnregisterGattServerCb = 11,
+    eBLEHALEventPropertyCb = 12,
+    eBLEHALEventSetAdvCb = 13,
+    eBLEHALEventStartAdvCb = 14,
+    eBLEHALEventConnectionCb = 15,
+    eBLEHALEventConnectionUpdateCb = 16,
+    eBLEHALEventReadAttrCb = 17,
+    eBLEHALEventWriteAttrCb = 18,
+    eBLEHALEventIndicateCb = 19,
+    eBLEHALEventConfimCb = 20,
+    eBLEHALEventSSPrequestCb = 21,
+    eBLEHALEventSSPrequestConfirmationCb = 22,
+    eBLEHALEventPairingStateChangedCb = 23,
+    eBLEHALEventRequestExecWriteCb = 24,
+    eBLEHALEventBondedCb = 25,
+    eBLENbHALEvents,
+} BLEHALEventsTypes_t;
 
-    typedef struct
-    {
-        IotLink_t eventList;
-        BLEHALEventsTypes_t xEventTypes;
-        int32_t lHandle;
-    } BLEHALEventsInternals_t;
+typedef struct
+{
+    IotLink_t eventList;
+    BLEHALEventsTypes_t xEventTypes;
+    int32_t lHandle;
+} BLEHALEventsInternals_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        BTState_t xBLEState;
-    } BLETESTInitDeinitCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    BTState_t xBLEState;
+} BLETESTInitDeinitCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        uint16_t usAttrHandle;
-        uint16_t usSrvHandle;
-        BTUuid_t xUUID;
-    } BLETESTAttrCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    uint16_t usAttrHandle;
+    uint16_t usSrvHandle;
+    BTUuid_t xUUID;
+} BLETESTAttrCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        uint16_t usAttrHandle;
-        BTStatus_t xStatus;
-        BTGattSrvcId_t xSrvcId;
-    } BLETESTServiceCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    uint16_t usAttrHandle;
+    BTStatus_t xStatus;
+    BTGattSrvcId_t xSrvcId;
+} BLETESTServiceCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        uint32_t ulNumProperties;
-        BTProperty_t xProperties;
-    } BLETESTSetGetPropertyCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    uint32_t ulNumProperties;
+    BTProperty_t xProperties;
+} BLETESTSetGetPropertyCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        bool bStart;
-    } BLETESTAdvParamCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    bool bStart;
+} BLETESTAdvParamCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        IotBleConnectionParam_t xConnParam;
-        BTBdaddr_t xBda;
-    } BLETESTUpdateConnectionParamReqCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    IotBleConnectionParam_t xConnParam;
+    BTBdaddr_t xBda;
+} BLETESTUpdateConnectionParamReqCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        uint16_t usConnId;
-        uint32_t ulTransId;
-        BTBdaddr_t xBda;
-        uint16_t usAttrHandle;
-        uint16_t usOffset;
-    } BLETESTreadAttrCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    uint16_t usConnId;
+    uint32_t ulTransId;
+    BTBdaddr_t xBda;
+    uint16_t usAttrHandle;
+    uint16_t usOffset;
+} BLETESTreadAttrCallback_t;
 
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        uint16_t usConnId;
-        uint32_t ulTransId;
-        BTBdaddr_t xBda;
-        uint16_t usAttrHandle;
-        uint16_t usOffset;
-        size_t xLength;
-        bool bNeedRsp;
-        bool bIsPrep;
-        uint8_t ucValue[ bletestsSTRINGYFIED_UUID_SIZE ];
-    } BLETESTwriteAttrCallback_t;
-
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        uint16_t usConnId;
-        BTStatus_t xStatus;
-    } BLETESTindicateCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        uint16_t usAttrHandle;
-    } BLETESTconfirmCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTBdaddr_t xRemoteBdAddr;
-        BTBdname_t xRemoteBdName;
-        uint32_t ulCod;
-        BTSspVariant_t xPairingVariant;
-        uint32_t ulPassKey;
-    } BLETESTsspRequestCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        BTBdaddr_t xRemoteBdAddr;
-        BTSecurityLevel_t xSecurityLevel;
-        BTAuthFailureReason_t xReason;
-    } BLETESTPairingStateChangedCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        uint16_t usConnId;
-        uint32_t ulTransId;
-        BTBdaddr_t xBda;
-        bool bExecWrite;
-    } BLETESTRequestExecWriteCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        uint16_t usConnId;
-        uint8_t ucServerIf;
-        BTBdaddr_t pxBda;
-        bool bConnected;
-    } BLETESTConnectionCallback_t;
-
-    typedef struct
-    {
-        BLEHALEventsInternals_t xEvent;
-        BTStatus_t xStatus;
-        BTBdaddr_t xRemoteBdAddr;
-        bool bIsBonded;
-    } BLETESTBondedCallback_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    uint16_t usConnId;
+    uint32_t ulTransId;
+    BTBdaddr_t xBda;
+    uint16_t usAttrHandle;
+    uint16_t usOffset;
+    size_t xLength;
+    bool bNeedRsp;
+    bool bIsPrep;
+    uint8_t ucValue[ bletestsSTRINGYFIED_UUID_SIZE ];
+} BLETESTwriteAttrCallback_t;
 
 
-    typedef enum
-    {
-        bletestATTR_SRVCA_SERVICE,
-        bletestATTR_SRVCA_CHAR_A,
-        bletestATTR_SRVCA_NUMBER
-    } bletestAttSrvA_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    uint16_t usConnId;
+    BTStatus_t xStatus;
+} BLETESTindicateCallback_t;
 
-    typedef enum
-    {
-        bletestATTR_SRVCB_SERVICE,
-        bletestATTR_SRVCB_CHAR_A,
-        bletestATTR_SRVCB_CHAR_B,
-        bletestATTR_SRVCB_CHAR_C,
-        bletestATTR_SRVCB_CHAR_D,
-        bletestATTR_SRVCB_CHAR_E,
-        bletestATTR_SRVCB_CCCD_E,
-        bletestATTR_SRVCB_CHAR_F,
-        bletestATTR_SRVCB_CCCD_F,
-        bletestATTR_SRVCB_CHARF_DESCR_A,
-        bletestATTR_SRVCB_CHARF_DESCR_B,
-        bletestATTR_SRVCB_CHARF_DESCR_C,
-        bletestATTR_SRVCB_CHARF_DESCR_D,
-        bletestATTR_INCLUDED_SERVICE,
-        bletestATTR_SRVCB_NUMBER
-    } bletestAttSrvB_t;
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    uint16_t usAttrHandle;
+} BLETESTconfirmCallback_t;
 
-    void prvDeviceStateChangedCb( BTState_t xState );
-    void prvRegisterBleAdapterCb( BTStatus_t xStatus,
-                                  uint8_t ucAdapterIf,
-                                  BTUuid_t * pxAppUuid );
-    void prvBTRegisterServerCb( BTStatus_t xStatus,
-                                uint8_t ucServerIf,
-                                BTUuid_t * pxAppUuid );
-    void prvBTUnregisterServerCb( BTStatus_t xStatus,
-                                  uint8_t ucServerIf );
-    void prvServiceAddedCb( BTStatus_t xStatus,
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTBdaddr_t xRemoteBdAddr;
+    BTBdname_t xRemoteBdName;
+    uint32_t ulCod;
+    BTSspVariant_t xPairingVariant;
+    uint32_t ulPassKey;
+} BLETESTsspRequestCallback_t;
+
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    BTBdaddr_t xRemoteBdAddr;
+    BTSecurityLevel_t xSecurityLevel;
+    BTAuthFailureReason_t xReason;
+} BLETESTPairingStateChangedCallback_t;
+
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    uint16_t usConnId;
+    uint32_t ulTransId;
+    BTBdaddr_t xBda;
+    bool bExecWrite;
+} BLETESTRequestExecWriteCallback_t;
+
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    uint16_t usConnId;
+    uint8_t ucServerIf;
+    BTBdaddr_t pxBda;
+    bool bConnected;
+} BLETESTConnectionCallback_t;
+
+typedef struct
+{
+    BLEHALEventsInternals_t xEvent;
+    BTStatus_t xStatus;
+    BTBdaddr_t xRemoteBdAddr;
+    bool bIsBonded;
+} BLETESTBondedCallback_t;
+
+
+typedef enum
+{
+    bletestATTR_SRVCA_SERVICE,
+    bletestATTR_SRVCA_CHAR_A,
+    bletestATTR_SRVCA_NUMBER
+} bletestAttSrvA_t;
+
+typedef enum
+{
+    bletestATTR_SRVCB_SERVICE,
+    bletestATTR_SRVCB_CHAR_A,
+    bletestATTR_SRVCB_CHAR_B,
+    bletestATTR_SRVCB_CHAR_C,
+    bletestATTR_SRVCB_CHAR_D,
+    bletestATTR_SRVCB_CHAR_E,
+    bletestATTR_SRVCB_CCCD_E,
+    bletestATTR_SRVCB_CHAR_F,
+    bletestATTR_SRVCB_CCCD_F,
+    bletestATTR_SRVCB_CHARF_DESCR_A,
+    bletestATTR_SRVCB_CHARF_DESCR_B,
+    bletestATTR_SRVCB_CHARF_DESCR_C,
+    bletestATTR_SRVCB_CHARF_DESCR_D,
+    bletestATTR_INCLUDED_SERVICE,
+    bletestATTR_SRVCB_NUMBER
+} bletestAttSrvB_t;
+
+void prvDeviceStateChangedCb( BTState_t xState );
+void prvRegisterBleAdapterCb( BTStatus_t xStatus,
+                              uint8_t ucAdapterIf,
+                              BTUuid_t * pxAppUuid );
+void prvBTRegisterServerCb( BTStatus_t xStatus,
                             uint8_t ucServerIf,
-                            BTGattSrvcId_t * pxSrvcId,
-                            uint16_t usServiceHandle );
-    void prvIncludedServiceAddedCb( BTStatus_t xStatus,
-                                    uint8_t ucServerIf,
-                                    uint16_t usServiceHandle,
-                                    uint16_t usInclSrvcHandle );
-    void prvServiceStartedCb( BTStatus_t xStatus,
-                              uint8_t ucServerIf,
-                              uint16_t usServiceHandle );
-    void prvServiceStoppedCb( BTStatus_t xStatus,
-                              uint8_t ucServerIf,
-                              uint16_t usServiceHandle );
-    void prvServiceDeletedCb( BTStatus_t xStatus,
-                              uint8_t ucServerIf,
-                              uint16_t usServiceHandle );
-    void prvCharacteristicAddedCb( BTStatus_t xStatus,
-                                   uint8_t ucServerIf,
-                                   BTUuid_t * pxUuid,
-                                   uint16_t usServiceHandle,
-                                   uint16_t usCharHandle );
-    void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
-                                        uint8_t ucServerIf,
-                                        BTUuid_t * pxUuid,
-                                        uint16_t usServiceHandle,
-                                        uint16_t usCharHandle );
-    void prvAdapterPropertiesCb( BTStatus_t xStatus,
-                                 uint32_t ulNumProperties,
-                                 BTProperty_t * pxProperties );
-    void prvSetAdvDataCb( BTStatus_t xStatus );
-    void prvAdvStatusCb( BTStatus_t xStatus,
-                         uint32_t ulServerIf,
-                         bool bStart );
-    void prvConnectionCb( uint16_t usConnId,
+                            BTUuid_t * pxAppUuid );
+void prvBTUnregisterServerCb( BTStatus_t xStatus,
+                              uint8_t ucServerIf );
+void prvServiceAddedCb( BTStatus_t xStatus,
+                        uint8_t ucServerIf,
+                        BTGattSrvcId_t * pxSrvcId,
+                        uint16_t usServiceHandle );
+void prvIncludedServiceAddedCb( BTStatus_t xStatus,
+                                uint8_t ucServerIf,
+                                uint16_t usServiceHandle,
+                                uint16_t usInclSrvcHandle );
+void prvServiceStartedCb( BTStatus_t xStatus,
                           uint8_t ucServerIf,
-                          bool bConnected,
-                          BTBdaddr_t * pxBda );
-    void prvConnParameterUpdateCb( BTStatus_t xStatus,
-                                   const BTBdaddr_t * pxBdAddr,
-                                   uint32_t minInterval,
-                                   uint32_t maxInterval,
-                                   uint32_t latency,
-                                   uint32_t usConnInterval,
-                                   uint32_t timeout );
-    void prvRequestReadCb( uint16_t usConnId,
-                           uint32_t ulTransId,
-                           BTBdaddr_t * pxBda,
-                           uint16_t usAttrHandle,
-                           uint16_t usOffset );
-    void prvRequestWriteCb( uint16_t usConnId,
+                          uint16_t usServiceHandle );
+void prvServiceStoppedCb( BTStatus_t xStatus,
+                          uint8_t ucServerIf,
+                          uint16_t usServiceHandle );
+void prvServiceDeletedCb( BTStatus_t xStatus,
+                          uint8_t ucServerIf,
+                          uint16_t usServiceHandle );
+void prvCharacteristicAddedCb( BTStatus_t xStatus,
+                               uint8_t ucServerIf,
+                               BTUuid_t * pxUuid,
+                               uint16_t usServiceHandle,
+                               uint16_t usCharHandle );
+void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
+                                    uint8_t ucServerIf,
+                                    BTUuid_t * pxUuid,
+                                    uint16_t usServiceHandle,
+                                    uint16_t usCharHandle );
+void prvAdapterPropertiesCb( BTStatus_t xStatus,
+                             uint32_t ulNumProperties,
+                             BTProperty_t * pxProperties );
+void prvSetAdvDataCb( BTStatus_t xStatus );
+void prvAdvStatusCb( BTStatus_t xStatus,
+                     uint32_t ulServerIf,
+                     bool bStart );
+void prvConnectionCb( uint16_t usConnId,
+                      uint8_t ucServerIf,
+                      bool bConnected,
+                      BTBdaddr_t * pxBda );
+void prvConnParameterUpdateCb( BTStatus_t xStatus,
+                               const BTBdaddr_t * pxBdAddr,
+                               uint32_t minInterval,
+                               uint32_t maxInterval,
+                               uint32_t latency,
+                               uint32_t usConnInterval,
+                               uint32_t timeout );
+void prvRequestReadCb( uint16_t usConnId,
+                       uint32_t ulTransId,
+                       BTBdaddr_t * pxBda,
+                       uint16_t usAttrHandle,
+                       uint16_t usOffset );
+void prvRequestWriteCb( uint16_t usConnId,
+                        uint32_t ulTransId,
+                        BTBdaddr_t * pxBda,
+                        uint16_t usAttrHandle,
+                        uint16_t usOffset,
+                        size_t xLength,
+                        bool bNeedRsp,
+                        bool bIsPrep,
+                        uint8_t * pucValue );
+void prvIndicationSentCb( uint16_t usConnId,
+                          BTStatus_t xStatus );
+void prvResponseConfirmationCb( BTStatus_t xStatus,
+                                uint16_t usHandle );
+void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
+                      BTBdname_t * pxRemoteBdName,
+                      uint32_t ulCod,
+                      BTSspVariant_t xPairingVariant,
+                      uint32_t ulPassKey );
+void prvPairingStateChangedCb( BTStatus_t xStatus,
+                               BTBdaddr_t * pxRemoteBdAddr,
+                               BTBondState_t xState,
+                               BTSecurityLevel_t xSecurityLevel,
+                               BTAuthFailureReason_t xReason );
+void prvRequestExecWriteCb( uint16_t usConnId,
                             uint32_t ulTransId,
                             BTBdaddr_t * pxBda,
-                            uint16_t usAttrHandle,
-                            uint16_t usOffset,
-                            size_t xLength,
-                            bool bNeedRsp,
-                            bool bIsPrep,
-                            uint8_t * pucValue );
-    void prvIndicationSentCb( uint16_t usConnId,
-                              BTStatus_t xStatus );
-    void prvResponseConfirmationCb( BTStatus_t xStatus,
-                                    uint16_t usHandle );
-    void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
-                          BTBdname_t * pxRemoteBdName,
-                          uint32_t ulCod,
-                          BTSspVariant_t xPairingVariant,
-                          uint32_t ulPassKey );
-    void prvPairingStateChangedCb( BTStatus_t xStatus,
-                                   BTBdaddr_t * pxRemoteBdAddr,
-                                   BTBondState_t xState,
-                                   BTSecurityLevel_t xSecurityLevel,
-                                   BTAuthFailureReason_t xReason );
-    void prvRequestExecWriteCb( uint16_t usConnId,
-                                uint32_t ulTransId,
-                                BTBdaddr_t * pxBda,
-                                bool bExecWrite );
-    void prvBondedCb( BTStatus_t xStatus,
-                      BTBdaddr_t * pxRemoteBdAddr,
-                      bool bIsBonded );
-    void prvStartAdvertisement( void );
-    BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
-                                      int32_t lhandle,
-                                      void * pxMessage,
-                                      size_t xMessageLength,
-                                      uint32_t timeoutMs );
-    void prvBLEManagerInit( void );
-    void prvBLEEnable( bool bEnable );
-    void prvStartService( BTService_t * xRefSrvc );
-    void prvCreateServiceA( void );
-    void prvCreateServiceB( void );
-    void prvWaitConnection( bool bConnected );
-    void prvStopService( BTService_t * xRefSrvc );
-    void prvDeleteService( BTService_t * xRefSrvc );
-    void checkNotificationIndication( bletestAttSrvB_t xAttribute,
-                                      bool enable );
-    void prvBTUnregister( void );
-    void prvBLEGAPInit( void );
-    void prvBLEGATTInit( void );
-    void prvSetAdvProperty( void );
-    void prvSetAdvData( void );
+                            bool bExecWrite );
+void prvBondedCb( BTStatus_t xStatus,
+                  BTBdaddr_t * pxRemoteBdAddr,
+                  bool bIsBonded );
+void prvStartAdvertisement( void );
+BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
+                                  int32_t lhandle,
+                                  void * pxMessage,
+                                  size_t xMessageLength,
+                                  uint32_t timeoutMs );
+void prvBLEManagerInit( void );
+void prvBLEEnable( bool bEnable );
+void prvStartService( BTService_t * xRefSrvc );
+void prvCreateServiceA( void );
+void prvCreateServiceB( void );
+void prvWaitConnection( bool bConnected );
+void prvStopService( BTService_t * xRefSrvc );
+void prvDeleteService( BTService_t * xRefSrvc );
+void checkNotificationIndication( bletestAttSrvB_t xAttribute,
+                                  bool enable );
+void prvBTUnregister( void );
+void prvBLEGAPInit( void );
+void prvBLEGATTInit( void );
+void prvSetAdvProperty( void );
+void prvSetAdvData( void );
 
 #endif /* _IOT_TEST_BLE_HAL_COMMON_H */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -469,7 +469,6 @@ void prvBondedCb( BTStatus_t xStatus,
                   bool bIsBonded );
 void prvStartStopAdvCheck( bool start );
 BTStatus_t bleStackInit( void );
-void prvBLESetUp( void );
 void prvBLEManagerInit( void );
 void prvBLEEnable( bool bEnable );
 void prvStartService( BTService_t * xRefSrvc );

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -49,13 +49,13 @@
 /**
  * @brief Connection parameters.
  */
-typedef struct
-{
-    uint32_t minInterval; /**< Minimum connection interval. */
-    uint32_t maxInterval; /**< Maximum connection interval. */
-    uint32_t latency;     /**< Slave latency. */
-    uint32_t timeout;     /**< Connection timeout. */
-} IotBleConnectionParam_t;
+    typedef struct
+    {
+        uint32_t minInterval; /**< Minimum connection interval. */
+        uint32_t maxInterval; /**< Maximum connection interval. */
+        uint32_t latency;     /**< Slave latency. */
+        uint32_t timeout;     /**< Connection timeout. */
+    } IotBleConnectionParam_t;
 
 #define bletestsAPP_UUID                 { 0x11, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
 #define bletestsSERVER_UUID              { 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
@@ -167,327 +167,327 @@ typedef struct
 #define BLE_TESTS_WAIT                        60000                 /* Wait 60s max */
 #define BLE_TESTS_SHORT_WAIT                  4000                  /* Wait 4s max */
 
-typedef enum
-{
-    eBLEHALEventServerRegisteredCb = 0,
-    eBLEHALEventEnableDisableCb = 1,
-    eBLEHALEventCharAddedCb = 2,
-    eBLEHALEventServiceAddedCb = 3,
-    eBLEHALEventServiceStartedCb = 4,
-    eBLEHALEventServiceStoppedCb = 5,
-    eBLEHALEventServiceDeletedCb = 6,
-    eBLEHALEventCharDescrAddedCb = 7,
-    eBLEHALEventIncludedServiceAdded = 8,
-    eBLEHALEventRegisterBleAdapterCb = 9,
-    eBLEHALEventAdapterPropertiesCb = 10,
-    eBLEHALEventRegisterUnregisterGattServerCb = 11,
-    eBLEHALEventPropertyCb = 12,
-    eBLEHALEventSetAdvCb = 13,
-    eBLEHALEventStartAdvCb = 14,
-    eBLEHALEventConnectionCb = 15,
-    eBLEHALEventConnectionUpdateCb = 16,
-    eBLEHALEventReadAttrCb = 17,
-    eBLEHALEventWriteAttrCb = 18,
-    eBLEHALEventIndicateCb = 19,
-    eBLEHALEventConfimCb = 20,
-    eBLEHALEventSSPrequestCb = 21,
-    eBLEHALEventSSPrequestConfirmationCb = 22,
-    eBLEHALEventPairingStateChangedCb = 23,
-    eBLEHALEventRequestExecWriteCb = 24,
-    eBLEHALEventBondedCb = 25,
-    eBLENbHALEvents,
-} BLEHALEventsTypes_t;
+    typedef enum
+    {
+        eBLEHALEventServerRegisteredCb = 0,
+        eBLEHALEventEnableDisableCb = 1,
+        eBLEHALEventCharAddedCb = 2,
+        eBLEHALEventServiceAddedCb = 3,
+        eBLEHALEventServiceStartedCb = 4,
+        eBLEHALEventServiceStoppedCb = 5,
+        eBLEHALEventServiceDeletedCb = 6,
+        eBLEHALEventCharDescrAddedCb = 7,
+        eBLEHALEventIncludedServiceAdded = 8,
+        eBLEHALEventRegisterBleAdapterCb = 9,
+        eBLEHALEventAdapterPropertiesCb = 10,
+        eBLEHALEventRegisterUnregisterGattServerCb = 11,
+        eBLEHALEventPropertyCb = 12,
+        eBLEHALEventSetAdvCb = 13,
+        eBLEHALEventStartAdvCb = 14,
+        eBLEHALEventConnectionCb = 15,
+        eBLEHALEventConnectionUpdateCb = 16,
+        eBLEHALEventReadAttrCb = 17,
+        eBLEHALEventWriteAttrCb = 18,
+        eBLEHALEventIndicateCb = 19,
+        eBLEHALEventConfimCb = 20,
+        eBLEHALEventSSPrequestCb = 21,
+        eBLEHALEventSSPrequestConfirmationCb = 22,
+        eBLEHALEventPairingStateChangedCb = 23,
+        eBLEHALEventRequestExecWriteCb = 24,
+        eBLEHALEventBondedCb = 25,
+        eBLENbHALEvents,
+    } BLEHALEventsTypes_t;
 
-typedef struct
-{
-    IotLink_t eventList;
-    BLEHALEventsTypes_t xEventTypes;
-    int32_t lHandle;
-} BLEHALEventsInternals_t;
+    typedef struct
+    {
+        IotLink_t eventList;
+        BLEHALEventsTypes_t xEventTypes;
+        int32_t lHandle;
+    } BLEHALEventsInternals_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    BTState_t xBLEState;
-} BLETESTInitDeinitCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        BTState_t xBLEState;
+    } BLETESTInitDeinitCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    uint16_t usAttrHandle;
-    uint16_t usSrvHandle;
-    BTUuid_t xUUID;
-} BLETESTAttrCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        uint16_t usAttrHandle;
+        uint16_t usSrvHandle;
+        BTUuid_t xUUID;
+    } BLETESTAttrCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    uint16_t usAttrHandle;
-    BTStatus_t xStatus;
-    BTGattSrvcId_t xSrvcId;
-} BLETESTServiceCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        uint16_t usAttrHandle;
+        BTStatus_t xStatus;
+        BTGattSrvcId_t xSrvcId;
+    } BLETESTServiceCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    uint32_t ulNumProperties;
-    BTProperty_t xProperties;
-} BLETESTSetGetPropertyCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        uint32_t ulNumProperties;
+        BTProperty_t xProperties;
+    } BLETESTSetGetPropertyCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    bool bStart;
-} BLETESTAdvParamCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        bool bStart;
+    } BLETESTAdvParamCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    IotBleConnectionParam_t xConnParam;
-    BTBdaddr_t xBda;
-} BLETESTUpdateConnectionParamReqCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        IotBleConnectionParam_t xConnParam;
+        BTBdaddr_t xBda;
+    } BLETESTUpdateConnectionParamReqCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    uint16_t usConnId;
-    uint32_t ulTransId;
-    BTBdaddr_t xBda;
-    uint16_t usAttrHandle;
-    uint16_t usOffset;
-} BLETESTreadAttrCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        uint16_t usConnId;
+        uint32_t ulTransId;
+        BTBdaddr_t xBda;
+        uint16_t usAttrHandle;
+        uint16_t usOffset;
+    } BLETESTreadAttrCallback_t;
 
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    uint16_t usConnId;
-    uint32_t ulTransId;
-    BTBdaddr_t xBda;
-    uint16_t usAttrHandle;
-    uint16_t usOffset;
-    size_t xLength;
-    bool bNeedRsp;
-    bool bIsPrep;
-    uint8_t ucValue[ bletestsSTRINGYFIED_UUID_SIZE ];
-} BLETESTwriteAttrCallback_t;
-
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    uint16_t usConnId;
-    BTStatus_t xStatus;
-} BLETESTindicateCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    uint16_t usAttrHandle;
-} BLETESTconfirmCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTBdaddr_t xRemoteBdAddr;
-    BTBdname_t xRemoteBdName;
-    uint32_t ulCod;
-    BTSspVariant_t xPairingVariant;
-    uint32_t ulPassKey;
-} BLETESTsspRequestCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    BTBdaddr_t xRemoteBdAddr;
-    BTSecurityLevel_t xSecurityLevel;
-    BTAuthFailureReason_t xReason;
-} BLETESTPairingStateChangedCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    uint16_t usConnId;
-    uint32_t ulTransId;
-    BTBdaddr_t xBda;
-    bool bExecWrite;
-} BLETESTRequestExecWriteCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    uint16_t usConnId;
-    uint8_t ucServerIf;
-    BTBdaddr_t pxBda;
-    bool bConnected;
-} BLETESTConnectionCallback_t;
-
-typedef struct
-{
-    BLEHALEventsInternals_t xEvent;
-    BTStatus_t xStatus;
-    BTBdaddr_t xRemoteBdAddr;
-    bool bIsBonded;
-} BLETESTBondedCallback_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        uint16_t usConnId;
+        uint32_t ulTransId;
+        BTBdaddr_t xBda;
+        uint16_t usAttrHandle;
+        uint16_t usOffset;
+        size_t xLength;
+        bool bNeedRsp;
+        bool bIsPrep;
+        uint8_t ucValue[ bletestsSTRINGYFIED_UUID_SIZE ];
+    } BLETESTwriteAttrCallback_t;
 
 
-typedef enum
-{
-    bletestATTR_SRVCA_SERVICE,
-    bletestATTR_SRVCA_CHAR_A,
-    bletestATTR_SRVCA_NUMBER
-} bletestAttSrvA_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        uint16_t usConnId;
+        BTStatus_t xStatus;
+    } BLETESTindicateCallback_t;
 
-typedef enum
-{
-    bletestATTR_SRVCB_SERVICE,
-    bletestATTR_SRVCB_CHAR_A,
-    bletestATTR_SRVCB_CHAR_B,
-    bletestATTR_SRVCB_CHAR_C,
-    bletestATTR_SRVCB_CHAR_D,
-    bletestATTR_SRVCB_CHAR_E,
-    bletestATTR_SRVCB_CCCD_E,
-    bletestATTR_SRVCB_CHAR_F,
-    bletestATTR_SRVCB_CCCD_F,
-    bletestATTR_SRVCB_CHARF_DESCR_A,
-    bletestATTR_SRVCB_CHARF_DESCR_B,
-    bletestATTR_SRVCB_CHARF_DESCR_C,
-    bletestATTR_SRVCB_CHARF_DESCR_D,
-    bletestATTR_INCLUDED_SERVICE,
-    bletestATTR_SRVCB_NUMBER
-} bletestAttSrvB_t;
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        uint16_t usAttrHandle;
+    } BLETESTconfirmCallback_t;
 
-void pushToQueue( IotLink_t * pEventList );
-void prvSetGetProperty( BTProperty_t * pxProperty,
-                        bool bIsSet );
-void prvStartAdvertisement( void );
-void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
-                          uint16_t usServiceDataLen,
-                          char * pcServiceData,
-                          BTUuid_t * pxServiceUuid,
-                          size_t xNbServices );
-BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
-                                  int32_t lhandle,
-                                  void * pxMessage,
-                                  size_t xMessageLength,
-                                  uint32_t timeoutMs );
-void prvDeviceStateChangedCb( BTState_t xState );
-void prvRegisterBleAdapterCb( BTStatus_t xStatus,
-                              uint8_t ucAdapterIf,
-                              BTUuid_t * pxAppUuid );
-void prvBTRegisterServerCb( BTStatus_t xStatus,
-                            uint8_t ucServerIf,
-                            BTUuid_t * pxAppUuid );
-void prvBTUnregisterServerCb( BTStatus_t xStatus,
-                              uint8_t ucServerIf );
-void prvServiceAddedCb( BTStatus_t xStatus,
-                        uint8_t ucServerIf,
-                        BTGattSrvcId_t * pxSrvcId,
-                        uint16_t usServiceHandle );
-void prvIncludedServiceAddedCb( BTStatus_t xStatus,
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTBdaddr_t xRemoteBdAddr;
+        BTBdname_t xRemoteBdName;
+        uint32_t ulCod;
+        BTSspVariant_t xPairingVariant;
+        uint32_t ulPassKey;
+    } BLETESTsspRequestCallback_t;
+
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        BTBdaddr_t xRemoteBdAddr;
+        BTSecurityLevel_t xSecurityLevel;
+        BTAuthFailureReason_t xReason;
+    } BLETESTPairingStateChangedCallback_t;
+
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        uint16_t usConnId;
+        uint32_t ulTransId;
+        BTBdaddr_t xBda;
+        bool bExecWrite;
+    } BLETESTRequestExecWriteCallback_t;
+
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        uint16_t usConnId;
+        uint8_t ucServerIf;
+        BTBdaddr_t pxBda;
+        bool bConnected;
+    } BLETESTConnectionCallback_t;
+
+    typedef struct
+    {
+        BLEHALEventsInternals_t xEvent;
+        BTStatus_t xStatus;
+        BTBdaddr_t xRemoteBdAddr;
+        bool bIsBonded;
+    } BLETESTBondedCallback_t;
+
+
+    typedef enum
+    {
+        bletestATTR_SRVCA_SERVICE,
+        bletestATTR_SRVCA_CHAR_A,
+        bletestATTR_SRVCA_NUMBER
+    } bletestAttSrvA_t;
+
+    typedef enum
+    {
+        bletestATTR_SRVCB_SERVICE,
+        bletestATTR_SRVCB_CHAR_A,
+        bletestATTR_SRVCB_CHAR_B,
+        bletestATTR_SRVCB_CHAR_C,
+        bletestATTR_SRVCB_CHAR_D,
+        bletestATTR_SRVCB_CHAR_E,
+        bletestATTR_SRVCB_CCCD_E,
+        bletestATTR_SRVCB_CHAR_F,
+        bletestATTR_SRVCB_CCCD_F,
+        bletestATTR_SRVCB_CHARF_DESCR_A,
+        bletestATTR_SRVCB_CHARF_DESCR_B,
+        bletestATTR_SRVCB_CHARF_DESCR_C,
+        bletestATTR_SRVCB_CHARF_DESCR_D,
+        bletestATTR_INCLUDED_SERVICE,
+        bletestATTR_SRVCB_NUMBER
+    } bletestAttSrvB_t;
+
+    void pushToQueue( IotLink_t * pEventList );
+    void prvSetGetProperty( BTProperty_t * pxProperty,
+                            bool bIsSet );
+    void prvStartAdvertisement( void );
+    void prvSetAdvertisement( BTGattAdvertismentParams_t * pxParams,
+                              uint16_t usServiceDataLen,
+                              char * pcServiceData,
+                              BTUuid_t * pxServiceUuid,
+                              size_t xNbServices );
+    BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
+                                      int32_t lhandle,
+                                      void * pxMessage,
+                                      size_t xMessageLength,
+                                      uint32_t timeoutMs );
+    void prvDeviceStateChangedCb( BTState_t xState );
+    void prvRegisterBleAdapterCb( BTStatus_t xStatus,
+                                  uint8_t ucAdapterIf,
+                                  BTUuid_t * pxAppUuid );
+    void prvBTRegisterServerCb( BTStatus_t xStatus,
                                 uint8_t ucServerIf,
-                                uint16_t usServiceHandle,
-                                uint16_t usInclSrvcHandle );
-void prvServiceStartedCb( BTStatus_t xStatus,
-                          uint8_t ucServerIf,
-                          uint16_t usServiceHandle );
-void prvServiceStoppedCb( BTStatus_t xStatus,
-                          uint8_t ucServerIf,
-                          uint16_t usServiceHandle );
-void prvServiceDeletedCb( BTStatus_t xStatus,
-                          uint8_t ucServerIf,
-                          uint16_t usServiceHandle );
-void prvCharacteristicAddedCb( BTStatus_t xStatus,
-                               uint8_t ucServerIf,
-                               BTUuid_t * pxUuid,
-                               uint16_t usServiceHandle,
-                               uint16_t usCharHandle );
-void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
+                                BTUuid_t * pxAppUuid );
+    void prvBTUnregisterServerCb( BTStatus_t xStatus,
+                                  uint8_t ucServerIf );
+    void prvServiceAddedCb( BTStatus_t xStatus,
+                            uint8_t ucServerIf,
+                            BTGattSrvcId_t * pxSrvcId,
+                            uint16_t usServiceHandle );
+    void prvIncludedServiceAddedCb( BTStatus_t xStatus,
                                     uint8_t ucServerIf,
-                                    BTUuid_t * pxUuid,
                                     uint16_t usServiceHandle,
-                                    uint16_t usCharHandle );
-void prvAdapterPropertiesCb( BTStatus_t xStatus,
-                             uint32_t ulNumProperties,
-                             BTProperty_t * pxProperties );
-void prvSetAdvDataCb( BTStatus_t xStatus );
-void prvAdvStatusCb( BTStatus_t xStatus,
-                     uint32_t ulServerIf,
-                     bool bStart );
-void prvConnectionCb( uint16_t usConnId,
-                      uint8_t ucServerIf,
-                      bool bConnected,
-                      BTBdaddr_t * pxBda );
-void prvConnParameterUpdateCb( BTStatus_t xStatus,
-                               const BTBdaddr_t * pxBdAddr,
-                               uint32_t minInterval,
-                               uint32_t maxInterval,
-                               uint32_t latency,
-                               uint32_t usConnInterval,
-                               uint32_t timeout );
-void prvRequestReadCb( uint16_t usConnId,
-                       uint32_t ulTransId,
-                       BTBdaddr_t * pxBda,
-                       uint16_t usAttrHandle,
-                       uint16_t usOffset );
-void prvRequestWriteCb( uint16_t usConnId,
-                        uint32_t ulTransId,
-                        BTBdaddr_t * pxBda,
-                        uint16_t usAttrHandle,
-                        uint16_t usOffset,
-                        size_t xLength,
-                        bool bNeedRsp,
-                        bool bIsPrep,
-                        uint8_t * pucValue );
-void prvIndicationSentCb( uint16_t usConnId,
-                          BTStatus_t xStatus );
-void prvResponseConfirmationCb( BTStatus_t xStatus,
-                                uint16_t usHandle );
-void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
-                      BTBdname_t * pxRemoteBdName,
-                      uint32_t ulCod,
-                      BTSspVariant_t xPairingVariant,
-                      uint32_t ulPassKey );
-void prvPairingStateChangedCb( BTStatus_t xStatus,
-                               BTBdaddr_t * pxRemoteBdAddr,
-                               BTBondState_t xState,
-                               BTSecurityLevel_t xSecurityLevel,
-                               BTAuthFailureReason_t xReason );
-void prvRequestExecWriteCb( uint16_t usConnId,
+                                    uint16_t usInclSrvcHandle );
+    void prvServiceStartedCb( BTStatus_t xStatus,
+                              uint8_t ucServerIf,
+                              uint16_t usServiceHandle );
+    void prvServiceStoppedCb( BTStatus_t xStatus,
+                              uint8_t ucServerIf,
+                              uint16_t usServiceHandle );
+    void prvServiceDeletedCb( BTStatus_t xStatus,
+                              uint8_t ucServerIf,
+                              uint16_t usServiceHandle );
+    void prvCharacteristicAddedCb( BTStatus_t xStatus,
+                                   uint8_t ucServerIf,
+                                   BTUuid_t * pxUuid,
+                                   uint16_t usServiceHandle,
+                                   uint16_t usCharHandle );
+    void prvCharacteristicDescrAddedCb( BTStatus_t xStatus,
+                                        uint8_t ucServerIf,
+                                        BTUuid_t * pxUuid,
+                                        uint16_t usServiceHandle,
+                                        uint16_t usCharHandle );
+    void prvAdapterPropertiesCb( BTStatus_t xStatus,
+                                 uint32_t ulNumProperties,
+                                 BTProperty_t * pxProperties );
+    void prvSetAdvDataCb( BTStatus_t xStatus );
+    void prvAdvStatusCb( BTStatus_t xStatus,
+                         uint32_t ulServerIf,
+                         bool bStart );
+    void prvConnectionCb( uint16_t usConnId,
+                          uint8_t ucServerIf,
+                          bool bConnected,
+                          BTBdaddr_t * pxBda );
+    void prvConnParameterUpdateCb( BTStatus_t xStatus,
+                                   const BTBdaddr_t * pxBdAddr,
+                                   uint32_t minInterval,
+                                   uint32_t maxInterval,
+                                   uint32_t latency,
+                                   uint32_t usConnInterval,
+                                   uint32_t timeout );
+    void prvRequestReadCb( uint16_t usConnId,
+                           uint32_t ulTransId,
+                           BTBdaddr_t * pxBda,
+                           uint16_t usAttrHandle,
+                           uint16_t usOffset );
+    void prvRequestWriteCb( uint16_t usConnId,
                             uint32_t ulTransId,
                             BTBdaddr_t * pxBda,
-                            bool bExecWrite );
-void prvBondedCb( BTStatus_t xStatus,
-                  BTBdaddr_t * pxRemoteBdAddr,
-                  bool bIsBonded );
-void prvStartStopAdvCheck( bool start );
-BTStatus_t bleStackInit( void );
-void prvBLEManagerInit( void );
-void prvBLEEnable( bool bEnable );
-void prvStartService( BTService_t * xRefSrvc );
+                            uint16_t usAttrHandle,
+                            uint16_t usOffset,
+                            size_t xLength,
+                            bool bNeedRsp,
+                            bool bIsPrep,
+                            uint8_t * pucValue );
+    void prvIndicationSentCb( uint16_t usConnId,
+                              BTStatus_t xStatus );
+    void prvResponseConfirmationCb( BTStatus_t xStatus,
+                                    uint16_t usHandle );
+    void prvSspRequestCb( BTBdaddr_t * pxRemoteBdAddr,
+                          BTBdname_t * pxRemoteBdName,
+                          uint32_t ulCod,
+                          BTSspVariant_t xPairingVariant,
+                          uint32_t ulPassKey );
+    void prvPairingStateChangedCb( BTStatus_t xStatus,
+                                   BTBdaddr_t * pxRemoteBdAddr,
+                                   BTBondState_t xState,
+                                   BTSecurityLevel_t xSecurityLevel,
+                                   BTAuthFailureReason_t xReason );
+    void prvRequestExecWriteCb( uint16_t usConnId,
+                                uint32_t ulTransId,
+                                BTBdaddr_t * pxBda,
+                                bool bExecWrite );
+    void prvBondedCb( BTStatus_t xStatus,
+                      BTBdaddr_t * pxRemoteBdAddr,
+                      bool bIsBonded );
+    void prvStartStopAdvCheck( bool start );
+    BTStatus_t bleStackInit( void );
+    void prvBLEManagerInit( void );
+    void prvBLEEnable( bool bEnable );
+    void prvStartService( BTService_t * xRefSrvc );
 /* void prvCreateService( BTService_t * xRefSrvc ); */
-void prvCreateServiceA( void );
-void prvCreateServiceB( void );
-void prvWaitConnection( bool bConnected );
-void prvStopService( BTService_t * xRefSrvc );
-void prvDeleteService( BTService_t * xRefSrvc );
+    void prvCreateServiceA( void );
+    void prvCreateServiceB( void );
+    void prvWaitConnection( bool bConnected );
+    void prvStopService( BTService_t * xRefSrvc );
+    void prvDeleteService( BTService_t * xRefSrvc );
 /* void prvCreateCharacteristic( BTService_t * xSrvc, */
 /*                               int xAttribute ); */
 /* void prvCreateCharacteristicDescriptor( BTService_t * xSrvc, */
 /*                                         int xAttribute ); */
-void checkNotificationIndication( bletestAttSrvB_t xAttribute,
-                                  bool enable );
-void prvBTUnregister( void );
-void prvBLEGAPInit( void );
-void prvBLEGATTInit( void );
-void prvSetAdvProperty( void );
-void prvSetAdvData( void );
+    void checkNotificationIndication( bletestAttSrvB_t xAttribute,
+                                      bool enable );
+    void prvBTUnregister( void );
+    void prvBLEGAPInit( void );
+    void prvBLEGATTInit( void );
+    void prvSetAdvProperty( void );
+    void prvSetAdvData( void );
 
 #endif /* _IOT_TEST_BLE_HAL_COMMON_H */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
@@ -38,12 +38,12 @@
 
 #define bletestsFAIL_CHAR_VALUE    "fail"
 
-    void prvGAPInitEnableTwice( void );
+void prvGAPInitEnableTwice( void );
 
-    void prvGetResult( bletestAttSrvB_t xAttribute,
-                       bool IsPrep,
-                       uint16_t usOffset );
-    void prvCreateAndStartServiceB( void );
+void prvGetResult( bletestAttSrvB_t xAttribute,
+                   bool IsPrep,
+                   uint16_t usOffset );
+void prvCreateAndStartServiceB( void );
 /* void prvCreateService( BTService_t * xRefSrvc ); */
 
 #endif /* ifndef _IOT_TEST_BLE_HAL_INTEGRATION_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
@@ -24,13 +24,26 @@
  */
 
 /**
- * @file iot_test_ble_hal_stress_test.h
+ *
+ * @file iot_test_ble_hal_integration.h
  * @brief
  */
 
-#ifndef _IOT_TEST_BLE_HAL_INTEGRATION_TEST_H_
-#define _IOT_TEST_BLE_HAL_INTEGRATION_TEST_H_
+
+
+#ifndef _IOT_TEST_BLE_HAL_INTEGRATION_H_
+#define _IOT_TEST_BLE_HAL_INTEGRATION_H_
 
 #include "iot_test_ble_hal_common.h"
 
-#endif /* _IOT_TEST_BLE_HAL_INTEGRATION_TEST_H_ */
+#define bletestsFAIL_CHAR_VALUE    "fail"
+
+void prvGAPInitEnableTwice( void );
+
+void prvGetResult( bletestAttSrvB_t xAttribute,
+                   bool IsPrep,
+                   uint16_t usOffset );
+void prvCreateAndStartServiceB( void );
+/* void prvCreateService( BTService_t * xRefSrvc ); */
+
+#endif /* ifndef _IOT_TEST_BLE_HAL_INTEGRATION_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_integration.h
@@ -38,12 +38,12 @@
 
 #define bletestsFAIL_CHAR_VALUE    "fail"
 
-void prvGAPInitEnableTwice( void );
+    void prvGAPInitEnableTwice( void );
 
-void prvGetResult( bletestAttSrvB_t xAttribute,
-                   bool IsPrep,
-                   uint16_t usOffset );
-void prvCreateAndStartServiceB( void );
+    void prvGetResult( bletestAttSrvB_t xAttribute,
+                       bool IsPrep,
+                       uint16_t usOffset );
+    void prvCreateAndStartServiceB( void );
 /* void prvCreateService( BTService_t * xRefSrvc ); */
 
 #endif /* ifndef _IOT_TEST_BLE_HAL_INTEGRATION_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_kpi.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_kpi.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iot_test_ble_hal_stress_test.h
+ * @file iot_test_ble_hal_kpi.h
  * @brief
  */
 
@@ -32,5 +32,7 @@
 #define _IOT_TEST_BLE_HAL_STRESS_TEST_H_
 
 #include "iot_test_ble_hal_common.h"
+
+#define TOTAL_NUMBER_RECONNECT    3
 
 #endif /* _IOT_TEST_BLE_HAL_STRESS_TEST_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
@@ -33,11 +33,15 @@
 
 #include "iot_test_ble_hal_common.h"
 
+
+/*The stress test cases are related.
+ * e.g. If only one stress test case needs to be run,
+ * the parameters of outside cases should be set to 1 and inside and parallel ones should be set to 0.*/
 #define RESTART_NUMBER_STRESS_TEST           1
 #define RECONNECT_NUMBER_STRESS_TEST         1
 #define INIT_DEINIT_NUMBER_STRESS_TEST       1
 #define ENABLE_DISABLE_NUMBER_STRESS_TEST    1
 
-void prvRestartService( BTService_t * xRefSrvc );
+    void prvRestartService( BTService_t * xRefSrvc );
 
 #endif /* _IOT_TEST_BLE_HAL_STRESS_TEST_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
@@ -33,6 +33,11 @@
 
 #include "iot_test_ble_hal_common.h"
 
-static void prvDeviceStateChangedCb( BTState_t xState );
+#define RESTART_NUMBER_STRESS_TEST           1
+#define RECONNECT_NUMBER_STRESS_TEST         1
+#define INIT_DEINIT_NUMBER_STRESS_TEST       1
+#define ENABLE_DISABLE_NUMBER_STRESS_TEST    1
+
+void prvRestartService( BTService_t * xRefSrvc );
 
 #endif /* _IOT_TEST_BLE_HAL_STRESS_TEST_H_ */

--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_stress_test.h
@@ -42,6 +42,6 @@
 #define INIT_DEINIT_NUMBER_STRESS_TEST       1
 #define ENABLE_DISABLE_NUMBER_STRESS_TEST    1
 
-    void prvRestartService( BTService_t * xRefSrvc );
+void prvRestartService( BTService_t * xRefSrvc );
 
 #endif /* _IOT_TEST_BLE_HAL_STRESS_TEST_H_ */

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -1234,6 +1234,19 @@ TEST( Full_BLE, BLE_Initialize_BLE_GAP )
     prvBLEGAPInit();
 }
 
+void prvBLEManagerInit()
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+
+    /* Get BT interface */
+    _pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
+    TEST_ASSERT_NOT_EQUAL( NULL, _pxBTInterface );
+
+    /* Initialize callbacks */
+    xStatus = _pxBTInterface->pxBtManagerInit( &_xBTManagerCb );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
 void prvBLEGAPInit()
 {
     BTStatus_t xStatus = eBTStatusSuccess;
@@ -1275,19 +1288,6 @@ void prvBLESetUp()
     }
 
     IotListDouble_Create( &eventQueueHead );
-}
-
-void prvBLEManagerInit()
-{
-    BTStatus_t xStatus = eBTStatusSuccess;
-
-    /* Get BT interface */
-    _pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
-    TEST_ASSERT_NOT_EQUAL( NULL, _pxBTInterface );
-
-    /* Initialize callbacks */
-    xStatus = _pxBTInterface->pxBtManagerInit( &_xBTManagerCb );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }
 
 void prvBLEEnable( bool bEnable )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -35,27 +35,16 @@ IotSemaphore_t g_eventSemaphore;
 
 BTInterface_t * g_pxBTInterface;
 BTBleAdapter_t * g_pxBTLeAdapterInterface;
-BTUuid_t g_xServerUUID =
-{
-    .ucType   = eBTuuidType128,
-    .uu.uu128 = bletestsSERVER_UUID
-};
-BTUuid_t g_xAppUUID =
-{
-    .ucType   = eBTuuidType128,
-    .uu.uu128 = bletestsAPP_UUID
-};
-uint8_t g_ucBLEAdapterIf;
-uint8_t g_ucBLEServerIf;
-BTBdaddr_t g_xAddressConnectedDevice;
-BTGattServerInterface_t * g_pxGattServerInterface;
-uint16_t g_usBLEConnId;
 
+uint16_t usHandlesBufferA[ bletestATTR_SRVCA_NUMBER ];
+uint16_t usHandlesBufferB[ bletestATTR_SRVCB_NUMBER ];
 
 uint8_t ucCbPropertyBuffer[ bletestsMAX_PROPERTY_SIZE ];
 uint32_t usCbConnInterval;
 
-static uint16_t usHandlesBufferA[ bletestATTR_SRVCA_NUMBER ];
+response_t ucRespBuffer[ bletestATTR_SRVCB_NUMBER ];
+
+/* service A */
 
 static const BTAttribute_t pxAttributeTableA[] =
 {
@@ -73,7 +62,7 @@ static const BTAttribute_t pxAttributeTableA[] =
     }
 };
 
-BTService_t xSrvcA =
+BTService_t g_xSrvcA =
 {
     .ucInstId            = 0,
     .xType               = eBTServiceTypePrimary,
@@ -82,77 +71,7 @@ BTService_t xSrvcA =
     .pxBLEAttributes     = ( BTAttribute_t * ) pxAttributeTableA
 };
 
-static BTCallbacks_t xBTManagerCb =
-{
-    .pxDeviceStateChangedCb     = prvDeviceStateChangedCb,
-    .pxAdapterPropertiesCb      = prvAdapterPropertiesCb,
-    .pxRemoteDevicePropertiesCb = NULL,
-    .pxSspRequestCb             = prvSspRequestCb,
-    .pxPairingStateChangedCb    = prvPairingStateChangedCb,
-    .pxBondedCb                 = prvBondedCb,
-    .pxDutModeRecvCb            = NULL,
-    .pxleTestModeCb             = NULL,
-    .pxEnergyInfoCb             = NULL,
-    .pxReadRssiCb               = NULL,
-    .pxTxPowerCb                = NULL,
-    .pxSlaveSecurityRequestCb   = NULL,
-};
-
-static BTBleAdapterCallbacks_t xBTBleAdapterCb =
-{
-    .pxRegisterBleAdapterCb          = prvRegisterBleAdapterCb,
-    .pxScanResultCb                  = NULL,
-    .pxBleAdapterPropertiesCb        = NULL,
-    .pxBleRemoteDevicePropertiesCb   = NULL,
-    .pxOpenCb                        = NULL,
-    .pxCloseCb                       = NULL,
-    .pxReadRemoteRssiCb              = NULL,
-    .pxAdvStatusCb                   = prvAdvStatusCb,
-    .pxSetAdvDataCb                  = prvSetAdvDataCb,
-    .pxConnParameterUpdateCb         = prvConnParameterUpdateCb,
-    .pxScanFilterCfgCb               = NULL,
-    .pxScanFilterParamCb             = NULL,
-    .pxScanFilterStatusCb            = NULL,
-    .pxMultiAdvEnableCb              = NULL,
-    .pxMultiAdvUpdateCb              = NULL,
-    .pxMultiAdvDataCb                = NULL,
-    .pxMultiAdvDisableCb             = NULL,
-    .pxCongestionCb                  = NULL,
-    .pxBatchscanCfgStorageCb         = NULL,
-    .pxBatchscanEnbDisableCb         = NULL,
-    .pxBatchscanReportsCb            = NULL,
-    .pxBatchscanThresholdCb          = NULL,
-    .pxTrackAdvEventCb               = NULL,
-    .pxScanParameterSetupCompletedCb = NULL,
-    .pxPhyUpdatedCb                  = NULL,
-};
-
-static BTGattServerCallbacks_t xBTGattServerCb =
-{
-    .pxRegisterServerCb       = prvBTRegisterServerCb,
-    .pxUnregisterServerCb     = prvBTUnregisterServerCb,
-    .pxConnectionCb           = prvConnectionCb,
-    .pxServiceAddedCb         = prvServiceAddedCb,
-    .pxIncludedServiceAddedCb = prvIncludedServiceAddedCb,
-    .pxCharacteristicAddedCb  = prvCharacteristicAddedCb,
-    .pxSetValCallbackCb       = NULL,
-    .pxDescriptorAddedCb      = prvCharacteristicDescrAddedCb,
-    .pxServiceStartedCb       = prvServiceStartedCb,
-    .pxServiceStoppedCb       = prvServiceStoppedCb,
-    .pxServiceDeletedCb       = prvServiceDeletedCb,
-    .pxRequestReadCb          = prvRequestReadCb,
-    .pxRequestWriteCb         = prvRequestWriteCb,
-    .pxRequestExecWriteCb     = prvRequestExecWriteCb,
-    .pxResponseConfirmationCb = prvResponseConfirmationCb,
-    .pxIndicationSentCb       = prvIndicationSentCb,
-    .pxCongestionCb           = NULL,
-    .pxMtuChangedCb           = NULL
-};
-
-
-response_t ucRespBuffer[ bletestATTR_SRVCB_NUMBER ];
-
-static uint16_t usHandlesBufferB[ bletestATTR_SRVCB_NUMBER ];
+/* Service B */
 
 static const BTAttribute_t pxAttributeTableB[] =
 {
@@ -266,12 +185,12 @@ static const BTAttribute_t pxAttributeTableB[] =
         .xIncludedService =
         {
             .xUuid          = bletestsFREERTOS_SVC_A_UUID,
-            .pxPtrToService = &xSrvcA
+            .pxPtrToService = &g_xSrvcA
         }
     }
 };
 
-BTService_t xSrvcB =
+BTService_t g_xSrvcB =
 {
     .ucInstId            = 0,
     .xType               = eBTServiceTypePrimary,
@@ -281,7 +200,7 @@ BTService_t xSrvcB =
 };
 
 
-BTGattAdvertismentParams_t xAdvertisementConfigA =
+BTGattAdvertismentParams_t g_xAdvertisementConfigA =
 {
     .usAdvertisingEventProperties = BTAdvInd,
     .bIncludeTxPower              = true,
@@ -296,7 +215,7 @@ BTGattAdvertismentParams_t xAdvertisementConfigA =
     .xAddrType                    = BTAddrTypePublic,
 };
 
-BTGattAdvertismentParams_t xAdvertisementConfigB =
+BTGattAdvertismentParams_t g_xAdvertisementConfigB =
 {
     .usAdvertisingEventProperties = BTAdvInd,
     .bIncludeTxPower              = true,
@@ -318,6 +237,94 @@ IotBleConnectionParam_t xConnectionParamA =
     .latency     = 4,
     .timeout     = 400
 };
+
+BTUuid_t g_xServerUUID =
+{
+    .ucType   = eBTuuidType128,
+    .uu.uu128 = bletestsSERVER_UUID
+};
+BTUuid_t g_xAppUUID =
+{
+    .ucType   = eBTuuidType128,
+    .uu.uu128 = bletestsAPP_UUID
+};
+
+uint8_t g_ucBLEAdapterIf;
+uint8_t g_ucBLEServerIf;
+BTBdaddr_t g_xAddressConnectedDevice;
+BTGattServerInterface_t * g_pxGattServerInterface;
+uint16_t g_usBLEConnId;
+
+const uint32_t bletestWAIT_MODE1_LEVEL2_QUERY = 10000; /* Wait 10s max */
+
+BTCallbacks_t g_xBTManagerCb =
+{
+    .pxDeviceStateChangedCb     = prvDeviceStateChangedCb,
+    .pxAdapterPropertiesCb      = prvAdapterPropertiesCb,
+    .pxRemoteDevicePropertiesCb = NULL,
+    .pxSspRequestCb             = prvSspRequestCb,
+    .pxPairingStateChangedCb    = prvPairingStateChangedCb,
+    .pxBondedCb                 = prvBondedCb,
+    .pxDutModeRecvCb            = NULL,
+    .pxleTestModeCb             = NULL,
+    .pxEnergyInfoCb             = NULL,
+    .pxReadRssiCb               = NULL,
+    .pxTxPowerCb                = NULL,
+    .pxSlaveSecurityRequestCb   = NULL,
+};
+
+BTBleAdapterCallbacks_t g_xBTBleAdapterCb =
+{
+    .pxRegisterBleAdapterCb          = prvRegisterBleAdapterCb,
+    .pxScanResultCb                  = NULL,
+    .pxBleAdapterPropertiesCb        = NULL,
+    .pxBleRemoteDevicePropertiesCb   = NULL,
+    .pxOpenCb                        = NULL,
+    .pxCloseCb                       = NULL,
+    .pxReadRemoteRssiCb              = NULL,
+    .pxAdvStatusCb                   = prvAdvStatusCb,
+    .pxSetAdvDataCb                  = prvSetAdvDataCb,
+    .pxConnParameterUpdateCb         = prvConnParameterUpdateCb,
+    .pxScanFilterCfgCb               = NULL,
+    .pxScanFilterParamCb             = NULL,
+    .pxScanFilterStatusCb            = NULL,
+    .pxMultiAdvEnableCb              = NULL,
+    .pxMultiAdvUpdateCb              = NULL,
+    .pxMultiAdvDataCb                = NULL,
+    .pxMultiAdvDisableCb             = NULL,
+    .pxCongestionCb                  = NULL,
+    .pxBatchscanCfgStorageCb         = NULL,
+    .pxBatchscanEnbDisableCb         = NULL,
+    .pxBatchscanReportsCb            = NULL,
+    .pxBatchscanThresholdCb          = NULL,
+    .pxTrackAdvEventCb               = NULL,
+    .pxScanParameterSetupCompletedCb = NULL,
+    .pxPhyUpdatedCb                  = NULL,
+};
+
+
+BTGattServerCallbacks_t g_xBTGattServerCb =
+{
+    .pxRegisterServerCb       = prvBTRegisterServerCb,
+    .pxUnregisterServerCb     = prvBTUnregisterServerCb,
+    .pxConnectionCb           = prvConnectionCb,
+    .pxServiceAddedCb         = prvServiceAddedCb,
+    .pxIncludedServiceAddedCb = prvIncludedServiceAddedCb,
+    .pxCharacteristicAddedCb  = prvCharacteristicAddedCb,
+    .pxSetValCallbackCb       = NULL,
+    .pxDescriptorAddedCb      = prvCharacteristicDescrAddedCb,
+    .pxServiceStartedCb       = prvServiceStartedCb,
+    .pxServiceStoppedCb       = prvServiceStoppedCb,
+    .pxServiceDeletedCb       = prvServiceDeletedCb,
+    .pxRequestReadCb          = prvRequestReadCb,
+    .pxRequestWriteCb         = prvRequestWriteCb,
+    .pxRequestExecWriteCb     = prvRequestExecWriteCb,
+    .pxResponseConfirmationCb = prvResponseConfirmationCb,
+    .pxIndicationSentCb       = prvIndicationSentCb,
+    .pxCongestionCb           = NULL,
+    .pxMtuChangedCb           = NULL
+};
+
 /*-----------------------------------------------------------*/
 
 TEST_GROUP( Full_BLE );
@@ -399,27 +406,7 @@ void prvRemoveBond( BTBdaddr_t * pxDeviceAddress )
 
 TEST( Full_BLE, BLE_Setup )
 {
-    BTStatus_t xStatus;
-
-    xStatus = bleStackInit();
-
-    if( xStatus != eBTStatusSuccess )
-    {
-        TEST_FAIL_MESSAGE( "Unable to initialize BLE stask.\n" );
-    }
-
-    /* Create a queue, semaphore and mutexes for callbacks. */
-    if( IotMutex_Create( &g_threadSafetyMutex, false ) != true )
-    {
-        TEST_FAIL_MESSAGE( "Could not create g_threadSafetyMutex.\n" );
-    }
-
-    if( IotSemaphore_Create( &g_eventSemaphore, 0, MAX_EVENT ) != true )
-    {
-        TEST_FAIL_MESSAGE( "Could not create g_eventSemaphore.\n" );
-    }
-
-    IotListDouble_Create( &g_eventQueueHead );
+    prvBLESetUp();
 }
 
 TEST( Full_BLE, BLE_Free )
@@ -920,6 +907,12 @@ TEST( Full_BLE, BLE_Advertising_StartAdvertisement )
 
 TEST( Full_BLE, BLE_Advertising_SetAvertisementData )
 {
+    prvSetAdvData();
+}
+
+
+void prvSetAdvData( void )
+{
     uint16_t usServiceDataLen;
     char * pcServiceData;
     BTUuid_t xServiceUuid =
@@ -934,14 +927,14 @@ TEST( Full_BLE, BLE_Advertising_SetAvertisementData )
     pcServiceData = NULL;
     xNbServices = 1;
 
-    prvSetAdvertisement( &xAdvertisementConfigA,
+    prvSetAdvertisement( &g_xAdvertisementConfigA,
                          usServiceDataLen,
                          pcServiceData,
                          &xServiceUuid,
                          xNbServices );
 
 
-    prvSetAdvertisement( &xAdvertisementConfigB,
+    prvSetAdvertisement( &g_xAdvertisementConfigB,
                          usServiceDataLen,
                          pcServiceData,
                          NULL,
@@ -984,6 +977,11 @@ void prvSetGetProperty( BTProperty_t * pxProperty,
 }
 
 TEST( Full_BLE, BLE_Advertising_SetProperties )
+{
+    prvSetAdvProperty();
+}
+
+void prvSetAdvProperty( void )
 {
     BTProperty_t pxProperty;
     uint16_t usMTUsize = bletestsMTU_SIZE1;
@@ -1028,15 +1026,15 @@ TEST( Full_BLE, BLE_CreateAttTable_IncludedService )
     BTStatus_t xStatus = eBTStatusSuccess;
 
     xStatus = g_pxGattServerInterface->pxAddIncludedService( g_ucBLEServerIf,
-                                                             xSrvcB.pusHandlesBuffer[ 0 ],
-                                                             xSrvcA.pusHandlesBuffer[ 0 ] );
+                                                             g_xSrvcB.pusHandlesBuffer[ 0 ],
+                                                             g_xSrvcA.pusHandlesBuffer[ 0 ] );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
     xStatus = prvWaitEventFromQueue( eBLEHALEventIncludedServiceAdded, NO_HANDLE, ( void * ) &xBLETESTInclServiceCb, sizeof( BLETESTAttrCallback_t ), BLE_TESTS_WAIT );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xBLETESTInclServiceCb.xStatus );
-    TEST_ASSERT_EQUAL( xSrvcB.pusHandlesBuffer[ 0 ], xBLETESTInclServiceCb.usSrvHandle );
-    xSrvcB.pusHandlesBuffer[ bletestATTR_INCLUDED_SERVICE ] = xBLETESTInclServiceCb.usAttrHandle;
+    TEST_ASSERT_EQUAL( g_xSrvcB.pusHandlesBuffer[ 0 ], xBLETESTInclServiceCb.usSrvHandle );
+    g_xSrvcB.pusHandlesBuffer[ bletestATTR_INCLUDED_SERVICE ] = xBLETESTInclServiceCb.usAttrHandle;
 }
 
 void prvCreateCharacteristicDescriptor( BTService_t * xSrvc,
@@ -1152,43 +1150,60 @@ TEST( Full_BLE, BLE_CreateAttTable_CreateServices )
 
     /* Try to create using blob service API first.
      * If blob is not supported then try legacy APIs. */
-    xStatus = g_pxGattServerInterface->pxAddServiceBlob( g_ucBLEServerIf, &xSrvcA );
+    xStatus = g_pxGattServerInterface->pxAddServiceBlob( g_ucBLEServerIf, &g_xSrvcA );
 
     if( xStatus != eBTStatusUnsupported )
     {
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-        xStatus = g_pxGattServerInterface->pxAddServiceBlob( g_ucBLEServerIf, &xSrvcB );
+        xStatus = g_pxGattServerInterface->pxAddServiceBlob( g_ucBLEServerIf, &g_xSrvcB );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
     }
     else
     {
         /* Create service A */
-        prvCreateService( &xSrvcA );
-        prvCreateCharacteristic( &xSrvcA, bletestATTR_SRVCA_CHAR_A );
+        prvCreateServiceA();
 
         /* Create service B */
-        prvCreateService( &xSrvcB );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_A );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_B );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_C );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_D );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_E );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CCCD_E );
-        prvCreateCharacteristic( &xSrvcB, bletestATTR_SRVCB_CHAR_F );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CCCD_F );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_A );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_B );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_C );
-        prvCreateCharacteristicDescriptor( &xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_D );
+        prvCreateServiceB();
 
         /* Start service A */
-        prvStartService( &xSrvcA );
+        prvStartService( &g_xSrvcA );
         /* Start service B */
-        prvStartService( &xSrvcB );
+        prvStartService( &g_xSrvcB );
     }
 }
 
+void prvCreateServiceA()
+{
+    prvCreateService( &g_xSrvcA );
+    prvCreateCharacteristic( &g_xSrvcA, bletestATTR_SRVCA_CHAR_A );
+}
+
+void prvCreateServiceB()
+{
+    prvCreateService( &g_xSrvcB );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_A );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_B );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_C );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_D );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_E );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CCCD_E );
+    prvCreateCharacteristic( &g_xSrvcB, bletestATTR_SRVCB_CHAR_F );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CCCD_F );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_A );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_B );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_C );
+    prvCreateCharacteristicDescriptor( &g_xSrvcB, bletestATTR_SRVCB_CHARF_DESCR_D );
+}
+
+
+
 TEST( Full_BLE, BLE_Initialize_BLE_GATT )
+{
+    prvBLEGATTInit();
+}
+
+void prvBLEGATTInit()
 {
     BTStatus_t xStatus = eBTStatusSuccess;
     BLETESTInitDeinitCallback_t xInitDeinitCb;
@@ -1196,7 +1211,7 @@ TEST( Full_BLE, BLE_Initialize_BLE_GATT )
     g_pxGattServerInterface = ( BTGattServerInterface_t * ) g_pxBTLeAdapterInterface->ppvGetGattServerInterface();
     TEST_ASSERT_NOT_EQUAL( NULL, g_pxGattServerInterface );
 
-    g_pxGattServerInterface->pxGattServerInit( &xBTGattServerCb );
+    g_pxGattServerInterface->pxGattServerInit( &g_xBTGattServerCb );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
     xStatus = g_pxGattServerInterface->pxRegisterServer( &g_xServerUUID );
@@ -1209,27 +1224,16 @@ TEST( Full_BLE, BLE_Initialize_BLE_GATT )
 
 TEST( Full_BLE, BLE_Initialize_common_GAP )
 {
-    BTStatus_t xStatus = eBTStatusSuccess;
-    BLETESTInitDeinitCallback_t xInitDeinitCb;
-
-    /* Get BT interface */
-    g_pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
-    TEST_ASSERT_NOT_EQUAL( NULL, g_pxBTInterface );
-
-    /* Initialize callbacks */
-    xStatus = g_pxBTInterface->pxBtManagerInit( &xBTManagerCb );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    /* Enable RADIO and wait for callback. */
-    xStatus = g_pxBTInterface->pxEnable( 0 );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
+    prvBLEManagerInit();
+    prvBLEEnable( true );
 }
 
 TEST( Full_BLE, BLE_Initialize_BLE_GAP )
+{
+    prvBLEGAPInit();
+}
+
+void prvBLEGAPInit()
 {
     BTStatus_t xStatus = eBTStatusSuccess;
     BLETESTInitDeinitCallback_t xInitDeinitCb;
@@ -1237,7 +1241,7 @@ TEST( Full_BLE, BLE_Initialize_BLE_GAP )
     g_pxBTLeAdapterInterface = ( BTBleAdapter_t * ) g_pxBTInterface->pxGetLeAdapter();
     TEST_ASSERT_NOT_EQUAL( NULL, g_pxBTLeAdapterInterface );
 
-    xStatus = g_pxBTLeAdapterInterface->pxBleAdapterInit( &xBTBleAdapterCb );
+    xStatus = g_pxBTLeAdapterInterface->pxBleAdapterInit( &g_xBTBleAdapterCb );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
     xStatus = g_pxBTLeAdapterInterface->pxRegisterBleApp( &g_xAppUUID );
@@ -1247,18 +1251,79 @@ TEST( Full_BLE, BLE_Initialize_BLE_GAP )
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xInitDeinitCb.xStatus );
 }
 
-void prvStopAndDeleteService( BTService_t * xRefSrvc )
+void prvBLESetUp()
+{
+    BTStatus_t xStatus;
+
+    xStatus = bleStackInit();
+
+    if( xStatus != eBTStatusSuccess )
+    {
+        TEST_FAIL_MESSAGE( "Unable to initialize BLE stack.\n" );
+    }
+
+    /* Create a queue, semaphore and mutexes for callbacks. */
+    if( IotMutex_Create( &g_threadSafetyMutex, false ) != true )
+    {
+        TEST_FAIL_MESSAGE( "Could not create g_threadSafetyMutex.\n" );
+    }
+
+    if( IotSemaphore_Create( &g_eventSemaphore, 0, MAX_EVENT ) != true )
+    {
+        TEST_FAIL_MESSAGE( "Could not create g_eventSemaphore.\n" );
+    }
+
+    IotListDouble_Create( &g_eventQueueHead );
+}
+
+void prvBLEManagerInit()
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+
+    /* Get BT interface */
+    g_pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
+    TEST_ASSERT_NOT_EQUAL( NULL, g_pxBTInterface );
+
+    /* Initialize callbacks */
+    xStatus = g_pxBTInterface->pxBtManagerInit( &g_xBTManagerCb );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+void prvBLEEnable( bool bEnable )
+{
+    BLETESTInitDeinitCallback_t xInitDeinitCb;
+    BTStatus_t xStatus = eBTStatusSuccess;
+
+    /* Enable RADIO and wait for callback. */
+    if( bEnable )
+    {
+        xStatus = g_pxBTInterface->pxEnable( 0 );
+    }
+    else
+    {
+        xStatus = g_pxBTInterface->pxDisable( 0 );
+    }
+
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    if( bEnable )
+    {
+        TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
+    }
+    else
+    {
+        TEST_ASSERT_EQUAL( eBTstateOff, xInitDeinitCb.xBLEState );
+    }
+}
+
+
+void prvDeleteService( BTService_t * xRefSrvc )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
     BLETESTServiceCallback_t xStopDeleteServiceCb;
-
-
-    xStatus = g_pxGattServerInterface->pxStopService( g_ucBLEServerIf, xRefSrvc->pusHandlesBuffer[ 0 ] );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = prvWaitEventFromQueue( eBLEHALEventServiceStoppedCb, xRefSrvc->pusHandlesBuffer[ 0 ], ( void * ) &xStopDeleteServiceCb, sizeof( BLETESTServiceCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStopDeleteServiceCb.xStatus );
 
     xStatus = g_pxGattServerInterface->pxDeleteService( g_ucBLEServerIf, xRefSrvc->pusHandlesBuffer[ 0 ] );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
@@ -1268,13 +1333,39 @@ void prvStopAndDeleteService( BTService_t * xRefSrvc )
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStopDeleteServiceCb.xStatus );
 }
 
+void prvStopService( BTService_t * xRefSrvc )
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+    BLETESTServiceCallback_t xStopDeleteServiceCb;
+
+    xStatus = g_pxGattServerInterface->pxStopService( g_ucBLEServerIf, xRefSrvc->pusHandlesBuffer[ 0 ] );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    xStatus = prvWaitEventFromQueue( eBLEHALEventServiceStoppedCb, xRefSrvc->pusHandlesBuffer[ 0 ], ( void * ) &xStopDeleteServiceCb, sizeof( BLETESTServiceCallback_t ), BLE_TESTS_WAIT );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStopDeleteServiceCb.xStatus );
+}
+
 TEST( Full_BLE, BLE_DeInitialize )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
-    BLETESTInitDeinitCallback_t xInitDeinitCb;
 
-    prvStopAndDeleteService( &xSrvcA );
-    prvStopAndDeleteService( &xSrvcB );
+    prvStopService( &g_xSrvcA );
+    prvStopService( &g_xSrvcB );
+
+    prvDeleteService( &g_xSrvcA );
+    prvDeleteService( &g_xSrvcB );
+
+    prvBTUnregister();
+    prvBLEEnable( false );
+    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+void prvBTUnregister( void )
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+    BLETESTInitDeinitCallback_t xInitDeinitCb;
 
     xStatus = g_pxGattServerInterface->pxUnregisterServer( g_ucBLEServerIf );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
@@ -1285,17 +1376,6 @@ TEST( Full_BLE, BLE_DeInitialize )
 
 
     xStatus = g_pxBTLeAdapterInterface->pxUnregisterBleApp( g_ucBLEAdapterIf );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = g_pxBTInterface->pxDisable( 0 );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTstateOff, xInitDeinitCb.xBLEState );
-
-
-    xStatus = g_pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }
 
@@ -1938,7 +2018,8 @@ BTStatus_t prvWaitEventFromQueue( BLEHALEventsTypes_t xEventName,
             {
                 xStatus = eBTStatusFail;
             }
-        } while( xStatus == eBTStatusSuccess ); /* If there is an error exit */
+        }
+        while( xStatus == eBTStatusSuccess ); /* If there is an error exit */
     }
 
     if( xStatus == eBTStatusSuccess )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -24,17 +24,44 @@
  */
 
 /**
- * @file aws_test_ble_stress_test.c
+ * @file aws_test_ble_integration.c
  * @brief Tests for ble.
  */
 
+
+#include <time.h>
+/* #include <unistd.h> */
+
+
 #include "iot_test_ble_hal_integration.h"
 
-/*-----------------------------------------------------------*/
+extern BTUuid_t g_xServerUUID;
+extern BTUuid_t g_xAppUUID;
+
+extern BTGattAdvertismentParams_t g_xAdvertisementConfigA;
+
+extern BTGattAdvertismentParams_t g_xAdvertisementConfigB;
+
+extern BTCallbacks_t g_xBTManagerCb;
+
+extern BTBleAdapterCallbacks_t g_xBTBleAdapterCb;
+
+
+extern BTGattServerCallbacks_t g_xBTGattServerCb;
+
+extern BTGattServerInterface_t * g_pxGattServerInterface;
+extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
+extern BTInterface_t * g_pxBTInterface;
+extern uint8_t g_ucBLEAdapterIf;
+extern uint8_t g_ucBLEServerIf;
+extern uint16_t g_usBLEConnId;
+extern BTBdaddr_t g_xAddressConnectedDevice;
+
+extern BTService_t g_xSrvcB;
+extern uint16_t usHandlesBufferB[ bletestATTR_SRVCB_NUMBER ];
+
 
 TEST_GROUP( Full_BLE_Integration_Test );
-
-/*-----------------------------------------------------------*/
 
 TEST_SETUP( Full_BLE_Integration_Test )
 {
@@ -50,4 +77,223 @@ TEST_TEAR_DOWN( Full_BLE_Integration_Test )
 
 TEST_GROUP_RUNNER( Full_BLE_Integration_Test )
 {
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Init_Enable_Twice );
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Enable_Disable_BT_Module );
+
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Advertise_Without_Properties );
+    /* RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Advertise_Before_Set_Data ); */
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Advertise_Interval_Consistent_After_BT_Reset );
+
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Write_Notification_Size_Greater_Than_MTU_3 );
+
+    RUN_TEST_CASE( Full_BLE_Integration_Test, BLE_Integration_Teardown );
+    RUN_TEST_CASE( Full_BLE, BLE_Free );
+}
+
+
+TEST( Full_BLE_Integration_Test, BLE_Advertise_Without_Properties )
+{
+    prvBLEGAPInit();
+    prvBLEGATTInit();
+    prvSetAdvData();
+    prvStartAdvertisement();
+    prvWaitConnection( true );
+}
+
+TEST( Full_BLE_Integration_Test, BLE_Advertise_Before_Set_Data )
+{
+    prvStartAdvertisement();
+    prvSetAdvData();
+    BTStatus_t xStatus = g_pxBTLeAdapterInterface->pxStopAdv( g_ucBLEAdapterIf );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+TEST( Full_BLE_Integration_Test, BLE_Enable_Disable_BT_Module )
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+    BLETESTInitDeinitCallback_t xInitDeinitCb;
+    clock_t returnTime, cbRecvTime;
+
+    /* disable */
+    prvBLEEnable( false );
+
+    /* enable */
+    xStatus = g_pxBTInterface->pxEnable( 0 );
+    returnTime = clock();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
+    cbRecvTime = clock();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
+    TEST_ASSERT_LESS_THAN( CLOCKS_PER_SEC * 5, ( cbRecvTime - returnTime ) * 2 );
+}
+
+
+/* Crash if calling pxEnable twice (MTK)                                        */
+/* (1)init -> (2)enable -> (3)deinit -> (4)init -> (5)enable                    */
+/* There are 2 issues with this sequence:                                       */
+/* (4)init reset stack state to disabled even though it's still enabled         */
+/* (5)enable trigger pxEnable again while MTK stack is enabled -> mtk crashed   */
+TEST( Full_BLE_Integration_Test, BLE_Init_Enable_Twice )
+{
+    prvBLESetUp();
+    /* init -> enable -> deinit -> init -> enable */
+    prvGAPInitEnableTwice();
+}
+
+TEST( Full_BLE_Integration_Test, BLE_Advertise_Interval_Consistent_After_BT_Reset )
+{
+    prvWaitConnection( false );
+
+    BTStatus_t xStatus = eBTStatusSuccess;
+    BLETESTInitDeinitCallback_t xInitDeinitCb;
+
+    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    xStatus = g_pxBTInterface->pxBtManagerInit( &g_xBTManagerCb );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    prvBLEEnable( true );
+    prvBLEGAPInit();
+    prvBLEGATTInit();
+    prvCreateAndStartServiceB();
+    prvSetAdvProperty();
+    prvSetAdvData();
+    prvStartAdvertisement();
+
+    prvWaitConnection( true );
+    prvGetResult( bletestATTR_SRVCB_CHAR_D,
+                  false,
+                  0 );
+}
+
+TEST( Full_BLE_Integration_Test, BLE_Write_Notification_Size_Greater_Than_MTU_3 )
+{
+    BTStatus_t xStatus, xfStatus;
+    BLETESTindicateCallback_t xIndicateEvent;
+    uint8_t ucLargeBuffer[ bletestsMTU_SIZE1 + 2 ];
+
+    char bletests_MTU_2_CHAR_VALUE[ bletestsMTU_SIZE1 + 2 ];
+
+    for( int i = 0; i < bletestsMTU_SIZE1 + 1; i++ )
+    {
+        bletests_MTU_2_CHAR_VALUE[ i ] = 'a';
+    }
+
+    bletests_MTU_2_CHAR_VALUE[ bletestsMTU_SIZE1 + 1 ] = '\0';
+
+    checkNotificationIndication( bletestATTR_SRVCB_CCCD_E, true );
+    memcpy( ucLargeBuffer, bletests_MTU_2_CHAR_VALUE, bletestsMTU_SIZE1 + 1 );
+
+    xStatus = g_pxGattServerInterface->pxSendIndication( g_ucBLEServerIf,
+                                                         usHandlesBufferB[ bletestATTR_SRVCB_CHAR_E ],
+                                                         g_usBLEConnId,
+                                                         bletestsMTU_SIZE1 + 1,
+                                                         ucLargeBuffer,
+                                                         false );
+
+    if( xStatus != eBTStatusSuccess )
+    {
+        /* Notify RPI failure here. Expect to receive failure message. */
+        memcpy( ucLargeBuffer, bletestsFAIL_CHAR_VALUE, sizeof( bletestsFAIL_CHAR_VALUE ) - 1 );
+        xfStatus = g_pxGattServerInterface->pxSendIndication( g_ucBLEServerIf,
+                                                              usHandlesBufferB[ bletestATTR_SRVCB_CHAR_E ],
+                                                              g_usBLEConnId,
+                                                              sizeof( bletestsFAIL_CHAR_VALUE ) - 1,
+                                                              ucLargeBuffer,
+                                                              false );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xfStatus );
+    }
+
+    TEST_ASSERT_NOT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+TEST( Full_BLE_Integration_Test, BLE_Integration_Teardown )
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+
+    prvWaitConnection( false );
+    prvStopService( &g_xSrvcB );
+    prvDeleteService( &g_xSrvcB );
+    prvBTUnregister();
+    prvBLEEnable( false );
+
+    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+
+void prvGetResult( bletestAttSrvB_t xAttribute,
+                   bool IsPrep,
+                   uint16_t usOffset )
+{
+    BLETESTwriteAttrCallback_t xWriteEvent;
+    BLETESTconfirmCallback_t xConfirmEvent;
+    BTGattResponse_t xGattResponse;
+    BTStatus_t xStatus;
+
+    xStatus = prvWaitEventFromQueue( eBLEHALEventWriteAttrCb, usHandlesBufferB[ xAttribute ], ( void * ) &xWriteEvent, sizeof( BLETESTwriteAttrCallback_t ), BLE_TESTS_WAIT );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    TEST_ASSERT_EQUAL( IsPrep, xWriteEvent.bIsPrep );
+    TEST_ASSERT_EQUAL( 49, xWriteEvent.ucValue[ 0 ] );
+    TEST_ASSERT_EQUAL( g_usBLEConnId, xWriteEvent.usConnId );
+    TEST_ASSERT_EQUAL( 0, memcmp( &xWriteEvent.xBda, &g_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+    TEST_ASSERT_EQUAL( usOffset, xWriteEvent.usOffset );
+}
+
+void prvCreateAndStartServiceB()
+{
+    BTStatus_t xStatus;
+
+    xStatus = g_pxGattServerInterface->pxAddServiceBlob( g_ucBLEServerIf, &g_xSrvcB );
+
+    if( xStatus == eBTStatusUnsupported )
+    {
+        prvCreateServiceB();
+        prvStartService( &g_xSrvcB );
+    }
+
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+}
+
+
+void prvGAPInitEnableTwice()
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+    BLETESTInitDeinitCallback_t xInitDeinitCb;
+
+    /* Get BT interface */
+    g_pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
+    TEST_ASSERT_NOT_EQUAL( NULL, g_pxBTInterface );
+
+    uint32_t loop;
+
+    for( loop = 0; loop < 2; loop++ )
+    {
+        /* Initialize callbacks */
+        xStatus = g_pxBTInterface->pxBtManagerInit( &g_xBTManagerCb );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+        if( loop == 1 )
+        {
+            TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
+        }
+
+        /* Enable RADIO and wait for callback. */
+        xStatus = g_pxBTInterface->pxEnable( 0 );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+        xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+        TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
+
+        /*First time Deinit*/
+        if( loop == 0 )
+        {
+            xStatus = g_pxBTInterface->pxBtManagerCleanup();
+            TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+        }
+    }
 }

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -149,6 +149,9 @@ TEST( Full_BLE_Integration_Test, BLE_Advertise_Interval_Consistent_After_BT_Rese
     BTStatus_t xStatus = eBTStatusSuccess;
     BLETESTInitDeinitCallback_t xInitDeinitCb;
 
+    prvBTUnregister();
+    prvBLEEnable( false );
+
     xStatus = g_pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -185,10 +185,11 @@ TEST( Full_BLE_Integration_Test, BLE_Write_Notification_Size_Greater_Than_MTU_3 
     /* Create a data payload whose length = MTU + 1. */
     static char bletests_MTU_2_CHAR_VALUE[ bletestsMTU_SIZE1 + 2 ];
 
-    for( int i = 0; i < bletestsMTU_SIZE1 + 1; i++ )
-    {
-        bletests_MTU_2_CHAR_VALUE[ i ] = 'a';
-    }
+    /* for( int i = 0; i < bletestsMTU_SIZE1 + 1; i++ ) */
+    /* { */
+    /*     bletests_MTU_2_CHAR_VALUE[ i ] = 'a'; */
+    /* } */
+    memset( bletests_MTU_2_CHAR_VALUE, 'a', ( bletestsMTU_SIZE1 + 1 ) * sizeof( char ) );
 
     bletests_MTU_2_CHAR_VALUE[ bletestsMTU_SIZE1 + 1 ] = '\0';
 

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_kpi.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_kpi.c
@@ -30,11 +30,7 @@
 
 #include "iot_test_ble_hal_kpi.h"
 
-extern BTGattServerInterface_t * g_pxGattServerInterface;
-extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
-extern BTInterface_t * g_pxBTInterface;
-extern uint8_t g_ucBLEAdapterIf;
-extern uint8_t g_ucBLEServerIf;
+extern BTInterface_t * _pxBTInterface;
 
 /*-----------------------------------------------------------*/
 
@@ -90,6 +86,6 @@ TEST( Full_BLE_KPI_Test, BLE_KPI_Teardown )
     prvBTUnregister();
     prvBLEEnable( false );
 
-    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    xStatus = _pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_kpi.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_kpi.c
@@ -24,11 +24,17 @@
  */
 
 /**
- * @file aws_test_ble_stress_test.c
+ * @file aws_test_ble_kpi.c
  * @brief Tests for ble.
  */
 
 #include "iot_test_ble_hal_kpi.h"
+
+extern BTGattServerInterface_t * g_pxGattServerInterface;
+extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
+extern BTInterface_t * g_pxBTInterface;
+extern uint8_t g_ucBLEAdapterIf;
+extern uint8_t g_ucBLEServerIf;
 
 /*-----------------------------------------------------------*/
 
@@ -50,4 +56,40 @@ TEST_TEAR_DOWN( Full_BLE_KPI_Test )
 
 TEST_GROUP_RUNNER( Full_BLE_KPI_Test )
 {
+    RUN_TEST_CASE( Full_BLE, BLE_Setup );
+    RUN_TEST_CASE( Full_BLE, BLE_Initialize_common_GAP );
+    RUN_TEST_CASE( Full_BLE, BLE_Initialize_BLE_GAP );
+    RUN_TEST_CASE( Full_BLE, BLE_Initialize_BLE_GATT );
+
+    RUN_TEST_CASE( Full_BLE, BLE_Advertising_SetProperties ); /*@TOTO, incomplete */
+    RUN_TEST_CASE( Full_BLE, BLE_Connection_RemoveAllBonds );
+
+    RUN_TEST_CASE( Full_BLE, BLE_Advertising_SetAvertisementData ); /*@TOTO, incomplete */
+    RUN_TEST_CASE( Full_BLE_KPI_Test, BLE_KPI_ReConnect );
+
+    RUN_TEST_CASE( Full_BLE_KPI_Test, BLE_KPI_Teardown );
+    RUN_TEST_CASE( Full_BLE, BLE_Free );
+}
+
+TEST( Full_BLE_KPI_Test, BLE_KPI_ReConnect )
+{
+    uint32_t loop;
+
+    for( loop = 0; loop < TOTAL_NUMBER_RECONNECT; loop++ )
+    {
+        prvStartAdvertisement();
+        prvWaitConnection( true );
+        prvWaitConnection( false );
+    }
+}
+
+TEST( Full_BLE_KPI_Test, BLE_KPI_Teardown )
+{
+    BTStatus_t xStatus = eBTStatusSuccess;
+
+    prvBTUnregister();
+    prvBLEEnable( false );
+
+    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_stress_test.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_stress_test.c
@@ -30,14 +30,9 @@
 
 #include "iot_test_ble_hal_stress_test.h"
 
-extern BTService_t g_xSrvcA;
-extern BTService_t g_xSrvcB;
-extern BTInterface_t * g_pxBTInterface;
-extern uint8_t g_ucBLEServerIf;
-extern BTCallbacks_t g_xBTManagerCb;
-extern BTGattServerInterface_t * g_pxGattServerInterface;
-extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
-extern uint8_t g_ucBLEAdapterIf;
+extern BTService_t _xSrvcA;
+extern BTService_t _xSrvcB;
+extern BTInterface_t * _pxBTInterface;
 
 /*-----------------------------------------------------------*/
 
@@ -115,14 +110,14 @@ TEST( Full_BLE_Stress_Test, BLE_Stack_Deinit )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
 
-    xStatus = g_pxBTInterface->pxBtManagerCleanup();
+    xStatus = _pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }
 
 TEST( Full_BLE_Stress_Test, BLE_Service_Delete )
 {
-    prvDeleteService( &g_xSrvcA );
-    prvDeleteService( &g_xSrvcB );
+    prvDeleteService( &_xSrvcA );
+    prvDeleteService( &_xSrvcB );
 }
 
 TEST( Full_BLE_Stress_Test, BLE_Teardown )
@@ -138,8 +133,8 @@ TEST( Full_BLE_Stress_Test, BLE_Service_Create )
 
 TEST( Full_BLE_Stress_Test, BLE_Service_Restart )
 {
-    prvRestartService( &g_xSrvcA );
-    prvRestartService( &g_xSrvcB );
+    prvRestartService( &_xSrvcA );
+    prvRestartService( &_xSrvcB );
 }
 
 TEST( Full_BLE_Stress_Test, BLE_Connection_ReConnect )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_stress_test.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_stress_test.c
@@ -30,23 +30,14 @@
 
 #include "iot_test_ble_hal_stress_test.h"
 
-#define TOTAL_NUMBER_STRESS_TEST    10
-
-static BTCallbacks_t xBTManagerCb =
-{
-    .pxDeviceStateChangedCb     = prvDeviceStateChangedCb,
-    .pxAdapterPropertiesCb      = NULL,
-    .pxRemoteDevicePropertiesCb = NULL,
-    .pxSspRequestCb             = NULL,
-    .pxPairingStateChangedCb    = NULL,
-    .pxBondedCb                 = NULL,
-    .pxDutModeRecvCb            = NULL,
-    .pxleTestModeCb             = NULL,
-    .pxEnergyInfoCb             = NULL,
-    .pxReadRssiCb               = NULL,
-    .pxTxPowerCb                = NULL,
-    .pxSlaveSecurityRequestCb   = NULL,
-};
+extern BTService_t g_xSrvcA;
+extern BTService_t g_xSrvcB;
+extern BTInterface_t * g_pxBTInterface;
+extern uint8_t g_ucBLEServerIf;
+extern BTCallbacks_t g_xBTManagerCb;
+extern BTGattServerInterface_t * g_pxGattServerInterface;
+extern BTBleAdapter_t * g_pxBTLeAdapterInterface;
+extern uint8_t g_ucBLEAdapterIf;
 
 /*-----------------------------------------------------------*/
 
@@ -68,90 +59,108 @@ TEST_TEAR_DOWN( Full_BLE_Stress_Test )
 
 TEST_GROUP_RUNNER( Full_BLE_Stress_Test )
 {
-    uint16_t loop;
-
     /* Initializations that need to be done once for all the tests. */
     RUN_TEST_CASE( Full_BLE, BLE_Setup );
 
-    RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit_Setup );
-
-    for( loop = 0; loop < TOTAL_NUMBER_STRESS_TEST; loop++ )
+    for( uint32_t init_loop = 0; init_loop < INIT_DEINIT_NUMBER_STRESS_TEST; init_loop++ )
     {
-        RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit );
+        RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Init );
+
+        for( uint32_t enable_loop = 0; enable_loop < ENABLE_DISABLE_NUMBER_STRESS_TEST; enable_loop++ )
+        {
+            /*TODO: add some randomness to catch timing issues */
+
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Enable );
+
+            RUN_TEST_CASE( Full_BLE, BLE_Initialize_BLE_GAP );
+            RUN_TEST_CASE( Full_BLE, BLE_Initialize_BLE_GATT );
+
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Service_Create );
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Service_Restart );
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Service_Delete );
+
+            RUN_TEST_CASE( Full_BLE, BLE_Advertising_SetProperties );       /*@TOTO, incomplete */
+            RUN_TEST_CASE( Full_BLE, BLE_Connection_RemoveAllBonds );
+            RUN_TEST_CASE( Full_BLE, BLE_Advertising_SetAvertisementData ); /*@TOTO, incomplete */
+
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Connection_ReConnect );
+
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Teardown );
+
+            RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Disable );
+        }
+
+        RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Deinit );
     }
 
-    RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit_Teardown );
-
-    /* RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Simple_Connect_Setup ); */
-    /* for ( loop = 0; loop < TOTAL_NUMBER_STRESS_TEST; loop++ ) */
-    /* { */
-    /*     RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Simple_Connect ); */
-    /* } */
-    /* RUN_TEST_CASE( Full_BLE_Stress_Test, BLE_Simple_Connect_Teardown ); */
+    RUN_TEST_CASE( Full_BLE, BLE_Free );
 }
 
-TEST( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit_Setup )
+TEST( Full_BLE_Stress_Test, BLE_Stack_Init )
+{
+    prvBLEManagerInit();
+}
+
+TEST( Full_BLE_Stress_Test, BLE_Stack_Enable )
+{
+    prvBLEEnable( true );
+}
+
+TEST( Full_BLE_Stress_Test, BLE_Stack_Disable )
+{
+    prvBLEEnable( false );
+}
+
+TEST( Full_BLE_Stress_Test, BLE_Stack_Deinit )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
 
-    /* Get BT interface */
-    g_pxBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
-    TEST_ASSERT_NOT_EQUAL( NULL, g_pxBTInterface );
-
-    /* Initialize callbacks */
-    xStatus = g_pxBTInterface->pxBtManagerInit( &xBTManagerCb );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-}
-
-TEST( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit )
-{
-    BLETESTInitDeinitCallback_t xInitDeinitCb;
-    BTStatus_t xStatus = eBTStatusSuccess;
-
-    /* Enable RADIO and wait for callback. */
-    xStatus = g_pxBTInterface->pxEnable( 0 );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
-
-    /* Enable RADIO and wait for callback. */
-    xStatus = g_pxBTInterface->pxDisable( 0 );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-
-    xStatus = prvWaitEventFromQueue( eBLEHALEventEnableDisableCb, NO_HANDLE, ( void * ) &xInitDeinitCb, sizeof( BLETESTInitDeinitCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTstateOff, xInitDeinitCb.xBLEState );
-}
-
-TEST( Full_BLE_Stress_Test, BLE_Stack_Init_DeInit_Teardown )
-{
-    BTStatus_t xStatus = eBTStatusSuccess;
-
-    /* Initialize callbacks */
     xStatus = g_pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 }
 
-void prvDeviceStateChangedCb( BTState_t xState )
+TEST( Full_BLE_Stress_Test, BLE_Service_Delete )
 {
-    BLETESTInitDeinitCallback_t * pxInitDeinitCb = IotTest_Malloc( sizeof( BLETESTInitDeinitCallback_t ) );
-
-    pxInitDeinitCb->xBLEState = xState;
-    pxInitDeinitCb->xEvent.lHandle = NO_HANDLE;
-    pxInitDeinitCb->xEvent.xEventTypes = eBLEHALEventEnableDisableCb;
-    pushToQueue( &pxInitDeinitCb->xEvent.eventList );
+    prvDeleteService( &g_xSrvcA );
+    prvDeleteService( &g_xSrvcB );
 }
 
-TEST( Full_BLE_Stress_Test, BLE_Simple_Connect_Setup )
+TEST( Full_BLE_Stress_Test, BLE_Teardown )
 {
+    prvBTUnregister();
 }
 
-TEST( Full_BLE_Stress_Test, BLE_Simple_Connect )
+TEST( Full_BLE_Stress_Test, BLE_Service_Create )
 {
+    prvCreateServiceA();
+    prvCreateServiceB();
 }
 
-TEST( Full_BLE_Stress_Test, BLE_Simple_Connect_Teardown )
+TEST( Full_BLE_Stress_Test, BLE_Service_Restart )
 {
+    prvRestartService( &g_xSrvcA );
+    prvRestartService( &g_xSrvcB );
+}
+
+TEST( Full_BLE_Stress_Test, BLE_Connection_ReConnect )
+{
+    uint32_t loop;
+
+    for( loop = 0; loop < RECONNECT_NUMBER_STRESS_TEST; loop++ )
+    {
+        prvStartAdvertisement();
+        prvWaitConnection( true );
+        prvWaitConnection( false );
+    }
+}
+
+void prvRestartService( BTService_t * xRefSrvc )
+{
+    uint16_t loop;
+
+    for( loop = 0; loop < RESTART_NUMBER_STRESS_TEST; loop++ )
+    {
+        prvStartService( xRefSrvc );
+        prvStopService( xRefSrvc );
+    }
 }

--- a/tests/bleTestsScripts/startTests_integration.py
+++ b/tests/bleTestsScripts/startTests_integration.py
@@ -1,7 +1,9 @@
 import Queue
 import sys
+import os
 import threading
 import securityAgent
+import testutils
 import time
 from testClass import runTest
 from bleAdapter import bleAdapter
@@ -12,10 +14,126 @@ except ImportError:
   import gobject as GObject
 
 mainloop = GObject.MainLoop()
+notificationEvent = threading.Event()
+indicationEvent = threading.Event()
+discoveryEvent = threading.Event()
+servicesResolvedEvent = threading.Event()
+pairingEvent = threading.Event()
 
+def discoveryStartedCb(testDevice):
+    mainloop.quit()
+
+
+def discoveryEventCb(testDevice):
+    isTestSuccessFull = runTest.advertisement(testDevice)
+
+    if isTestSuccessFull == True:
+        runTest.setTestDevice(testDevice)
+        #discoveryEvent.set()
+        mainloop.quit()
+
+def notificationCb(uuid, value):
+    isNotificationTestSuccessFull = runTest.notification(uuid, value)
+    if isNotificationTestSuccessFull == True:
+        #notificationEvent.set()
+        mainloop.quit()
+
+    isIndicationTestSuccessFull = runTest.indication(uuid, value)
+    if isIndicationTestSuccessFull == True:
+        #indicationEvent.set()
+        mainloop.quit()
+
+def notificationMTUCb(uuid, value):
+    notification = runTest.notificationMTU2(uuid, value)
+    if notification == runTest.DUT_FAIL_STRING:
+        mainloop.quit()
+        runTest.isNotificationDeclinedSuccessFull = True
+    if notification == runTest.DUT_MTU_2_STRING:
+        mainloop.quit()
+        runTest.isNotificationDeclinedSuccessFull = False
+    
+            
+
+def teardown_test(agent):
+    securityAgent.removeSecurityAgent()
+
+    os.system("sudo rm -rf \"/var/lib/bluetooth/*\"")
+    os.system("sudo hciconfig hci0 reset")
+
+    testutils.removeBondedDevices()
+    return agent
+    
 def main():
-    time.sleep(2)
+    scan_filter = dict()
+
+    bleAdapter.init()
+    agent = securityAgent.createSecurityAgent()
+
+    scan_filter.update({ "UUIDs": [runTest.DUT_UUID]})
+
+    # default DUT_name: nimble(without set_property)
+    # TODO: check DUT with MAC address instead of name.
+    runTest.DUT_NAME = "nimb"
+    bleAdapter.setDiscoveryFilter(scan_filter)
+
+
+    # Advertisement interval consistent after reset test
+    # TODO: the first time uses different callback to get/check test device information. we can choose to use the second time and third time KPI to compare.
+    # First time connection
+    isTestSuccessFull = True
+    bleAdapter.startDiscovery(discoveryEventCb)
+    firstStartScan = time.time()
+    mainloop.run()
+    firstKPI = time.time() - firstStartScan
+    runTest.submitTestResult(isTestSuccessFull, runTest.advertisement)
+    bleAdapter.stopDiscovery()
+
+    testDevice = runTest.getTestDevice()
+    isTestSuccessFull = bleAdapter.connect(testDevice)
+    runTest.submitTestResult(isTestSuccessFull, runTest.simpleConnection)
+    time.sleep(2) #wait for connection parameters update
+
+    isTestSuccessFull &= bleAdapter.disconnect()
+
+    # Second time connection
+    bleAdapter.startDiscovery(discoveryStartedCb)#wait for DUT to start advertising
+    secondStartScan = time.time()
+    mainloop.run()
+    secondKPI = time.time() - secondStartScan
+    bleAdapter.stopDiscovery()
+    isConnectSuccessFull = bleAdapter.connect(testDevice)
+    isTestSuccessFull &= isConnectSuccessFull
+    runTest.submitTestResult(isTestSuccessFull, runTest.reConnection)
+
+    bleAdapter.gatt.updateLocalAttributeTable()
+    print firstKPI
+    print secondKPI
+    if secondKPI > firstKPI * 10:
+        isTestSuccessFull &= false
+
+    # write result back to peripheral
+    isTestSuccessFull &= runTest.writeResultWithoutResponse(chr(isTestSuccessFull + 48))
+    runTest.submitTestResult(isTestSuccessFull, runTest.writeWithoutResponse)
+
+
+    # Data size > MTU - 3 send notification test
+    bleAdapter.setNotificationCallBack(notificationMTUCb)
+    bleAdapter.subscribeForNotification(runTest.DUT_NOTIFY_CHAR_UUID) #subscribe for next test
+    isTestSuccessFull = True
+    mainloop.run()
+    isTestSuccessFull = runTest.isNotificationDeclinedSuccessFull
+    runTest.submitTestResult(isTestSuccessFull, runTest.notification)
+
+    # unsubscribe
+    isTestSuccessFull = bleAdapter.subscribeForNotification(runTest.DUT_NOTIFY_CHAR_UUID, subscribe = False) #unsubscribe
+    isTestSuccessFull = True
+    runTest.submitTestResult(isTestSuccessFull, runTest.removeNotification)
+
+
+    isTestSuccessFull &= bleAdapter.disconnect()
+    time.sleep(2) #wait for connection parameters update
     runTest.printTestsSummary()
+    agent = teardown_test(agent)
 
 def errorConnectCb():
     print("Connection error")

--- a/tests/bleTestsScripts/startTests_kpi.py
+++ b/tests/bleTestsScripts/startTests_kpi.py
@@ -63,6 +63,8 @@ def main():
     bleAdapter.setDiscoveryFilter(scan_filter)
 
     #KPI test
+    # Evaluate KPI from scanning start to advertisement received.
+    # Evaluate KPI from scanning start to connection created.
     isTestSuccessFull = True
     startToReceivedSum = 0
     startToConnectedSum = 0

--- a/tests/bleTestsScripts/startTests_kpi.py
+++ b/tests/bleTestsScripts/startTests_kpi.py
@@ -1,7 +1,9 @@
 import Queue
 import sys
+import os
 import threading
 import securityAgent
+import testutils
 import time
 from testClass import runTest
 from bleAdapter import bleAdapter
@@ -12,10 +14,93 @@ except ImportError:
   import gobject as GObject
 
 mainloop = GObject.MainLoop()
+notificationEvent = threading.Event()
+indicationEvent = threading.Event()
+discoveryEvent = threading.Event()
+servicesResolvedEvent = threading.Event()
+pairingEvent = threading.Event()
+
+def discoveryStartedCb(testDevice):
+    mainloop.quit()
+
+
+def discoveryEventCb(testDevice):
+    isTestSuccessFull = runTest.advertisement(testDevice)
+
+    if isTestSuccessFull == True:
+        runTest.setTestDevice(testDevice)
+        #discoveryEvent.set()
+        mainloop.quit()
+
+def notificationCb(uuid, value):
+    isNotificationTestSuccessFull = runTest.notification(uuid, value)
+    if isNotificationTestSuccessFull == True:
+        #notificationEvent.set()
+        mainloop.quit()
+
+    isIndicationTestSuccessFull = runTest.indication(uuid, value)
+    if isIndicationTestSuccessFull == True:
+        #indicationEvent.set()
+        mainloop.quit()
+
+def teardown_test(agent):
+    securityAgent.removeSecurityAgent()
+
+    os.system("sudo rm -rf \"/var/lib/bluetooth/*\"")
+    os.system("sudo hciconfig hci0 reset")
+
+    testutils.removeBondedDevices()
+    return agent
 
 def main():
+    agent = None
+    scan_filter = dict()
+
+    bleAdapter.init()
+    agent = securityAgent.createSecurityAgent(agent=agent)
+
+    scan_filter.update({ "UUIDs": [runTest.DUT_UUID]})
+    bleAdapter.setDiscoveryFilter(scan_filter)
+
+    #KPI test
+    isTestSuccessFull = True
+    startToReceivedSum = 0
+    startToConnectedSum = 0
+    numberOfReconnect = 3
+    numberOfSuccess = 0
+
+    for i in range(numberOfReconnect):
+        if i == 0:
+            bleAdapter.startDiscovery(discoveryEventCb)
+        else:
+            bleAdapter.startDiscovery(discoveryStartedCb)   #wait for DUT to start advertising
+        tStartScan = time.time()
+        mainloop.run()
+        startToReceived = time.time() - tStartScan  
+        bleAdapter.stopDiscovery()
+        
+        testDevice = runTest.getTestDevice()
+        isConnectSuccessFull = bleAdapter.connect(testDevice)
+        startToConnected = time.time() - tStartScan
+        
+        isTestSuccessFull &= isConnectSuccessFull
+        startToReceivedSum += startToReceived
+        if isConnectSuccessFull:
+            startToConnectedSum += startToConnected
+            numberOfSuccess += 1
+        isTestSuccessFull &= bleAdapter.disconnect()
+
+    if numberOfReconnect:
+        startToReceivedAvg = startToReceivedSum / numberOfReconnect
+        print "start scanning to received:" + str(startToReceivedAvg)
+    if numberOfSuccess:
+        startToConnectedAvg = startToConnectedSum / numberOfSuccess
+        print "start scanning to connected:" + str(startToConnectedAvg)
+    runTest.submitTestResult(isTestSuccessFull, runTest.reConnection)
+
     time.sleep(2)
     runTest.printTestsSummary()
+    agent = teardown_test(agent)
 
 def errorConnectCb():
     print("Connection error")

--- a/tests/bleTestsScripts/startTests_stress.py
+++ b/tests/bleTestsScripts/startTests_stress.py
@@ -1,10 +1,12 @@
 import Queue
 import sys
+import os
 import threading
 import securityAgent
 import time
 from testClass import runTest
 from bleAdapter import bleAdapter
+import testutils
 import dbus.mainloop.glib
 try:
   from gi.repository import GObject
@@ -12,10 +14,82 @@ except ImportError:
   import gobject as GObject
 
 mainloop = GObject.MainLoop()
+notificationEvent = threading.Event()
+indicationEvent = threading.Event()
+discoveryEvent = threading.Event()
+servicesResolvedEvent = threading.Event()
+pairingEvent = threading.Event()
+
+def discoveryStartedCb(testDevice):
+    mainloop.quit()
+
+
+def discoveryEventCb(testDevice):
+    isTestSuccessFull = runTest.advertisement(testDevice)
+
+    if isTestSuccessFull == True:
+        runTest.setTestDevice(testDevice)
+        #discoveryEvent.set()
+        mainloop.quit()
+
+def notificationCb(uuid, value):
+    isNotificationTestSuccessFull = runTest.notification(uuid, value)
+    if isNotificationTestSuccessFull == True:
+        #notificationEvent.set()
+        mainloop.quit()
+
+    isIndicationTestSuccessFull = runTest.indication(uuid, value)
+    if isIndicationTestSuccessFull == True:
+        #indicationEvent.set()
+        mainloop.quit()
+
+def teardown_test(agent):
+    securityAgent.removeSecurityAgent()
+
+    os.system("sudo rm -rf \"/var/lib/bluetooth/*\"")
+    os.system("sudo hciconfig hci0 reset")
+
+    testutils.removeBondedDevices()
+    return agent
 
 def main():
-    time.sleep(2)
+    agent = None
+    numberOfReconnect = 1
+    numberOfInit = 1
+    numberOfEnable = 1
+    isTestSuccessFull = True
+
+    scan_filter = dict()
+
+    bleAdapter.init()
+    agent = securityAgent.createSecurityAgent(agent=agent)
+
+    scan_filter.update({ "UUIDs": [runTest.DUT_UUID]})
+
+    for i in range(numberOfInit * numberOfEnable):
+        bleAdapter.setDiscoveryFilter(scan_filter)
+        for j in range(numberOfReconnect):
+            if i == 0 and j == 0:
+                bleAdapter.startDiscovery(discoveryEventCb)
+            else:
+                bleAdapter.startDiscovery(discoveryStartedCb) 
+            mainloop.run() 
+            bleAdapter.stopDiscovery()
+            
+            testDevice = runTest.getTestDevice()
+            isConnectSuccessFull = bleAdapter.connect(testDevice)
+            
+            isTestSuccessFull &= isConnectSuccessFull
+            runTest.stopAdvertisement(scan_filter)
+            isTestSuccessFull &= bleAdapter.disconnect()
+        
+        if numberOfReconnect:
+            runTest.submitTestResult(isTestSuccessFull, runTest.reConnection)
+        # runTest.setTestDevice([]);
+        time.sleep(2)
+
     runTest.printTestsSummary()
+    agent = teardown_test(agent)
 
 def errorConnectCb():
     print("Connection error")

--- a/tests/bleTestsScripts/testClass.py
+++ b/tests/bleTestsScripts/testClass.py
@@ -20,6 +20,7 @@ def discoveryStoppedCb(testDevice = None):
 
 class runTest:
     DUT_GENERIC_STRING = "hello"
+    DUT_FAIL_STRING = "fail"
     DUT_OPEN_CHAR_UUID = "8a7f1168-48af-4efb-83b5-e679f9320002"
     DUT_OPEN_DESCR_UUID = "8a7f1168-48af-4efb-83b5-e679f9320008"
     DUT_WRITE_NO_RESP_CHAR_UUID = "8a7f1168-48af-4efb-83b5-e679f9320005"
@@ -55,11 +56,15 @@ class runTest:
     SERVICE_DISCOVERY_TEST_TIMEOUT = 120
     PAIRING_TEST_TIMEOUT = 120
     GENERIC_TEST_TIMEOUT = 120
+    MTU_SIZE = 200
 
     numberOfTests = 0
     numberOfFailedTests = 0
 
     testDevice = []
+
+    DUT_MTU_2_STRING = "a" * (MTU_SIZE - 3)
+    isNotificationDeclinedSuccessFull = False
 
     @staticmethod
     def stopAdvertisement(scan_filter):
@@ -183,8 +188,26 @@ class runTest:
         return isSuccessfull
 
     @staticmethod
+    def notificationMTU2(uuid, value):
+        if uuid == runTest.DUT_NOTIFY_CHAR_UUID:
+            return value;
+
+    @staticmethod
+    def notifyFailure(uuid, value):
+        isSuccessfull = False
+        if (uuid == runTest.DUT_NOTIFY_CHAR_UUID) and (value == runTest.DUT_FAIL_STRING):
+            isSuccessfull = True
+
+        return isSuccessfull
+
+
+    @staticmethod
     def writeWithoutResponse():
         return bleAdapter.writeCharacteristic(runTest.DUT_WRITE_NO_RESP_CHAR_UUID, runTest.DUT_WRITE_NO_RESP_CHAR_UUID, False)
+
+    @staticmethod
+    def writeResultWithoutResponse(result):
+        return bleAdapter.writeCharacteristic(runTest.DUT_WRITE_NO_RESP_CHAR_UUID, result, False)
 
     @staticmethod
     def _readWriteChecks(charUUID, descrUUID):
@@ -262,6 +285,10 @@ class runTest:
         return isConnected
 
     @staticmethod
+    def reConnection(isConnected):
+        return isConnected
+
+    @staticmethod
     def removeIndication(isSuccessfull):
         return isSuccessfull
 
@@ -325,6 +352,7 @@ class runTest:
             runTest.advertisement: "_advertisement",
             runTest.discoverPrimaryServices: "_discoverPrimaryServices",
             runTest.simpleConnection: "_simpleConnection",
+            runTest.reConnection: "_reConnection",
             runTest.checkProperties: "_checkProperties",
             runTest.checkUUIDs: "_checkUUIDs",
             runTest.readWriteSimpleConnection: "_readWriteSimpleConnection",


### PR DESCRIPTION

<!--- Title -->
New integration test, stress test and KPI test
Description
-----------
<!--- Describe your changes in detail -->
-Add stress tests
  -init/deinit
  -enable/disable
  -restart service
  -reconnect
-Add KPI tests
  -between scan begin and advertisement received
  -between scan begin and connection created
-Add integration tests
  -Crash if calling pxEnable twice (MTK)
  -Callback timeout
  -Advertisement issue with NULL properties
  -Hal API(pxEnable) doesn't implemented as expected
  -Wrong Adv Interval
  -Callback timeout
  -MTK stack doesn't check data size
you can refer to this link for more details:
https://wiki.labcollab.net/confluence/pages/viewpage.action?pageId=629941320

Issues: On Nordic pxBleAdapterInit() fails when BLE stack enable more than once.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.