### PR TITLE
Fix Bug in OTA

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1621,7 +1621,7 @@ static void prvOTAUpdateTask( void * pvUnused )
                         while( xQueueReceive( xOTA_Agent.xOTA_MsgQ, &pxMsgMetaData, 0 ) != pdFALSE )
                         {
                             /* Check for OTA update job messages. */
-                            if( pxMsgMetaData->eMsgType == eOTA_PubMsgType_Job )
+                            if( ( pxMsgMetaData->eMsgType == eOTA_PubMsgType_Job ) && ( xOTA_Agent.eState == eOTA_AgentState_Ready ) )
                             {
                                 if( C != NULL )
                                 {


### PR DESCRIPTION
Fix Bug in OTA

Description
-----------
Since we are using QOS1, the broker can potentially send a job message while it is performing a stream.
In that case the stream get's interrupted and OTA fails.
This fix will discard job message while OTA is performing streaming operations.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.