### PR TITLE
Delete unused include of MQTT headers in Nordic's main.c

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/application_code/main.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/application_code/main.c
@@ -57,9 +57,6 @@
 #include "app_uart.h"
 #include "queue.h"
 
-/* MQTT v4 include. */
-#include "iot_mqtt.h"
-
 #include "iot_ble.h"
 #include "iot_ble_numericComparison.h"
 #include "iot_network_manager_private.h"


### PR DESCRIPTION
The build combination tests for the "Amazon FreeRTOS Device Software" configuration page in AWS IoT Core were improved. When the user to selects just the BLE library from the Nordic NRF52840 DK, then MQTT library and all of it's source and header files are stripped away. 

This header in main.c is deleted so that the build will pass for the scenario mentioned and also because it is unused anyways in the file. 

I have built the package downloaded from "Amazon FreeRTOS Device Software" for Nordic with only the BLE library selected. I have built this amazon-freertos source with the change.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.