### PR TITLE
ARM CM0 tickless support

### DIFF
--- a/freertos_kernel/portable/GCC/ARM_CM0/port.c
+++ b/freertos_kernel/portable/GCC/ARM_CM0/port.c
@@ -42,6 +42,7 @@
 #define portNVIC_SYSTICK_CLK			0x00000004
 #define portNVIC_SYSTICK_INT			0x00000002
 #define portNVIC_SYSTICK_ENABLE			0x00000001
+#define portNVIC_SYSTICK_COUNTFLAG		0x00010000
 #define portNVIC_PENDSVSET				0x10000000
 #define portMIN_INTERRUPT_PRIORITY		( 255UL )
 #define portNVIC_PENDSV_PRI				( portMIN_INTERRUPT_PRIORITY << 16UL )
@@ -49,6 +50,14 @@
 
 /* Constants required to set up the initial stack. */
 #define portINITIAL_XPSR			( 0x01000000 )
+
+/* The systick is a 24-bit counter. */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/* A fiddle factor to estimate the number of SysTick counts that would have
+occurred while the SysTick counter is stopped during tickless idle
+calculations. */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
 
 /* Let the user override the pre-loading of the initial LR with the address of
 prvTaskExitError() in case it messes up unwinding of the stack in the
@@ -86,6 +95,29 @@ static void prvTaskExitError( void );
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
 static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
+
+/*
+ * The number of SysTick increments that make up one tick period.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulTimerCountsForOneTick = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * The maximum number of tick periods that can be suppressed is limited by the
+ * 24 bit resolution of the SysTick timer.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * Compensate for the CPU cycles that pass while the SysTick is stopped (low
+ * power functionality only.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 
 /*-----------------------------------------------------------*/
 
@@ -350,6 +382,15 @@ uint32_t ulPreviousMask;
  */
 void prvSetupTimerInterrupt( void )
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR;
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
 	*(portNVIC_SYSTICK_CTRL) = 0UL;
 	*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
@@ -360,3 +401,168 @@ void prvSetupTimerInterrupt( void )
 }
 /*-----------------------------------------------------------*/
 
+#if( configUSE_TICKLESS_IDLE == 1 )
+
+	__attribute__((weak)) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily.  The time the SysTick is stopped for
+		is accounted for as best it can be, but using the tickless mode will
+		inevitably result in some tiny drift of the time maintained by the
+		kernel with respect to calendar time. */
+		*(portNVIC_SYSTICK_CTRL) &= ~portNVIC_SYSTICK_ENABLE;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		tick periods.  -1 is used because this code will execute part way
+		through one of the tick periods. */
+		ulReloadValue = *(portNVIC_SYSTICK_CURRENT_VALUE) + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		method as that will mask interrupts that should exit sleep mode. */
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		to be unsuspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			this tick period. */
+			*(portNVIC_SYSTICK_LOAD) = *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Reset the reload register to the value required for normal tick
+			periods. */
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above the cpsid instruction()
+			above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+		else
+		{
+			/* Set the new reload value. */
+			*(portNVIC_SYSTICK_LOAD) = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			zero. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Sleep until something happens.  configPRE_SLEEP_PROCESSING() can
+			set its parameter to 0 to indicate that its implementation contains
+			its own wait for interrupt or wait for event instruction, and so wfi
+			should not be executed again.  However, the original expected idle
+			time variable must remain unmodified, so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__asm volatile( "dsb" ::: "memory" );
+				__asm volatile( "wfi" );
+				__asm volatile( "isb" );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			out of sleep mode to execute immediately.  see comments above
+			__disable_interrupt() call above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			and interrupts that execute while the clock is stopped will increase
+			any slippage between the time maintained by the RTOS and calendar
+			time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable the SysTick clock without reading the
+			portNVIC_SYSTICK_CTRL register to ensure the
+			portNVIC_SYSTICK_COUNTFLAG is not cleared if it is set.  Again,
+			the time the SysTick is stopped for is accounted for as best it can
+			be, but using the tickless mode will inevitably result in some tiny
+			drift of the time maintained by the kernel with respect to calendar
+			time*/
+			*(portNVIC_SYSTICK_CTRL) = ( portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			been set back to the current reload value (the reload back being
+			correct for the entire expected idle time) or if the SysTick is yet
+			to count to zero (in which case an interrupt other than the SysTick
+			must have brought the system out of sleep mode). */
+			if( ( *(portNVIC_SYSTICK_CTRL) & portNVIC_SYSTICK_COUNTFLAG ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				reloaded with ulReloadValue.  Reset the
+				portNVIC_SYSTICK_LOAD with whatever remains of this tick
+				period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - *(portNVIC_SYSTICK_CURRENT_VALUE) );
+
+				/* Don't allow a tiny value, or values that have somehow
+				underflowed because the post sleep hook did something
+				that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				*(portNVIC_SYSTICK_LOAD) = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				function exits, the tick value maintained by the tick is stepped
+				forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				Work out how long the sleep lasted rounded to complete tick
+				periods (not the ulReload value which accounted for part
+				ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+				/* How many complete tick periods passed while the processor
+				was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				period remains. */
+				*(portNVIC_SYSTICK_LOAD) = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD
+			again, then set portNVIC_SYSTICK_LOAD back to its standard
+			value. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+			vTaskStepTick( ulCompleteTickPeriods );
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrpts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+	}
+
+#endif /* configUSE_TICKLESS_IDLE */

--- a/freertos_kernel/portable/IAR/ARM_CM0/port.c
+++ b/freertos_kernel/portable/IAR/ARM_CM0/port.c
@@ -44,6 +44,7 @@
 #define portNVIC_SYSTICK_CLK		0x00000004
 #define portNVIC_SYSTICK_INT		0x00000002
 #define portNVIC_SYSTICK_ENABLE		0x00000001
+#define portNVIC_SYSTICK_COUNTFLAG	0x00010000
 #define portMIN_INTERRUPT_PRIORITY	( 255UL )
 #define portNVIC_PENDSV_PRI			( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI		( portMIN_INTERRUPT_PRIORITY << 24UL )
@@ -61,6 +62,37 @@ FreeRTOS.org versions prior to V4.3.0 did not include this definition. */
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
 static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
+
+/* The systick is a 24-bit counter. */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/* A fiddle factor to estimate the number of SysTick counts that would have
+occurred while the SysTick counter is stopped during tickless idle
+calculations. */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
+
+/*
+ * The number of SysTick increments that make up one tick period.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulTimerCountsForOneTick = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * The maximum number of tick periods that can be suppressed is limited by the
+ * 24 bit resolution of the SysTick timer.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * Compensate for the CPU cycles that pass while the SysTick is stopped (low
+ * power functionality only.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 
 /*
  * Setup the timer to generate the tick interrupts.
@@ -206,6 +238,15 @@ uint32_t ulPreviousMask;
  */
 static void prvSetupTimerInterrupt( void )
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR;
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
 	*(portNVIC_SYSTICK_CTRL) = 0UL;
 	*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
@@ -216,3 +257,168 @@ static void prvSetupTimerInterrupt( void )
 }
 /*-----------------------------------------------------------*/
 
+#if( configUSE_TICKLESS_IDLE == 1 )
+
+	__weak void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily.  The time the SysTick is stopped for
+		is accounted for as best it can be, but using the tickless mode will
+		inevitably result in some tiny drift of the time maintained by the
+		kernel with respect to calendar time. */
+		*(portNVIC_SYSTICK_CTRL) &= ~portNVIC_SYSTICK_ENABLE;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		tick periods.  -1 is used because this code will execute part way
+		through one of the tick periods. */
+		ulReloadValue = *(portNVIC_SYSTICK_CURRENT_VALUE) + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		method as that will mask interrupts that should exit sleep mode. */
+		__disable_interrupt();
+		__DSB();
+		__ISB();
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		to be unsuspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			this tick period. */
+			*(portNVIC_SYSTICK_LOAD) = *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Reset the reload register to the value required for normal tick
+			periods. */
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above __disable_interrupt()
+			call above. */
+			__enable_interrupt();
+		}
+		else
+		{
+			/* Set the new reload value. */
+			*(portNVIC_SYSTICK_LOAD) = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			zero. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Sleep until something happens.  configPRE_SLEEP_PROCESSING() can
+			set its parameter to 0 to indicate that its implementation contains
+			its own wait for interrupt or wait for event instruction, and so wfi
+			should not be executed again.  However, the original expected idle
+			time variable must remain unmodified, so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__DSB();
+				__WFI();
+				__ISB();
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			out of sleep mode to execute immediately.  see comments above
+			__disable_interrupt() call above. */
+			__enable_interrupt();
+			__DSB();
+			__ISB();
+
+			/* Disable interrupts again because the clock is about to be stopped
+			and interrupts that execute while the clock is stopped will increase
+			any slippage between the time maintained by the RTOS and calendar
+			time. */
+			__disable_interrupt();
+			__DSB();
+			__ISB();
+			
+			/* Disable the SysTick clock without reading the 
+			portNVIC_SYSTICK_CTRL register to ensure the
+			portNVIC_SYSTICK_COUNTFLAG is not cleared if it is set.  Again, 
+			the time the SysTick is stopped for is accounted for as best it can 
+			be, but using the tickless mode will inevitably result in some tiny 
+			drift of the time maintained by the kernel with respect to calendar 
+			time*/
+			*(portNVIC_SYSTICK_CTRL) = ( portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			been set back to the current reload value (the reload back being
+			correct for the entire expected idle time) or if the SysTick is yet
+			to count to zero (in which case an interrupt other than the SysTick
+			must have brought the system out of sleep mode). */
+			if( ( *(portNVIC_SYSTICK_CTRL) & portNVIC_SYSTICK_COUNTFLAG ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				reloaded with ulReloadValue.  Reset the
+				portNVIC_SYSTICK_LOAD with whatever remains of this tick
+				period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - *(portNVIC_SYSTICK_CURRENT_VALUE) );
+
+				/* Don't allow a tiny value, or values that have somehow
+				underflowed because the post sleep hook did something
+				that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				*(portNVIC_SYSTICK_LOAD) = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				function exits, the tick value maintained by the tick is stepped
+				forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				Work out how long the sleep lasted rounded to complete tick
+				periods (not the ulReload value which accounted for part
+				ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+				/* How many complete tick periods passed while the processor
+				was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				period remains. */
+				*(portNVIC_SYSTICK_LOAD) = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD
+			again, then set portNVIC_SYSTICK_LOAD back to its standard
+			value. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+			vTaskStepTick( ulCompleteTickPeriods );
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrpts enabled. */
+			__enable_interrupt();
+		}
+	}
+
+#endif /* configUSE_TICKLESS_IDLE */

--- a/freertos_kernel/portable/RVDS/ARM_CM0/port.c
+++ b/freertos_kernel/portable/RVDS/ARM_CM0/port.c
@@ -42,6 +42,7 @@
 #define portNVIC_SYSTICK_CLK		0x00000004
 #define portNVIC_SYSTICK_INT		0x00000002
 #define portNVIC_SYSTICK_ENABLE		0x00000001
+#define portNVIC_SYSTICK_COUNTFLAG 	0x00010000
 #define portNVIC_PENDSVSET			0x10000000
 #define portMIN_INTERRUPT_PRIORITY	( 255UL )
 #define portNVIC_PENDSV_PRI			( portMIN_INTERRUPT_PRIORITY << 16UL )
@@ -50,12 +51,43 @@
 /* Constants required to set up the initial stack. */
 #define portINITIAL_XPSR			( 0x01000000 )
 
+/* The systick is a 24-bit counter. */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/* A fiddle factor to estimate the number of SysTick counts that would have
+occurred while the SysTick counter is stopped during tickless idle
+calculations. */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
+
 /* Constants used with memory barrier intrinsics. */
 #define portSY_FULL_READ_WRITE		( 15 )
 
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
 static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
+
+/*
+ * The number of SysTick increments that make up one tick period.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulTimerCountsForOneTick = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * The maximum number of tick periods that can be suppressed is limited by the
+ * 24 bit resolution of the SysTick timer.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+
+/*
+ * Compensate for the CPU cycles that pass while the SysTick is stopped (low
+ * power functionality only.
+ */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 
 /*
  * Setup the timer to generate the tick interrupts.
@@ -300,6 +332,15 @@ uint32_t ulPreviousMask;
  */
 void prvSetupTimerInterrupt( void )
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR;
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
 	*(portNVIC_SYSTICK_CTRL) = 0UL;
 	*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
@@ -310,3 +351,169 @@ void prvSetupTimerInterrupt( void )
 }
 /*-----------------------------------------------------------*/
 
+
+#if( configUSE_TICKLESS_IDLE == 1 )
+
+	__weak void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily.  The time the SysTick is stopped for
+		is accounted for as best it can be, but using the tickless mode will
+		inevitably result in some tiny drift of the time maintained by the
+		kernel with respect to calendar time. */
+		*(portNVIC_SYSTICK_CTRL) &= ~portNVIC_SYSTICK_ENABLE;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		tick periods.  -1 is used because this code will execute part way
+		through one of the tick periods. */
+		ulReloadValue = *(portNVIC_SYSTICK_CURRENT_VALUE) + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		method as that will mask interrupts that should exit sleep mode. */
+		__disable_irq();
+		__dsb( portSY_FULL_READ_WRITE );
+		__isb( portSY_FULL_READ_WRITE );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		to be unsuspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			this tick period. */
+			*(portNVIC_SYSTICK_LOAD) = *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Reset the reload register to the value required for normal tick
+			periods. */
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above __disable_irq() call
+			above. */
+			__enable_irq();
+		}
+		else
+		{
+			/* Set the new reload value. */
+			*(portNVIC_SYSTICK_LOAD) = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			zero. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+
+			/* Restart SysTick. */
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+
+			/* Sleep until something happens.  configPRE_SLEEP_PROCESSING() can
+			set its parameter to 0 to indicate that its implementation contains
+			its own wait for interrupt or wait for event instruction, and so wfi
+			should not be executed again.  However, the original expected idle
+			time variable must remain unmodified, so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__dsb( portSY_FULL_READ_WRITE );
+				__wfi();
+				__isb( portSY_FULL_READ_WRITE );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			out of sleep mode to execute immediately.  see comments above
+			__disable_interrupt() call above. */
+			__enable_irq();
+			__dsb( portSY_FULL_READ_WRITE );
+			__isb( portSY_FULL_READ_WRITE );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			and interrupts that execute while the clock is stopped will increase
+			any slippage between the time maintained by the RTOS and calendar
+			time. */
+			__disable_irq();
+			__dsb( portSY_FULL_READ_WRITE );
+			__isb( portSY_FULL_READ_WRITE );
+			
+			/* Disable the SysTick clock without reading the 
+			portNVIC_SYSTICK_CTRL register to ensure the
+			portNVIC_SYSTICK_COUNTFLAG is not cleared if it is set.  Again, 
+			the time the SysTick is stopped for is accounted for as best it can 
+			be, but using the tickless mode will inevitably result in some tiny 
+			drift of the time maintained by the kernel with respect to calendar 
+			time*/
+			*(portNVIC_SYSTICK_CTRL) = ( portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			been set back to the current reload value (the reload back being
+			correct for the entire expected idle time) or if the SysTick is yet
+			to count to zero (in which case an interrupt other than the SysTick
+			must have brought the system out of sleep mode). */
+			if( ( *(portNVIC_SYSTICK_CTRL) & portNVIC_SYSTICK_COUNTFLAG ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				reloaded with ulReloadValue.  Reset the
+				portNVIC_SYSTICK_LOAD with whatever remains of this tick
+				period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - *(portNVIC_SYSTICK_CURRENT_VALUE) );
+
+				/* Don't allow a tiny value, or values that have somehow
+				underflowed because the post sleep hook did something
+				that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				*(portNVIC_SYSTICK_LOAD) = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				function exits, the tick value maintained by the tick is stepped
+				forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				Work out how long the sleep lasted rounded to complete tick
+				periods (not the ulReload value which accounted for part
+				ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - *(portNVIC_SYSTICK_CURRENT_VALUE);
+
+				/* How many complete tick periods passed while the processor
+				was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				period remains. */
+				*(portNVIC_SYSTICK_LOAD) = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD
+			again, then set portNVIC_SYSTICK_LOAD back to its standard
+			value. */
+			*(portNVIC_SYSTICK_CURRENT_VALUE) = 0UL;
+			*(portNVIC_SYSTICK_CTRL) |= portNVIC_SYSTICK_ENABLE;
+			vTaskStepTick( ulCompleteTickPeriods );
+			*(portNVIC_SYSTICK_LOAD) = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrpts enabled. */
+			__enable_irq();
+		}
+	}
+
+#endif /* #if configUSE_TICKLESS_IDLE */


### PR DESCRIPTION
Description
-----------
Though CM0 is ARMv6 and CM3/4/7 are ARMv7, the key instructions used in tickless mode are the same. (```wfi``` and etc.) Also checked register bit mapping (```SYST_CSR```, ```SYST_RVR```, ```SYST_CVR```, ```SYST_CALIB```) and those register addresses in two ISAs, same. Given kernel does the same thing, the implementation of ```vPortSuppressTicksAndSleep()``` is merely a "copy-paste" from CM3/4/7 with minor edits.

```portMISSED_COUNTS_FACTOR``` is using the same value for now, given CM0 also has three pipeline stages, and we are not increasing instruction count or memory access pattern. 

**Tests performed:**
In the absence of CM0 hardware and emulator, compiled these three projects. Further register checks to be done on hardware. 

- ```freertos-code\FreeRTOS\Demo\CORTEX_M0_LPC1114_LPCXpresso```
    Using dependency: ```GCC/ARM_CM0```. 
    IDE version: ```LPCXpresso v8.2.2 [Build 650] [2016-09-09] ```

- ```freertos-code\FreeRTOS\Demo\CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC``` 
    Using dependency: ```IAR/ARM_CM0```.
    IDE version: ```IAR Embedded Workbench for ARM 8.32.3.20228)``` 

- ```freertos-code\FreeRTOS\Demo\CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC```
    Using dependency: ```RVDS/ARM_CM0```.
    IDE version: ```uVision V5.28.0.0```

**Callout:**
- CM0+ is not updated. 

**This PR is for review only, it is not intended to be merged into this repo.** 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.