### PR TITLE
RVDS/Keil weak linkage for vPortSetupTimerInterrupt() -- CM4F, CM3

### DIFF
--- a/freertos_kernel/portable/RVDS/ARM_CM3/port.c
+++ b/freertos_kernel/portable/RVDS/ARM_CM3/port.c
@@ -603,7 +603,7 @@ void xPortSysTickHandler( void )
  */
 #if( configOVERRIDE_DEFAULT_TICK_CONFIGURATION == 0 )
 
-	void vPortSetupTimerInterrupt( void )
+	__weak void vPortSetupTimerInterrupt( void )
 	{
 		/* Calculate the constants required to configure the tick interrupt. */
 		#if( configUSE_TICKLESS_IDLE == 1 )

--- a/freertos_kernel/portable/RVDS/ARM_CM4F/port.c
+++ b/freertos_kernel/portable/RVDS/ARM_CM4F/port.c
@@ -693,7 +693,7 @@ void xPortSysTickHandler( void )
  */
 #if( configOVERRIDE_DEFAULT_TICK_CONFIGURATION == 0 )
 
-	void vPortSetupTimerInterrupt( void )
+	__weak void vPortSetupTimerInterrupt( void )
 	{
 		/* Calculate the constants required to configure the tick interrupt. */
 		#if( configUSE_TICKLESS_IDLE == 1 )


### PR DESCRIPTION
Description
-----------
Provide another way for user to override default ```vPortSetupTimerInterrupt()``` in CM4F and CM3.

Without this change to override ```vPortSetupTimerInterrupt()```, user needs to:
- define ```configOVERRIDE_DEFAULT_TICK_CONFIGURATION``` in ```FreeRTOSConfig.h```
- provide ```vPortSetupTimerInterrupt()``` in application code. 

To address part of comments in https://github.com/aws/amazon-freertos/pull/959, adding ```__weak```. 

**Tested:**
With ```freertos-code\FreeRTOS\Demo\CORTEX_M4F_Infineon_XMC4000_Keil``` -- 
dependency: ```RVDS/ARM_CM4```
IDE version: uVision V5.28.0.0
Checked disassembly with and without ```vPortSetupTimerInterrupt()``` defined in ```main.c```. Linked to the correct implementation in both scenarios. 

**This PR is for review only, it is not intended to be merged into this repo.**

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.