### PR TITLE
Add demo start and end markers

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -291,6 +291,10 @@ void runDemoTask( void * pArgument )
     void * pConnectionParams = NULL, * pCredentials = NULL;
     int status;
 
+    /* DO NOT EDIT - This demo start marker is used in the test framework to
+     * determine the start of a demo. */
+    IotLogInfo( "---------STARTING DEMO---------\n" );
+
     status = _initialize( pContext );
 
     if( status == EXIT_SUCCESS )
@@ -311,6 +315,8 @@ void runDemoTask( void * pArgument )
         /* Log the demo status. */
         if( status == EXIT_SUCCESS )
         {
+            /* DO NOT EDIT - This message is used in the test framework to
+             * determine whether or not the demo was successful. */
             IotLogInfo( "Demo completed successfully." );
         }
         else
@@ -324,6 +330,10 @@ void runDemoTask( void * pArgument )
     {
         IotLogError( "Failed to initialize the demo. exiting..." );
     }
+
+    /* DO NOT EDIT - This demo end marker is used in the test framework to
+     * determine the end of a demo. */
+    IotLogInfo( "-------DEMO FINISHED-------\n" );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------

The following messages are printed before starting and finishing the
demos:

* ---------STARTING DEMO---------
* -------DEMO FINISHED-------

These messages are used by the test framework to determine when a demo
starts and when it finishes. If these messages are not available, the
test framework has to rely on a timeout which may not be accurate
always.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.