### PR TITLE
August 28, Added Router Advertisement/SLAAC

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOSIPConfigDefaults.h
@@ -385,6 +385,29 @@ from the FreeRTOSIPConfig.h configuration header file. */
 	#define ipconfigARP_USE_CLASH_DETECTION		0
 #endif
 
+/* RA or Router Advertisement/SLAAC: see end-point flag 'bWantRA'.
+An Router Solicitation will be sent. It will wait for ipconfigRA_SEARCH_TIME_OUT_MSEC ms.
+When there is no reponse, it will be repeated ipconfigRA_SEARCH_COUNT times.
+Then it will be checked if the chosen IP-address already exists, repeating this
+ipconfigRA_IP_TEST_COUNT times, each time with a timeout of ipconfigRA_IP_TEST_TIME_OUT_MSEC ms.
+Finally the end-point will go in the UP state.
+*/
+#ifndef ipconfigRA_SEARCH_COUNT
+	#define ipconfigRA_SEARCH_COUNT				( 3 )
+#endif
+
+#ifndef ipconfigRA_SEARCH_TIME_OUT_MSEC
+	#define ipconfigRA_SEARCH_TIME_OUT_MSEC		( 10000u )
+#endif
+
+#ifndef ipconfigRA_IP_TEST_COUNT
+	#define ipconfigRA_IP_TEST_COUNT			( 3 )
+#endif
+
+#ifndef ipconfigRA_IP_TEST_TIME_OUT_MSEC
+	#define ipconfigRA_IP_TEST_TIME_OUT_MSEC	( 1500u )
+#endif
+
 #ifndef ipconfigNETWORK_MTU
 	#define ipconfigNETWORK_MTU		1500
 #endif
@@ -567,6 +590,13 @@ from the FreeRTOSIPConfig.h configuration header file. */
 
 #ifndef ipconfigUSE_IPv6
 	#define ipconfigUSE_IPv6 0
+#endif
+
+#if( ipconfigUSE_IPv6 == 0 ) && ( ipconfigUSE_RA == 1 )
+	/* ipconfigUSE_RA depends on ipconfigUSE_IPv6. When ipconfigUSE_IPv6 is disabled,
+	disable ipconfigUSE_RA as well. */
+	#undef ipconfigUSE_RA
+	#define ipconfigUSE_RA		0
 #endif
 
 #ifndef ipconfigUSE_NBNS

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP_Private.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_IP_Private.h
@@ -188,6 +188,16 @@ typedef struct xICMP_HEADER ICMPHeader_t;
 	typedef struct xICMPEcho_IPv6 ICMPEcho_IPv6_t;
 #endif /* ipconfigUSE_IPv6 */
 
+#include "pack_struct_start.h"
+	struct xICMPRouterSolicitation_IPv6 {
+		uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
+		uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
+		uint16_t usChecksum;           /*  2 +  2 =  4 */
+		uint32_t ulReserved;           /*  4 +  4 =  8 */
+	}
+#include "pack_struct_end.h"
+typedef struct xICMPRouterSolicitation_IPv6 ICMPRouterSolicitation_IPv6_t;
+
 #if( ipconfigUSE_IPv6 != 0 )
 	#include "pack_struct_start.h"
 	struct xICMPRouterAdvertisement_IPv6
@@ -204,6 +214,24 @@ typedef struct xICMP_HEADER ICMPHeader_t;
 	#include "pack_struct_end.h"
 	typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
 #endif /* ipconfigUSE_IPv6 */
+
+#if( ipconfigUSE_IPv6 != 0 )
+	/* This is an option with the Router Advertisement. */
+	#include "pack_struct_start.h"
+	struct xICMPPrefixOption_IPv6
+	{
+		uint8_t ucType;					/*  0 +  1 =  1 */
+		uint8_t ucLength;				/*  1 +  1 =  2 */
+		uint8_t ucPrefixLength;			/*  2 +  1 =  3 */
+		uint8_t ucFlags;				/*  3 +  1 =  4 */
+		uint32_t ulValidLifeTime;		/*  4 +  4 =  8 */
+		uint32_t ulPreferredLifeTime;	/*  8 +  4 = 12 */
+		uint32_t ulReserved;			/* 12 +  4 = 16 */
+		uint8_t ucPrefix[16];			/* 16 + 16 = 32 */
+	}
+	#include "pack_struct_end.h"
+	typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
+#endif
 
 #include "pack_struct_start.h"
 struct xUDP_HEADER
@@ -389,7 +417,7 @@ typedef enum
 	eNetworkRxEvent,		/* 1: The network interface has queued a received Ethernet frame. */
 	eARPTimerEvent,			/* 2: The ARP timer expired. */
 	eStackTxEvent,			/* 3: The software stack has queued a packet to transmit. */
-	eDHCPEvent,				/* 4: Process the DHCP state machine. */
+	eDHCP_RA_Event,			/* 4: Process the DHCP or RA/SLAAC state machine. */
 	eTCPTimerEvent,			/* 5: See if any TCP socket needs attention. */
 	eTCPAcceptEvent,		/* 6: Client API FreeRTOS_accept() waiting for client connections. */
 	eTCPNetStat,			/* 7: IP-task is asked to produce a netstat listing. */
@@ -1057,8 +1085,14 @@ extern void vSocketSelect( SocketSelect_t *pxSocketSet );
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
 
-void vIPSetDHCPTimerEnableState( struct xNetworkEndPoint *pxEndPoint, BaseType_t xEnableState );
-void vIPReloadDHCPTimer( struct xNetworkEndPoint *pxEndPoint, uint32_t ulLeaseTime );
+#if( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
+	void vIPSetDHCP_RATimerEnableState( struct xNetworkEndPoint *pxEndPoint, BaseType_t xEnableState );
+#endif	/* ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 ) */
+
+#if( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
+	void vIPReloadDHCP_RATimer( struct xNetworkEndPoint *pxEndPoint, TickType_t uxClockTicks );
+#endif	/* ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 ) */
+
 #if( ipconfigDNS_USE_CALLBACKS != 0 )
 	void vIPReloadDNSTimer( uint32_t ulCheckTime );
 	void vIPSetDnsTimerEnableState( BaseType_t xEnableState );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_ND.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_ND.h
@@ -114,12 +114,21 @@ void vNDAgeCache( void );
  * add an entry into the ND table that indicates that an ND reply is
  * outstanding so re-transmissions can be generated.
  */
-void vNDGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress );
+void vNDSendNeighbourSolicitation( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress );
 
-/*
- * Send out a ROuter Sollicitaion.
- */
-void vNDGenerateRASolicitationPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress );
+#if( ipconfigUSE_RA != 0 )
+	/*
+	 * Send out a ROuter Sollicitaion.
+	 */
+	void vNDSendRouterSolicitation( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress );
+#endif	/* ( ipconfigUSE_RA != 0 ) */
+
+#if( ipconfigUSE_RA != 0 )
+	/*
+	 * Work on the RA/SLAAC processing.
+	 */
+	void vRAProcess( BaseType_t xDoReset, NetworkEndPoint_t *pxEndPoint );
+#endif	/* ( ipconfigUSE_RA != 0 ) */
 
 /*
  * After DHCP is ready and when changing IP address, force a quick send of our new IP

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_errno_TCP.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/FreeRTOS_errno_TCP.h
@@ -104,6 +104,9 @@ already been made. */
 
 #endif /* pdFREERTOS_ERRNO_NONE */
 
+/* Translate a pdFREERTOS_ERRNO code to a human readable string. */
+const char *FreeRTOS_strerror_r( BaseType_t xErrnum, char *pcBuffer, size_t uxLength );
+
 #endif /* FREERTOS_ERRNO_TCP */
 
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/IPTraceMacroDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/include/IPTraceMacroDefaults.h
@@ -162,6 +162,14 @@ http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Trace.html */
 	#define iptraceDHCP_SUCCEDEED( address )
 #endif
 
+#ifndef iptraceRA_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS
+	#define iptraceRA_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( ipv6_address )
+#endif
+
+#ifndef iptraceRA_SUCCEDEED
+	#define iptraceRA_SUCCEDEED( ipv6_address )
+#endif
+
 #ifndef iptraceNETWORK_INTERFACE_TRANSMIT
 	#define iptraceNETWORK_INTERFACE_TRANSMIT()
 #endif

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_DHCP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_DHCP.c
@@ -37,11 +37,12 @@
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
 #include "FreeRTOS_ARP.h"
-#include "FreeRTOS_Routing.h"
-#include "NetworkBufferManagement.h"
 
 /* Exclude the entire file if DHCP is not enabled. */
 #if( ipconfigUSE_DHCP != 0 )
+
+#include "FreeRTOS_Routing.h"
+#include "NetworkBufferManagement.h"
 
 #if ( ipconfigUSE_DHCP != 0 ) && ( ipconfigNETWORK_MTU < 586u )
 	/* DHCP must be able to receive an options field of 312 bytes, the fixed
@@ -323,6 +324,7 @@ BaseType_t xDoProcess = pdTRUE;
 		for( ;; )
 		{
 		NetworkEndPoint_t *pxIterator = NULL;
+
 			/* Peek the next UDP message. */
 			lBytes = FreeRTOS_recvfrom( xDHCPSocket, &( pucUDPPayload ), 0, FREERTOS_ZERO_COPY | FREERTOS_MSG_PEEK, NULL, NULL );
 			if( lBytes <= 0 )
@@ -596,7 +598,7 @@ BaseType_t xGivingUp = pdFALSE;
 
 				/* Check for clashes. */
 				vARPSendGratuitous();
-				vIPReloadDHCPTimer( pxEndPoint, pxEndPoint->xDHCPData.ulLeaseTime );
+				vIPReloadDHCP_RATimer( pxEndPoint, pxEndPoint->xDHCPData.ulLeaseTime );
 			}
 			else
 			{
@@ -644,13 +646,13 @@ BaseType_t xGivingUp = pdFALSE;
 				prvSendDHCPRequest( pxEndPoint );
 				pxEndPoint->xDHCPData.eDHCPState = eWaitingAcknowledge;
 				/* From now on, we should be called more often */
-				vIPReloadDHCPTimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
+				vIPReloadDHCP_RATimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
 			}
 			break;
 
 		case eNotUsingLeasedAddress:
 
-			vIPSetDHCPTimerEnableState( pxEndPoint, pdFALSE );
+			vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
 			break;
 		default:
 			/* Lint: all options are included. */
@@ -673,7 +675,7 @@ BaseType_t xGivingUp = pdFALSE;
 		taskEXIT_CRITICAL();
 
 		pxEndPoint->xDHCPData.eDHCPState = eNotUsingLeasedAddress;
-		vIPSetDHCPTimerEnableState( pxEndPoint, pdFALSE );
+		vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
 
 		/* DHCP failed, the default configured IP-address will be used
 		Now call vIPNetworkUpCalls() to send the network-up event, start Nabto
@@ -779,7 +781,7 @@ static void prvInitialiseDHCP( NetworkEndPoint_t *pxEndPoint )
 		pxEndPoint->xMACAddress.ucBytes[ 4 ],
 		pxEndPoint->xMACAddress.ucBytes[ 5 ],
 		dhcpINITIAL_TIMER_PERIOD ) );
-	vIPReloadDHCPTimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
+	vIPReloadDHCP_RATimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_ND.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_ND.c
@@ -80,10 +80,10 @@
 #define	ndICMP_MTU_OPTION						5
 
 /* Possible values of ucFlags in a neighbour advertisement. */
-#ifndef _lint	/* Defines will soon be used. */
-#define ndFlags_IsRouter		0x8000u
-#define ndFlags_Solicited		0x4000u
-#define ndFlags_Override		0x2000u
+#ifndef _lint
+	#define ndFlags_IsRouter		0x8000u
+	#define ndFlags_Solicited		0x4000u
+	#define ndFlags_Override		0x2000u
 #endif
 
 /* A block time of 0 simply means "don't block". */
@@ -96,30 +96,6 @@ character expected to fill ICMP echo replies. */
 /*lint -e754 local struct member not referenced. */
 /*lint -e766 Header file pack_struct_end.h' not used in module. */
 
-#include "pack_struct_start.h"	/*lint !e537 !e451 !e9019 !e766*/
-struct xICMPPrefixOption_IPv6
-{
-	uint8_t ucType;					/*  0 +  1 =  1 */
-	uint8_t ucLength;				/*  1 +  1 =  2 */
-	uint8_t ucPrefixLength;			/*  2 +  1 =  3 */
-	uint8_t ucFlags;				/*  3 +  1 =  4 */
-	uint32_t ulValidLifeTime;		/*  4 +  4 =  8 */
-	uint32_t ulPreferredLifeTime;	/*  8 +  4 = 12 */
-	uint32_t ulReserved;			/* 12 +  4 = 16 */
-	uint8_t ucPrefix[16];			/* 16 + 16 = 32 */
-}	/*lint !e659*/
-#include "pack_struct_end.h"	/*lint !e537 !e451 !e9019 !e766*/
-typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
-
-#include "pack_struct_start.h"	/*lint !e537 !e451 !e9019 !e766*/
-struct xRASolicitationRequest_IPv6 {
-	uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
-	uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
-	uint16_t usChecksum;           /*  2 +  2 =  4 */
-	uint32_t ulReserved;           /*  4 +  4 =  8 */
-}	/*lint !e659*/
-#include "pack_struct_end.h"	/*lint !e537 !e451 !e9019 !e766*/
-typedef struct xRASolicitationRequest_IPv6 RASolicitationRequest_IPv6_t;
 
 // All nodes on the local network segment
 static const uint8_t pcLOCAL_NETWORK_MULTICAST_IP[ 16 ] = { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
@@ -130,11 +106,9 @@ static const uint8_t pcLOCAL_NETWORK_MULTICAST_MAC[ ipMAC_ADDRESS_LENGTH_BYTES ]
  */
 static eARPLookupResult_t prvCacheLookup( IPv6_Address_t *pxAddressToLookup, MACAddress_t * const pxMACAddress, NetworkEndPoint_t **ppxEndPoint );
 
-/*-----------------------------------------------------------*/
-
 /* The ND cache. */
 static NDCacheRow_t xNDCache[ ipconfigND_CACHE_ENTRIES ];
-
+/*-----------------------------------------------------------*/
 
 eARPLookupResult_t eNDGetCacheEntry( IPv6_Address_t *pxIPAddress, MACAddress_t * const pxMACAddress, struct xNetworkEndPoint **ppxEndPoint )
 {
@@ -327,68 +301,12 @@ ICMPHeader_IPv6_t *pxICMPHeader_IPv6 = ( ICMPHeader_IPv6_t * )&( pxICMPPacket->x
 }
 /*-----------------------------------------------------------*/
 
-#ifndef _lint
-	void nd_test()
-	{
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	size_t uxNeededSize;
-	IPv6_Address_t xIPAddress;
-	NetworkEndPoint_t *pxEndPoint;
-	/*
-	BaseType_t xIndex;
-	const char *ip_address[] = {
-		"fe80::9355:69c7:585a:afe7",	// raspberry ff02::1:ff5a:afe7, 33:33:ff:5a:af:e7
-		"fe80::6816:5e9b:80a0:9edb",	// laptop _HT_
-	};
-		for( xIndex = 0; xIndex < ARRAY_SIZE( ip_address ); xIndex++ )
-		{
-			FreeRTOS_inet_pton6( ip_address[ xIndex ], xIPAddress.ucBytes );
-			FreeRTOS_printf( ( "nd_test: Looking up %pip\n", xIPAddress.ucBytes ) );
-			pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv6( &xIPAddress );
-			if( pxEndPoint != NULL )
-			{
-				uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPHeader_IPv6_t ) );
-				pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, ndDONT_BLOCK );
-				if( pxNetworkBuffer != NULL )
-				{
-					pxNetworkBuffer->pxEndPoint = pxEndPoint;
-					vNDGenerateRequestPacket( pxNetworkBuffer, &xIPAddress );
-				}
-			}
-			else
-			{
-				FreeRTOS_printf( ( "nd_test: can not find and endpoint for %pip\n", xIPAddress.ucBytes ) );
-			}
-		}
-	*/
-		{
-			// ff:02::2
-			memset( xIPAddress.ucBytes, '\0', sizeof xIPAddress.ucBytes );
-			xIPAddress.ucBytes[  0 ] = 0xff;
-			xIPAddress.ucBytes[  1 ] = 0x02;
-			xIPAddress.ucBytes[ 15 ] = 0x02;
-			pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv6( &xIPAddress );
-			if( pxEndPoint != NULL )
-			{
-				uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( RASolicitationRequest_IPv6_t ) );
-				pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, ndDONT_BLOCK );
-				if( pxNetworkBuffer != NULL )
-				{
-					pxNetworkBuffer->pxEndPoint = pxEndPoint;
-					vNDGenerateRASolicitationPacket( pxNetworkBuffer, &( xIPAddress ) );
-				}
-			}
-		}
-	}
-#endif
-/*-----------------------------------------------------------*/
-
 /*
  * Send out an ND request for the IPv6 address contained in pxNetworkBuffer, and
  * add an entry into the ND table that indicates that an ND reply is
  * outstanding so re-transmissions can be generated.
  */
-void vNDGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress )
+void vNDSendNeighbourSolicitation( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress )
 {
 ICMPPacket_IPv6_t *pxICMPPacket;
 ICMPHeader_IPv6_t *xICMPHeader_IPv6;
@@ -469,87 +387,462 @@ NetworkBufferDescriptor_t *pxDescriptor = pxNetworkBuffer;
 }
 /*-----------------------------------------------------------*/
 
-void vNDGenerateRASolicitationPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress )
-{
-ICMPPacket_IPv6_t *pxICMPPacket;
-RASolicitationRequest_IPv6_t *xRASolicitationRequest;
-NetworkEndPoint_t *pxEndPoint = pxNetworkBuffer->pxEndPoint;
-size_t uxNeededSize;
-MACAddress_t xMultiCastMacAddress;
-NetworkBufferDescriptor_t *pxDescriptor = pxNetworkBuffer;
-
-	configASSERT( pxEndPoint != NULL );
-	uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( RASolicitationRequest_IPv6_t ) );
-	if( pxDescriptor->xDataLength < uxNeededSize )
+#if( ipconfigUSE_RA != 0 )
+	void vNDSendRouterSolicitation( NetworkBufferDescriptor_t * const pxNetworkBuffer, IPv6_Address_t *pxIPAddress )
 	{
-		pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
-		if( pxDescriptor == NULL )
+	ICMPPacket_IPv6_t *pxICMPPacket;
+	ICMPRouterSolicitation_IPv6_t *xRASolicitationRequest;
+	NetworkEndPoint_t *pxEndPoint = pxNetworkBuffer->pxEndPoint;
+	size_t uxNeededSize;
+	MACAddress_t xMultiCastMacAddress;
+	NetworkBufferDescriptor_t *pxDescriptor = pxNetworkBuffer;
+
+		configASSERT( pxEndPoint != NULL );
+		uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t ) );
+		if( pxDescriptor->xDataLength < uxNeededSize )
 		{
-			return;	/*lint !e904 Return statement before end of function [MISRA 2012 Rule 15.5, advisory]. */
+			pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
+			if( pxDescriptor == NULL )
+			{
+				return;	/*lint !e904 Return statement before end of function [MISRA 2012 Rule 15.5, advisory]. */
+			}
 		}
+		pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxDescriptor->pucEthernetBuffer );
+		xRASolicitationRequest = ipPOINTER_CAST( ICMPRouterSolicitation_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
+
+		pxDescriptor->xDataLength = uxNeededSize;
+
+		xMultiCastMacAddress.ucBytes[ 0 ] = 0x33;
+		xMultiCastMacAddress.ucBytes[ 1 ] = 0x33;
+		xMultiCastMacAddress.ucBytes[ 2 ] = 0x00;
+		xMultiCastMacAddress.ucBytes[ 3 ] = 0x00;
+		xMultiCastMacAddress.ucBytes[ 4 ] = 0x00;
+		xMultiCastMacAddress.ucBytes[ 5 ] = 0x02;
+
+		/* Set Ethernet header. Will be swapped. */
+		memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+		memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+		pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
+
+		/* Set IP-header. */
+		pxICMPPacket->xIPHeader.ucVersionTrafficClass = 0x60;
+		pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0;
+		pxICMPPacket->xIPHeader.usFlowLabel = 0;
+		pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) );
+		pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
+		pxICMPPacket->xIPHeader.ucHopLimit = 255;
+
+		configASSERT( pxEndPoint != NULL );
+		configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
+		memcpy( pxICMPPacket->xIPHeader.xSourceIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, 16 );
+
+		//ff02::1:ff5a:afe7
+		// ff02::2
+		memcpy( pxICMPPacket->xIPHeader.xDestinationIPv6Address.ucBytes, pxIPAddress->ucBytes, 16 );
+	/*
+		uint8_t ucTypeOfMessage;       //  0 +  1 =  1
+		uint8_t ucTypeOfService;       //  1 +  1 =  2
+		uint16_t usChecksum;           //  2 +  2 =  4
+		uint32_t ulReserved;           //  4 +  4 =  8
+		uint8_t ucOptionType;          //  8 +  1 =  9
+		uint8_t ucOptionLength;        //  9 +  1 = 10
+		uint8_t ucOptionBytes[6];      // 10 +  6 = 16
+	*/
+
+		/* Set ICMP header. */
+		memset( xRASolicitationRequest, '\0', sizeof( *xRASolicitationRequest ) );
+		xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
+
+	/*
+		xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
+		xRASolicitationRequest->ucOptionLength = 1;
+		memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+	*/
+		/* Checmsums. */
+		xRASolicitationRequest->usChecksum = 0;
+		/* calculate the UDP checksum for outgoing package */
+		( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+
+	// FreeRTOS_printf( ( "ICMPv6 return %d bytes\n", pxDescriptor->xDataLength ) );
+		/* This function will fill in the eth addresses and send the packet */
+		vReturnEthernetFrame( pxDescriptor, pdTRUE );
 	}
-	pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxDescriptor->pucEthernetBuffer );
-	xRASolicitationRequest = ipPOINTER_CAST( RASolicitationRequest_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
-
-	pxDescriptor->xDataLength = uxNeededSize;
-
-	xMultiCastMacAddress.ucBytes[ 0 ] = 0x33;
-	xMultiCastMacAddress.ucBytes[ 1 ] = 0x33;
-	xMultiCastMacAddress.ucBytes[ 2 ] = 0x00;
-	xMultiCastMacAddress.ucBytes[ 3 ] = 0x00;
-	xMultiCastMacAddress.ucBytes[ 4 ] = 0x00;
-	xMultiCastMacAddress.ucBytes[ 5 ] = 0x02;
-
-	/* Set Ethernet header. Will be swapped. */
-	memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-	memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-	pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
-
-	/* Set IP-header. */
-	pxICMPPacket->xIPHeader.ucVersionTrafficClass = 0x60;
-	pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0;
-	pxICMPPacket->xIPHeader.usFlowLabel = 0;
-	pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( RASolicitationRequest_IPv6_t ) );
-	pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-	pxICMPPacket->xIPHeader.ucHopLimit = 255;
-
-	configASSERT( pxEndPoint != NULL );
-	configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
-	memcpy( pxICMPPacket->xIPHeader.xSourceIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, 16 );
-
-	//ff02::1:ff5a:afe7
-	// ff02::2
-	memcpy( pxICMPPacket->xIPHeader.xDestinationIPv6Address.ucBytes, pxIPAddress->ucBytes, 16 );
-/*
-	uint8_t ucTypeOfMessage;       //  0 +  1 =  1
-	uint8_t ucTypeOfService;       //  1 +  1 =  2
-	uint16_t usChecksum;           //  2 +  2 =  4
-	uint32_t ulReserved;           //  4 +  4 =  8
-	uint8_t ucOptionType;          //  8 +  1 =  9
-	uint8_t ucOptionLength;        //  9 +  1 = 10
-	uint8_t ucOptionBytes[6];      // 10 +  6 = 16
-*/
-
-	/* Set ICMP header. */
-	memset( xRASolicitationRequest, '\0', sizeof( *xRASolicitationRequest ) );
-	xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
-
-/*
-	xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
-	xRASolicitationRequest->ucOptionLength = 1;
-	memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-*/
-	/* Checmsums. */
-	xRASolicitationRequest->usChecksum = 0;
-	/* calculate the UDP checksum for outgoing package */
-	( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
-
-// FreeRTOS_printf( ( "ICMPv6 return %d bytes\n", pxDescriptor->xDataLength ) );
-	/* This function will fill in the eth addresses and send the packet */
-	vReturnEthernetFrame( pxDescriptor, pdTRUE );
-}
+#endif	/* ( ipconfigUSE_RA != 0 ) */
 /*-----------------------------------------------------------*/
 
+#if( ipconfigUSE_RA != 0 )
+	static void prvReceiveRA( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+	{
+	ICMPPacket_IPv6_t *pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxNetworkBuffer->pucEthernetBuffer );
+	ICMPRouterAdvertisement_IPv6_t *pxAdvertisement = ipPOINTER_CAST( ICMPRouterAdvertisement_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
+	ICMPPrefixOption_IPv6_t *pxPrefixOption = NULL;
+	size_t uxIndex;
+	size_t uxLast;
+	size_t uxICMPSize;
+	size_t uxNeededSize;
+	uint8_t *pucBytes;
+
+		/* A Router Advertisement was received, handle it here. */
+		uxICMPSize = sizeof( ICMPRouterAdvertisement_IPv6_t );
+		uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
+		if( uxNeededSize > pxNetworkBuffer->xDataLength )
+		{
+			FreeRTOS_printf( ("Too small\n" ) );
+			return;	/*lint !e904 Return statement before end of function [MISRA 2012 Rule 15.5, advisory]. */
+		}
+
+		FreeRTOS_printf( ( "RA: Type %02x Srv %02x Checksum %04x Hops %d Flags %02x Life %d\n",
+			pxAdvertisement->ucTypeOfMessage,
+			pxAdvertisement->ucTypeOfService,
+			FreeRTOS_ntohs( pxAdvertisement->usChecksum ),
+			pxAdvertisement->ucHopLimit,
+			pxAdvertisement->ucFlags,
+			FreeRTOS_ntohs( pxAdvertisement->usLifetime ) ) );
+		uxIndex = 0;
+		/* uxLast points to the first byte after the buffer. */
+		uxLast = pxNetworkBuffer->xDataLength - uxNeededSize;
+		pucBytes = &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
+		while( ( uxIndex + 1 ) < uxLast )
+		{
+			uint8_t ucType = pucBytes[ uxIndex ];
+			size_t uxLength = ( size_t ) pucBytes[ uxIndex + 1 ] * 8uL;
+			if( uxLast < ( uxIndex + uxLength ) )
+			{
+				FreeRTOS_printf( ( "RA: Not enough bytes ( %u > %u )\n", ( unsigned ) uxIndex + uxLength, ( unsigned ) uxLast ) );
+				break;
+			}
+			switch( ucType )
+			{ 
+				case ndICMP_SOURCE_LINK_LAYER_ADDRESS:	// 1
+					{
+						FreeRTOS_printf( ( "RA: Source = %02x-%02x-%02x-%02x-%02x-%02x\n",
+							pucBytes[ uxIndex + 2 ],
+							pucBytes[ uxIndex + 3 ],
+							pucBytes[ uxIndex + 4 ],
+							pucBytes[ uxIndex + 5 ],
+							pucBytes[ uxIndex + 6 ],
+							pucBytes[ uxIndex + 7 ] ) );
+					}
+					break;
+				case ndICMP_TARGET_LINK_LAYER_ADDRESS:	// 2
+					{
+					}
+					break;
+				case ndICMP_PREFIX_INFORMATION:			// 3
+					{
+					pxPrefixOption = ipPOINTER_CAST( ICMPPrefixOption_IPv6_t *, &( pucBytes[ uxIndex ] ) );
+
+						FreeRTOS_printf( ( "RA: Prefix len %d Life %lu, %lu (%pip)\n",
+							pxPrefixOption->ucPrefixLength,
+							FreeRTOS_ntohl( pxPrefixOption->ulValidLifeTime ),
+							FreeRTOS_ntohl( pxPrefixOption->ulPreferredLifeTime ),
+							pxPrefixOption->ucPrefix ) );
+					}
+					break;
+				case ndICMP_REDIRECTED_HEADER:			// 4
+					{
+					}
+					break;
+				case ndICMP_MTU_OPTION:					// 5
+					{
+					uint32_t ulMTU;
+
+						/* ulChar2u32 returns host-endian numbers. */
+						ulMTU = ulChar2u32 ( &( pucBytes[ uxIndex + 4 ] ) );
+						FreeRTOS_printf( ( "RA: MTU = %lu\n",  ulMTU ) );
+					}
+					break;
+				default:
+					{
+						FreeRTOS_printf( ( "RA: Type %02x not implemented\n", ucType ) );
+					}
+					break;
+			}
+			uxIndex = uxIndex + uxLength;
+		}	/* while( ( uxIndex + 1 ) < uxLast ) */
+		configASSERT( pxNetworkBuffer->pxInterface != NULL );
+
+		if( pxPrefixOption != NULL )
+		{
+		NetworkEndPoint_t *pxEndPoint;
+
+			for( pxEndPoint = FreeRTOS_FirstEndPoint( pxNetworkBuffer->pxInterface );
+				pxEndPoint != NULL;
+				pxEndPoint = FreeRTOS_NextEndPoint( pxNetworkBuffer->pxInterface, pxEndPoint ) )
+			{
+				if( ( pxEndPoint->bits.bWantRA != pdFALSE_UNSIGNED ) && ( pxEndPoint->xRAData.eRAState == eRAStateWait ) )
+				{
+					pxEndPoint->ipv6_settings.uxPrefixLength = pxPrefixOption->ucPrefixLength;
+					memcpy( pxEndPoint->ipv6_settings.xPrefix.ucBytes, pxPrefixOption->ucPrefix, ipSIZE_OF_IPv6_ADDRESS );
+					memcpy( pxEndPoint->ipv6_settings.xGatewayAddress.ucBytes, pxICMPPacket->xIPHeader.xSourceIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+					pxEndPoint->xRAData.bits.bRouterReplied = pdTRUE_UNSIGNED;
+					pxEndPoint->xRAData.uxRetryCount = 0uL;
+					pxEndPoint->xRAData.ulPreferredLifeTime = FreeRTOS_ntohl( pxPrefixOption->ulPreferredLifeTime );
+					/* Force taking a new random IP-address. */
+					pxEndPoint->xRAData.bits.bIPAddressInUse = pdTRUE_UNSIGNED;
+					pxEndPoint->xRAData.eRAState = eRAStateIPTest;
+					vRAProcess( pdFALSE, pxEndPoint );
+				}
+			}
+		}
+
+	}
+#endif	/* ( ipconfigUSE_RA != 0 ) */
+/*-----------------------------------------------------------*/
+
+#if( ipconfigUSE_RA != 0 )
+static BaseType_t prvGetTestAddress( BaseType_t xIndex, IPv6_Address_t *pxIPAddress )
+{
+	( void ) xIndex;
+	( void ) pxIPAddress;
+	return 0;
+#if 0
+BaseType_t xResult;
+
+	/* For testing only: return an IPv6 address that is already taken in the LAN. */
+	const char *ip_address[] = {
+		"fe80::6816:5e9b:80a0:9edb",	// laptop _HT_
+		"fe80::9355:69c7:585a:afe7",	// raspberry
+	};
+	if( xIndex < ARRAY_SIZE( ip_address ) )
+	{
+		( void ) FreeRTOS_inet_pton6( ip_address[ xIndex ], pxIPAddress->ucBytes );
+		xResult = pdPASS;
+	}
+	else
+	{
+		xResult = pdFAIL;
+	}
+
+	return xResult;
+#endif /* 0 */
+}
+#endif	/* ( ipconfigUSE_RA != 0 ) */
+/*-----------------------------------------------------------*/
+
+#if( ipconfigUSE_RA != 0 )
+	static void vRAProcessInit( NetworkEndPoint_t *pxEndPoint )
+	{
+		pxEndPoint->xRAData.uxRetryCount = 0;
+		pxEndPoint->xRAData.eRAState = eRAStateApply;
+	}
+#endif	/* ( ipconfigUSE_RA != 0 ) */
+
+#if( ipconfigUSE_RA != 0 )
+	void vRAProcess( BaseType_t xDoReset, NetworkEndPoint_t *pxEndPoint )
+	{
+		configASSERT( pxEndPoint != NULL );
+		
+		if( ( pxEndPoint->bits.bIPv6 == pdFALSE_UNSIGNED ) ||
+			( pxEndPoint->bits.bWantRA == pdFALSE_UNSIGNED ) )
+		{
+			/* For IPv4 end-points, or when RA is not enabled, disable the DHCP/RA timer. */
+			vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
+		}
+		else
+		{
+		eRAState_t eRAState = pxEndPoint->xRAData.eRAState;
+		TickType_t uxReloadTime = pdMS_TO_TICKS( 5000uL );
+		BaseType_t xSkipLease = pdFALSE;
+
+			if( xDoReset != pdFALSE )
+			{
+				vRAProcessInit( pxEndPoint );
+			}
+			switch( pxEndPoint->xRAData.eRAState )
+			{
+				case eRAStateWait:
+					{
+						/* A Router Solicitation has been sent, waited for a reply, but no came.
+						All replies will be handled in the function prvReceiveRA(). */
+						pxEndPoint->xRAData.uxRetryCount++;
+						if( pxEndPoint->xRAData.uxRetryCount < ipconfigRA_SEARCH_COUNT )
+						{
+							pxEndPoint->xRAData.eRAState = eRAStateApply;
+						}
+						else
+						{
+							FreeRTOS_printf( ( "RA: Giving up waiting for a Router.\n" ) );
+							memcpy( &( pxEndPoint->ipv6_settings ), &( pxEndPoint->ipv6_defaults ), sizeof( pxEndPoint->ipv6_settings ) );
+
+							pxEndPoint->xRAData.bits.bRouterReplied = pdFALSE_UNSIGNED;
+							pxEndPoint->xRAData.uxRetryCount = 0uL;
+							/* Force taking a new random IP-address. */
+							pxEndPoint->xRAData.bits.bIPAddressInUse = pdTRUE_UNSIGNED;
+							pxEndPoint->xRAData.eRAState = eRAStateIPTest;
+						}
+					}
+					break;
+				case eRAStateIPWait:
+					{
+						/* A Neighbour Solicitation has been sent, waited for a reply.
+						Repeat this 'ipconfigRA_IP_TEST_COUNT' times to be sure. */
+						if( pxEndPoint->xRAData.bits.bIPAddressInUse )
+						{
+							/* Another device has responded with the same IPv4 address. */
+							pxEndPoint->xRAData.uxRetryCount = 0uL;
+							pxEndPoint->xRAData.eRAState = eRAStateIPTest;
+							uxReloadTime = pdMS_TO_TICKS( ipconfigRA_IP_TEST_TIME_OUT_MSEC );
+						}
+						else if( pxEndPoint->xRAData.uxRetryCount < ipconfigRA_IP_TEST_COUNT )
+						{
+							/* Try again. */
+							pxEndPoint->xRAData.uxRetryCount++;
+							pxEndPoint->xRAData.eRAState = eRAStateIPTest;
+							uxReloadTime = pdMS_TO_TICKS( ipconfigRA_IP_TEST_TIME_OUT_MSEC );
+						}
+						else
+						{
+							/* Now it is assumed that there is no other device using the same IP-address. */
+							if( pxEndPoint->xRAData.bits.bRouterReplied != pdFALSE_UNSIGNED )
+							{
+								/* Obtained configuration from a router. */
+								uxReloadTime = pdMS_TO_TICKS( 1000uL * pxEndPoint->xRAData.ulPreferredLifeTime );
+								pxEndPoint->xRAData.eRAState = eRAStateLease;
+								xSkipLease = pdTRUE;
+								iptraceRA_SUCCEDEED( &( pxEndPoint->ipv6_settings.xIPAddress ) );
+								FreeRTOS_printf( ( "RA: succeeded, using IP address %pip\n", pxEndPoint->ipv6_settings.xIPAddress.ucBytes ) );
+							}
+							else
+							{
+								/* Using the default network parameters. */
+								pxEndPoint->xRAData.eRAState = eRAStateFailed;
+
+								iptraceRA_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( &( pxEndPoint->ipv6_settings.xIPAddress ) );
+
+								FreeRTOS_printf( ( "RA: failed, using default parameters and IP address %pip\n", pxEndPoint->ipv6_settings.xIPAddress.ucBytes ) );
+								/* Disable the timer. */
+								uxReloadTime = 0uL;
+							}
+							/* Now call vIPNetworkUpCalls() to send the network-up event and
+							start the ARP timer. */
+							vIPNetworkUpCalls( pxEndPoint );
+						}
+					}
+					break;
+				case eRAStateApply:
+				case eRAStateIPTest:
+				case eRAStateLease:
+				case eRAStateFailed:
+				default:
+					{
+						/* Other states are handled here below. */
+					}
+					break;
+			}
+			switch( pxEndPoint->xRAData.eRAState )
+			{
+				case eRAStateApply:
+					{
+					IPv6_Address_t xIPAddress;
+					size_t uxNeededSize;
+					NetworkBufferDescriptor_t *pxNetworkBuffer;
+
+						/* Send a Router Solicitation to ff:02::2 */
+						memset( xIPAddress.ucBytes, '\0', sizeof xIPAddress.ucBytes );
+						xIPAddress.ucBytes[  0 ] = 0xff;
+						xIPAddress.ucBytes[  1 ] = 0x02;
+						xIPAddress.ucBytes[ 15 ] = 0x02;
+						uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t ) );
+						pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, ndDONT_BLOCK );
+						if( pxNetworkBuffer != NULL )
+						{
+							pxNetworkBuffer->pxEndPoint = pxEndPoint;
+							vNDSendRouterSolicitation( pxNetworkBuffer, &( xIPAddress ) );
+						}
+						FreeRTOS_printf( ( "vRAProcess: Router Solicitation, attempt %d/%u\n",
+										   ( int ) ( pxEndPoint->xRAData.uxRetryCount + 1u ),
+											ipconfigRA_SEARCH_COUNT ) );
+						/* Wait a configurable time for a router advertisement. */
+						uxReloadTime = pdMS_TO_TICKS( ipconfigRA_SEARCH_TIME_OUT_MSEC );
+						pxEndPoint->xRAData.eRAState = eRAStateWait;
+					}
+					break;
+				case eRAStateWait:
+					{
+						/* Waiting for a router advertisement. */
+						/* Handled here above. */
+					}
+					break;
+				case eRAStateIPTest:	/* Assuming an IP address, test if another device is using it already. */
+					{
+					size_t uxNeededSize;
+					NetworkBufferDescriptor_t *pxNetworkBuffer;
+
+						/* Get an IP-address, using the network prefix and a random host address. */
+						if( pxEndPoint->xRAData.bits.bIPAddressInUse )
+						{
+						static BaseType_t xUseIndex = 0;
+
+							pxEndPoint->xRAData.bits.bIPAddressInUse = pdFALSE_UNSIGNED;
+							if( prvGetTestAddress( xUseIndex, &( pxEndPoint->ipv6_settings.xIPAddress ) ) == pdPASS )
+							{
+								/* TESTING ONLY */
+								xUseIndex++;
+							}
+							else
+							{
+								( void ) FreeRTOS_CreateIPv6Address( &pxEndPoint->ipv6_settings.xIPAddress, &pxEndPoint->ipv6_settings.xPrefix, pxEndPoint->ipv6_settings.uxPrefixLength, pdTRUE );
+							}
+							FreeRTOS_printf( ( "RA: Creating a random IP-address\n" ) );
+						}
+						FreeRTOS_printf( ( "RA: Neighbour solicitation for %pip\n", pxEndPoint->ipv6_settings.xIPAddress.ucBytes ) );
+
+						uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPHeader_IPv6_t ) );
+						pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, ndDONT_BLOCK );
+						if( pxNetworkBuffer != NULL )
+						{
+							pxNetworkBuffer->pxEndPoint = pxEndPoint;
+							vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxEndPoint->ipv6_settings.xIPAddress ) );
+						}
+
+						uxReloadTime = pdMS_TO_TICKS( 1000uL );
+						pxEndPoint->xRAData.eRAState = eRAStateIPWait;
+					}
+					break;
+				case eRAStateIPWait:
+					{
+						/* Assuming an IP address, test if another device is using it already. */
+						/* Handled here above. */
+					}
+					break;
+				case eRAStateLease:
+					{
+						if( xSkipLease == pdFALSE )
+						{
+							vRAProcessInit( pxEndPoint );
+							uxReloadTime = pdMS_TO_TICKS( 1000uL );
+						}
+					}
+					break;
+				case eRAStateFailed:
+					{
+					}
+					break;
+				default:
+					/* All states were handled. */
+					break;
+			}
+			FreeRTOS_printf( ( "vRAProcess( %ld, %pip) state %d -> %d\n",
+							   xDoReset,
+							   pxEndPoint->ipv6_defaults.xIPAddress.ucBytes,
+							   eRAState,
+							   pxEndPoint->xRAData.eRAState ) );
+			if( uxReloadTime != 0uL )
+			{
+				vIPReloadDHCP_RATimer( pxEndPoint, uxReloadTime );
+			}
+			else
+			{
+				/* Disable the timer, this function vRAProcess() won't be called anymore for this end-point. */
+				FreeRTOS_printf( ( "RA: Disabled timer.\n" ) );
+				vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
+			}
+		}
+	}
+#endif	/* ( ipconfigUSE_RA != 0 ) */
+/*-----------------------------------------------------------*/
 
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 
@@ -678,6 +971,7 @@ static const char *pcMessageType( BaseType_t xType )
 	}
 	return pcReturn;
 }
+/*-----------------------------------------------------------*/
 
 eFrameProcessingResult_t prvProcessICMPMessage_IPv6( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
@@ -699,29 +993,11 @@ size_t uxNeededSize;
 		switch( xICMPHeader_IPv6->ucTypeOfMessage )
 		{
 			default:
-				{
-					FreeRTOS_printf( ("prvProcessICMPMessage_IPv6: unknown type %u\n", ( unsigned ) xICMPHeader_IPv6->ucTypeOfMessage ) );
-				}
-				break;
 			case ipICMP_DEST_UNREACHABLE_IPv6:
-				{
-					FreeRTOS_printf( ("prvProcessICMPMessage_IPv6: DEST_UNREACHABLE\n" ) );
-				}
-				break;
 			case ipICMP_PACKET_TOO_BIG_IPv6:
-				{
-					FreeRTOS_printf( ("prvProcessICMPMessage_IPv6: PACKET_TOO_BIG\n" ) );
-				}
-				break;
 			case ipICMP_TIME_EXEEDED_IPv6:
-				{
-					FreeRTOS_printf( ("prvProcessICMPMessage_IPv6: TIME_EXEEDED\n" ) );
-				}
-				break;
 			case ipICMP_PARAMETER_PROBLEM_IPv6:
-				{
-					FreeRTOS_printf( ("prvProcessICMPMessage_IPv6: PARAMETER_PROBLEM\n" ) );
-				}
+				/* These message types are not implemented. They are logged here above. */
 				break;
 			case ipICMP_PING_REQUEST_IPv6 :
 				{
@@ -744,7 +1020,6 @@ size_t uxNeededSize;
 				ICMPEcho_IPv6_t * pxICMPEchoHeader = ipPOINTER_CAST( ICMPEcho_IPv6_t *, xICMPHeader_IPv6 );
 				size_t usDataLength, usCount;
 				const uint8_t * pucByte;
-					FreeRTOS_printf( ("ping %pip answered\n", pxICMPPacket->xIPHeader.xSourceIPv6Address.ucBytes ) );
 
 					/* Find the total length of the IP packet. */
 					usDataLength = FreeRTOS_ntohs( pxICMPPacket->xIPHeader.usPayloadLength );
@@ -772,16 +1047,7 @@ size_t uxNeededSize;
 			case ipICMP_NEIGHBOR_SOLICITATION_IPv6 :
 				{
 				size_t uxICMPSize;
-	/*
-		uint8_t ucTypeOfMessage;       //  0 +  1 = 1
-		uint8_t ucTypeOfService;       //  1 +  1 = 2
-		uint16_t usChecksum;           //  2 +  2 = 4
-		uint32_t ulReserved;           //  4 +  4 = 8
-		IPv6_Address_t xIPv6_Address;  //  8 + 16 = 24
-		uint8_t ucOptionType;          // 24 +  1 = 25
-		uint8_t ucOptionLength;        // 25 +  1 = 26
-		uint8_t ucOptionBytes[6];      // 26 +  6 = 32
-	*/
+
 					uxICMPSize = sizeof( ICMPHeader_IPv6_t );
 					uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
 					if( uxNeededSize > pxNetworkBuffer->xDataLength )
@@ -811,111 +1077,37 @@ size_t uxNeededSize;
 					vNDRefreshCacheEntry( ipPOINTER_CAST( MACAddress_t *, xICMPHeader_IPv6->ucOptionBytes ),
 										  &( xICMPHeader_IPv6->xIPv6_Address ),
 										  pxEndPoint );
+					FreeRTOS_printf( ( "NA from %pip\n", xICMPHeader_IPv6->xIPv6_Address.ucBytes ) );
+					{
+					NetworkInterface_t *pxInterface = pxNetworkBuffer->pxInterface;
+					NetworkEndPoint_t *pxPoint;
+						for( pxPoint = FreeRTOS_FirstEndPoint( pxInterface );
+							pxPoint != NULL;
+							pxPoint = FreeRTOS_NextEndPoint( pxInterface, pxPoint ) )
+						{
+							if( ( pxPoint->bits.bWantRA != pdFALSE_UNSIGNED ) && ( pxPoint->xRAData.eRAState == eRAStateIPWait ) )
+							{
+								if( memcmp( pxPoint->ipv6_settings.xIPAddress.ucBytes, &( xICMPHeader_IPv6->xIPv6_Address ), ipSIZE_OF_IPv6_ADDRESS ) == 0 )
+								{
+									pxPoint->xRAData.bits.bIPAddressInUse = pdTRUE_UNSIGNED;
+									vIPReloadDHCP_RATimer( pxPoint, 100uL );
+								}
+							}
+						}
+					}
 				}
 				break;
 			case ipICMP_ROUTER_SOLICITATION_IPv6:
 				{
 				}
 				break;
+			#if( ipconfigUSE_RA != 0 )
 			case ipICMP_ROUTER_ADVERTISEMENT_IPv6:
 				{
-				ICMPRouterAdvertisement_IPv6_t *pxAdvertisement = ipPOINTER_CAST( ICMPRouterAdvertisement_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
-				size_t uxIndex;
-				size_t uxLast;
-				size_t uxICMPSize;
-				uint8_t *pucBytes;
-	/*
-		uint8_t ucTypeOfMessage;       //  0 +  1 =  1
-		uint8_t ucTypeOfService;       //  1 +  1 =  2
-		uint16_t usChecksum;           //  2 +  2 =  4
-		uint8_t ucHopLimit;            //  4 +  1 =  5
-		uint8_t ucFlags;               //  5 +  1 =  6
-		uint16_t usLifetime;           //  6 +  2 =  8
-		uint16_t usReachableTime[2];   //  8 +  4 = 12
-		uint16_t usRetransTime[2];     // 12 +  4 = 16
-		ICMPRouterAdvertisement_IPv6_t
-	*/
-					uxICMPSize = sizeof( ICMPRouterAdvertisement_IPv6_t );
-					uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
-					if( uxNeededSize > pxNetworkBuffer->xDataLength )
-					{
-						FreeRTOS_printf( ("Too small\n" ) );
-						break;
-					}
-//	14 + 40 + 16 = 70
-//	Total length 118
-//	118 - 70 = 48
-					FreeRTOS_printf( ( "RA: Type %02x Srv %02x Checksum %04x Hops %d Flags %02x Life %d\n",
-						pxAdvertisement->ucTypeOfMessage,
-						pxAdvertisement->ucTypeOfService,
-						FreeRTOS_ntohs( pxAdvertisement->usChecksum ),
-						pxAdvertisement->ucHopLimit,
-						pxAdvertisement->ucFlags,
-						FreeRTOS_ntohs( pxAdvertisement->usLifetime ) ) );
-					uxIndex = 0;
-					/* uxLast points to the first byte after the buffer. */
-					uxLast = pxNetworkBuffer->xDataLength - uxNeededSize;
-					pucBytes = &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
-					while( ( uxIndex + 1 ) < uxLast )
-					{
-						uint8_t ucType = pucBytes[ uxIndex ];
-						size_t uxLength = ( size_t ) pucBytes[ uxIndex + 1 ] * 8uL;
-						if( uxLast < ( uxIndex + uxLength ) )
-						{
-							FreeRTOS_printf( ( "RA: Not enough bytes ( %u > %u )\n", ( unsigned ) uxIndex + uxLength, ( unsigned ) uxLast ) );
-							break;
-						}
-						switch( ucType )
-						{ 
-							case ndICMP_SOURCE_LINK_LAYER_ADDRESS:	// 1
-								{
-									FreeRTOS_printf( ( "RA: Source = %02x-%02x-%02x-%02x-%02x-%02x\n",
-										pucBytes[ uxIndex + 2 ],
-										pucBytes[ uxIndex + 3 ],
-										pucBytes[ uxIndex + 4 ],
-										pucBytes[ uxIndex + 5 ],
-										pucBytes[ uxIndex + 6 ],
-										pucBytes[ uxIndex + 7 ] ) );
-								}
-								break;
-							case ndICMP_TARGET_LINK_LAYER_ADDRESS:	// 2
-								{
-								}
-								break;
-							case ndICMP_PREFIX_INFORMATION:			// 3
-								{
-								ICMPPrefixOption_IPv6_t *pxPrefixOption = ipPOINTER_CAST( ICMPPrefixOption_IPv6_t *, &( pucBytes[ uxIndex ] ) );
-
-									FreeRTOS_printf( ( "RA: Prefix len %d Life %lu, %lu (%pip)\n",
-										pxPrefixOption->ucPrefixLength,
-										FreeRTOS_ntohl( pxPrefixOption->ulValidLifeTime ),
-										FreeRTOS_ntohl( pxPrefixOption->ulPreferredLifeTime ),
-										pxPrefixOption->ucPrefix ) );
- 								}
-								break;
-							case ndICMP_REDIRECTED_HEADER:			// 4
-								{
-								}
-								break;
-							case ndICMP_MTU_OPTION:					// 5
-								{
-								uint32_t ulMTU;
-
-									/* ulChar2u32 returns host-endian numbers. */
-									ulMTU = ulChar2u32 ( &( pucBytes[ uxIndex + 4 ] ) );
-									FreeRTOS_printf( ( "RA: MTU = %lu\n",  ulMTU ) );
-								}
-								break;
-							default:
-								{
-									FreeRTOS_printf( ( "RA: Type %02x not implemented\n", ucType ) );
-								}
-								break;
-						}
-						uxIndex = uxIndex + uxLength;
-					}
+					prvReceiveRA( pxNetworkBuffer );
 				}
 				break;
+			#endif	/* ( ipconfigUSE_RA != 0 ) */
 		}	/* switch( xICMPHeader_IPv6->ucTypeOfMessage ) */
 	}	/* if( pxEndPoint != NULL ) */
 
@@ -990,7 +1182,6 @@ size_t xPacketSize;
 	}
 }
 /*-----------------------------------------------------------*/
-
 
 BaseType_t FreeRTOS_CreateIPv6Address( IPv6_Address_t *pxIPAddress, const IPv6_Address_t *pxPrefix, size_t uxPrefixLength, BaseType_t xDoRandom )
 {

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Routing.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_Routing.c
@@ -260,6 +260,7 @@ NetworkEndPoint_t *pxEndPoint = pxNetworkEndPoints;
 	return pxEndPoint;
 }
 /*-----------------------------------------------------------*/
+
 /*_RB_ Is it best, from the end user's perspective, to pass in an end point here, or for data hiding purposes, is it best to pass in a interface number (0, 1, etc.)? */
 void FreeRTOS_GetAddressConfiguration( NetworkEndPoint_t *pxEndPoint, uint32_t *pulIPAddress, uint32_t *pulNetMask, uint32_t *pulGatewayAddress, uint32_t *pulDNSServerAddress )
 {
@@ -349,6 +350,7 @@ NetworkEndPoint_t *FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress, uint32_
 	/* The 'ulWhere' parameter is only for debugging puposes. */
 	return FreeRTOS_InterfaceEndPointOnNetMask( NULL, ulIPAddress, ulWhere );
 }
+/*-----------------------------------------------------------*/
 
 NetworkEndPoint_t *FreeRTOS_InterfaceEndPointOnNetMask( NetworkInterface_t *pxInterface, uint32_t ulIPAddress, uint32_t ulWhere )
 {
@@ -500,7 +502,7 @@ uint32_t ulIPAddress;
 		}
 
 		/* Copy the current values to the default values. */
-		memcpy( &( pxEndPoint->ipv6_defaults ), &( pxEndPoint->ipv6_settings ), sizeof( pxEndPoint->ipv4_defaults ) );
+		memcpy( &( pxEndPoint->ipv6_defaults ), &( pxEndPoint->ipv6_settings ), sizeof( pxEndPoint->ipv6_defaults ) );
 
 		memcpy( pxEndPoint->ipv6_defaults.xIPAddress.ucBytes, pxIPAddress->ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
@@ -508,6 +510,7 @@ uint32_t ulIPAddress;
 		( void ) FreeRTOS_AddEndPoint( pxNetworkInterface, pxEndPoint );
 	}
 #endif
+/*-----------------------------------------------------------*/
 
 #if( ipconfigUSE_IPv6 != 0 )
 	static NetworkEndPoint_t *prvFindFirstAddress_IPv6( void )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_TCP_IP.c
@@ -1220,7 +1220,7 @@ FreeRTOS_printf( ( "Looking up %pip with%s end-point\n", xRemoteIP.ucBytes, ( px
 					if( pxNetworkBuffer )
 					{
 						pxNetworkBuffer->pxEndPoint = pxEndPoint;
-						vNDGenerateRequestPacket( pxNetworkBuffer, &( xRemoteIP ) );
+						vNDSendNeighbourSolicitation( pxNetworkBuffer, &( xRemoteIP ) );
 					}
 				}
 			}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_UDP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp_multi/source/FreeRTOS_UDP_IP.c
@@ -312,7 +312,7 @@ NetworkEndPoint_t *pxEndPoint = pxNetworkBuffer->pxEndPoint;
 FreeRTOS_printf( ( "Looking up %pip with%s end-point\n", pxNetworkBuffer->xIPv6_Address.ucBytes, ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
 				if( pxNetworkBuffer->pxEndPoint )
 				{
-					vNDGenerateRequestPacket( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6_Address ) );
+					vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6_Address ) );
 					/* When xIsIPV6 is true, pxIPHeader_IPv6 has been assigned a proper value. */
 					configASSERT( pxIPHeader_IPv6 != NULL );
 					memcpy( pxIPHeader_IPv6->xDestinationIPv6Address.ucBytes, pxNetworkBuffer->xIPv6_Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
@@ -587,13 +587,9 @@ UDPPacket_t *pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEt
 			{
 				if( xIsDHCPSocket( pxSocket ) )
 				{
-				IPStackEvent_t xEventMessage;
-				const TickType_t xDontBlock = 0;
-
-					xEventMessage.eEventType = eDHCPEvent;
-					xEventMessage.pvData = ( void* )NULL;
-
-					( void ) xSendEventStructToIPTask( &xEventMessage, xDontBlock );
+					/* This is the DHCP clients socket, bound to port 68. */
+					/* Can call this function directly, because this code is running from the IP-task. */
+					vDHCPProcess( pdFALSE, NULL );
 				}
 			}
 			#endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Until now, IPv6 end-points had to be configured statically.
This PR makes it possible to solicit for a Router Advertisement, which may provide the following parameters:

- Network prefix
- Prefix length
- Address of a IPv6 gateway

When these parameters are known, the device will choose a **random IP-address that uses the prefix and prefix-length**.

It will be tested if the IP-address already exists by issuing a few neighbour solicitations, and wait for replies.
When no other device replies, the address will be taken and the end-point will go UP. When there are replies, a new one will be chosen, and the procedure is repeated.

These are the default configuration macro's that control the entire process:

~~~c
    /* Ask for a Router Advertisement at most 3 times. */
    #define ipconfigRA_SEARCH_COUNT             ( 3 )
    /* Each time waiting at most 10 seconds for an answer. */
    #define ipconfigRA_SEARCH_TIME_OUT_MSEC     ( 10000u )

    /* Test the self-chose IP-address 3 times. */
    #define ipconfigRA_IP_TEST_COUNT            ( 3 )
    /* Each time waiting at most 1.5 seconds for a reply. */
    #define ipconfigRA_IP_TEST_TIME_OUT_MSEC    ( 1500u )
~~~

All sources were PC-LINT-ed, and tested in several ways, both with IPv4 and IPv6:

- Ping to the Internet
- Connect to a web-site
- Receive pings from the Internet [using this tool](https://www.ipaddressguide.com/ping6)
- Connect from a laptop to the device


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.