### PR TITLE
Fix cmake scope issue for source file properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,16 @@ elseif(DEFINED AFR_MANIFEST_BOARD_DIR)
 else()
     message(FATAL_ERROR "Could not import board CMakeLists.txt.")
 endif()
-add_subdirectory("${AFR_BOARD_PATH}")
+# Use include here because we need portable layer targets defined by vendor to be at
+# the same directory level as our library components.
+include("${AFR_BOARD_PATH}/CMakeLists.txt")
 
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS modules
 # -------------------------------------------------------------------------------------------------
+# Do not prefix the output library file.
+set(CMAKE_STATIC_LIBRARY_PREFIX "")
+
 # Initialize all modules.
 add_subdirectory("libraries")
 add_subdirectory("demos")

--- a/libraries/abstractions/ble_hal/CMakeLists.txt
+++ b/libraries/abstractions/ble_hal/CMakeLists.txt
@@ -1,11 +1,11 @@
-afr_module(INTERFACE)
+afr_module()
 
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    INTERFACE
+    PUBLIC
         "${inc_dir}/bt_hal_avsrc_profile.h"
         "${inc_dir}/bt_hal_gatt_client.h"
         "${inc_dir}/bt_hal_gatt_server.h"
@@ -18,12 +18,14 @@ afr_module_sources(
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    INTERFACE "${inc_dir}"
+    PUBLIC "${inc_dir}"
 )
 
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::ble_hal::mcu_port
+    PRIVATE
+        AFR::ble_hal::mcu_port
+        AFR::ble
 )
 
 # BLE hal test

--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -3,9 +3,6 @@ if(CMAKE_CROSSCOMPILING)
     enable_language(ASM)
 endif()
 
-# Do not prefix the output library file.
-set(CMAKE_STATIC_LIBRARY_PREFIX "")
-
 # Set some global path variables.
 get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 set(AFR_ROOT_DIR ${__root_dir} CACHE INTERNAL "Amazon FreeRTOS source root.")

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 if("${AFR_BOARD_NAME}" STREQUAL "esp32_devkitc")
-    include("esp32_devkitc.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/esp32_devkitc.cmake")
 endif()
 if("${AFR_BOARD_NAME}" STREQUAL "esp32_wrover_kit")
-    include("esp32_wrover_kit.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/esp32_wrover_kit.cmake")
 endif()
 
 # -------------------------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ target_sources(
     INTERFACE
         "${afr_ports_dir}/ble/iot_ble_hal_common_gap.c"
         "${afr_ports_dir}/ble/iot_ble_hal_gap.c"
-        "${afr_ports_dir}/ble/iot_ble_hal_gatt_server.c"     
+        "${afr_ports_dir}/ble/iot_ble_hal_gatt_server.c"
         ${bluedroid_src}
         ${nimble_src}
 )

--- a/vendors/marvell/boards/mw300_rd/CMakeLists.txt
+++ b/vendors/marvell/boards/mw300_rd/CMakeLists.txt
@@ -14,10 +14,10 @@ endif()
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 if("${AFR_BOARD_NAME}" STREQUAL "mw320")
-    include("mw320.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/mw320.cmake")
 endif()
 if("${AFR_BOARD_NAME}" STREQUAL "mw322")
-    include("mw322.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/mw322.cmake")
 endif()
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
+++ b/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 if("${AFR_BOARD_NAME}" STREQUAL "curiosity_pic32mzef")
-    include("curiosity_pic32mzef.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/curiosity_pic32mzef.cmake")
 endif()
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
+++ b/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
@@ -12,9 +12,9 @@ endif()
 
 # Include IDE specific cmake file.
 if(${AFR_TOOLCHAIN} STREQUAL "arm-gcc")
-    include("mcuxpresso.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/mcuxpresso.cmake")
 elseif(${AFR_TOOLCHAIN} STREQUAL "arm-iar")
-    include("iar.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/iar.cmake")
 elseif(NOT AFR_METADATA_MODE)
     message( FATAL_ERROR "The toolchain is not supported." )
 endif()

--- a/vendors/ti/boards/cc3220_launchpad/CMakeLists.txt
+++ b/vendors/ti/boards/cc3220_launchpad/CMakeLists.txt
@@ -12,9 +12,9 @@ endif()
 
 # Include IDE specific cmake file.
 if(${AFR_TOOLCHAIN} STREQUAL "arm-ti")
-    include("ccs.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/ccs.cmake")
 elseif(${AFR_TOOLCHAIN} STREQUAL "arm-iar")
-    include("iar.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/iar.cmake")
     if(NOT AFR_METADATA_MODE)
         message(FATAL_ERROR "CMake support for TI using IAR is not complete yet.")
     endif()
@@ -148,7 +148,7 @@ target_sources(
         "${afr_ports_dir}/pkcs11/iot_pkcs11_pal.c"
 )
 target_link_libraries(
-    AFR::pkcs11_implementation::mcu_port    
+    AFR::pkcs11_implementation::mcu_port
     INTERFACE
         AFR::pkcs11_mbedtls
         3rdparty::mbedtls


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

This PR addresses issues in #832 and #1131,

- Use `include` for vendor CMake file instead of `add_subdirectory`.
- BLE hal layer is now defined as static library.

Some use cases require vendor to set some custom settings at source file level. Specifically in issue #1131, some source files in BLE hal porting layer needs to be treated as header files. However, CMake does not support passing these settings outside of current directory scope. `add_subdirectory` will create a new scope which makes this impossible. So we need to use `include` which do not create a new scope.

Test results are pending at this moment.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] ~~My code is Linted.~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.