### PR TITLE
Add unit tests for mbox functions in lwIP

### DIFF
--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/Makefile
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/Makefile
@@ -1,0 +1,22 @@
+TEST_SRC:=$(wildcard test-*.c)
+TEMP_SRC:=$(patsubst test-%,%,$(TEST_SRC))
+TESTS=$(patsubst %.c,%,$(TEST_SRC))
+
+CFLAGS+=-std=c99 -Wall -fprofile-arcs -ftest-coverage -O0 -ggdb
+
+build: $(TESTS)
+
+test: build
+	@rm -f *.gcov *.gcda
+	@./report $(TESTS)
+
+clean:
+	rm -f $(TESTS) $(TEMP_SRC) *.gc??
+
+.PHONY: build test clean
+
+$(TEMP_SRC): ../sys_arch.c
+	sed -nr '/^(void|u32_t|err_t) $(patsubst %.c,%,$@)\(.*[^;]$$/,/^}/p' $< > $@
+
+$(TESTS): test-%: test-%.c %.c common.h tap.h
+	$(CC) $(CFLAGS) $< -o $@

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/README
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/README
@@ -1,0 +1,4 @@
+These are unit tests for the mbox functions from sys_arch.c.
+They demonstrate a cpp-based approach to writing tests.
+A write-up of the approach and these tests may be found at
+https://git.io/fjxVo

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/common.h
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/common.h
@@ -1,0 +1,36 @@
+#include "tap.h"
+
+struct sys_mbox {
+    void *xMbox;
+    void *xTask;
+};
+typedef struct sys_mbox sys_mbox_t;
+
+typedef unsigned u32_t;
+
+typedef int err_t;
+typedef int BaseType_t;
+typedef int portBASE_TYPE;
+
+typedef void * QueueHandle_t;
+typedef void * TaskHandle_t;
+
+#define UNDEFINED 0xcafecafe
+
+#define pdTRUE  1
+#define pdFALSE 0
+
+#define ERR_OK  0
+#define ERR_MEM 1
+#define ERR_ASSERT 255
+
+#define SYS_ARCH_TIMEOUT 99
+
+#define portMAX_DELAY 999
+#define portTICK_PERIOD_MS 10
+
+int critical;
+#define post_crit_hook()        /* initially empty - redefine as needed */
+#define taskENTER_CRITICAL()    do { critical++; } while (0)
+#define taskEXIT_CRITICAL()     do { critical--; post_crit_hook(); } while (0)
+#define critReset()             do { critical = 0; } while (0)

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/report
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/report
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for t in "$@"; do
+    [[ -x $t ]] || continue
+    fn=${t#test-}
+    result=`./$t | egrep 'PASS|FAIL'`
+    coverage=`gcov -f $t | sed -nr "/^Function '$fn'/{n;p;q;}"`
+    printf "%-30s%-15s%s\n" "$t" "$result" "$coverage"
+    egrep -B2 -A2 '#{5}' $fn.c.gcov
+done
+exit 0

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/tap.h
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/tap.h
@@ -1,0 +1,46 @@
+/* minimal TAP: test anything protocol */
+/* https://testanything.org/ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int _plan;      /* number of tests */
+int _ok_cnt;    /* number of passing tests */
+int _index;     /* ordinal of current test */
+int _verbose;   /* flag: show all expressions */
+
+/* how many tests should run? */
+/* set verbose flag if environment var VERBOSE exists */
+#define plan(x)  do {                               \
+    _plan = (x);                                    \
+    if (_plan)                                      \
+        printf("%d..%d\n", 1, _plan);               \
+    if (getenv("VERBOSE"))                          \
+        _verbose = 1;                               \
+} while (0)
+
+/* test expression x and keep count of true values */
+/* output diagnostic if false or if VERBOSE is set */
+#define ok(x) do {                                  \
+    char *msg = "not ok";                           \
+    _index++;                                       \
+    int pass = (x);                                 \
+    if (pass) {                                     \
+        _ok_cnt++;                                  \
+        msg += 4;                                   \
+    }                                               \
+    if (_verbose || !pass)                          \
+        printf("%s %d - %s:%d\t%s\n", msg, _index,  \
+                __FILE__, __LINE__, #x);            \
+    else                                            \
+        printf("%s %d\n", msg, _index);             \
+} while (0)
+
+/* summarize test run, and return an exit value for main() */
+#define tally() ({                                  \
+    if (!_plan)                                     \
+        plan(_index);                               \
+    int pass = _plan == _ok_cnt;                    \
+    printf("%s\n", pass ? "PASSED" : "FAILED");     \
+    pass ? EXIT_SUCCESS : EXIT_FAILURE;             \
+})

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_arch_mbox_fetch.c
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_arch_mbox_fetch.c
@@ -1,0 +1,138 @@
+#include "common.h"
+
+/* invariant to test upon exit of taskEXIT_CRITICAL() */
+/* initially disabled for early failure tests */
+int run_hook;
+#undef  post_crit_hook
+#define post_crit_hook()  do {          \
+    if (run_hook)                       \
+        ok(pxMailBox->xTask == task);   \
+} while (0)
+
+void *task;
+#define xTaskGetCurrentTaskHandle() ({ task; })
+#define xtgcReset()     do { task = &task; } while (0)
+
+int xqrRet;
+void *xqrSaveHandle;
+void *xqrSaveBuffer;
+int xqrSaveTmout;
+int xqrCallCount;
+#define xQueueReceive(handle, buffer, tmout)  ({ \
+    xqrSaveHandle = (handle);           \
+    xqrSaveBuffer = (buffer);           \
+    xqrSaveTmout  = (tmout);            \
+    if (!xqrRet && ++xqrCallCount == 3) \
+        xqrRet = pdTRUE;                \
+    xqrRet;                             \
+})
+#define xqrReset()  do {        \
+    xqrCallCount = 0;           \
+    xqrSaveHandle = NULL;       \
+    xqrSaveBuffer = NULL;       \
+    xqrSaveTmout = UNDEFINED;   \
+    xqrRet = pdFALSE;           \
+} while (0)
+
+int xInsideISR;
+#define configASSERT(x)  do { if (!(x)) return ERR_ASSERT; } while (0)
+
+#include "sys_arch_mbox_fetch.c"
+
+int main(void) {
+    unsigned ret;
+    void *mbox;
+    sys_mbox_t foo, fooDflt = { &mbox, NULL };
+    void *buffer;
+
+    #define reset() do {    \
+        critReset();        \
+        xtgcReset();        \
+        xqrReset();         \
+        critical = 0;       \
+        xInsideISR = 0;     \
+        foo = fooDflt;      \
+        ret = UNDEFINED;    \
+    } while (0)
+    reset();
+
+    /* invariant sets are cumulative */
+    #define invariants(x) do {                      \
+        switch (x) {                                \
+            case 2:                                 \
+                ok(xqrSaveHandle == &mbox);         \
+                ok(xqrSaveBuffer == &buffer);       \
+                ok(foo.xTask == NULL);              \
+            case 1:                                 \
+                ok(critical == 0);                  \
+        }                                           \
+        reset();                                    \
+    } while (0)
+
+    plan(42);
+
+    /* trip ISR assertion */
+    xInsideISR = 1;
+    ret = sys_arch_mbox_fetch(NULL, NULL, 0);
+    ok(ret == ERR_ASSERT);
+    invariants(1);
+
+    /* bad first arg */
+    ret = sys_arch_mbox_fetch(NULL, NULL, 0);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(1);
+
+    /* bad struct first element */
+    foo.xMbox = NULL;
+    ret = sys_arch_mbox_fetch(&foo, NULL, 0);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(1);
+
+    /* mbox in use by another */
+    foo.xTask = &foo;
+    ret = sys_arch_mbox_fetch(&foo, NULL, 0);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(1);
+
+    /* bad return from xTaskGetCurrentTaskHandle() */
+    task = NULL;
+    ret = sys_arch_mbox_fetch(&foo, NULL, 0);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(1);
+
+    /* enable post_crit_hook() for remaining cases */
+    run_hook = 1;
+
+    /* xQueueReceive fails, no buffer provided */
+    ret = sys_arch_mbox_fetch(&foo, NULL, 1);
+    ok(xqrSaveTmout == 1/portTICK_PERIOD_MS);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(1);
+
+    /* xQueueReceive fails */
+    ret = sys_arch_mbox_fetch(&foo, &buffer, 1);
+    ok(xqrSaveTmout == 1/portTICK_PERIOD_MS);
+    ok(ret == SYS_ARCH_TIMEOUT);
+    invariants(2);
+
+    /* xQueueReceive fails, but later succeeds - only for timeout=0 */
+    ret = sys_arch_mbox_fetch(&foo, &buffer, 0);
+    ok(xqrSaveTmout == portMAX_DELAY);
+    ok(ret == 1);
+    invariants(2);
+
+    /* happy path, with and without timeout */
+    xqrRet = pdTRUE;
+    ret = sys_arch_mbox_fetch(&foo, &buffer, 1);
+    ok(xqrSaveTmout == 1/portTICK_PERIOD_MS);
+    ok(ret == 1);
+    invariants(2);
+
+    xqrRet = pdTRUE;
+    ret = sys_arch_mbox_fetch(&foo, &buffer, 0);
+    ok(xqrSaveTmout == portMAX_DELAY);
+    ok(ret == 1);
+    invariants(2);
+
+    return tally();
+}

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_mbox_free.c
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_mbox_free.c
@@ -1,0 +1,107 @@
+#include "common.h"
+
+int uqmwRet;
+void *uqmwHandle;
+#define uxQueueMessagesWaiting(x)  ({ uqmwHandle = (x); uqmwRet; })
+#define uqmwReset()         do { uqmwRet = 0; uqmwHandle = &uqmwHandle; } while (0)
+
+void *xtadHandle;
+int xtadCallCount;
+#define xTaskAbortDelay(x)  do { xtadCallCount++; xtadHandle = (x); } while (0)
+#define xtadReset()         do { xtadCallCount = 0; xtadHandle = &xtadHandle; } while (0)
+
+void *vqdHandle;
+int vqdCallCount;
+#define vQueueDelete(x)     do { vqdCallCount++; vqdHandle = (x); } while (0)
+#define vqdReset()          do { vqdCallCount = 0; vqdHandle = &vqdHandle; } while (0)
+
+int assertCount;
+#define configASSERT(x)     do { if (!(x)) { assertCount++; return; } } while (0)
+#define assertReset()       do { assertCount = 0; } while (0)
+
+#include "sys_mbox_free.c"
+
+int main(void) {
+    void *mbox, *task;
+    sys_mbox_t foo, fooDflt = { &mbox, &task };
+
+    #define reset() do {    \
+        critReset();        \
+        uqmwReset();        \
+        xtadReset();        \
+        vqdReset();         \
+        assertReset();      \
+        foo = fooDflt;      \
+    } while (0)
+    reset();
+
+    /* invariant sets are cumulative */
+    #define invariants(x) do {      \
+        switch (x) {                \
+        /* crit section reached */  \
+        case 2:                     \
+            ok(foo.xMbox == NULL);  \
+            ok(assertCount == 0);   \
+        /* always */                \
+        case 1:                     \
+            ok(critical == 0);      \
+        }                           \
+        reset();                    \
+    } while (0)
+
+    plan(38);
+
+    /* NULL arg is NOOP */
+    sys_mbox_free(NULL);
+    ok(uqmwHandle == &uqmwHandle);
+    ok(assertCount == 0);
+    ok(xtadCallCount == 0);
+    ok(vqdCallCount == 0);
+    invariants(1);
+
+    /* trip no-messages assertion */
+    uqmwRet = 1;
+    sys_mbox_free(&foo);
+    ok(uqmwHandle == &mbox);
+    ok(assertCount == 1);
+    ok(xtadCallCount == 0);
+    ok(vqdCallCount == 0);
+    invariants(1);
+
+    /* NULL struct members */
+    foo = (sys_mbox_t){NULL, NULL};
+    sys_mbox_free(&foo);
+    ok(uqmwHandle == NULL);
+    ok(xtadCallCount == 0);
+    ok(vqdCallCount == 0);
+    invariants(2);
+
+    /* NULL mbox member */
+    foo.xMbox = NULL;
+    sys_mbox_free(&foo);
+    ok(uqmwHandle == NULL);
+    ok(xtadCallCount == 1);
+    ok(xtadHandle == &task);
+    ok(vqdCallCount == 0);
+    invariants(2);
+
+    /* NULL task member */
+    foo.xTask = NULL;
+    sys_mbox_free(&foo);
+    ok(uqmwHandle == &mbox);
+    ok(xtadCallCount == 0);
+    ok(vqdCallCount == 1);
+    ok(vqdHandle == &mbox);
+    invariants(2);
+
+    /* happy path */
+    sys_mbox_free(&foo);
+    ok(uqmwHandle == &mbox);
+    ok(xtadCallCount == 1);
+    ok(xtadHandle == &task);
+    ok(vqdCallCount == 1);
+    ok(vqdHandle == &mbox);
+    invariants(2);
+
+    return tally();
+}

--- a/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_mbox_new.c
+++ b/libraries/3rdparty/lwip/src/portable/arch/unit-test/test-sys_mbox_new.c
@@ -1,0 +1,42 @@
+#include "common.h"
+
+int keep;
+void *mbox;
+#define xQueueCreate(x, y) ({ keep = (x); mbox; })
+#define xqcReset() do { \
+    keep = -UNDEFINED;  \
+    mbox = &mbox;       \
+} while (0)
+
+#include "sys_mbox_new.c"
+
+int main(void) {
+    int err;
+    sys_mbox_t foo, fooDflt = { &foo, &foo };
+
+    #define reset() do {    \
+        xqcReset();         \
+        foo = fooDflt;      \
+    } while (0)
+
+    plan(8);
+
+    /* happy path */
+    reset();
+    err = sys_mbox_new(&foo, 123);
+    ok(err == ERR_OK);
+    ok(keep == 123);
+    ok(foo.xTask == NULL);
+    ok(foo.xMbox == &mbox);
+
+    /* xQueueCreate returns NULL */
+    reset();
+    mbox = NULL;
+    err = sys_mbox_new(&foo, 234);
+    ok(err == ERR_MEM);
+    ok(keep == 234);
+    ok(foo.xTask == &foo); /* unchanged */
+    ok(foo.xMbox == &foo); /* unchanged */
+
+    return tally();
+}


### PR DESCRIPTION
These are unit tests for the mbox functions from sys_arch.c.
They demonstrate a cpp-based approach to writing tests.
A write-up of the approach and these tests may be found at
https://git.io/fjxVo