### PR TITLE
Update RX100 port.c interrupt vector pragma

### DIFF
--- a/freertos_kernel/portable/Renesas/RX100/port.c
+++ b/freertos_kernel/portable/Renesas/RX100/port.c
@@ -296,7 +296,7 @@ static void prvStartFirstTask( void )
 }
 /*-----------------------------------------------------------*/
 
-#pragma interrupt ( prvTickISR( vect = configTICK_VECTOR, enable ) )
+#pragma interrupt ( prvTickISR( vect = _VECT( configTICK_VECTOR ), enable ) )
 void prvTickISR( void )
 {
 	/* Increment the tick, and perform any processing the new tick value


### PR DESCRIPTION
This updates the RX100 port.c #pragma interrupt to work with
CC-RX V3.00.00 compiler.

Resolves https://github.com/aws/amazon-freertos/issues/1006

<!--- Title -->

Description
-----------
NOTE: This now matches the syntax of RX200 and RX600 and RX600v2 port.c files.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.