### PR TITLE
Fix BLE testcase setup and teardown

### DIFF
--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -119,8 +119,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
 #if ( configUSE_TRACE_FACILITY == 1 )
     void threadPriorityTestFunction( void * param )
     {
-
-        *(int32_t*) param = uxTaskPriorityGet( NULL );
+        *( int32_t * ) param = uxTaskPriorityGet( NULL );
     }
 
     TEST( UTIL_Platform_Threads, IotThreads_ThreadPriority )
@@ -171,7 +170,6 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
  */
     void threadStackSizeTestFunction( void * param )
     {
-
         *( int32_t * ) param = 300 + uxTaskGetStackHighWaterMark( NULL );
     }
 #endif /* if ( configUSE_TRACE_FACILITY == 1 ) */

--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -71,7 +71,7 @@ TEST_TEAR_DOWN( UTIL_Platform_Threads )
 TEST_GROUP_RUNNER( UTIL_Platform_Threads )
 {
     RUN_TEST_CASE( UTIL_Platform_Threads, IotThreads_CreateDetachedThread );
-    #if ( configUSE_TRACE_FACILITY == 1 )
+    #if ( INCLUDE_uxTaskPriorityGet == 1 )
         RUN_TEST_CASE( UTIL_Platform_Threads, IotThreads_ThreadPriority );
     #endif
     RUN_TEST_CASE( UTIL_Platform_Threads, IotThreads_MutexTest );
@@ -116,7 +116,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
 /**
  * @brief helper function for testing thread priority
  */
-#if ( configUSE_TRACE_FACILITY == 1 )
+#if ( INCLUDE_uxTaskPriorityGet == 1 )
     void threadPriorityTestFunction( void * param )
     {
         *( int32_t * ) param = uxTaskPriorityGet( NULL );
@@ -163,16 +163,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
 
         printf( "Expected Pri = 7, actual = %d\r\n", ( int ) attrData );
     }
-/*-----------------------------------------------------------*/
-
-/**
- * @brief helper function for testing thread priority
- */
-    void threadStackSizeTestFunction( void * param )
-    {
-        *( int32_t * ) param = 300 + uxTaskGetStackHighWaterMark( NULL );
-    }
-#endif /* if ( configUSE_TRACE_FACILITY == 1 ) */
+#endif /* if ( INCLUDE_uxTaskPriorityGet == 1 ) */
 
 /**
  * @brief helper function for testing mutex

--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -119,23 +119,8 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
 #if ( configUSE_TRACE_FACILITY == 1 )
     void threadPriorityTestFunction( void * param )
     {
-        TaskStatus_t xTaskDetails;
 
-        /* Use the handle to obtain further information about the task. */
-        vTaskGetInfo( /* The handle of the task being queried. */
-            NULL,
-
-            /* The TaskStatus_t structure to complete with information
-             * on xTask. */
-            &xTaskDetails,
-
-            /* Include the stack high water mark value in the
-             * TaskStatus_t structure. */
-            pdTRUE,
-            /* Include the task state in the TaskStatus_t structure. */
-            eInvalid );
-
-        *( int32_t * ) param = xTaskDetails.uxCurrentPriority;
+        *(int32_t*) param = uxTaskPriorityGet( NULL );
     }
 
     TEST( UTIL_Platform_Threads, IotThreads_ThreadPriority )
@@ -186,23 +171,8 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
  */
     void threadStackSizeTestFunction( void * param )
     {
-        TaskStatus_t xTaskDetails;
 
-        /* Use the handle to obtain further information about the task. */
-        vTaskGetInfo( /* The handle of the task being queried. */
-            NULL,
-
-            /* The TaskStatus_t structure to complete with information
-             * on xTask. */
-            &xTaskDetails,
-
-            /* Include the stack high water mark value in the
-             * TaskStatus_t structure. */
-            pdTRUE,
-            /* Include the task state in the TaskStatus_t structure. */
-            eInvalid );
-
-        *( int32_t * ) param = 300 + xTaskDetails.usStackHighWaterMark;
+        *( int32_t * ) param = 300 + uxTaskGetStackHighWaterMark( NULL );
     }
 #endif /* if ( configUSE_TRACE_FACILITY == 1 ) */
 

--- a/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_declare.h
+++ b/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_declare.h
@@ -53,7 +53,7 @@ BaseType_t test_HandleDeleteNetworkRequest( uint8_t * pucData,
 
 WIFIReturnCode_t test_AppendNetwork( WIFINetworkProfile_t * pxProfile );
 
-WIFIReturnCode_t test_AddNewNetwork( WIFINetworkProfile_t * pxProfile );
+WIFIReturnCode_t test_AddNewNetwork( WIFINetworkProfile_t * pxProfile, bool connect );
 
 WIFIReturnCode_t test_PopNetwork( uint16_t usIndex,
                                   WIFINetworkProfile_t * pxProfile );

--- a/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_declare.h
+++ b/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_declare.h
@@ -53,7 +53,8 @@ BaseType_t test_HandleDeleteNetworkRequest( uint8_t * pucData,
 
 WIFIReturnCode_t test_AppendNetwork( WIFINetworkProfile_t * pxProfile );
 
-WIFIReturnCode_t test_AddNewNetwork( WIFINetworkProfile_t * pxProfile, bool connect );
+WIFIReturnCode_t test_AddNewNetwork( WIFINetworkProfile_t * pxProfile,
+                                     bool connect );
 
 WIFIReturnCode_t test_PopNetwork( uint16_t usIndex,
                                   WIFINetworkProfile_t * pxProfile );

--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
@@ -49,17 +49,17 @@ static bool bBLEInitialized = pdFALSE;
 /**
  * @brief Declares and runs an MQTT system test.
  */
-#define RUN_MQTT_SYSTEM_TEST( name )                    \
-    extern void TEST_MQTT_System_ ## name ## _( void ); \
-    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" );\
+#define RUN_MQTT_SYSTEM_TEST( name )                               \
+    extern void TEST_MQTT_System_ ## name ## _( void );            \
+    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" ); \
     TEST_MQTT_System_ ## name ## _();
 
 /**
  * @brief Declares and runs shadow system test.
  */
-#define RUN_SHADOW_SYSTEM_TEST( name )                    \
-    extern void TEST_Shadow_System_ ## name ## _( void ); \
-    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" );\
+#define RUN_SHADOW_SYSTEM_TEST( name )                             \
+    extern void TEST_Shadow_System_ ## name ## _( void );          \
+    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" ); \
     TEST_Shadow_System_ ## name ## _();
 /*-----------------------------------------------------------*/
 

--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
@@ -43,13 +43,15 @@
 
 /*-----------------------------------------------------------*/
 
-extern void IotTestNetwork_SelectNetworkType( uint16_t networkType );
+extern bool IotTestNetwork_SelectNetworkType( uint16_t networkType );
+static bool bBLEInitialized = pdFALSE;
 
 /**
  * @brief Declares and runs an MQTT system test.
  */
 #define RUN_MQTT_SYSTEM_TEST( name )                    \
     extern void TEST_MQTT_System_ ## name ## _( void ); \
+    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" );\
     TEST_MQTT_System_ ## name ## _();
 
 /**
@@ -57,6 +59,7 @@ extern void IotTestNetwork_SelectNetworkType( uint16_t networkType );
  */
 #define RUN_SHADOW_SYSTEM_TEST( name )                    \
     extern void TEST_Shadow_System_ ## name ## _( void ); \
+    TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" );\
     TEST_Shadow_System_ ## name ## _();
 /*-----------------------------------------------------------*/
 
@@ -87,7 +90,7 @@ TEST_TEAR_DOWN( Full_BLE_END_TO_END_MQTT )
 TEST_GROUP_RUNNER( Full_BLE_END_TO_END_MQTT )
 {
     /* For these tests, use the BLE network interface. */
-    IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
+    bBLEInitialized = IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
 
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, SubscribePublishWaitQoS0 );
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, SubscribePublishWaitQoS1 );
@@ -178,7 +181,7 @@ TEST_TEAR_DOWN( Full_BLE_END_TO_END_SHADOW )
 TEST_GROUP_RUNNER( Full_BLE_END_TO_END_SHADOW )
 {
     /* For these tests, use the BLE network interface. */
-    IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
+    bBLEInitialized = IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
 
     RUN_TEST_CASE( Full_BLE_END_TO_END_SHADOW, UpdateGetDeleteAsyncQoS0 );
     RUN_TEST_CASE( Full_BLE_END_TO_END_SHADOW, UpdateGetDeleteAsyncQoS1 );

--- a/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
@@ -36,6 +36,7 @@
 #include "FreeRTOS.h"
 #include "iot_ble_wifi_provisioning.h"
 #include "iot_ble_wifi_prov_test_access_declare.h"
+#include "iot_ble_data_transfer.h"
 #include "aws_clientcredential.h"
 /* Test framework includes. */
 #include "unity_fixture.h"
@@ -59,17 +60,43 @@ TEST_GROUP( Full_WiFi_Provisioning );
 
 /*-----------------------------------------------------------*/
 
+#include "bt_hal_manager_types.h"
+static bool bleInitialized = false;
+static bool iotBleInitialized = false;
+static bool iotBleWifiProvisioningInitialized = false;
+extern BTStatus_t bleStackInit( void );
+
+static bool bleInit() {
+    if (!bleInitialized) {
+        bleInitialized = ( eBTStatusSuccess == bleStackInit() );
+    }
+    if (bleInitialized && ! iotBleInitialized ) {
+        iotBleInitialized = ( eBTStatusSuccess == IotBle_Init() );
+    }
+    return iotBleInitialized;
+}
+
+/*-----------------------------------------------------------*/
+
 TEST_SETUP( Full_WiFi_Provisioning )
 {
-    IotBleWifiProv_Init();
+    if ( bleInit() ) { 
+        iotBleWifiProvisioningInitialized = IotBleWifiProv_Init();
+    }
+
+    TEST_ASSERT_EQUAL( bleInitialized, true);
+    TEST_ASSERT_EQUAL( iotBleInitialized, true);
+    TEST_ASSERT_EQUAL( iotBleWifiProvisioningInitialized, true);
 }
 
 /*-----------------------------------------------------------*/
 
 TEST_TEAR_DOWN( Full_WiFi_Provisioning )
 {
-    IotBleWifiProv_Deinit();
-    prvRemoveSavedNetworks();
+    if (iotBleWifiProvisioningInitialized) {
+        IotBleWifiProv_Deinit();
+        prvRemoveSavedNetworks();
+    }
 }
 
 

--- a/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
@@ -66,13 +66,18 @@ static bool iotBleInitialized = false;
 static bool iotBleWifiProvisioningInitialized = false;
 extern BTStatus_t bleStackInit( void );
 
-static bool bleInit() {
-    if (!bleInitialized) {
+static bool bleInit()
+{
+    if( !bleInitialized )
+    {
         bleInitialized = ( eBTStatusSuccess == bleStackInit() );
     }
-    if (bleInitialized && ! iotBleInitialized ) {
+
+    if( bleInitialized && !iotBleInitialized )
+    {
         iotBleInitialized = ( eBTStatusSuccess == IotBle_Init() );
     }
+
     return iotBleInitialized;
 }
 
@@ -80,20 +85,22 @@ static bool bleInit() {
 
 TEST_SETUP( Full_WiFi_Provisioning )
 {
-    if ( bleInit() ) { 
+    if( bleInit() )
+    {
         iotBleWifiProvisioningInitialized = IotBleWifiProv_Init();
     }
 
-    TEST_ASSERT_EQUAL( bleInitialized, true);
-    TEST_ASSERT_EQUAL( iotBleInitialized, true);
-    TEST_ASSERT_EQUAL( iotBleWifiProvisioningInitialized, true);
+    TEST_ASSERT_EQUAL( bleInitialized, true );
+    TEST_ASSERT_EQUAL( iotBleInitialized, true );
+    TEST_ASSERT_EQUAL( iotBleWifiProvisioningInitialized, true );
 }
 
 /*-----------------------------------------------------------*/
 
 TEST_TEAR_DOWN( Full_WiFi_Provisioning )
 {
-    if (iotBleWifiProvisioningInitialized) {
+    if( iotBleWifiProvisioningInitialized )
+    {
         IotBleWifiProv_Deinit();
         prvRemoveSavedNetworks();
     }

--- a/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
@@ -129,7 +129,7 @@ TEST( Full_WiFi_Provisioning, WIFI_PROVISION_AddNetwork )
     if( TEST_PROTECT() )
     {
         prvGetRealWIFINetwork( &xNetwork );
-        xStatus = test_AddNewNetwork( &xNetwork );
+        xStatus = test_AddNewNetwork( &xNetwork, true );
 
         TEST_ASSERT_EQUAL( eWiFiSuccess, xStatus );
         /* Verify that the network is connected */
@@ -185,7 +185,7 @@ TEST( Full_WiFi_Provisioning, WIFI_PROVISION_DeleteNetwork )
     if( TEST_PROTECT() )
     {
         /* Add the new network */
-        xStatus = test_AddNewNetwork( &xNetwork );
+        xStatus = test_AddNewNetwork( &xNetwork, true );
         TEST_ASSERT_EQUAL( eWiFiSuccess, xStatus );
         /* Verify that network is added */
         TEST_ASSERT_EQUAL( eWiFiSuccess, WIFI_NetworkGet( &xNetwork, 0 ) );
@@ -287,7 +287,7 @@ TEST( Full_WiFi_Provisioning, WIFI_PROVISION_ChangeConnectedNetworkPriority )
 
         /* Add real network */
         prvGetRealWIFINetwork( &xNetwork );
-        xStatus = test_AddNewNetwork( &xNetwork );
+        xStatus = test_AddNewNetwork( &xNetwork, true );
 
 
         TEST_ASSERT_EQUAL( eWiFiSuccess, xStatus );
@@ -326,7 +326,7 @@ TEST( Full_WiFi_Provisioning, WIFI_PROVISION_DeleteConnectedNetwork )
     {
         /* Add real network */
         prvGetRealWIFINetwork( &xNetwork );
-        xStatus = test_AddNewNetwork( &xNetwork );
+        xStatus = test_AddNewNetwork( &xNetwork, true );
         TEST_ASSERT_EQUAL( eWiFiSuccess, xStatus );
         TEST_ASSERT_EQUAL( pdTRUE, WIFI_IsConnected() );
 

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
@@ -171,7 +171,10 @@ TEST_SETUP( Full_OTA_AGENT )
 TEST_TEAR_DOWN( Full_OTA_AGENT )
 {
     /* Disconnect from the MQTT broker. */
-    IotMqtt_Disconnect( xMQTTClientHandle, 0 );
+    /* This must be protected against a Null xMQTTClientHandle if setup failed, for example due to an intermittent network connection */
+    if ( xMQTTClientHandle != NULL ) {
+        IotMqtt_Disconnect( xMQTTClientHandle, 0 );
+    }
 
     xMQTTClientHandle = NULL;
     IotMqtt_Cleanup();

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
@@ -172,7 +172,8 @@ TEST_TEAR_DOWN( Full_OTA_AGENT )
 {
     /* Disconnect from the MQTT broker. */
     /* This must be protected against a Null xMQTTClientHandle if setup failed, for example due to an intermittent network connection */
-    if ( xMQTTClientHandle != NULL ) {
+    if( xMQTTClientHandle != NULL )
+    {
         IotMqtt_Disconnect( xMQTTClientHandle, 0 );
     }
 

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -210,6 +210,7 @@ const IotNetworkInterface_t * IotTestNetwork_GetNetworkInterface( void )
 bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
 {
     bool bInitializeSucceeded = pdFALSE;
+
     switch( networkType )
     {
         #if ( BLE_SUPPORTED == 1 )
@@ -230,6 +231,7 @@ bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
         default:
             break;
     }
+
     _IotTestNetworkType = networkType;
     return bInitializeSucceeded;
 }

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -207,8 +207,9 @@ const IotNetworkInterface_t * IotTestNetwork_GetNetworkInterface( void )
 
 /*-----------------------------------------------------------*/
 
-void IotTestNetwork_SelectNetworkType( uint16_t networkType )
+bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
 {
+    bool bInitializeSucceeded = pdFALSE;
     switch( networkType )
     {
         #if ( BLE_SUPPORTED == 1 )
@@ -216,20 +217,21 @@ void IotTestNetwork_SelectNetworkType( uint16_t networkType )
 
                 if( bleEnabled == false )
                 {
-                    bleEnabled = true;
-                    _BLEEnable();
+                    bleEnabled = pdTRUE;
+                    bInitializeSucceeded = _BLEEnable();
                 }
                 break;
         #endif
         #if !defined( WIFI_SUPPORTED ) || ( WIFI_SUPPORTED != 0 )
             case AWSIOT_NETWORK_TYPE_WIFI:
+                bInitializeSucceeded = pdTRUE;
                 break;
         #endif
         default:
             break;
     }
-
     _IotTestNetworkType = networkType;
+    return bInitializeSucceeded;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Fix BLE testcase setup and teardown

Description
-----------
Miscellaneous fixes for testcases encountered during testing with ESP-IDF FreeRTOS. Check return values, initialize BLE as needed, and use some older APIs during assertions.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have tested my changes. No regression in existing tests.
- [ X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.