### PR TITLE
Fix integer overflow in CBMC proofs caused by long buffer lengths.

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/IotHttpsClient_AddHeader_harness.c
@@ -47,8 +47,8 @@ void harness() {
     __CPROVER_assume(is_valid_IotRequestHandle(reqHandle));
   uint32_t nameLen;
   uint32_t valueLen;
-  __CPROVER_assume(nameLen < UINT32_MAX-1);
-  __CPROVER_assume(valueLen < UINT32_MAX-1);
+  __CPROVER_assume(nameLen < CBMC_MAX_OBJECT_SIZE);
+  __CPROVER_assume(valueLen < CBMC_MAX_OBJECT_SIZE);
   char * pName = safeMalloc(nameLen+1);
   char * pValue = safeMalloc(valueLen+1);
   if (pName)

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
@@ -5,6 +5,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -43,6 +48,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -5,6 +5,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -46,6 +51,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -5,6 +5,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -46,6 +51,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -5,6 +5,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -38,6 +43,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -10,6 +10,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -45,7 +50,9 @@
   "DEF":
   [
     "USER_DATA_SIZE={USER_DATA_SIZE}",
-    "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}"
+    "MAX_ACCEPTED_SIZE={MAX_ACCEPTED_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }
 

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -1,9 +1,14 @@
 {
   "ENTRY": "IotHttpsClient_ReadResponseStatus",
-  
+
   # This is the length of the user data after the header in a buffer.
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
+
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
 
   "CBMCFLAGS":
   [
@@ -38,6 +43,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -5,6 +5,11 @@
   # This can be set to any size.
   "USER_DATA_SIZE": "1000",
 
+  # A CBMC pointer is an object id followed by an offest into the object.
+  # The size of the offset is limited by the size of the object id.
+  "CBMC_OBJECTID_BITS": "7",
+  "CBMC_MAX_OBJECT_SIZE": "\"(UINT32_MAX>>CBMC_OBJECTID_BITS)\"",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
@@ -45,6 +50,8 @@
   ],
   "DEF":
   [
-    "USER_DATA_SIZE={USER_DATA_SIZE}"
+    "USER_DATA_SIZE={USER_DATA_SIZE}",
+    "CBMC_OBJECTID_BITS={CBMC_OBJECTID_BITS}",
+    "CBMC_MAX_OBJECT_SIZE={CBMC_MAX_OBJECT_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -407,5 +407,7 @@ IotHttpsResponseInfo_t * allocate_IotResponseInfo() {
 int is_valid_IotResponseInfo(IotHttpsResponseInfo_t * pRespInfo){
   return
     pRespInfo->pSyncInfo &&
-    pRespInfo->pSyncInfo->pBody;
+    pRespInfo->pSyncInfo->pBody &&
+    pRespInfo->pSyncInfo->bodyLen <= CBMC_MAX_OBJECT_SIZE &&
+    pRespInfo->userBuffer.bufferLen <= CBMC_MAX_OBJECT_SIZE;
 }


### PR DESCRIPTION
Fix integer overflow in CBMC proofs caused by choosing buffer lengths longer than the 
maximum object size allowed by CBMC.

In CBMC, a pointer is an object id followed by an offset into the object.  The number of bits of the pointer used for the object id limits the number of bits remaining for the offset, and hence limits the size of the object.  If the top 7 bits are used for the object id, then offsets into the object must fit into the bottom 32-7 bits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.