### PR TITLE
Simplify disabling public modules for a hardware platform

### DIFF
--- a/tools/cmake/afr_module.cmake
+++ b/tools/cmake/afr_module.cmake
@@ -15,7 +15,6 @@ endforeach()
 set(AFR_MODULES                 "" CACHE INTERNAL "List of Amazon FreeRTOS modules.")
 set(AFR_MODULES_PORT            "" CACHE INTERNAL "List of porting layer targets defined from vendors.")
 set(AFR_MODULES_PUBLIC          "" CACHE INTERNAL "List of public Amazon FreeRTOS modules.")
-set(AFR_MODULES_PUBLIC_DISABLED "" CACHE INTERNAL "List of public Amazon FreeRTOS modules explicitly disabled for a board.")
 set(AFR_MODULES_BUILD           "" CACHE INTERNAL "List of Amazon FreeRTOS modules to build.")
 set(AFR_MODULES_ENABLED         "" CACHE INTERNAL "List of enabled Amazon FreeRTOS modules.")
 set(AFR_MODULES_ENABLED_USER    "" CACHE INTERNAL "List of Amazon FreeRTOS modules enabled by user.")
@@ -58,10 +57,7 @@ function(afr_module)
     endif()
 
     if(NOT (ARG_INTERNAL OR ARG_INTERFACE))
-        # Do not append if the module is explicitly disabled for the board.
-        if(NOT ${module_name} IN_LIST AFR_MODULES_PUBLIC_DISABLED)
-            afr_cache_append(AFR_MODULES_PUBLIC ${module_name})
-        endif()
+        afr_cache_append(AFR_MODULES_PUBLIC ${module_name})
     endif()
 
     # All modules implicitly depends on kernel unless INTERFACE or KERNEL is provided.
@@ -137,12 +133,6 @@ endfunction()
 # Define a 3rdparty module.
 function(afr_3rdparty_module arg_name)
     add_library(3rdparty::${arg_name} INTERFACE IMPORTED GLOBAL)
-endfunction()
-
-# Disable a list of public modules. This can be used to disable public modules
-# for a specific board.
-function(afr_disable_public_modules)
-    afr_cache_append(AFR_MODULES_PUBLIC_DISABLED ${ARGN})
 endfunction()
 
 # Add properties to a module, will set these global variables accordingly:

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -9,16 +9,13 @@ else()
 endif()
 
 
-set(AFR_MODULE_defender 0 CACHE INTERNAL "")
-
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS disabled libraries
 # -------------------------------------------------------------------------------------------------
-
+set(AFR_MODULE_defender 0 CACHE INTERNAL "")
 # HTTPS is not supported for Nordic as this board does not have WiFi/Ethernet.
-afr_disable_public_modules(
-    https
-)
+set(AFR_MODULE_https 0 CACHE INTERNAL "")
+
 
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS Console metadata


### PR DESCRIPTION
Description
-----------

AFR public modules are the modules which are selectable by the user in
the FreeRTOS console (OCW). We need to disable some public modules for
some hardware platforms - for example, the Nordic board cannot support
HTTPS library because it does not have WiFi/Ethernet. We added a
function, namely ```afr_disable_public_modules```, to disable public modules
for a hardware platform. Later we realized that this function is not
needed and a module (regardless of whether it is public or not) can be
disabled by just calling ```set(AFR_MODULE_<module> 0 CACHE INTERNAL "")``` in
the board's CMakeLists.txt.

This change removes the function ```afr_disable_public_modules``` and instead
uses ```set(AFR_MODULE_https 0 CACHE INTERNAL "")``` to disable HTTPS module
for the Nordic board.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.