### PR TITLE
Stop CBMC patch generation from generating 0-length patches.

### DIFF
--- a/tools/cbmc/patches/compute_patch.py
+++ b/tools/cbmc/patches/compute_patch.py
@@ -172,8 +172,9 @@ def create_patch(defines, header_file):
     header_path_part = header_file.replace(os.sep, "_")
     path_name = "auto_patch_" + header_path_part + ".patch"
     path_name = os.path.join(PATCHES_DIR, path_name)
-    with open(path_name, "w") as patch_file:
-        patch_file.write(patch.stdout)
+    if patch.stdout:
+        with open(path_name, "w") as patch_file:
+            patch_file.write(patch.stdout)
 
 
 def create_patches(headers):


### PR DESCRIPTION
This pull request causes CBMC to skip the generation of patch files that would be zero-length patch files.

The patch command complains when it is invoked with a zero-length patch file.

CBMC proofs check the memory safety of some functions in multiple build configurations.  CBMC does this by patching header files to make it easy to configure a build from the command line with build invocations of the form "make -Dconfigvar1=val1 -Dconfigvar2=var2".  CBMC generates the patch files, then applies the patch files, then builds the desired configurations.  This pull request suppresses complaints by patch during the patch file application.

This pull request has been tested by running the CBMC proofs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.