### PR TITLE
fix: Remove mbedtls/base64 reference from OTA agent

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -53,7 +53,6 @@
 
 /* JSON job document parser includes. */
 #include "jsmn.h" /*lint !e537 All headers have multiple inclusion prevention. */
-#include "mbedtls/base64.h"
 
 /* Returns the byte offset of the element 'e' in the typedef structure 't'.
  * Setting an arbitrarily large base of 0x10000 and masking off that base allows


### PR DESCRIPTION
Remove mbedtls/base64 reference  from OTA agent source.

<!--- Title -->

Description.
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.