### PR TITLE
Make FreeRTOS_OutputARPRequest() available for application code

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
@@ -244,16 +244,17 @@ typedef enum
 	eNoEvent = -1,
 	eNetworkDownEvent,		/* 0: The network interface has been lost and/or needs [re]connecting. */
 	eNetworkRxEvent,		/* 1: The network interface has queued a received Ethernet frame. */
-	eARPTimerEvent,			/* 2: The ARP timer expired. */
-	eStackTxEvent,			/* 3: The software stack has queued a packet to transmit. */
-	eDHCPEvent,				/* 4: Process the DHCP state machine. */
-	eTCPTimerEvent,			/* 5: See if any TCP socket needs attention. */
-	eTCPAcceptEvent,		/* 6: Client API FreeRTOS_accept() waiting for client connections. */
-	eTCPNetStat,			/* 7: IP-task is asked to produce a netstat listing. */
-	eSocketBindEvent,		/* 8: Send a message to the IP-task to bind a socket to a port. */
-	eSocketCloseEvent,		/* 9: Send a message to the IP-task to close a socket. */
-	eSocketSelectEvent,		/*10: Send a message to the IP-task for select(). */
-	eSocketSignalEvent,		/*11: A socket must be signalled. */
+	eNetworkTxEvent,		/* 2: Let the IP-task send a network packet. */
+	eARPTimerEvent,			/* 3: The ARP timer expired. */
+	eStackTxEvent,			/* 4: The software stack has queued a packet to transmit. */
+	eDHCPEvent,				/* 5: Process the DHCP state machine. */
+	eTCPTimerEvent,			/* 6: See if any TCP socket needs attention. */
+	eTCPAcceptEvent,		/* 7: Client API FreeRTOS_accept() waiting for client connections. */
+	eTCPNetStat,			/* 8: IP-task is asked to produce a netstat listing. */
+	eSocketBindEvent,		/* 9: Send a message to the IP-task to bind a socket to a port. */
+	eSocketCloseEvent,		/*10: Send a message to the IP-task to close a socket. */
+	eSocketSelectEvent,		/*11: Send a message to the IP-task for select(). */
+	eSocketSignalEvent,		/*12: A socket must be signalled. */
 } eIPEvent_t;
 
 typedef struct IP_TASK_COMMANDS

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -396,6 +396,12 @@ struct freertos_sockaddr xAddress;
 				prvHandleEthernetPacket( ( NetworkBufferDescriptor_t * ) ( xReceivedEvent.pvData ) );
 				break;
 
+			case eNetworkTxEvent:
+				/* Send a network packet. The ownership will  be transferred to
+				the driver, which will release it after delivery. */
+				xNetworkInterfaceOutput( ( NetworkBufferDescriptor_t * ) ( xReceivedEvent.pvData ), pdTRUE );
+				break;
+
 			case eARPTimerEvent :
 				/* The ARP timer has expired, process the ARP cache. */
 				vARPAgeCache();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

The function `FreeRTOS_OutputARPRequest()` was developed to be used by both the IP-task, as well as the application. However, when the application calls it, `xNetworkInterfaceOutput()` may land in a `configASSERT()`, because only the IP-task is allowed to call that (non re-entrant) function.

Solution:

~~~c
    if( xIsCallingFromIPTask() != 0 )
    {
        /* Only the IP-task is allowed to call this function directly. */
        xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
    }
    else
    {
        /* Let the IP-task send the packet. */
    }
~~~

A new event-type is added: `eNetworkTxEvent`, which is sent as:

~~~c
IPStackEvent_t xSendEvent;
    xSendEvent.eEventType = eNetworkTxEvent;
    xSendEvent.pvData = ( void * ) pxNetworkBuffer;
    xSendEventStructToIPTask( &xSendEvent, ( TickType_t ) portMAX_DELAY );
~~~

The IP-task will release the network buffer once the packet has been sent.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.