### PR TITLE
Prepare Microchip/Curiosity driver for IPv6

### DIFF
--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/NetworkConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/NetworkConfig.h
@@ -59,11 +59,17 @@ SOFTWARE
 //  - the Harmony MAC driver: TCPIP_MAC_PACKET 
 // from the beginning of the buffer:
 //      - 4 bytes pointer to the network descriptor (FreeRTOS)
-//      - 4 bytes pointer to the MAC packet (pic32_NetworkInterface.c)
+//      - 4 bytes pointer to the MAC packet ( only when PIC32_USE_ETHERNET is
+//          defined and NetworkInterface_eth.c is included )
+//      - 4 bytes space to store IP-type ( IPv4 / v6 )
 //      - 2 bytes offset from the MAC packet (Harmony MAC driver: segLoadOffset)
-// NOTE: the ipBUFFER_PADDING should be set to 10 to match the TCPIP_MAC_FRAME_OFFSET value!
-#define PIC32_BUFFER_PKT_PTR_OSSET    6
+// NOTE: the ipconfigBUFFER_PADDING should be set to 14 when PIC32_USE_ETHERNET is defined.
+// It is set to 10 when the WiFi driver is used.
+// Note that ipconfigBUFFER_PADDING == TCPIP_MAC_FRAME_OFFSET.
 
+#ifdef PIC32_USE_ETHERNET
+	#define PIC32_BUFFER_PKT_PTR_OSSET    ( ipconfigBUFFER_PADDING - 4 )
+#endif
 
 
 // standard PIC32 MAC driver configuration

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -272,7 +272,15 @@ extern uint32_t ulRand();
  * This has to do with the contents of the IP-packets: all 32-bit fields are
  * 32-bit-aligned, plus 16-bit(!) */
 #define ipconfigPACKET_FILLER_SIZE                     2
-#define ipconfigBUFFER_PADDING                         10
+#ifdef PIC32_USE_ETHERNET
+	/* The Ethernet driver wants to store an extra pointer before the actual network packet.
+	However, the upcoming IPv6 library will use that space to store the packet type. */
+	#define ipconfigBUFFER_PADDING                         14
+#else
+	/* The WiFi driver has a regular buffer allocation using pvPortMalloc().
+	The driver doesn't store anything in the space before the Ethernet packet. */
+	#define ipconfigBUFFER_PADDING                         10
+#endif
 
 /* Define the size of the pool of TCP window descriptors.  On the average, each
  * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/NetworkConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/NetworkConfig.h
@@ -59,10 +59,17 @@ SOFTWARE
 //  - the Harmony MAC driver: TCPIP_MAC_PACKET 
 // from the beginning of the buffer:
 //      - 4 bytes pointer to the network descriptor (FreeRTOS)
-//      - 4 bytes pointer to the MAC packet (pic32_NetworkInterface.c)
+//      - 4 bytes pointer to the MAC packet ( only when PIC32_USE_ETHERNET is
+//          defined and NetworkInterface_eth.c is included )
+//      - 4 bytes space to store IP-type ( IPv4 / v6 )
 //      - 2 bytes offset from the MAC packet (Harmony MAC driver: segLoadOffset)
-// NOTE: the ipBUFFER_PADDING should be set to 10 to match the TCPIP_MAC_FRAME_OFFSET value!
-#define PIC32_BUFFER_PKT_PTR_OSSET    6
+// NOTE: the ipconfigBUFFER_PADDING should be set to 14 when PIC32_USE_ETHERNET is defined.
+// It is set to 10 when the WiFi driver is used.
+// Note that ipconfigBUFFER_PADDING == TCPIP_MAC_FRAME_OFFSET.
+
+#ifdef PIC32_USE_ETHERNET
+	#define PIC32_BUFFER_PKT_PTR_OSSET    ( ipconfigBUFFER_PADDING - 4 )
+#endif
 
 
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -277,7 +277,15 @@ extern uint32_t ulRand();
  * This has to do with the contents of the IP-packets: all 32-bit fields are
  * 32-bit-aligned, plus 16-bit(!) */
 #define ipconfigPACKET_FILLER_SIZE                     2
-#define ipconfigBUFFER_PADDING                         10
+#ifdef PIC32_USE_ETHERNET
+	/* The Ethernet driver wants to store an extra pointer before the actual network packet.
+	However, the upcoming IPv6 library will use that space to store the packet type. */
+	#define ipconfigBUFFER_PADDING                         14
+#else
+	/* The WiFi driver has a regular buffer allocation using pvPortMalloc().
+	The driver doesn't store anything in the space before the Ethernet packet. */
+	#define ipconfigBUFFER_PADDING                         10
+#endif
 
 /* Define the size of the pool of TCP window descriptors.  On the average, each
  * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6

--- a/vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c
+++ b/vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c
@@ -76,7 +76,19 @@ SUBSTITUTE GOODS, TECHNOLOGY, SERVICES, OR ANY CLAIMS BY THIRD PARTIES
     #define TCPIP_MAC_FRAME_OFFSET      2
 #endif
 #endif
-#define TCPIP_MAC_FRAME_OFFSET      10  // this should match FreeRTOSIP ipconfigBUFFER_PADDING!
+
+/* The space between the start of the network buffer and the actual start of the
+Ethernet header.
+The value should be the same as FreeRTOS+TCP's 'ipconfigBUFFER_PADDING'. */
+
+#ifdef PIC32_USE_ETHERNET
+    /* The Ethernet library wants to store a pointer to a 'TCPIP_MAC_PACKET'.
+    See also the projects' FreeRTOSIPConfig.h, in which ipconfigBUFFER_PADDING
+    must be defined with the same value. */
+    #define TCPIP_MAC_FRAME_OFFSET      14
+#else
+    #define TCPIP_MAC_FRAME_OFFSET      10
+#endif
 
 static TCPIP_STACK_HEAP_HANDLE    pktMemH = 0;
 static bool                 pktK0Heap = 0;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The FreeRTOS+TCP [IPv6 branch](https://github.com/aws/amazon-freertos/tree/hein/tcpipv6) is being developed with the assumption that the IP-type (v4/v6) can be stored in the Network Buffers, a few bytes before the actual packet data.
However, the Microchip Ethernet driver for the Curiosity board is using the same space to store a pointer to a `TCPIP_MAC_PACKET`.

In C language:

~~~c
struct
{
    NetworkBufferDescriptor_t * pxDescriptor;   /* 0 + 4 =  4 */
    uint32_t ulIPv6Info;                        /* 4 + 4 =  8 */
    uint16_t usFiller;                          /* 8 + 2 = 10 */
    char pcEthernetHeader[ 14 ];                /* The Ethernet header and the rest */
};
~~~

The driver would overwrite the value in `ulIPv6Info` to store its own information.

In order to let the Microchip driver work with IPv6, more space must be created with this change to `FreeRTOSIPConfig.h`:

~~~c
-    #define ipconfigBUFFER_PADDING     10
+    #ifdef PIC32_USE_ETHERNET
+        #define ipconfigBUFFER_PADDING     14
+    #else
+        #define ipconfigBUFFER_PADDING     10
+    #endif
~~~

The same for `TCPIP_MAC_FRAME_OFFSET` in `tcpip_packet.c` :

~~~c
#ifdef PIC32_USE_ETHERNET
    #define TCPIP_MAC_FRAME_OFFSET      14
#else
    #define TCPIP_MAC_FRAME_OFFSET      10
#endif
~~~

Now the Network Buffer has space for the extra pointer:

~~~c
 struct
 {
     NetworkBufferDescriptor_t * pxDescriptor;   /*  0 + 4 =  4 */
+    TCPIP_MAC_PACKET * pxPacketPointer;         /*  4 + 4 =  8 */
     uint32_t ulIPv6Info;                        /*  8 + 4 = 12 */
     uint16_t usFiller;                          /* 12 + 2 = 14 */
     char pcEthernetHeader[ 14 ];                /* The Ethernet header and the rest */
 };
~~~

What I verified if that the access to these fields is always using the macro's.
I also ran the demo, it still runs as before, both with Ethernet as well as WiFi.
And also I checked if the value stored in `ulIPv6Info` will remain untouched by the Microchip driver, which it did.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.