### PR TITLE
AFR NimBLE: Fix pairing request GAP event handling for SC only mode

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -246,25 +246,39 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                                              0 );
             }
 
-            if( ble_hs_cfg.sm_sc && ( event->pairing_req.authreq & BLE_SM_PAIR_AUTHREQ_SC ) &&
-                ( ble_sm_sc_ioa[ ble_hs_cfg.sm_io_cap ][ event->pairing_req.io_cap ] == BLE_SM_IOACT_NONE ) )
+            if( ble_hs_cfg.sm_sc && ( event->pairing_req.authreq & BLE_SM_PAIR_AUTHREQ_SC ))
             {
-                ESP_LOGE( TAG, "Just works in Secure Connections only mode" );
-
-                if( xBTCallbacks.pxPairingStateChangedCb != NULL )
+                if ( ble_sm_sc_ioa[ ble_hs_cfg.sm_io_cap ][ event->pairing_req.io_cap ] == BLE_SM_IOACT_NONE )
                 {
-                    xBTCallbacks.pxPairingStateChangedCb( eBTStatusFail, ( BTBdaddr_t * ) desc.peer_id_addr.val,
-                                                          eBTbondStateNone,
-                                                          eBTSecLevelNoSecurity,
-                                                          eBTauthFailInsuffSecurity );
-                }
+                    ESP_LOGE( TAG, "Just works in Secure Connections only mode" );
 
-                return BLE_SM_ERR_AUTHREQ;
+                    if( xBTCallbacks.pxPairingStateChangedCb != NULL )
+                    {
+                        xBTCallbacks.pxPairingStateChangedCb( eBTStatusFail, ( BTBdaddr_t * ) desc.peer_id_addr.val,
+                                                              eBTbondStateNone,
+                                                              eBTSecLevelNoSecurity,
+                                                              eBTauthFailInsuffSecurity );
+                    }
+
+                    return BLE_SM_ERR_AUTHREQ;
+
+                }
+                else if (event->pairing_req.max_enc_key_size < BLE_SM_PAIR_KEY_SZ_MAX)
+                {
+
+                    if( xBTCallbacks.pxPairingStateChangedCb != NULL )
+                    {
+                        xBTCallbacks.pxPairingStateChangedCb( eBTStatusFail, ( BTBdaddr_t * ) desc.peer_id_addr.val,
+                                                              eBTbondStateNone,
+                                                              eBTSecLevelNoSecurity,
+                                                              eBTauthFailInsuffSecurity );
+                    }
+
+                    return BLE_SM_ERR_ENC_KEY_SZ;
+                }
             }
-            else
-            {
-                return 0;
-            }
+
+            return 0;
 
         case BLE_GAP_EVENT_ENC_CHANGE:
             /* Encryption has been enabled or disabled for this connection. */

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -246,9 +246,9 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                                              0 );
             }
 
-            if( ble_hs_cfg.sm_sc && ( event->pairing_req.authreq & BLE_SM_PAIR_AUTHREQ_SC ))
+            if( ble_hs_cfg.sm_sc && ( event->pairing_req.authreq & BLE_SM_PAIR_AUTHREQ_SC ) )
             {
-                if ( ble_sm_sc_ioa[ ble_hs_cfg.sm_io_cap ][ event->pairing_req.io_cap ] == BLE_SM_IOACT_NONE )
+                if( ble_sm_sc_ioa[ ble_hs_cfg.sm_io_cap ][ event->pairing_req.io_cap ] == BLE_SM_IOACT_NONE )
                 {
                     ESP_LOGE( TAG, "Just works in Secure Connections only mode" );
 
@@ -263,7 +263,7 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                     return BLE_SM_ERR_AUTHREQ;
 
                 }
-                else if (event->pairing_req.max_enc_key_size < BLE_SM_PAIR_KEY_SZ_MAX)
+                else if( event->pairing_req.max_enc_key_size < BLE_SM_PAIR_KEY_SZ_MAX )
                 {
 
                     if( xBTCallbacks.pxPairingStateChangedCb != NULL )

--- a/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/include/host/ble_gap.h
+++ b/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/include/host/ble_gap.h
@@ -313,6 +313,7 @@ struct ble_gap_pairing_req {
     uint8_t io_cap;
     uint8_t oob_data_flag;
     uint8_t authreq;
+    uint8_t max_enc_key_size;
 };
 
 struct ble_gap_repeat_pairing {

--- a/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/src/ble_gap.c
+++ b/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/src/ble_gap.c
@@ -4501,6 +4501,7 @@ ble_gap_pairing_req_event(const struct ble_gap_pairing_req *req)
     event.pairing_req.io_cap = req->io_cap;
     event.pairing_req.oob_data_flag = req->oob_data_flag;
     event.pairing_req.authreq = req->authreq;
+    event.pairing_req.max_enc_key_size = req->max_enc_key_size;
 
     rc = ble_gap_call_conn_event_cb(&event, req->conn_handle);
     return rc;

--- a/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/src/ble_sm.c
+++ b/vendors/espressif/esp-idf/components/nimble/nimble/nimble/host/src/ble_sm.c
@@ -834,6 +834,7 @@ ble_sm_pairing_req(uint16_t conn_handle, struct ble_sm_pair_cmd *req)
     pair_req.io_cap = req->io_cap;
     pair_req.oob_data_flag = req->oob_data_flag;
     pair_req.authreq = req->authreq;
+    pair_req.max_enc_key_size = req->max_enc_key_size;
 
     return ble_gap_pairing_req_event(&pair_req);
 }


### PR DESCRIPTION
- Additional check added to confirm the `max_enc_key_size` in pairing request is not less than 16
  Bytes in case of secure connection only mode.

Description
-----------
<!--- Describe your changes in detail -->

1. Modifies `iot_ble_hal_common_gap.c` to reject pairing request if the max encryption key size is less than 16 Bytes with reason `BLE_SM_ERR_ENC_KEY_SZ`.
2. Adds `max_enc_key_size` to structure `ble_gap_pairing_req`, so that can be used while handling GAP pairing request event.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.