### PR TITLE
PKCS #11 private key import capability check

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -831,6 +831,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetTokenInfo )( CK_SLOT_ID slotID,
  * @brief This function obtains information about a particular
  * mechanism possibly supported by a token.
  *
+ *  \param[in]  xSlotID         This parameter is unused in this port.
+ *  \param[in]  type            The cryptographic capability for which support
+ *                              information is being queried.
+ *  \param[out] pInfo           Algorithm sizes and flags for the requested
+ *                              mechanism, if supported.
+ *
  * @return CKR_OK if the mechanism is supported. Otherwise, CKR_MECHANISM_INVALID.
  */
 CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
@@ -845,9 +851,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
     }
     pxSupportedMechanisms[] =
     {
-        { CKM_RSA_PKCS,        { 2048, 2048, 0 } },
-        { CKM_ECDSA,           { 256,  256,  0 } },
-        { CKM_EC_KEY_PAIR_GEN, { 256,  256,  0 } }
+        { CKM_RSA_PKCS,        { 2048, 2048, CKF_SIGN              } },
+        { CKM_ECDSA,           { 256,  256,  CKF_SIGN              } },
+        { CKM_EC_KEY_PAIR_GEN, { 256,  256,  CKF_GENERATE_KEY_PAIR } },
+        { CKM_SHA256,          { 0,    0,    CKF_DIGEST            } }
     };
     uint32_t ulMech = 0;
 
@@ -856,7 +863,9 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
     {
         if( pxSupportedMechanisms[ ulMech ].xType == type )
         {
-            memcpy( pInfo, &( pxSupportedMechanisms[ ulMech ] ), sizeof( CK_MECHANISM_INFO ) );
+            /* The mechanism is supported. Copy out the details and break
+             * out of the loop. */
+            memcpy( pInfo, &( pxSupportedMechanisms[ ulMech ].xInfo ), sizeof( CK_MECHANISM_INFO ) );
             xResult = CKR_OK;
             break;
         }

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -185,7 +185,7 @@ static CK_FUNCTION_LIST prvP11FunctionList =
     NULL, /*C_GetSlotInfo*/
     C_GetTokenInfo,
     NULL, /*C_GetMechanismList*/
-    NULL, /*C_GetMechansimInfo */
+    C_GetMechanismInfo,
     C_InitToken,
     NULL, /*C_InitPIN*/
     NULL, /*C_SetPIN*/
@@ -830,32 +830,33 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetTokenInfo )( CK_SLOT_ID slotID,
 /**
  * @brief This function obtains information about a particular
  * mechanism possibly supported by a token.
- * 
+ *
  * @return CKR_OK if the mechanism is supported. Otherwise, CKR_MECHANISM_INVALID.
  */
-CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo)( CK_SLOT_ID slotID,
-                                                 CK_MECHANISM_TYPE type,
-                                                 CK_MECHANISM_INFO_PTR pInfo )
+CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
+                                                  CK_MECHANISM_TYPE type,
+                                                  CK_MECHANISM_INFO_PTR pInfo )
 {
     CK_RV xResult = CKR_MECHANISM_INVALID;
     struct CryptoMechanisms
     {
         CK_MECHANISM_TYPE xType;
         CK_MECHANISM_INFO xInfo;
-    } pxSupportedMechanisms[] =
+    }
+    pxSupportedMechanisms[] =
     {
-        {CKM_RSA_PKCS, {2048, 2048, 0}},
-        {CKM_ECDSA, {256, 256, 0}},
-        {CKM_EC_KEY_PAIR_GEN, {256, 256, 0}}
+        { CKM_RSA_PKCS,        { 2048, 2048, 0 } },
+        { CKM_ECDSA,           { 256,  256,  0 } },
+        { CKM_EC_KEY_PAIR_GEN, { 256,  256,  0 } }
     };
     uint32_t ulMech = 0;
 
     /* Look for the requested mechanism in the above table. */
-    for (; ulMech < sizeof(pxSupportedMechanisms) / sizeof(pxSupportedMechanisms[0]); ulMech++)
+    for( ; ulMech < sizeof( pxSupportedMechanisms ) / sizeof( pxSupportedMechanisms[ 0 ] ); ulMech++ )
     {
-        if( pxSupportedMechanisms[ulMech].xType == type)
+        if( pxSupportedMechanisms[ ulMech ].xType == type )
         {
-            memcpy(pInfo, &(pxSupportedMechanisms[ulMech]), sizeof(CK_MECHANISM_INFO));
+            memcpy( pInfo, &( pxSupportedMechanisms[ ulMech ] ), sizeof( CK_MECHANISM_INFO ) );
             xResult = CKR_OK;
             break;
         }

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -852,7 +852,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
     pxSupportedMechanisms[] =
     {
         { CKM_RSA_PKCS,        { 2048, 2048, CKF_SIGN              } },
-        { CKM_ECDSA,           { 256,  256,  CKF_SIGN              } },
+        { CKM_RSA_X_509,       { 2048, 2048, CKF_VERIFY            } },
+        { CKM_ECDSA,           { 256,  256,  CKF_SIGN | CKF_VERIFY } },
         { CKM_EC_KEY_PAIR_GEN, { 256,  256,  CKF_GENERATE_KEY_PAIR } },
         { CKM_SHA256,          { 0,    0,    CKF_DIGEST            } }
     };

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -827,6 +827,42 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetTokenInfo )( CK_SLOT_ID slotID,
     return CKR_OK;
 }
 
+/**
+ * @brief This function obtains information about a particular
+ * mechanism possibly supported by a token.
+ * 
+ * @return CKR_OK if the mechanism is supported. Otherwise, CKR_MECHANISM_INVALID.
+ */
+CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo)( CK_SLOT_ID slotID,
+                                                 CK_MECHANISM_TYPE type,
+                                                 CK_MECHANISM_INFO_PTR pInfo )
+{
+    CK_RV xResult = CKR_MECHANISM_INVALID;
+    struct CryptoMechanisms
+    {
+        CK_MECHANISM_TYPE xType;
+        CK_MECHANISM_INFO xInfo;
+    } pxSupportedMechanisms[] =
+    {
+        {CKM_RSA_PKCS, {2048, 2048, 0}},
+        {CKM_ECDSA, {256, 256, 0}},
+        {CKM_EC_KEY_PAIR_GEN, {256, 256, 0}}
+    };
+    uint32_t ulMech = 0;
+
+    /* Look for the requested mechanism in the above table. */
+    for (; ulMech < sizeof(pxSupportedMechanisms) / sizeof(pxSupportedMechanisms[0]); ulMech++)
+    {
+        if( pxSupportedMechanisms[ulMech].xType == type)
+        {
+            memcpy(pInfo, &(pxSupportedMechanisms[ulMech]), sizeof(CK_MECHANISM_INFO));
+            xResult = CKR_OK;
+            break;
+        }
+    }
+
+    return xResult;
+}
 
 /**
  * @brief This function is not implemented for this port.

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -758,31 +758,31 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to get slot count" );
 
     /* Check for RSA PKCS #1 signing support. */
-    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[0], CKM_RSA_PKCS, &MechanismInfo );
-    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_RSA_PKCS, &MechanismInfo );
+    TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
+
     if( CKR_OK == xResult )
     {
-        configPRINTF(("The PKCS #11 module supports RSA signing.\r\n"));
+        configPRINTF( ( "The PKCS #11 module supports RSA signing.\r\n" ) );
     }
 
     /* Check for ECDSA support. */
-    xResult = pxGlobalFunctionList->C_GetMechanismInfo(pxSlotId[0], CKM_ECDSA, &MechanismInfo);
-    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
+    TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
+
     if( CKR_OK == xResult )
     {
-        configPRINTF(("The PKCS #11 module supports ECDSA.\r\n"));
+        configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
     }
 
     /* Check for elliptic-curve key generation support. */
-    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[0], CKM_EC_KEY_PAIR_GEN, &MechanismInfo );
-    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_EC_KEY_PAIR_GEN, &MechanismInfo );
+    TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
+
     if( CKR_OK == xResult )
     {
-        configPRINTF(("The PKCS #11 module supports elliptic-curve key generation.\r\n"));
+        configPRINTF( ( "The PKCS #11 module supports elliptic-curve key generation.\r\n" ) );
     }
-
-    /* Check for key import support. */
-    /* TODO */
 }
 
 /*--------------------------------------------------------*/

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -744,6 +744,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     CK_ULONG xSlotCount = 0;
     CK_SLOT_ID_PTR pxSlotId = NULL;
     CK_MECHANISM_INFO MechanismInfo = { 0 };
+    CK_BBOOL xSupportsKeyGen = CK_FALSE;
 
     /* Determine the number of slots. */
     xResult = pxGlobalFunctionList->C_GetSlotList( CK_TRUE, NULL, &xSlotCount );
@@ -801,6 +802,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
 
     if( CKR_OK == xResult )
     {
+        xSupportsKeyGen = CK_TRUE;
         configPRINTF( ( "The PKCS #11 module supports elliptic-curve key generation.\r\n" ) );
 
         TEST_ASSERT_TRUE( 0 != ( CKF_GENERATE_KEY_PAIR & MechanismInfo.flags ) );
@@ -814,6 +816,26 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_SHA256, &MechanismInfo );
     TEST_ASSERT_TRUE( CKR_OK == xResult );
     TEST_ASSERT_TRUE( 0 != ( CKF_DIGEST & MechanismInfo.flags ) );
+
+    /* Check for consistency between static configuration and runtime key
+     * generation settings. */
+    if( CK_TRUE == xSupportsKeyGen )
+    {
+        #ifndef pkcs11testGENERATE_KEYPAIR_SUPPORT
+            TEST_FAIL_MESSAGE( "Static and runtime configuration for key generation support are inconsistent." );
+        #endif
+    }
+    else
+    {
+        #ifdef pkcs11testGENERATE_KEYPAIR_SUPPORT
+            TEST_FAIL_MESSAGE( "Static and runtime configuration for key generation support are inconsistent." );
+        #endif
+    }
+
+    /* Report on static configuration for key import support. */
+    #ifdef pkcs11testIMPORT_PRIVATE_KEY_SUPPORT
+        configPRINTF( ( "The PKCS #11 module supports private key import.\r\n" ) );
+    #endif
 }
 
 /*--------------------------------------------------------*/

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -757,9 +757,31 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     xResult = pxGlobalFunctionList->C_GetSlotList( CK_TRUE, pxSlotId, &xSlotCount );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to get slot count" );
 
-    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[0], CKM_ECDSA, &MechanismInfo );
-    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+    /* Check for RSA PKCS #1 signing support. */
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[0], CKM_RSA_PKCS, &MechanismInfo );
+    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    if( CKR_OK == xResult )
+    {
+        configPRINTF(("The PKCS #11 module supports RSA signing.\r\n"));
+    }
 
+    /* Check for ECDSA support. */
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo(pxSlotId[0], CKM_ECDSA, &MechanismInfo);
+    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    if( CKR_OK == xResult )
+    {
+        configPRINTF(("The PKCS #11 module supports ECDSA.\r\n"));
+    }
+
+    /* Check for elliptic-curve key generation support. */
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[0], CKM_EC_KEY_PAIR_GEN, &MechanismInfo );
+    TEST_ASSERT_TRUE(CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult);
+    if( CKR_OK == xResult )
+    {
+        configPRINTF(("The PKCS #11 module supports elliptic-curve key generation.\r\n"));
+    }
+
+    /* Check for key import support. */
     /* TODO */
 }
 

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -764,6 +764,11 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     if( CKR_OK == xResult )
     {
         configPRINTF( ( "The PKCS #11 module supports RSA signing.\r\n" ) );
+
+        TEST_ASSERT_TRUE( 0 != ( CKF_SIGN & MechanismInfo.flags ) );
+
+        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11RSA_2048_MODULUS_BITS &&
+                          MechanismInfo.ulMinKeySize <= pkcs11RSA_2048_MODULUS_BITS );
     }
 
     /* Check for ECDSA support. */
@@ -773,6 +778,11 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     if( CKR_OK == xResult )
     {
         configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
+
+        TEST_ASSERT_TRUE( 0 != ( CKF_SIGN & MechanismInfo.flags ) );
+
+        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
+                          MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
     }
 
     /* Check for elliptic-curve key generation support. */
@@ -782,7 +792,18 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     if( CKR_OK == xResult )
     {
         configPRINTF( ( "The PKCS #11 module supports elliptic-curve key generation.\r\n" ) );
+
+        TEST_ASSERT_TRUE( 0 != ( CKF_GENERATE_KEY_PAIR & MechanismInfo.flags ) );
+
+        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
+                          MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
     }
+
+    /* SHA-256 support is required, but we don't need to write it to the console,
+     * since it doesn't impact the execution sequence for IDT. */
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_SHA256, &MechanismInfo );
+    TEST_ASSERT_TRUE( CKR_OK == xResult );
+    TEST_ASSERT_TRUE( 0 != ( CKF_DIGEST & MechanismInfo.flags ) );
 }
 
 /*--------------------------------------------------------*/

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -769,6 +769,16 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
 
         TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11RSA_2048_MODULUS_BITS &&
                           MechanismInfo.ulMinKeySize <= pkcs11RSA_2048_MODULUS_BITS );
+
+        /* Check for RSA pre-padded signature verification support. This is required
+         * for testing RSA signing. */
+        xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_RSA_X_509, &MechanismInfo );
+        TEST_ASSERT_TRUE( CKR_OK == xResult );
+
+        TEST_ASSERT_TRUE( 0 != ( CKF_VERIFY & MechanismInfo.flags ) );
+
+        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11RSA_2048_MODULUS_BITS &&
+                          MechanismInfo.ulMinKeySize <= pkcs11RSA_2048_MODULUS_BITS );
     }
 
     /* Check for ECDSA support. */
@@ -779,7 +789,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     {
         configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
 
-        TEST_ASSERT_TRUE( 0 != ( CKF_SIGN & MechanismInfo.flags ) );
+        TEST_ASSERT_TRUE( 0 != ( ( CKF_SIGN | CKF_VERIFY ) & MechanismInfo.flags ) );
 
         TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
                           MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );

--- a/libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h
+++ b/libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h
@@ -64,6 +64,11 @@
 #define pkcs11ECDSA_P256_SIGNATURE_LENGTH    64
 
 /**
+ * @brief Key strength for elliptic-curve P-256.
+ */
+#define pkcs11ECDSA_P256_KEY_BITS            256
+
+/**
  * @brief Public exponent for RSA.
  */
 #define pkcs11RSA_PUBLIC_EXPONENT            { 0x01, 0x00, 0x01 }

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -136,6 +136,7 @@ static void RunTests( void )
 
     #if ( testrunnerFULL_PKCS11_ENABLED == 1 )
         RUN_TEST_GROUP( Full_PKCS11_StartFinish );
+        RUN_TEST_GROUP( Full_PKCS11_Capabilities );
         RUN_TEST_GROUP( Full_PKCS11_NoObject );
         RUN_TEST_GROUP( Full_PKCS11_RSA );
         RUN_TEST_GROUP( Full_PKCS11_EC );


### PR DESCRIPTION
Check consistency of static and runtime support for private key generation and import. This has been tested on the SoftHSM port as well.