### PR TITLE
Fix missed testrunnerFULL_MQTTv4_ENABLED in other board's aws_test_runner_config.h files.

### DIFF
--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_runner_config.h
@@ -46,7 +46,6 @@
 #define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
 #define testrunnerFULL_MQTT_AGENT_ENABLED          0
-#define testrunnerFULL_MQTT_ENABLED                0
 #define testrunnerFULL_MQTT_ALPN_ENABLED           0
 #define testrunnerFULL_DEFENDER_ENABLED            0
 #define testrunnerFULL_WIFI_ENABLED                0

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
@@ -44,7 +44,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_WIFI_ENABLED                0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_runner_config.h
@@ -43,7 +43,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_WIFI_ENABLED                0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h
@@ -49,7 +49,7 @@
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_MQTT_AGENT_ENABLED          0
 #define testrunnerFULL_MQTT_ALPN_ENABLED           0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
 #define testrunnerFULL_SHADOWv4_ENABLED            0
 #define testrunnerFULL_MQTTv4_ENABLED              0

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_runner_config.h
@@ -41,7 +41,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
 #define testrunnerFULL_MQTT_AGENT_ENABLED          0
 #define testrunnerFULL_WIFI_ENABLED                0

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_runner_config.h
@@ -48,7 +48,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0
 #define testrunnerFULL_HTTPS_CLIENT_ENABLED        0

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_test_runner_config.h
@@ -44,7 +44,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_WIFI_ENABLED                0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_runner_config.h
@@ -47,7 +47,7 @@
 #define testrunnerFULL_GGD_ENABLED                 0
 #define testrunnerFULL_GGD_HELPER_ENABLED          0
 #define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_MQTT_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED              0
 #define testrunnerFULL_MEMORYLEAK_ENABLED          0
 #define testrunnerFULL_TLS_ENABLED                 0
 #define testrunnerFULL_HTTPS_CLIENT_ENABLED        0


### PR DESCRIPTION
Fix missed testrunnerFULL_MQTTv4_ENABLED in other board's aws_test_runner_config.h files.

testrunnerFULL_MQTT_ENABLED is no longer supported and lingering in some boards.
https://docs.aws.amazon.com/freertos/latest/portingguide/afr-porting-mqtt.html

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.