### PR TITLE
Fixed to ALWAYS stop parsing for a head request in the HTTPS Client library.

### DIFF
--- a/doc/lib/https.txt
+++ b/doc/lib/https.txt
@@ -444,9 +444,9 @@ Size in bytes of the User Buffer used to store the internal connection context. 
 @brief The size of the static user buffer to store the HTTP Client request context and HTTP formatted request headers.
 
 Size in bytes of the user buffer used to store the internal request context and HTTP request header lines. 
-   The size presented here accounts for the storage of the internal context, the first request line in the HTTP
+   The size presented here accounts for the storage of the internal context, the first Request-Line in the HTTP
    formatted header and extra headers. The minimum size can be found in @ref requestUserBufferMinimumSize. Keep in mind that this @ref requestUserBufferMinimumSize does not include the size of the 
-   path in the request line. The path could be well over 100 characters long as it includes not only the object key name
+   path in the Request-Line. The path could be well over 100 characters long as it includes not only the object key name
    in S3, but also the query following. The query following has the AWSAccessKeyId, the expiration time, and the 
    AWS Signature Version 4 signature.
 
@@ -457,7 +457,7 @@ Size in bytes of the user buffer used to store the internal request context and 
 @brief The size of the static user buffer to store the HTTP Client response context and HTTP formatted response headers.
 
 Size in bytes of the user buffer used to store the internal response context and the HTTP response header lines. 
-   The size presented here accounts for the storage of the internal context, the first request line in the HTTP
+   The size presented here accounts for the storage of the internal context, the first Request-Line in the HTTP
    formatted header and extra headers. The minimum can be found in @ref requestUserBufferMinimumSize.
    Keep in mind that if the headers from the response do not all fit into this buffer, then the rest of the headers
    will be discarded. The minimum size can be found in @ref responseUserBufferMinimumSize.

--- a/libraries/c_sdk/standard/https/include/iot_https_client.h
+++ b/libraries/c_sdk/standard/https/include/iot_https_client.h
@@ -288,16 +288,16 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect( IotHttpsConnectionHandle_t connH
 /* @[declare_https_client_disconnect] */
 
 /**
- * @brief Initializes the request by adding a formatted Request Line to the start of HTTPS request header buffer.
+ * @brief Initializes the request by adding a formatted Request-Line to the start of HTTPS request header buffer.
  *
  * This function will initialize the HTTP request context by setting where to write the next headers to the start
  * of the configured header buffer in #IotHttpsRequestInfo_t.userBuffer.
  *
- * The request line will be added to the start of the headers space in #IotHttpsRequestInfo_t.userBuffer.
+ * The Request-Line will be added to the start of the headers space in #IotHttpsRequestInfo_t.userBuffer.
  * The header space follows the request context in the user buffer. See @ref requestUserBufferMinimumSize for more
  * information on sizing the #IotHttpsRequestInfo_t.userBuffer so that this function does not fail.
  *
- * The request line generated is of the following format:
+ * The Request-Line generated is of the following format:
  *
  * @code
  * method path version\r\n
@@ -317,8 +317,8 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect( IotHttpsConnectionHandle_t connH
  * @param[in] pReqInfo - HTTPS request information.
  *
  * @return One of the following:
- * - #IOT_HTTPS_OK if the request line was successfully added to the header space in #IotHttpsRequestInfo_t.userBuffer.
- * - #IOT_HTTPS_INSUFFICIENT_MEMORY if the request line generated exceeds #IotHttpsUserBuffer_t.bufferLen in #IotHttpsRequestInfo_t.userBuffer.
+ * - #IOT_HTTPS_OK if the Request-Line was successfully added to the header space in #IotHttpsRequestInfo_t.userBuffer.
+ * - #IOT_HTTPS_INSUFFICIENT_MEMORY if the Request-Line generated exceeds #IotHttpsUserBuffer_t.bufferLen in #IotHttpsRequestInfo_t.userBuffer.
  * - #IOT_HTTPS_INVALID_PARAMETER for NULL parameters.
  * - #IOT_HTTPS_INTERNAL_ERROR for library internal errors.
  *
@@ -688,9 +688,9 @@ IotHttpsReturnCode_t IotHttpsClient_CancelResponseAsync( IotHttpsResponseHandle_
 /**
  * @brief Retrieve the HTTPS response status.
  *
- * The HTTP response status code is contained in the status line of the response header buffer configured in
+ * The HTTP response status code is contained in the Status-Line of the response header buffer configured in
  * #IotHttpsResponseInfo_t.userBuffer. It is the first line of a standard HTTP response message. If the response
- * status line could not fit into #IotHttpsResponseInfo_t.userBuffer, then this function will return an error code.
+ * Status-Line could not fit into #IotHttpsResponseInfo_t.userBuffer, then this function will return an error code.
  * Please see #responseUserBufferMinimumSize for information about sizing the #IotHttpsResponseInfo_t.userBuffer.
  *
  * This routine can be used for both a synchronous and asynchronous response.

--- a/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
+++ b/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
@@ -125,16 +125,16 @@
  * This timeout encompasses the waiting time for the both sending of the request and receiving the response.
  */
 #ifndef IOT_TEST_HTTPS_SYNC_TIMEOUT_MS
-    #define IOT_TEST_HTTPS_SYNC_TIMEOUT_MS    ( ( uint32_t ) 60000 )
+    #define IOT_TEST_HTTPS_SYNC_TIMEOUT_MS    ( ( uint32_t ) 10000 )
 #endif
 
 /**
- * @brief Timeout in milliseconds for tests asynchronously send HTTP requests.
+ * @brief Timeout in milliseconds for tests asynchronously sending HTTP requests.
  *
  * This timeout is use to wait for the asynchronous test to finish.
  */
 #ifndef IOT_TEST_HTTPS_ASYNC_TIMEOUT_MS
-    #define IOT_TEST_HTTPS_ASYNC_TIMEOUT_MS    ( ( uint32_t ) 60000 )
+    #define IOT_TEST_HTTPS_ASYNC_TIMEOUT_MS    ( ( uint32_t ) 10000 )
 #endif
 
 /**
@@ -561,22 +561,22 @@ TEST_TEAR_DOWN( HTTPS_Client_System )
  */
 TEST_GROUP_RUNNER( HTTPS_Client_System )
 {
-    RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousNonPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousNonPersistent );
+    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousNonPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousNonPersistent ); */
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestSynchronousPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestSynchronousNonPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestAsynchronousPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestAsynchronousNonPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousNonPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousNonPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousNonPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousPersistent );
-    RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousNonPersistent );
+    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousNonPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousNonPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousNonPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousPersistent ); */
+    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousNonPersistent ); */
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
+++ b/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
@@ -561,22 +561,22 @@ TEST_TEAR_DOWN( HTTPS_Client_System )
  */
 TEST_GROUP_RUNNER( HTTPS_Client_System )
 {
-    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousNonPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousNonPersistent ); */
+    RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, GetRequestSynchronousNonPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, GetRequestAsynchronousNonPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestSynchronousPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestSynchronousNonPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestAsynchronousPersistent );
     RUN_TEST_CASE( HTTPS_Client_System, HeadRequestAsynchronousNonPersistent );
-    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousNonPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousNonPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousNonPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousPersistent ); */
-    /* RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousNonPersistent ); */
+    RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PutRequestSynchronousNonPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PutRequestAsynchronousNonPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PostRequestSynchronousNonPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousPersistent );
+    RUN_TEST_CASE( HTTPS_Client_System, PostRequestAsynchronousNonPersistent );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
The application provides a header buffer and and a body buffer for a response.
The steps internal to the library for receiving a response are:
1. Set the **bufferProcessingState** to PROCESSING_STATE_FILLING_HEADER_BUFFER
1. Fill the header buffer with network data.
1. Parse the header buffer (increments points denoting end of HTTP headers)
1. Set the bufferProcessingState to PROCESSING_STATE_FILLING_BODY_BUFFER
1. Fill the body buffer with network data.
1. Parse the body buffer (increments pointers denoting start and end of HTTP body)
1. Set the bufferProcessingState to PROCESSING_STATE_FINISHED
1. Fill the flush buffer with network data.
1. Parse the flush buffer (since bufferProcessingState == PROCESSING_STATE_FINISHED, no pointers updated only the state of the parser inside of the response)

Flushing is done when **parserState** == PARSER_STATE_BODY_COMPLETE.

During parsing of the flush buffer, if there is a HEAD request, the logic to set the parserState to PARSER_STATE_BODY_COMPLETE was being bypassed.

This was not caught in the unit tests because the timeout was too high. The library would keep trying to read from the network during flushing of the response until the server closed the connection. This was caught while writing a separate demo with a lower timeout on the HEAD request.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.