### PR TITLE
NimBLE AFR: Fix Notification/Indication tx handling

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -616,16 +616,6 @@ BTStatus_t prvBTSendIndication( uint8_t ucServerIf,
     {
         ESP_LOGD( TAG, "Send Notifications" );
         xESPstatus = ble_gattc_notify_custom( usConnId, usAttributeHandle + gattOffset, om );
-
-        if( xGattServerCb.pxIndicationSentCb != NULL )
-        {
-            if( xESPstatus != 0 )
-            {
-                xStatus = eBTStatusFail;
-            }
-
-            xGattServerCb.pxIndicationSentCb( usConnId, xStatus );
-        }
     }
 
     if( xESPstatus != 0 )


### PR DESCRIPTION


NimBLE AFR: Fix Notification/Indication tx handling

Description
-----------
The handling of notifications/indications is done in BLE_GAP_EVENT_NOTIFY_TX where the appropriate status is returned. So, it is not required in prvBTSendIndication

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.