### PR TITLE
Fix coding style for HTTPS Client Sync and Async demos

### DIFF
--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -1036,7 +1036,8 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Asynchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
-    /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. */
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+     * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL, strlen( IOT_DEMO_HTTPS_PRESIGNED_GET_URL ), &pPath, &pathLen );
 
     if( httpsClientStatus != IOT_HTTPS_OK )

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -270,7 +270,8 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Synchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
-    /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. */
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+     * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_GET_URL ),
                                                    &pPath,

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -260,7 +260,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     /* curByte indicates which starting byte we want to download next. */
     uint32_t curByte = 0;
     /* Buffer to write the Range: header value string. */
-    char rangeValueStr[ RANGE_VALUE_MAX_LENGTH ] = { 0 };
+    char pRangeValueStr[ RANGE_VALUE_MAX_LENGTH ] = { 0 };
     /* The current attempt in the number of connection tries. */
     uint32_t connAttempt = 0;
 
@@ -422,7 +422,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
         }
 
         /* Get the Range header value string. */
-        int numWritten = snprintf( rangeValueStr,
+        int numWritten = snprintf( pRangeValueStr,
                                    RANGE_VALUE_MAX_LENGTH,
                                    "bytes=%u-%u",
                                    ( unsigned int ) curByte,
@@ -438,16 +438,16 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
         }
 
         /* Set the header for a range request. */
-        httpsClientStatus = IotHttpsClient_AddHeader( reqHandle, RANGE_HEADER_FIELD, RANGE_HEADER_FIELD_LENGTH, rangeValueStr, numWritten );
+        httpsClientStatus = IotHttpsClient_AddHeader( reqHandle, RANGE_HEADER_FIELD, RANGE_HEADER_FIELD_LENGTH, pRangeValueStr, numWritten );
 
         if( httpsClientStatus != IOT_HTTPS_OK )
         {
-            IotLogError( "Failed to write the header Range: %.*s into the request. With error code: %d", numWritten, rangeValueStr, httpsClientStatus );
+            IotLogError( "Failed to write the header Range: %.*s into the request. With error code: %d", numWritten, pRangeValueStr, httpsClientStatus );
             IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
         }
 
         /* Send the request and receive the response synchronously. */
-        IotLogInfo( "Now requesting Range: %s.", rangeValueStr );
+        IotLogInfo( "Now requesting Range: %s.", pRangeValueStr );
 
         /* A new response handle is returned from IotHttpsClient_SendSync(). We reuse the respHandle variable because
          * the last response was already processed fully.  */

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -317,7 +317,8 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Asynchronous S3 upload demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_PUT_URL );
 
-    /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_PUT_URL. */
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+     * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL ),
                                                    &pPath,

--- a/demos/https/iot_demo_https_s3_upload_sync.c
+++ b/demos/https/iot_demo_https_s3_upload_sync.c
@@ -250,7 +250,8 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Synchronous S3 upload demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_PUT_URL );
 
-    /* Retrieve the path location and length from IOT_DEMO_HTTPS_PRESIGNED_PUT_URL. */
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+     * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL ),
                                                    &pPath,

--- a/libraries/c_sdk/standard/https/include/types/iot_https_types.h
+++ b/libraries/c_sdk/standard/https/include/types/iot_https_types.h
@@ -796,23 +796,23 @@ typedef struct IotHttpsRequestInfo
 {
     /**
      * @brief The absolute path to the HTTP request object.
-     * 
+     *
      * The absolute path includes the path to the file AND the optional query.
      * An example URI path: "/v20160207/directives?query".
-     * 
+     *
      * If this is NULL, a "/" will be added to the Request-Line automaticaly.
-     * 
-     * This is used to generate the Request-Line in the HTTP request message, see 
-     * @ref https_client_function_initializerequest for more information. 
+     *
+     * This is used to generate the Request-Line in the HTTP request message, see
+     * @ref https_client_function_initializerequest for more information.
      */
     const char * pPath;
-    uint32_t pathLen;        /**< @brief URI path length */
+    uint32_t pathLen; /**< @brief URI path length */
 
     /**
      * @brief On of the HTTP method tokens defined in #IotHttpsMethod_t.
-     * 
+     *
      * This is used to generate the Request-Line in the HTTP request message, see
-     * @ref https_client_function_initializerequest for more information. 
+     * @ref https_client_function_initializerequest for more information.
      */
     IotHttpsMethod_t method;
 

--- a/libraries/c_sdk/standard/https/include/types/iot_https_types.h
+++ b/libraries/c_sdk/standard/https/include/types/iot_https_types.h
@@ -103,8 +103,8 @@
  *
  * This helps to calculate the size of the buffer needed for #IotHttpsRequestInfo_t.userBuffer.
  *
- * This buffer size is calculated to fit the HTTP request line and the default headers. It does not account for the
- * length of the path in the request line nor does it account for the length of the host name. It also does not account
+ * This buffer size is calculated to fit the HTTP Request-Line and the default headers. It does not account for the
+ * length of the path in the Request-Line nor does it account for the length of the host name. It also does not account
  * for extra headers that the application may add. These sizes need to be accounted for by the application when
  * assigning a buffer.
  *
@@ -128,10 +128,10 @@ extern const uint32_t requestUserBufferMinimumSize;
  *
  * The buffer size is calculated to fit the HTTP response context only. It does not account for the HTTP response status
  * line. It does not account for any HTTP response headers. If the buffer assigned to
- * #IotHttpsResponseInfo_t.userBuffer is of this minimum size, then the response status line and the response headers
+ * #IotHttpsResponseInfo_t.userBuffer is of this minimum size, then the response Status-Line and the response headers
  * will not be stored. These sizes need to be accounted for by the application when assigning a buffer.
  *
- * If the response status line and response headers cannot fit into #IotHttpsResponseInfo_t.userBuffer, then after a
+ * If the response Status-Line and response headers cannot fit into #IotHttpsResponseInfo_t.userBuffer, then after a
  * call to @ref https_client_function_sendsync, calls to @ref https_client_function_readresponsestatus,
  * @ref https_client_function_readcontentlength, and @ref https_client_function_readheader will return a failure code.
  *
@@ -794,11 +794,27 @@ typedef struct IotHttpsConnectionInfo
  */
 typedef struct IotHttpsRequestInfo
 {
-    /* The path and the method are used to generate the first request line in the HTTP request message. See
-     * @ref https_client_function_initializerequest for more information. */
-    const char * pPath;      /**< @brief URI path, e.g., "/v20160207/directives?query". If this is NULL, a "/" will be added to the request line automaticaly. */
+    /**
+     * @brief The absolute path to the HTTP request object.
+     * 
+     * The absolute path includes the path to the file AND the optional query.
+     * An example URI path: "/v20160207/directives?query".
+     * 
+     * If this is NULL, a "/" will be added to the Request-Line automaticaly.
+     * 
+     * This is used to generate the Request-Line in the HTTP request message, see 
+     * @ref https_client_function_initializerequest for more information. 
+     */
+    const char * pPath;
     uint32_t pathLen;        /**< @brief URI path length */
-    IotHttpsMethod_t method; /**< @brief HTTP method. See #IotHttpsMethod_t for the list of available methods. */
+
+    /**
+     * @brief On of the HTTP method tokens defined in #IotHttpsMethod_t.
+     * 
+     * This is used to generate the Request-Line in the HTTP request message, see
+     * @ref https_client_function_initializerequest for more information. 
+     */
+    IotHttpsMethod_t method;
 
     /**
      * @brief Host address this request is intended for, e.g., "awsamazon.com".
@@ -828,7 +844,7 @@ typedef struct IotHttpsRequestInfo
     /**
      * @brief Application owned buffer for storing the request headers and internal request context.
      *
-     * For an asychronous request, if the application owns the memory for this buffer, then it must not be modified,
+     * For an asynchronous request, if the application owns the memory for this buffer, then it must not be modified,
      * freed, or reused until the the #IotHttpsClientCallbacks_t.responseCompleteCallback is invoked.
      *
      * Please see #IotHttpsUserBuffer_t for more information.

--- a/libraries/c_sdk/standard/https/include/types/iot_https_types.h
+++ b/libraries/c_sdk/standard/https/include/types/iot_https_types.h
@@ -450,7 +450,7 @@ typedef enum IotHttpsMethod
     IOT_HTTPS_METHOD_GET = 0, /* Client-to-server method GET */
     IOT_HTTPS_METHOD_HEAD,    /* Client-to-server method HEAD */
     IOT_HTTPS_METHOD_PUT,     /* Client-to-server method PUT */
-    IOT_HTTPS_METHOD_POST     /* Clietn-to-server method POST. */
+    IOT_HTTPS_METHOD_POST     /* Client-to-server method POST. */
 } IotHttpsMethod_t;
 
 /**

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -3294,7 +3294,7 @@ IotHttpsReturnCode_t IotHttpsClient_ReadHeader( IotHttpsResponseHandle_t respHan
     }
     else
     {
-        IotLogError( "IotHttpsClient_ReadHeader(): The header field %s was not found.", pName );
+        IotLogWarn( "IotHttpsClient_ReadHeader(): The header field %s was not found.", pName );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_NOT_FOUND );
     }
 


### PR DESCRIPTION
A post commit to master code review finds the "p" missing from char arrays and char pointer variables, in the HTTPS Client synchronous and asynchronous download demos.

This PR also elaborates on the difference between the path in IotHttpsRequest_t and returned from IotHttpsClient_GetUrlPath().
IotHttpsClient_GetUrlPath() returns the path length without a query.
The path with a query is defined to be the \"abs_path\" according to the HTTP/1.1 RFC and this is the path needed in IotHttpsRequest_t. This path is the one in the Request-Line.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.