### PR TITLE
Remove redundant loops from the same-socket/different-tasks test.

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -168,7 +168,7 @@ typedef struct
 } tcptestEchoClientsTaskParams_t;
 
 /* Number of time the test goes through all the modes. */
-#define tcptestMAX_LOOPS_ECHO_TEST            ( 4 * tcptestMAX_ECHO_TEST_MODES )
+#define tcptestMAX_LOOPS_ECHO_TEST            tcptestMAX_ECHO_TEST_MODES
 
 #define tcptestECHO_TEST_LOW_PRIORITY         tskIDLE_PRIORITY
 #define tcptestECHO_TEST_HIGH_PRIORITY        ( configMAX_PRIORITIES - 1 )


### PR DESCRIPTION
The same-socket/different-tasks TCP group test executes the same four variations in a loop four times consecutively. The architecture of the test is such that the sending and receiving threads are synchronized at the end of each loop. On some embedded boards with Wi-Fi connectivity, a single iteration can take several minutes to complete. A reasonable compromise would seem to be to run each variation once.