### PR TITLE
Remove redundant elliptic-curve TLS test execution.

### DIFF
--- a/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
+++ b/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
@@ -82,7 +82,6 @@ TEST_GROUP_RUNNER( Full_TLS )
 {
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectRSA );
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectMalformedCert );
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectUntrustedCert );
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );


### PR DESCRIPTION
There are currently two calls to the same test case: connecting to a test server with supplied elliptic-curve client credentials. This change preserves one of the calls, in order to balance code coverage with test suite execution time.