### PR TITLE
AFR Bluedroid: Add support to set minimum Encryption key size requirement

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
@@ -350,6 +350,11 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
 
     if( xESPstatus == ESP_OK )
     {
+        xESPstatus = esp_ble_gap_set_security_param( ESP_BLE_SM_MIN_KEY_SIZE, &xKeySize, sizeof( uint8_t ) );
+    }
+
+    if( xESPstatus == ESP_OK )
+    {
         xESPstatus = esp_ble_gap_set_security_param( ESP_BLE_SM_SET_INIT_KEY, &xInitKey, sizeof( uint8_t ) );
     }
 

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/api/include/api/esp_gap_ble_api.h
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/api/include/api/esp_gap_ble_api.h
@@ -263,14 +263,26 @@ typedef enum {
 
 typedef enum {
     ESP_BLE_SM_PASSKEY = 0,
+    /* Authentication requirements of local device */
     ESP_BLE_SM_AUTHEN_REQ_MODE,
+    /* The IO capability of local device */
     ESP_BLE_SM_IOCAP_MODE,
+    /* Initiator Key Distribution/Generation */
     ESP_BLE_SM_SET_INIT_KEY,
+    /* Responder Key Distribution/Generation */
     ESP_BLE_SM_SET_RSP_KEY,
+    /* Maximum Encryption key size to support */
     ESP_BLE_SM_MAX_KEY_SIZE,
+    /* Minimum Encryption key size requirement from Peer */
+    ESP_BLE_SM_MIN_KEY_SIZE,
+    /* Set static Passkey */
     ESP_BLE_SM_SET_STATIC_PASSKEY,
+    /* Reset static Passkey */
     ESP_BLE_SM_CLEAR_STATIC_PASSKEY,
+    /* Accept only specified SMP Authentication requirement */
     ESP_BLE_SM_ONLY_ACCEPT_SPECIFIED_SEC_AUTH,
+    /* Enable/Disable OOB support */
+    ESP_BLE_SM_OOB_SUPPORT,
     ESP_BLE_SM_MAX_PARAM,
 } esp_ble_sm_param_t;
 

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/bta/dm/bta_dm_co.c
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/bta/dm/bta_dm_co.c
@@ -45,6 +45,7 @@ tBTE_APPL_CFG bte_appl_cfg = {
     BTM_BLE_INITIATOR_KEY_SIZE,
     BTM_BLE_RESPONDER_KEY_SIZE,
     BTM_BLE_MAX_KEY_SIZE,
+    BTM_BLE_MIN_KEY_SIZE,
     BTM_BLE_ONLY_ACCEPT_SPECIFIED_SEC_AUTH_DISABLE
 };
 #endif
@@ -361,8 +362,19 @@ void bta_dm_co_ble_set_rsp_key_req(UINT8 rsp_key)
 void bta_dm_co_ble_set_max_key_size(UINT8 ble_key_size)
 {
 #if (SMP_INCLUDED == TRUE)
-    if(ble_key_size >= BTM_BLE_MIN_KEY_SIZE && ble_key_size <= BTM_BLE_MAX_KEY_SIZE) {
+    if(ble_key_size >= bte_appl_cfg.ble_min_key_size && ble_key_size <= BTM_BLE_MAX_KEY_SIZE) {
         bte_appl_cfg.ble_max_key_size = ble_key_size;
+    } else {
+        APPL_TRACE_ERROR("%s error:Invalid key size value, key_size =%d",__func__, ble_key_size);
+    }
+#endif  ///SMP_INCLUDED == TRUE
+}
+
+void bta_dm_co_ble_set_min_key_size(UINT8 ble_key_size)
+{
+#if (SMP_INCLUDED == TRUE)
+    if(ble_key_size >= BTM_BLE_MIN_KEY_SIZE && ble_key_size <= bte_appl_cfg.ble_max_key_size) {
+        bte_appl_cfg.ble_min_key_size = ble_key_size;
     } else {
         APPL_TRACE_ERROR("%s error:Invalid key size value, key_size =%d",__func__, ble_key_size);
     }

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/bta/include/bta/bta_dm_co.h
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/bta/include/bta/bta_dm_co.h
@@ -191,6 +191,8 @@ extern void bta_dm_co_ble_set_rsp_key_req(UINT8 rsp_key);
 
 extern void bta_dm_co_ble_set_max_key_size(UINT8 ble_key_size);
 
+extern void bta_dm_co_ble_set_min_key_size(UINT8 ble_key_size);
+
 extern void bta_dm_co_ble_set_accept_auth_enable(UINT8 enable);
 
 extern UINT8 bta_dm_co_ble_get_accept_auth_enable(void);

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
@@ -1120,6 +1120,12 @@ void btc_gap_ble_call_handler(btc_msg_t *msg)
                 bta_dm_co_ble_set_max_key_size(key_size);
                 break;
             }
+            case ESP_BLE_SM_MIN_KEY_SIZE: {
+                uint8_t key_size = 0;
+                STREAM_TO_UINT8(key_size, value);
+                bta_dm_co_ble_set_min_key_size(key_size);
+                break;
+            }
             case ESP_BLE_SM_SET_STATIC_PASSKEY: {
                 uint32_t passkey = 0;
                 for(uint8_t i = 0; i < arg->set_security_param.len; i++)

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/common/include/common/bte_appl.h
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/common/include/common/bte_appl.h
@@ -31,6 +31,7 @@ typedef struct {
     UINT8   ble_init_key;
     UINT8   ble_resp_key;
     UINT8   ble_max_key_size;
+    UINT8   ble_min_key_size;
     UINT8   ble_accept_auth_enable;
 #endif
 } tBTE_APPL_CFG;

--- a/vendors/espressif/esp-idf/components/bt/bluedroid/stack/smp/smp_utils.c
+++ b/vendors/espressif/esp-idf/components/bt/bluedroid/stack/smp/smp_utils.c
@@ -36,6 +36,7 @@
 #include "smp_int.h"
 #include "device/controller.h"
 #include "btm_int.h"
+#include "common/bte_appl.h"
 
 #define SMP_PAIRING_REQ_SIZE    7
 #define SMP_CONFIRM_CMD_SIZE    (BT_OCTET16_LEN + 1)
@@ -1109,9 +1110,27 @@ BOOLEAN smp_pairing_request_response_parameters_are_valid(tSMP_CB *p_cb)
         return FALSE;
     }
 
-    if ((enc_size < SMP_ENCR_KEY_SIZE_MIN) || (enc_size > SMP_ENCR_KEY_SIZE_MAX)) {
+    /* `bte_appl_cfg.ble_min_enc_key_size` will be `SMP_ENCR_KEY_SIZE_MIN` by
+     * default if not set explicitly  */
+#if (BLE_INCLUDED == TRUE)
+    if (enc_size < bte_appl_cfg.ble_min_key_size) {
         SMP_TRACE_WARNING("Rcvd from the peer cmd 0x%02x with Maximum Encryption \
-            Key value (0x%02x) out of range).\n",
+            Key value (0x%02x) less than minimum required key size).\n",
+                          p_cb->rcvd_cmd_code, enc_size);
+        return FALSE;
+    }
+#else
+    if (enc_size < SMP_ENCR_KEY_SIZE_MIN) {
+        SMP_TRACE_WARNING("Rcvd from the peer cmd 0x%02x with Maximum Encryption \
+            Key value (0x%02x) less than minimum required key size).\n",
+                          p_cb->rcvd_cmd_code, enc_size);
+        return FALSE;
+    }
+#endif
+
+    if (enc_size > SMP_ENCR_KEY_SIZE_MAX) {
+        SMP_TRACE_WARNING("Rcvd from the peer cmd 0x%02x with Maximum Encryption \
+            Key value (0x%02x) greater than supported by stack).\n",
                           p_cb->rcvd_cmd_code, enc_size);
         return FALSE;
     }


### PR DESCRIPTION
- Helps in fixing `Key Negotiations issue` by which Encryption Key size could be brought
  down to 7 Bytes from 16 Bytes in `Secure Connection only` mode as well.

<!--- Title -->

Description
-----------
- Modifies `esp_ble_gap_set_security_param` API to set Minimum Encryption Key size requirement.
- Modifies `iot_ble_hal_gap.c`, to set `ESP_BLE_SM_MIN_KEY_SIZE` to 16 Bytes.
- Additional check in `smp_utils.c` to reject pairing request in case peer device's key size is less than `ble_min_key_size` requirement set by application.
- Helps in mitigating `Key Negotiation attack`, by which the peer device can bring down `Encryption key size` to 7 Bytes from 16 Bytes in `secure connections`.
      

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.