### PR TITLE
Feature/notification channels

### DIFF
--- a/lib/FreeRTOS/tasks.c
+++ b/lib/FreeRTOS/tasks.c
@@ -4577,6 +4577,20 @@ TickType_t uxReturn;
 
 		taskENTER_CRITICAL();
 		{
+
+#if(configUSE_TASK_NOTIFICATION_CHANNELS == 1)
+			if( pxCurrentTCB->ucNotifyState == taskNOTIFICATION_RECEIVED )
+			{
+				/* Pending notification. If it's not coming from a
+					 listening channel, ignore it. */
+				uint8_t still_listening_on = pxCurrentTCB->ucNotifiedChannels & ucListeningChannels;
+				if(!still_listening_on){
+					pxCurrentTCB->ucNotifyState = taskWAITING_NOTIFICATION;
+				}
+
+			}
+#endif
+
 			/* Only block if a notification is not already pending. */
 			if( pxCurrentTCB->ucNotifyState != taskNOTIFICATION_RECEIVED )
 			{
@@ -4671,7 +4685,7 @@ TickType_t uxReturn;
 		taskENTER_CRITICAL();
 		{
 #if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
-    	uint8_t matching_channels = pxTCB->ucListeningChannels & ucNotifyChannelsMask; 
+    uint8_t matching_channels = pxTCB->ucListeningChannels & ucNotifyChannelsMask; 
 		if(matching_channels)
 		{
 			pxTCB->ucNotifiedChannels = matching_channels;

--- a/lib/FreeRTOS/tasks.c
+++ b/lib/FreeRTOS/tasks.c
@@ -998,7 +998,7 @@ UBaseType_t x;
 		pxNewTCB->ucNotifyState = taskNOT_WAITING_NOTIFICATION;
 	#if ( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
 	{
-		pxNewTCB->ucListeningChannels = 0;
+		pxNewTCB->ucListeningChannels = pdNOTIFICATION_CHANNEL_RESERVED;
 		pxNewTCB->ucNotifiedChannels = 0;
 	}
 	#endif

--- a/lib/include/task.h
+++ b/lib/include/task.h
@@ -1792,7 +1792,26 @@ void vTaskGetRunTimeStats( char *pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e9
  * \defgroup xTaskNotify xTaskNotify
  * \ingroup TaskNotifications
  */
+
+#if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
+#define pdNOTIFICATION_CHANNEL_0          0x01
+#define pdNOTIFICATION_CHANNEL_1          0x02
+#define pdNOTIFICATION_CHANNEL_2          0x04
+#define pdNOTIFICATION_CHANNEL_3          0x08
+#define pdNOTIFICATION_CHANNEL_4          0x10
+#define pdNOTIFICATION_CHANNEL_5          0x20
+#define pdNOTIFICATION_CHANNEL_6          0x40
+#define pdNOTIFICATION_CHANNEL_RESERVED   0x80 
+#define pdNOTIFICATION_CHANNEL_ALL        0xFF
+#endif /* configUSE_TASK_NOTIFICATION_CHANNELS */
+
+#if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
+BaseType_t xTaskGenericNotifyChannels( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, uint8_t ucNotifyChannels ) PRIVILEGED_FUNCTION;
+#define xTaskGenericNotify( xTaskToNotify, ulValue, eAction, pulPreviousNotificationValue ) xTaskGenericNotifyChannels( ( xTaskToNotify ), ( ulValue ), ( eAction ), ( pulPreviousNotificationValue ), ( pdNOTIFICATION_CHANNEL_RESERVED ) )
+#define xTaskNotifyChannels( xTaskToNotify, ulValue, eAction, ucNotifyChannels) xTaskGenericNotifyChannels( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( ucNotifyChannels ) )
+#else
 BaseType_t xTaskGenericNotify( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue ) PRIVILEGED_FUNCTION;
+#endif /* configUSE_TASK_NOTIFICATION_CHANNELS */
 #define xTaskNotify( xTaskToNotify, ulValue, eAction ) xTaskGenericNotify( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL )
 #define xTaskNotifyAndQuery( xTaskToNotify, ulValue, eAction, pulPreviousNotifyValue ) xTaskGenericNotify( ( xTaskToNotify ), ( ulValue ), ( eAction ), ( pulPreviousNotifyValue ) )
 
@@ -1883,7 +1902,14 @@ BaseType_t xTaskGenericNotify( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNo
  * \defgroup xTaskNotify xTaskNotify
  * \ingroup TaskNotifications
  */
+
+#if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
+BaseType_t xTaskGenericNotifyChannelsFromISR( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, BaseType_t *pxHigherPriorityTaskWoken, uint8_t ucNotifyChannels ) PRIVILEGED_FUNCTION;
+#define xTaskGenericNotifyFromISR( xTaskToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken ) xTaskGenericNotifyChannelsFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ) , ( pulPreviousNotificationValue ), ( pxHigherPriorityTaskWoken ), ( pdNOTIFICATION_CHANNEL_RESERVED ) )
+#define xTaskNotifyChannelsFromISR( xTaskToNotify, ulValue, eAction, pxHigherPriorityTaskWoken, ucNotifyChannels) xTaskGenericNotifyChannelsFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( pxHigherPriorityTaskWoken ), ( ucNotifyChannels ) )
+#else
 BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, BaseType_t *pxHigherPriorityTaskWoken ) PRIVILEGED_FUNCTION;
+#endif /* configUSE_TASK_NOTIFICATION_CHANNELS */
 #define xTaskNotifyFromISR( xTaskToNotify, ulValue, eAction, pxHigherPriorityTaskWoken ) xTaskGenericNotifyFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( pxHigherPriorityTaskWoken ) )
 #define xTaskNotifyAndQueryFromISR( xTaskToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken ) xTaskGenericNotifyFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ), ( pulPreviousNotificationValue ), ( pxHigherPriorityTaskWoken ) )
 
@@ -1960,7 +1986,12 @@ BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify, uint32_t ulVal
  * \defgroup xTaskNotifyWait xTaskNotifyWait
  * \ingroup TaskNotifications
  */
+#if(configUSE_TASK_NOTIFICATION_CHANNELS == 1)
+BaseType_t xTaskNotifyWaitChannels( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait, uint8_t ucListeningChannels) PRIVILEGED_FUNCTION;
+#define xTaskNotifyWait( ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait ) xTaskNotifyWaitChannels( ( ulBitsToClearOnEntry ), ( ulBitsToClearOnExit ),  ( pulNotificationValue ), ( xTicksToWait ), pdNOTIFICATION_CHANNEL_ALL)
+#else
 BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
+#endif
 
 /**
  * task. h

--- a/lib/include/task.h
+++ b/lib/include/task.h
@@ -1991,7 +1991,7 @@ BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify, uint32_t ulVal
  */
 #if(configUSE_TASK_NOTIFICATION_CHANNELS == 1)
 BaseType_t xTaskNotifyWaitChannels( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait, uint8_t ucListeningChannels) PRIVILEGED_FUNCTION;
-#define xTaskNotifyWait( ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait ) xTaskNotifyWaitChannels( ( ulBitsToClearOnEntry ), ( ulBitsToClearOnExit ),  ( pulNotificationValue ), ( xTicksToWait ), pdNOTIFICATION_CHANNEL_ALL)
+#define xTaskNotifyWait( ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait ) xTaskNotifyWaitChannels( ( ulBitsToClearOnEntry ), ( ulBitsToClearOnExit ),  ( pulNotificationValue ), ( xTicksToWait ), pdNOTIFICATION_CHANNEL_RESERVED)
 #else
 BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
 #endif

--- a/lib/include/task.h
+++ b/lib/include/task.h
@@ -1803,12 +1803,15 @@ void vTaskGetRunTimeStats( char *pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e9
 #define pdNOTIFICATION_CHANNEL_6          0x40
 #define pdNOTIFICATION_CHANNEL_RESERVED   0x80 
 #define pdNOTIFICATION_CHANNEL_ALL        0xFF
+
+uint8_t ucTaskGetCurrentNotifiedChannels( void );
+
 #endif /* configUSE_TASK_NOTIFICATION_CHANNELS */
 
 #if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
-BaseType_t xTaskGenericNotifyChannels( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, uint8_t ucNotifyChannels ) PRIVILEGED_FUNCTION;
+BaseType_t xTaskGenericNotifyChannels( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, uint8_t ucNotifyChannelsMask ) PRIVILEGED_FUNCTION;
 #define xTaskGenericNotify( xTaskToNotify, ulValue, eAction, pulPreviousNotificationValue ) xTaskGenericNotifyChannels( ( xTaskToNotify ), ( ulValue ), ( eAction ), ( pulPreviousNotificationValue ), ( pdNOTIFICATION_CHANNEL_RESERVED ) )
-#define xTaskNotifyChannels( xTaskToNotify, ulValue, eAction, ucNotifyChannels) xTaskGenericNotifyChannels( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( ucNotifyChannels ) )
+#define xTaskNotifyChannels( xTaskToNotify, ulValue, eAction, ucNotifyChannelsMask) xTaskGenericNotifyChannels( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( ucNotifyChannelsMask ) )
 #else
 BaseType_t xTaskGenericNotify( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue ) PRIVILEGED_FUNCTION;
 #endif /* configUSE_TASK_NOTIFICATION_CHANNELS */
@@ -1904,9 +1907,9 @@ BaseType_t xTaskGenericNotify( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNo
  */
 
 #if( configUSE_TASK_NOTIFICATION_CHANNELS == 1 )
-BaseType_t xTaskGenericNotifyChannelsFromISR( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, BaseType_t *pxHigherPriorityTaskWoken, uint8_t ucNotifyChannels ) PRIVILEGED_FUNCTION;
+BaseType_t xTaskGenericNotifyChannelsFromISR( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, BaseType_t *pxHigherPriorityTaskWoken, uint8_t ucNotifyChannelsMask ) PRIVILEGED_FUNCTION;
 #define xTaskGenericNotifyFromISR( xTaskToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken ) xTaskGenericNotifyChannelsFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ) , ( pulPreviousNotificationValue ), ( pxHigherPriorityTaskWoken ), ( pdNOTIFICATION_CHANNEL_RESERVED ) )
-#define xTaskNotifyChannelsFromISR( xTaskToNotify, ulValue, eAction, pxHigherPriorityTaskWoken, ucNotifyChannels) xTaskGenericNotifyChannelsFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( pxHigherPriorityTaskWoken ), ( ucNotifyChannels ) )
+#define xTaskNotifyChannelsFromISR( xTaskToNotify, ulValue, eAction, pxHigherPriorityTaskWoken, ucNotifyChannelsMask) xTaskGenericNotifyChannelsFromISR( ( xTaskToNotify ), ( ulValue ), ( eAction ), NULL, ( pxHigherPriorityTaskWoken ), ( ucNotifyChannelsMask ) )
 #else
 BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue, BaseType_t *pxHigherPriorityTaskWoken ) PRIVILEGED_FUNCTION;
 #endif /* configUSE_TASK_NOTIFICATION_CHANNELS */


### PR DESCRIPTION
<!--- Title -->
Extend the task notification feature to include the concept of channels.
Description
-----------
<!--- Describe your changes in detail -->
Currently, one task can notify another through the task notification value.

In a scenario where a task receives notification from many sources, could be interesting
a feature for ignoring the notifications from determinated sources, depending on the
moment.

Without this feature, the notified task must be awaken if it was blocked, check if the
notification applies in this moment and return to wait if it is not the case.

With this feature, one task can be listening for notification in up to 7 channels.
Notifications coming from channels the task is not listening at are ignored.

For compatibility there is one reserved channel , from where the standard notifications (from
calls not using this feature) come from.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.