### PR TITLE
FWPLATFORM-1184: Add check for SetGpioSpeed not supported in AFQP_Iot…

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -438,11 +438,14 @@ TEST( TEST_IOT_GPIO, AFQP_IotGpioSpeed )
         {
             ulPerfCountFastDelta = 0xFFFFFFFF - ulPerfCount0 + ulPerfCount1 + 1;
         }
+
+        TEST_ASSERT_GREATER_THAN( ulPerfCountFastDelta, ulPerfCountSlowDelta );
+
     }
+
     lRetVal = iot_gpio_close( xtestIotGpioHandleA );
     TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
 
-    TEST_ASSERT_GREATER_THAN( ulPerfCountFastDelta, ulPerfCountSlowDelta );
 }
 /*-----------------------------------------------------------*/
 /**


### PR DESCRIPTION
…GpioSpeed() GPIO tests. [1/1]

[Problem]
AFQP_IotGpioSpeed() is not supported on MTK board

[Solution]
Add check for SetGpioSpeed not supported in AFQP_IotGpioSpeed() GPIO tests.

-->iot_tests test 5
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenClose) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenOpenClose) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenCloseClose) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioIoctlSetGet) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioMode) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioPull) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioSpeed) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOperation)
GPIO[0] read value = 0x0
 PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenCloseFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioReadWriteSyncFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioIoctlFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioInterrupt) PASS

-----------------------
12 Tests 0 Failures 0 Ignored
OK
cli duration 462ms

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.