### PR TITLE
Fix the HTTPS Client doxygen configuration.

### DIFF
--- a/doc/config/https
+++ b/doc/config/https
@@ -13,7 +13,7 @@ HTML_OUTPUT = https
 HTML_EXTRA_FILES = doc/extra_files/https/gettysburg.txt
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/https.tag
+GENERATE_TAGFILE = doc/output/https.tag
 
 # Directories containing library source code.
 INPUT = doc \
@@ -32,7 +32,7 @@ INPUT = doc \
 FILE_PATTERNS = *https*.c *https*.h *https*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/linear_containers.tag=../linear_containers \
-           doc/tag/logging.tag=../logging \
-           doc/tag/platform.tag=../platform
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/linear_containers.tag=../linear_containers \
+           doc/output/logging.tag=../logging \
+           doc/output/platform.tag=../platform

--- a/doc/config/main
+++ b/doc/config/main
@@ -25,6 +25,7 @@ AUTOLINK_SUPPORT = NO
 TAGFILES = doc/output/logging.tag=../logging \
            doc/output/platform.tag=../platform \
            doc/output/mqtt.tag=../mqtt \
+           doc/output/https.tag=../https \
            doc/output/posix.tag=../posix \
            doc/output/posix.tag=../atomic \
            doc/output/shadow.tag=../shadow

--- a/doc/guidance.md
+++ b/doc/guidance.md
@@ -28,6 +28,7 @@ This is about how to use Doxygen to maintain the API documents. There are three 
 	- doxygen doc/config/shadow
 	- doxygen doc/config/defender
 	- doxygen doc/config/ble
+	- doxygen doc/config/https
 	- doxygen doc/config/main
 - the entry doc is $ROOT_AFR_DIR/doc/output/main/index.html, open it with browser and verify it looks good
 
@@ -61,7 +62,7 @@ PROJECT_NAME = "Foo"
 HTML_OUTPUT = foo
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/foo.tag
+GENERATE_TAGFILE = doc/output/foo.tag
 
 # Directories containing library source code.
 INPUT = [The source files path]
@@ -72,7 +73,7 @@ FILE_PATTERNS = *.h *.c *.txt
 EXAMPLE_PATH = [The source files path]
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
+TAGFILES = doc/output/main.tag=../main \
 ```
 
 ## 2. A separate file to structure the documents

--- a/doc/tag/README.md
+++ b/doc/tag/README.md
@@ -1,4 +1,0 @@
-This folder is for generating working Doxygen tags.
-During Doxygen generation, this folder needs to be present. 
-\<library-name\>.tag will be created in this folder.
-Deleting this folder may cause generation to fail.


### PR DESCRIPTION
Sometime in the past few weeks, the doxygen configurations were updated to not use the doc/tag folder and https was neglected in the update. 

This update fixes the HTTPS Client doxygen documentation to generated appropriately with the rest of libraries.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.