### PR TITLE
Fix comparison of 0 > UINT macro use in TCP tests

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1348,7 +1348,7 @@ static void prvSOCKETS_Shutdown( Server_t xConn )
     }
     while( xResult >= 0 );
 
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
 
     xResult = prvCloseHelper( xSocket, &xSocketOpen );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket failed to close" );
@@ -1371,7 +1371,7 @@ static void prvSOCKETS_Shutdown( Server_t xConn )
      *  xResult = SOCKETS_Send( xSocket, &ucBuf, 1, 0 );
      * }
      * while( xResult >= 0 );
-     * TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+     * TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
      */
 
     xResult = prvCloseHelper( xSocket, &xSocketOpen );
@@ -1392,7 +1392,7 @@ static void prvSOCKETS_Shutdown( Server_t xConn )
     }
     while( xResult >= 0 );
 
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
 
     xResult = prvCloseHelper( xSocket, &xSocketOpen );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket failed to close" );
@@ -1437,9 +1437,9 @@ static void prvTestSOCKETS_Close( Server_t xConn )
 
     /* Closed socket should not connect, send or receive */
     xResult = SOCKETS_Send( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
     xResult = SOCKETS_Recv( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
 
     /* Close a connected socket */
     xResult = prvConnectHelperWithRetry( &xSocket, xConn, xReceiveTimeOut, xSendTimeOut, &xSocketOpen );
@@ -1453,9 +1453,9 @@ static void prvTestSOCKETS_Close( Server_t xConn )
 
     /* Closed socket should not connect, send or receive */
     xResult = SOCKETS_Send( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
     xResult = SOCKETS_Recv( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
 
     /* Close a shutdown socket */
     xResult = prvConnectHelperWithRetry( &xSocket, xConn, xReceiveTimeOut, xSendTimeOut, &xSocketOpen );
@@ -1472,9 +1472,9 @@ static void prvTestSOCKETS_Close( Server_t xConn )
 
     /* Closed socket should not connect, send or receive */
     xResult = SOCKETS_Send( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
     xResult = SOCKETS_Recv( xSocket, &ucBuf, 1, 0 );
-    TEST_ASSERT_LESS_THAN_UINT32( 0, xResult );
+    TEST_ASSERT_LESS_THAN_INT32( 0, xResult );
 
     tcptestPRINTF( ( "%s passed\r\n", __FUNCTION__ ) );
 }


### PR DESCRIPTION
Mistake in TCP tests calling
TEST_ASSERT_LESS_THAN_UINT32( 0, xResult ) where negative
number is interpreted as positive.
Update in unity fixed a bug that caused this to go unnoticed
previously :)

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.