### PR TITLE
Increase the "test runner" task delay to 10 secs (from 5 secs)

### DIFF
--- a/tests/common/aws_test_framework.c
+++ b/tests/common/aws_test_framework.c
@@ -80,7 +80,7 @@ void TEST_NotifyTestStart()
 {
     /* Wait for test script to open serial port before starting tests on the
      * board.*/
-    vTaskDelay( pdMS_TO_TICKS( 5000UL ) );
+    vTaskDelay( pdMS_TO_TICKS( 10000UL ) );
     TEST_SubmitResult( "---------STARTING TESTS---------\n" );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
For test framework being able to catch the test runner task start marker ("----STARTING TESTS---") (for Microchip), the delay is change to 10 secs (from 5 secs).