### PR TITLE
Fix iot_tls.c - check for errors before retrieving P11 objects

### DIFF
--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -38,9 +38,11 @@
  * error codes, or codes from mbedTLS.
  */
 /**@{ */
-#define TLS_ERROR_HANDSHAKE_FAILED    ( -2001 )   /*!< Error in handshake. */
-#define TLS_ERROR_RNG                 ( -2002 )   /*!< Error in RNG. */
-#define TLS_ERROR_SIGN                ( -2003 )   /*!< Error in sign operation. */
+#define TLS_ERROR_HANDSHAKE_FAILED    ( -2001 ) /*!< Error in handshake. */
+#define TLS_ERROR_RNG                 ( -2002 ) /*!< Error in RNG. */
+#define TLS_ERROR_SIGN                ( -2003 ) /*!< Error in sign operation. */
+#define TLS_ERROR_NO_PRIVATE_KEY      ( -2004 ) /*!< Private key was not provisioned. */
+#define TLS_ERROR_NO_CERTIFICATE      ( -2005 ) /*!< Client certificate not provisioned. */
 
 /**@} */
 

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -193,7 +193,7 @@ static int prvGenerateRandomBytes( void * pvCtx,
 
     xResult = pxCtx->pxP11FunctionList->C_GenerateRandom( pxCtx->xP11Session, pucRandom, xRandomLength );
 
-    if( xResult != 0 )
+    if( xResult != CKR_OK )
     {
         TLS_PRINT( ( "ERROR: Failed to generate random bytes %d \r\n", xResult ) );
         xResult = TLS_ERROR_RNG;
@@ -399,11 +399,11 @@ static int prvPrivateKeySigningCallback( void * pvContext,
  */
 static int prvInitializeClientCredential( TLSContext_t * pxCtx )
 {
-    BaseType_t xResult = 0;
+    BaseType_t xResult = CKR_OK;
     CK_SLOT_ID * pxSlotIds = NULL;
     CK_ULONG xCount = 0;
     CK_ATTRIBUTE xTemplate[ 2 ];
-    CK_OBJECT_HANDLE xCertObj = 0;
+    CK_OBJECT_HANDLE xCertObj = CK_INVALID_HANDLE;
     CK_BYTE * pxCertificate = NULL;
     mbedtls_pk_type_t xKeyAlgo = ( mbedtls_pk_type_t ) ~0;
     char * pcJitrCertificate = keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM;
@@ -440,7 +440,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
 
     /* Start a private session with the P#11 module using the first
      * enumerated slot. */
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         xResult = ( BaseType_t ) pxCtx->pxP11FunctionList->C_OpenSession( pxSlotIds[ 0 ],
                                                                           CKF_SERIAL_SESSION,
@@ -450,7 +450,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     }
 
     /* Put the module in authenticated mode. */
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         xResult = ( BaseType_t ) pxCtx->pxP11FunctionList->C_Login( pxCtx->xP11Session,
                                                                     CKU_USER,
@@ -467,7 +467,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                 &pxCtx->xP11PrivateKey );
     }
 
-    if( pxCtx->xP11PrivateKey == CK_INVALID_HANDLE )
+    if( ( CKR_OK == xResult ) && ( pxCtx->xP11PrivateKey == CK_INVALID_HANDLE ) )
     {
         xResult = TLS_ERROR_NO_PRIVATE_KEY;
         TLS_PRINT( ( "ERROR: Private key not found. " ) );
@@ -526,7 +526,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
         TLS_PRINT( ( "No device certificate found." ) );
     }
 
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         /* Query the device certificate size. */
         xTemplate[ 0 ].type = CKA_VALUE;
@@ -538,7 +538,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                                                 1 );
     }
 
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         /* Create a buffer for the certificate. */
         pxCertificate = ( CK_BYTE_PTR ) pvPortMalloc( xTemplate[ 0 ].ulValueLen ); /*lint !e9079 Allow casting void* to other types. */
@@ -549,7 +549,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
         }
     }
 
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         /* Export the certificate. */
         xTemplate[ 0 ].pValue = pxCertificate;
@@ -560,7 +560,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     }
 
     /* Decode the client certificate. */
-    if( 0 == xResult )
+    if( CKR_OK == xResult )
     {
         xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509Cli,
                                           ( const unsigned char * ) pxCertificate,
@@ -619,7 +619,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
 BaseType_t TLS_Init( void ** ppvContext,
                      TLSParams_t * pxParams )
 {
-    BaseType_t xResult = 0;
+    BaseType_t xResult = CKR_OK;
     TLSContext_t * pxCtx = NULL;
     CK_C_GetFunctionList xCkGetFunctionList = NULL;
 
@@ -646,7 +646,7 @@ BaseType_t TLS_Init( void ** ppvContext,
         xResult = ( BaseType_t ) xCkGetFunctionList( &pxCtx->pxP11FunctionList );
 
         /* Ensure that the PKCS #11 module is initialized. */
-        if( 0 == xResult )
+        if( CKR_OK == xResult )
         {
             xResult = ( BaseType_t ) xInitializePKCS11();
 

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -458,14 +458,18 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                                     sizeof( configPKCS11_DEFAULT_USER_PIN ) - 1 );
     }
 
-    /* Get the handle of the device private key. */
-    xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
-                                            pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-                                            CKO_PRIVATE_KEY,
-                                            &pxCtx->xP11PrivateKey );
+    if( CKR_OK == xResult )
+    {
+        /* Get the handle of the device private key. */
+        xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
+                                                pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                                CKO_PRIVATE_KEY,
+                                                &pxCtx->xP11PrivateKey );
+    }
 
     if( pxCtx->xP11PrivateKey == CK_INVALID_HANDLE )
     {
+        xResult = TLS_ERROR_NO_PRIVATE_KEY;
         TLS_PRINT( ( "ERROR: Private key not found. " ) );
     }
 
@@ -518,6 +522,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
 
     if( xCertObj == CK_INVALID_HANDLE )
     {
+        xResult = TLS_ERROR_NO_CERTIFICATE;
         TLS_PRINT( ( "No device certificate found." ) );
     }
 


### PR DESCRIPTION
Add error codes for missing client credentials.

<!--- Title -->

https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/pc/job/windows-ide/10/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.