### PR TITLE
Disconnect and return in the event of an out-of-order HTTP response.

### DIFF
--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1184,6 +1184,14 @@ static void _networkReceiveCallback( void * pNetworkConnection,
 
     IOT_FUNCTION_CLEANUP_BEGIN();
 
+    /* Disconnect and return in the event of an out-of-order response */
+    if( fatalDisconnect && !pCurrentHttpsResponse )
+    {
+        IotLogDebug( "Disconnecting out-of-order response %d.", pCurrentHttpsResponse );
+        disconnectStatus = IotHttpsClient_Disconnect( pHttpsConnection );
+        return;
+    }
+
     /* Report errors back to the application. */
     if( HTTPS_FAILED( status ) )
     {

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1184,24 +1184,25 @@ static void _networkReceiveCallback( void * pNetworkConnection,
 
     IOT_FUNCTION_CLEANUP_BEGIN();
 
-    /* Disconnect and return in the event of an out-of-order response. If a response is received out of order 
-     * pCurrentHttpsResponse will be NULL because there will be no response in the connection's response queue. 
-     * If a response is received out of order that is an indication of a rougue server. */
+    /* Disconnect and return in the event of an out-of-order response. If a response is received out of order
+     * pCurrentHttpsResponse will be NULL because there will be no response in the connection's response queue.
+     * If a response is received out of order that is an indication of a rogue server. */
     if( fatalDisconnect && !pCurrentHttpsResponse )
     {
         IotLogError( "An out-of-order response was received. The connection will be disconnected." );
         disconnectStatus = IotHttpsClient_Disconnect( pHttpsConnection );
+
         if( HTTPS_FAILED( disconnectStatus ) )
         {
             IotLogWarn( "Failed to disconnect after an out of order response. Error code: %d.", disconnectStatus );
         }
-      
+
         /* In this case this routine returns immediately after to avoid further uses of pCurrentHttpsResponse. */
         return;
     }
 
     /* Report errors back to the application. */
-    if( HTTPS_FAILED( status ) && ( pCurrentHttpsResponse != NULL ) )
+    if( HTTPS_FAILED( status ) )
     {
         if( pCurrentHttpsResponse->isAsync && pCurrentHttpsResponse->pCallbacks->errorCallback )
         {


### PR DESCRIPTION
Preface HTTPS clean up code in _networkReceiveCallback to disconnect
and simply return in the event that an out-of-order response was
received with no matching request.

This issue was discovered by Nathan Chong while writing a CBMC proof.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.