### PR TITLE
Updating CMake for nordic port. 

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -106,16 +106,16 @@ afr_mcu_port(kernel)
 target_sources(
     AFR::kernel::mcu_port
     INTERFACE
-        "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk/port.c"
-        "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk/port_cmsis.c"
-        "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk/port_cmsis_systick.c"
-        "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk/portmacro.h"
-        "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk/portmacro_cmsis.h"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk/port.c"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk/port_cmsis.c"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk/port_cmsis_systick.c"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk/portmacro.h"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk/portmacro_cmsis.h"
         "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
 )
 set(
     kernel_inc_dirs
-    "${AFR_KERNEL_DIR}/portable/GCC/nrf52840-dk"
+    "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/nrf52840-dk"
     "${AFR_3RDPARTY_DIR}/tinycrypt/lib/include"
     "${AFR_3RDPARTY_DIR}/jsmn"
     "${AFR_3RDPARTY_DIR}/pkcs11"


### PR DESCRIPTION
Description
-----------
```portable/GCC/nrf52840-dk/``` was moved to ```portable/ThirdParty/GCC/nrf52840-dk/```. This is a followup PR for https://github.com/aws/amazon-freertos/pull/1260. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.