### PR TITLE
Make TLS test group aware of key import and type capabilities.

### DIFF
--- a/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
+++ b/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
@@ -80,11 +80,15 @@ TEST_TEAR_DOWN( Full_TLS )
 
 TEST_GROUP_RUNNER( Full_TLS )
 {
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectRSA );
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectMalformedCert );
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectUntrustedCert );
-    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );
+    RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectDefault );
+    #if ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED == 1 )
+        #ifdef pkcs11testEC_KEY_SUPPORT
+            RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
+        #endif
+        RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectMalformedCert );
+        RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectUntrustedCert );
+        RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );
+    #endif
 }
 
 /*-----------------------------------------------------------*/
@@ -269,7 +273,7 @@ static void prvExpectFailAfterDataSentWithProvisioning( ProvisioningParams_t * p
 }
 /*-----------------------------------------------------------*/
 
-TEST( Full_TLS, AFQP_TLS_ConnectRSA )
+TEST( Full_TLS, AFQP_TLS_ConnectDefault )
 {
     const char * pcAWSIoTAddress = clientcredentialMQTT_BROKER_ENDPOINT;
     uint16_t usAWSIoTPort = clientcredentialMQTT_BROKER_PORT;

--- a/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
+++ b/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
@@ -84,10 +84,10 @@ TEST_GROUP_RUNNER( Full_TLS )
     #if ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED == 1 )
         #ifdef pkcs11testEC_KEY_SUPPORT
             RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
+            RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );
         #endif
         RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectMalformedCert );
         RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectUntrustedCert );
-        RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );
     #endif
 }
 


### PR DESCRIPTION
This change improves TLS test group compatibility with secure element-equipped boards by respecting capability configuration settings for key import, ECDSA, and RSA.