### PR TITLE
BLE_HAL testing removing unnecessary Cb Testing's

### DIFF
--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -259,18 +259,6 @@ TEST( Full_BLE, BLE_Connection_BondedReconnectAndPair )
     IotTestBleHal_StartAdvertisement();
     IotTestBleHal_WaitConnection( true );
 
-    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xPairingStateChangedEvent.xStatus );
-    TEST_ASSERT_EQUAL( 0, memcmp( &xPairingStateChangedEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-    TEST_ASSERT_EQUAL( eBTSecLevelSecureConnect, xPairingStateChangedEvent.xSecurityLevel );
-
-    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventBondedCb, NO_HANDLE, ( void * ) &xBondedEvent, sizeof( BLETESTBondedCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xBondedEvent.xStatus );
-    TEST_ASSERT_EQUAL( true, xBondedEvent.bIsBonded );
-    TEST_ASSERT_EQUAL( 0, memcmp( &xBondedEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-
     prvWriteCheckAndResponse( bletestATTR_SRVCB_CHAR_B,
                               true,
                               false,
@@ -328,12 +316,6 @@ TEST( Full_BLE, BLE_Connection_Mode1Level4 )
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xPairingStateChangedEvent.xStatus );
     TEST_ASSERT_EQUAL( 0, memcmp( &xPairingStateChangedEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
     TEST_ASSERT_EQUAL( eBTSecLevelSecureConnect, xPairingStateChangedEvent.xSecurityLevel );
-
-    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventBondedCb, NO_HANDLE, ( void * ) &xBondedEvent, sizeof( BLETESTBondedCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xBondedEvent.xStatus );
-    TEST_ASSERT_EQUAL( true, xBondedEvent.bIsBonded );
-    TEST_ASSERT_EQUAL( 0, memcmp( &xBondedEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
 
     prvWriteCheckAndResponse( bletestATTR_SRVCB_CHAR_B,
                               true,

--- a/tests/bleTestsScripts/startTests_kpi.py
+++ b/tests/bleTestsScripts/startTests_kpi.py
@@ -59,7 +59,7 @@ def main():
             bleAdapter.startDiscovery(runTest.discoveryStartedCb)   #wait for DUT to start advertising
         tStartScan = time.time()
         runTest.mainloop.run()
-        startToReceived = time.time() - tStartScan  
+        startToReceived = time.time() - tStartScan
         bleAdapter.stopDiscovery()
 
         testDevice = runTest.getTestDevice()

--- a/tests/bleTestsScripts/startTests_stress.py
+++ b/tests/bleTestsScripts/startTests_stress.py
@@ -54,7 +54,7 @@ def main():
                 bleAdapter.startDiscovery(runTest.discoveryEventCb)
             else:
                 bleAdapter.startDiscovery(runTest.discoveryStartedCb)
-            runTest.mainloop.run() 
+            runTest.mainloop.run()
             bleAdapter.stopDiscovery()
 
             testDevice = runTest.getTestDevice()

--- a/tests/bleTestsScripts/testClass.py
+++ b/tests/bleTestsScripts/testClass.py
@@ -480,10 +480,10 @@ class runTest:
 
     @staticmethod
     def _advertisement_connection_tests(scan_filter,
-            bleAdapter, 
-            UUID, 
+            bleAdapter,
+            UUID,
             discoveryEvent_Cb):
-        runTest._advertisement_start(scan_filter=scan_filter, 
+        runTest._advertisement_start(scan_filter=scan_filter,
                                      UUID=UUID,
                                      discoveryEvent_Cb=discoveryEvent_Cb,
                                      bleAdapter=bleAdapter)
@@ -512,7 +512,7 @@ class runTest:
         isTestSuccessFull = True
 
         # Check when manufacture data length is 0, but pointer is valid
-        runTest._advertisement_start(scan_filter=scan_filter, 
+        runTest._advertisement_start(scan_filter=scan_filter,
                                     UUID=runTest.DUT_UUID_128,
                                     discoveryEvent_Cb=runTest.discoveryEventCb,
                                     bleAdapter=bleAdapter)
@@ -525,7 +525,7 @@ class runTest:
         testutils.removeBondedDevices()
 
         # Check when manufacture data pointer is NULL, but length is not 0
-        runTest._advertisement_start(scan_filter=scan_filter, 
+        runTest._advertisement_start(scan_filter=scan_filter,
                                     UUID=runTest.DUT_UUID_128,
                                     discoveryEvent_Cb=runTest.discoveryEventCb,
                                     bleAdapter=bleAdapter)
@@ -538,7 +538,7 @@ class runTest:
         testutils.removeBondedDevices()
 
         # Check when manufacture data length is not 0, and pointer is valid
-        runTest._advertisement_start(scan_filter=scan_filter, 
+        runTest._advertisement_start(scan_filter=scan_filter,
                                     UUID=runTest.DUT_UUID_128,
                                     discoveryEvent_Cb=runTest.discoveryEventCb,
                                     bleAdapter=bleAdapter)


### PR DESCRIPTION
BLE_HAL testing removing unnecessary Cb's

Description
-----------
Removing BondedCb and in the Reconnect Test case, remove status change
Removed trailing white spaces from python scripts

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.