### PR TITLE
Add power ioctl support to overwrite rtc wakeup time set in power implementation

### DIFF
--- a/libraries/abstractions/common_io/include/iot_power.h
+++ b/libraries/abstractions/common_io/include/iot_power.h
@@ -127,8 +127,9 @@ typedef enum IotPowerIoctlRequest
                                         and may are platform/SoC dependent. Takes input of type IotPowerWakeupSources_t */
     eGetWakeupSources,              /* Get the current wakeup sources set to wakeup the target from idle mode. Returns the
                                         wake-up sources as IotPowerWakeupSources_t type */
-    eGetLastIdleMode                /* Get the last Idle mode entered when the target was idle. Returns one of the modes
+    eGetLastIdleMode,               /* Get the last Idle mode entered when the target was idle. Returns one of the modes
                                         defined in IotPowerIdleMode_t */
+    eOverwriteWakeupTime            /* One-time overwrite default deep sleep wake up time to user provide value */
 } IotPowerIoctlRequest_t;
 
 /**


### PR DESCRIPTION
Add power ioctl support to overwrite rtc wakeup time set in power imp…lementation
The reason is we want to add feature if a product want to sleep for a longer period in some idle case
This will be a onetime overwrite

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.