### PR TITLE
Update IotNetworkAfr_Send() to give error feedback.

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -496,6 +496,10 @@ size_t IotNetworkAfr_Send( void * pConnection,
         {
             bytesSent = ( size_t ) socketStatus;
         }
+        else
+        {
+            IotLogError( "Error %ld while sending data.", ( long int ) socketStatus );
+        }
 
         xSemaphoreGive( ( QueueHandle_t ) &( pNetworkConnection->socketMutex ) );
     }


### PR DESCRIPTION
- The network interface send() function only gives feedback about the bytes sent.
- This gives debugging feeback about the network layer error returned.
- The function plugged into receive() gives this feedback.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ n/a ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.