### PR TITLE
Update 3rd party libaries path for http_parser folder name change.

### DIFF
--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.cproject
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.cproject
@@ -71,7 +71,7 @@
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/abstractions/pkcs11/mbedtls"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/pkcs11"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/tinycbor"/>
-									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/http-parser"/>
+									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/http_parser"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/jsmn"/>
 								</option>
 								<option id="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.preprocessor.def.2079822681" name="Defined symbols (-D)" superClass="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">

--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.project
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.project
@@ -407,14 +407,14 @@
 			<locationURI>AFR_HOME/libraries/3rdparty/jsmn/jsmn.c</locationURI>
 		</link>
 		<link>
-			<name>libraries/3rdparty/http-parser/http_parser.h</name>
+			<name>libraries/3rdparty/http_parser/http_parser.h</name>
 			<type>1</type>
-			<locationURI>AFR_HOME/libraries/3rdparty/http-parser/http_parser.h</locationURI>
+			<locationURI>AFR_HOME/libraries/3rdparty/http_parser/http_parser.h</locationURI>
 		</link>
 		<link>
-			<name>libraries/3rdparty/http-parser/http_parser.c</name>
+			<name>libraries/3rdparty/http_parser/http_parser.c</name>
 			<type>1</type>
-			<locationURI>AFR_HOME/libraries/3rdparty/http-parser/http_parser.c</locationURI>
+			<locationURI>AFR_HOME/libraries/3rdparty/http_parser/http_parser.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/3rdparty/jsmn/jsmn.h</name>

--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.cproject
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.cproject
@@ -80,7 +80,7 @@
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/unity/src"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/unity/extras/fixture/src"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/tinycbor"/>
-									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/http-parser"/>
+									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/http_parser"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/jsmn"/>
 								</option>
 								<option id="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.preprocessor.def.2079822681" name="Defined symbols (-D)" superClass="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">

--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.project
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.project
@@ -2559,14 +2559,14 @@
 			<locationURI>AFR_HOME/libraries/3rdparty/tinycbor/cborparser_dup_string.c</locationURI>
 		</link>
 		<link>
-			<name>libraries/3rdparty/http-parser/http_parser.h</name>
+			<name>libraries/3rdparty/http_parser/http_parser.h</name>
 			<type>1</type>
-			<locationURI>AFR_HOME/libraries/3rdparty/http-parser/http_parser.h</locationURI>
+			<locationURI>AFR_HOME/libraries/3rdparty/http_parser/http_parser.h</locationURI>
 		</link>
 		<link>
-			<name>libraries/3rdparty/http-parser/http_parser.c</name>
+			<name>libraries/3rdparty/http_parser/http_parser.c</name>
 			<type>1</type>
-			<locationURI>AFR_HOME/libraries/3rdparty/http-parser/http_parser.c</locationURI>
+			<locationURI>AFR_HOME/libraries/3rdparty/http_parser/http_parser.c</locationURI>
 		</link>
 		<link>
 			<name>libraries/3rdparty/jsmn/jsmn.h</name>


### PR DESCRIPTION
The purpose of this change is to update the aws_demos and aws_tests projects for the OPTIGA Trust X board to handle the recent 3rd http_parser folder name change.