### PR TITLE
iot_ble_wifi_provisioning: list_networks sends a response even if no wifi APs are found

### DIFF
--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -1411,6 +1411,7 @@ void _listNetworkTask( IotTaskPool_t taskPool,
     WIFINetworkProfile_t profile;
     uint16_t idx;
     WIFIReturnCode_t status;
+    uint32_t networks_found = 0;
 
     for( idx = 0; idx < wifiProvisioning.numNetworks; idx++ )
     {
@@ -1426,7 +1427,6 @@ void _listNetworkTask( IotTaskPool_t taskPool,
 
     status = WIFI_Scan( scanNetworks, wifiProvisioning.listNetworkRequest.maxNetworks );
 
-    uint32_t networks_found = 0;
     if( status == eWiFiSuccess )
     {
         for( idx = 0; idx < wifiProvisioning.listNetworkRequest.maxNetworks; idx++ )

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -1437,9 +1437,10 @@ void _listNetworkTask( IotTaskPool_t taskPool,
                 _sendScanNetwork( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, &scanNetworks[ idx ] );
             }
         }
-        if(!networks_found)
+
+        if( !networks_found )
         {
-          _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, status );
+            _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, status );
         }
     }
     else

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -1426,14 +1426,20 @@ void _listNetworkTask( IotTaskPool_t taskPool,
 
     status = WIFI_Scan( scanNetworks, wifiProvisioning.listNetworkRequest.maxNetworks );
 
+    uint32_t networks_found = 0;
     if( status == eWiFiSuccess )
     {
         for( idx = 0; idx < wifiProvisioning.listNetworkRequest.maxNetworks; idx++ )
         {
             if( strlen( scanNetworks[ idx ].cSSID ) > 0 )
             {
+                networks_found++;
                 _sendScanNetwork( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, &scanNetworks[ idx ] );
             }
+        }
+        if(!networks_found)
+        {
+          _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, status );
         }
     }
     else


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix for issue #1277 
list_network never sends a response if the wifi scan completes successfully but finds 0 APs.
This change checks how many networks were found and at least returns a status response, so the mobile app (or, more generally, BLE Central) can handle the situation instead of hanging.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.