### PR TITLE
Build fix for the OPTIGA Trust X board for Linux cmake

### DIFF
--- a/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/AlertProtocol.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/AlertProtocol.c
@@ -32,7 +32,7 @@
 
 #include "optiga/dtls/DtlsRecordLayer.h"
 #include "optiga/dtls/AlertProtocol.h"
-#include "optiga/dtls/DtlsFlightHandler.h"
+#include "optiga/dtls/DtlsFlighthandler.h"
 
 #ifdef MODULE_ENABLE_DTLS_MUTUAL_AUTH
 

--- a/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/DtlsHandshakeProtocol.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/DtlsHandshakeProtocol.c
@@ -34,7 +34,7 @@
 #include "optiga/dtls/AlertProtocol.h"
 #include "optiga/optiga_dtls.h"
 #include "optiga/dtls/DtlsRecordLayer.h"
-#include "optiga/dtls/DtlsFlightHandler.h"
+#include "optiga/dtls/DtlsFlighthandler.h"
 
 #ifdef MODULE_ENABLE_DTLS_MUTUAL_AUTH
 

--- a/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/OCPConfig.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/optiga/dtls/OCPConfig.c
@@ -31,7 +31,7 @@
 */
 #include "optiga/dtls/DtlsTransportLayer.h"
 #include "optiga/dtls/DtlsHandshakeProtocol.h" //To be put under ifdef
-#include "optiga/dtls/DtlsRecordlayer.h"
+#include "optiga/dtls/DtlsRecordLayer.h"
 #include "optiga/dtls/HardwareCrypto.h"
 #include "optiga/optiga_dtls.h"
 


### PR DESCRIPTION
This change fixes Linux cmake builds for the Infineon OPTIGA Trust X board.