### PR TITLE
Added Heap and stack analysis to AFR demos.

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -58,7 +58,7 @@ static IotSemaphore_t demoNetworkSemaphore;
 static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
 
 #ifdef democonfigMEMORY_ANALYSIS
-    extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
+    extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xDemoStackSize;
 #endif
 
 #if defined( MQTT_DEMO_TYPE_ENABLED )
@@ -363,7 +363,7 @@ void runDemoTask( void * pArgument )
         xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
         IotLogInfo( "Demo Memory Analysis Heap Total: %u Minimum heap size ever before running demo: %u after running demo: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize );
         xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-        IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u After: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark );
+        IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u After: %u \r\n", xDemoStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark );
     #endif /* democonfigMEMORY_ANALYSIS */
 
     /* DO NOT EDIT - This demo end marker is used in the test framework to

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -57,13 +57,13 @@ static IotSemaphore_t demoNetworkSemaphore;
 /* Variable used to indicate the connected network. */
 static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
 
+#ifdef democonfigMEMORY_ANALYSIS
+    extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
+#endif
+
 #if defined( MQTT_DEMO_TYPE_ENABLED )
     #if BLE_ENABLED
         extern const IotMqttSerializer_t IotBleMqttSerializer;
-    #endif
-
-    #ifdef democonfigMEMORY_ANALYSIS
-        extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
     #endif
 
 
@@ -315,7 +315,7 @@ void runDemoTask( void * pArgument )
         xBeforeDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
 
         size_t xBeforeDemoHeapSize, xAfterDemoHeapSize = 0;
-        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( );
+        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
     #endif /* democonfigMEMORY_ANALYSIS */
 
 
@@ -360,10 +360,10 @@ void runDemoTask( void * pArgument )
     }
 
     #ifdef democonfigMEMORY_ANALYSIS
-	 xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( );
-        IotLogInfo( "Demo Memory Analysis Heap Total: %u Before: %u After: %u Usage: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize, ( xBeforeDemoHeapSize - xAfterDemoHeapSize ) );
+        xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
+        IotLogInfo( "Demo Memory Analysis Heap Total: %u Before: %u After: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize );
         xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-        IotLogInfo( "Demo Memory Analysis StackWatermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
+        IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u After: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark );
     #endif /* democonfigMEMORY_ANALYSIS */
 
     /* DO NOT EDIT - This demo end marker is used in the test framework to

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -62,6 +62,10 @@ static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
         extern const IotMqttSerializer_t IotBleMqttSerializer;
     #endif
 
+    #ifdef democonfigMEMORY_ANALYSIS
+        extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
+    #endif
+
 
 /*-----------------------------------------------------------*/
 
@@ -306,6 +310,15 @@ void runDemoTask( void * pArgument )
         }
     #endif /* INSERT_DELAY_BEFORE_DEMO */
 
+    #ifdef democonfigMEMORY_ANALYSIS
+        demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark = 0;
+        xBeforeDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
+
+        size_t xBeforeDemoHeapSize, xAfterDemoHeapSize = 0;
+        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( NULL );
+    #endif /* democonfigMEMORY_ANALYSIS */
+
+
     /* DO NOT EDIT - This demo start marker is used in the test framework to
      * determine the start of a demo. */
     IotLogInfo( "---------STARTING DEMO---------\n" );
@@ -346,8 +359,17 @@ void runDemoTask( void * pArgument )
         IotLogError( "Failed to initialize the demo. exiting..." );
     }
 
+    #ifdef democonfigMEMORY_ANALYSIS
+        xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( NULL );
+        IotLogInfo( "Demo Heap Total: %u Before: %u After: %u Usage: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize, ( xBeforeDemoHeapSize - xAfterDemoHeapSize ) );
+
+        xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
+        IotLogInfo( "Demo Stack Total: %u Watermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
+    #endif /* democonfigMEMORY_ANALYSIS */
+
     /* DO NOT EDIT - This demo end marker is used in the test framework to
      * determine the end of a demo. */
+
     IotLogInfo( "-------DEMO FINISHED-------\n" );
 }
 

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -360,11 +360,10 @@ void runDemoTask( void * pArgument )
     }
 
     #ifdef democonfigMEMORY_ANALYSIS
-        xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( NULL );
-        IotLogInfo( "Demo Heap Total: %u Before: %u After: %u Usage: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize, ( xBeforeDemoHeapSize - xAfterDemoHeapSize ) );
+        IotLogInfo( "Demo Memory Analysis Heap Total: %u Before: %u After: %u Usage: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize, ( xBeforeDemoHeapSize - xAfterDemoHeapSize ) );
 
         xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-        IotLogInfo( "Demo Stack Total: %u Watermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
+        IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
     #endif /* democonfigMEMORY_ANALYSIS */
 
     /* DO NOT EDIT - This demo end marker is used in the test framework to

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -315,7 +315,7 @@ void runDemoTask( void * pArgument )
         xBeforeDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
 
         size_t xBeforeDemoHeapSize, xAfterDemoHeapSize = 0;
-        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( NULL );
+        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( );
     #endif /* democonfigMEMORY_ANALYSIS */
 
 
@@ -360,15 +360,14 @@ void runDemoTask( void * pArgument )
     }
 
     #ifdef democonfigMEMORY_ANALYSIS
+	 xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( );
         IotLogInfo( "Demo Memory Analysis Heap Total: %u Before: %u After: %u Usage: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize, ( xBeforeDemoHeapSize - xAfterDemoHeapSize ) );
-
         xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-        IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
+        IotLogInfo( "Demo Memory Analysis StackWatermark Before: %u Watermark After: %u Watermark Difference: %u \r\n", xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark, ( xBeforeDemoTaskWaterMark - xAfterDemoTaskWaterMark ) );
     #endif /* democonfigMEMORY_ANALYSIS */
 
     /* DO NOT EDIT - This demo end marker is used in the test framework to
      * determine the end of a demo. */
-
     IotLogInfo( "-------DEMO FINISHED-------\n" );
 }
 

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -361,7 +361,7 @@ void runDemoTask( void * pArgument )
 
     #ifdef democonfigMEMORY_ANALYSIS
         xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-        IotLogInfo( "Demo Memory Analysis Heap Total: %u Before: %u After: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize );
+        IotLogInfo( "Demo Memory Analysis Heap Total: %u Minimum heap size ever before running demo: %u after running demo: %u \r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize );
         xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
         IotLogInfo( "Demo Memory Analysis Stack Total: %u Watermark Before: %u After: %u \r\n", xMemoryAnalysisStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark );
     #endif /* democonfigMEMORY_ANALYSIS */

--- a/demos/demo_runner/iot_demo_runner.c
+++ b/demos/demo_runner/iot_demo_runner.c
@@ -70,6 +70,9 @@ int DEMO_entryFUNCTION( bool awsIotMqttMode,
     #define DEMO_networkDisconnectedCallback    ( NULL )
 #endif
 
+#ifdef democonfigMEMORY_ANALYSIS
+    demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -79,6 +82,11 @@ int DEMO_entryFUNCTION( bool awsIotMqttMode,
 void DEMO_RUNNER_RunDemos( void )
 {
     /* These demos are shared with the C SDK and perform their own initialization and cleanup. */
+
+    #ifdef democonfigMEMORY_ANALYSIS
+        xMemoryAnalysisStackSize = democonfigDEMO_STACKSIZE;
+    #endif
+
     static demoContext_t mqttDemoContext =
     {
         .networkTypes                = democonfigNETWORK_TYPES,

--- a/demos/demo_runner/iot_demo_runner.c
+++ b/demos/demo_runner/iot_demo_runner.c
@@ -71,7 +71,7 @@ int DEMO_entryFUNCTION( bool awsIotMqttMode,
 #endif
 
 #ifdef democonfigMEMORY_ANALYSIS
-    demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xMemoryAnalysisStackSize;
+    demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xDemoStackSize;
 #endif
 
 /*-----------------------------------------------------------*/
@@ -84,7 +84,7 @@ void DEMO_RUNNER_RunDemos( void )
     /* These demos are shared with the C SDK and perform their own initialization and cleanup. */
 
     #ifdef democonfigMEMORY_ANALYSIS
-        xMemoryAnalysisStackSize = democonfigDEMO_STACKSIZE;
+        xDemoStackSize = democonfigDEMO_STACKSIZE;
     #endif
 
     static demoContext_t mqttDemoContext =

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_SHADOW_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )
@@ -64,5 +64,17 @@
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */
 #define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS | mqttagentUSE_AWS_IOT_ALPN_443 )
+
+#define democonfigMEMORY_ANALYSIS
+
+#ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( x )     xPortGetMinimumEverFreeHeapSize()
+    #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+    #else
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    ( x )
+    #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
+#endif /* democonfigMEMORY_ANALYSIS */
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_SHADOW_DEMO_ENABLED
+#define CONFIG_MQTT_DEMO_ENABLE
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )
@@ -69,11 +69,11 @@
 
 #ifdef democonfigMEMORY_ANALYSIS
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( x )     xPortGetMinimumEverFreeHeapSize()
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( )     xPortGetMinimumEverFreeHeapSize( )
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
     #else
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    ( x )
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
 

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLE
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                       ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_DEMO_ENABLED
+#define CONFIG_SHADOW_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
@@ -68,5 +68,17 @@
 /* Greengrass discovery example task parameters. */
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 22 )
 #define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY      ( tskIDLE_PRIORITY )
+
+#define democonfigMEMORY_ANALYSIS
+
+#ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( x )     xPortGetMinimumEverFreeHeapSize()
+    #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+    #else
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    ( x )
+    #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
+#endif /* democonfigMEMORY_ANALYSIS */
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -43,7 +43,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_SHADOW_DEMO_ENABLED
+#define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                          ( configMINIMAL_STACK_SIZE * 8 )
@@ -73,11 +73,11 @@
 
 #ifdef democonfigMEMORY_ANALYSIS
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( x )     xPortGetMinimumEverFreeHeapSize()
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( )     xPortGetMinimumEverFreeHeapSize( )
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
     #else
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    ( x )
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
 

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -73,7 +73,7 @@
 
 #ifdef democonfigMEMORY_ANALYSIS
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( )     xPortGetMinimumEverFreeHeapSize( )
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
     #else

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -72,4 +72,17 @@
 
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 14 )
 
+
+#define democonfigMEMORY_ANALYSIS
+
+#ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()       xPortGetMinimumEverFreeHeapSize()
+    #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+    #else
+        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
+    #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
+#endif /* democonfigMEMORY_ANALYSIS */
+
 #endif /* _AWS_DEMO_CONFIG_H_ */


### PR DESCRIPTION
Added Heap and stack analysis to AFR demos.

Description
-----------
This is my proposal for a demo agnostic and port agnostic heap and stack usage collection. This has been tested on ST port and Windows Simulator. This is to be tested on CI to ensure it works for all demo and board combinations.

TODO: Test on CI
TODO: Add more granular analysis to individual demos. (Eg. Some demos use more than one task.) 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.