### PR TITLE
Add TCP memory safety proofs

### DIFF
--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -1,0 +1,31 @@
+{
+  "ENTRY": "TCPHandleState",
+  "TX_DRIVER":1,
+  "RX_MESSAGES":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--unwindset prvWinScaleFactor.0:2",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigZERO_COPY_TX_DRIVER={TX_DRIVER}",
+    "ipconfigUSE_LINKED_RX_MESSAGES={RX_MESSAGES}",
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INSTFLAGS":
+  [
+    "--remove-function-body prvTCPPrepareSend",
+    "--remove-function-body prvTCPReturnPacket"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "TCPHandleState",
   "TX_DRIVER":1,

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/README.md
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/README.md
@@ -1,0 +1,22 @@
+This is the memory safety proof for prvTCPHandleState.
+
+This proof is a work-in-progress.  Proof assumptions are described in
+the harness.  The proof also assumes the following functions are
+memory safe and have no side effects relevant to the memory safety of
+this function:
+
+* prvTCPPrepareSend (proved independently)
+* prvTCPReturnPacket (proved independently)
+
+* lTCPAddRxdata
+* lTCPWindowRxCheck
+* lTCPWindowTxAdd
+* ulTCPWindowTxAck
+* vTCPWindowInit
+* xTCPWindowRxEmpty
+* xTCPWindowTxDone
+
+* uxStreamBufferGet
+* vReleaseNetworkBufferAndDescriptor
+* vSocketWakeUpUser
+* xTaskGetTickCount

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -1,0 +1,45 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that prvTCPPrepareSend and prvTCPReturnPacket are correct.
+These functions are proved to be correct separately. */
+
+BaseType_t publicTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer );
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	size_t socketSize = sizeof(FreeRTOS_Socket_t);
+	if (ensure_memory_is_valid(pxSocket, socketSize)) {
+		/* ucOptionLength is the number of valid bytes in ulOptionsData[].
+		ulOptionsData[] is initialized as uint32_t ulOptionsData[ipSIZE_TCP_OPTIONS/sizeof(uint32_t)].
+		This assumption is required for a memcpy function that copies uxOptionsLength
+		data from pxTCPHeader->ucOptdata to pxTCPWindow->ulOptionsData.*/
+		__CPROVER_assume(pxSocket->u.xTCP.xTCPWindow.ucOptionLength == sizeof(uint32_t) * ipSIZE_TCP_OPTIONS/sizeof(uint32_t));
+		/* uxRxWinSize is initialized as size_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
+		__CPROVER_assume(pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof(size_t));
+		/* uxRxWinSize is initialized as uint16_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
+		__CPROVER_assume(pxSocket->u.xTCP.usInitMSS == sizeof(uint16_t));
+	}
+
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	size_t bufferSize = sizeof(NetworkBufferDescriptor_t);
+	if(ensure_memory_is_valid(pxNetworkBuffer, bufferSize)) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+	}
+	if (ensure_memory_is_valid(pxSocket, socketSize) &&
+		ensure_memory_is_valid(pxNetworkBuffer, bufferSize) &&
+		ensure_memory_is_valid(pxNetworkBuffer->pucEthernetBuffer, sizeof(TCPPacket_t)) &&
+		ensure_memory_is_valid(pxSocket->u.xTCP.pxPeerSocket, socketSize)) {
+
+			publicTCPHandleState(pxSocket, &pxNetworkBuffer);
+
+	}
+}

--- a/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "queue.h"

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "TCPPrepareSend",
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "TCPPrepareSend",
   "CBMCFLAGS":

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/README.md
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/README.md
@@ -1,0 +1,15 @@
+This is the memory safety proof for prvTCPPrepareSend.
+
+This proof is a work-in-progress.  Proof assumptions are described in
+the harness.  The proof also assumes the following functions are
+memory safe and have no side effects relevant to the memory safety of
+this function:
+
+* ulTCPWindowTxGet
+* xTCPWindowTxDone
+
+* xTaskGetTickCount
+
+* uxStreamBufferGet
+* vReleaseNetworkBufferAndDescriptor
+* vSocketWakeUpUser

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
@@ -1,0 +1,44 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_Stream_Buffer.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that pxGetNetworkBufferWithDescriptor is implemented correctly. */
+int32_t publicTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength );
+
+/* Abstraction of pxGetNetworkBufferWithDescriptor. It creates a buffer. */
+NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ){
+	NetworkBufferDescriptor_t *pxBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated ();
+	size_t bufferSize = sizeof(NetworkBufferDescriptor_t);
+	if (ensure_memory_is_valid(pxBuffer, bufferSize)) {
+		/* The code does not expect pucEthernetBuffer to be equal to NULL if
+		pxBuffer is not NULL. */
+		pxBuffer->pucEthernetBuffer = malloc(xRequestedSizeBytes);
+		pxBuffer->xDataLength = xRequestedSizeBytes;
+	}
+	return pxBuffer;
+}
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	size_t socketSize = sizeof(FreeRTOS_Socket_t);
+	size_t bufferSize = sizeof(TCPPacket_t);
+	if (ensure_memory_is_valid(pxNetworkBuffer, sizeof(*pxNetworkBuffer))) {
+		pxNetworkBuffer->xDataLength = bufferSize;
+		/* The code does not expect pucEthernetBuffer to be equal to NULL if
+		pxNetworkBuffer is not NULL. */
+		pxNetworkBuffer->pucEthernetBuffer = malloc(bufferSize);
+	}
+	UBaseType_t uxOptionsLength;
+	if(pxSocket) {
+		publicTCPPrepareSend(pxSocket, &pxNetworkBuffer, uxOptionsLength );
+	}
+}

--- a/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPPrepareSend/TCPPrepareSend_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "queue.h"

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
@@ -1,0 +1,23 @@
+{
+  "ENTRY": "TCPReturnPacket",
+  "RX_MESSAGES":1,
+  "CBMCFLAGS":
+  [
+    "--unwind 1",
+    "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_LINKED_RX_MESSAGES={RX_MESSAGES}",
+    "FREERTOS_TCP_ENABLE_VERIFICATION"
+  ],
+  "INC":
+  [
+    "$(FREERTOS)/tools/cbmc/include"
+  ]
+}

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "TCPReturnPacket",
   "RX_MESSAGES":1,

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/README.md
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/README.md
@@ -1,0 +1,10 @@
+This is the memory safety proof for prvTCPReturnPacket.
+
+This proof is a work-in-progress.  Proof assumptions are described in
+the harness.  The proof also assumes the following functions are
+memory safe and have no side effects relevant to the memory safety of
+this function:
+
+* usGenerateChecksum
+* usGenerateProtocolChecksum
+* xNetworkInterfaceOutput

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -1,0 +1,39 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+
+#include "../../utility/memory_assignments.c"
+
+/* This proof assumes that pxDuplicateNetworkBufferWithDescriptor is implemented correctly. */
+
+void publicTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer, uint32_t ulLen, BaseType_t xReleaseAfterSend );
+
+/* Abstraction of pxDuplicateNetworkBufferWithDescriptor*/
+NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+	BaseType_t xNewLength ) {
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if (ensure_memory_is_valid(pxNetworkBuffer, sizeof(*pxNetworkBuffer))) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+		__CPROVER_assume(pxNetworkBuffer->pucEthernetBuffer);
+	}
+	return pxNetworkBuffer;
+}
+
+void harness() {
+	FreeRTOS_Socket_t *pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();
+	NetworkBufferDescriptor_t *pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+	if (ensure_memory_is_valid(pxNetworkBuffer, sizeof(*pxNetworkBuffer))) {
+		pxNetworkBuffer->pucEthernetBuffer = safeMalloc(sizeof(TCPPacket_t));
+		__CPROVER_assume(pxNetworkBuffer->pucEthernetBuffer);
+	}
+	uint32_t ulLen;
+	BaseType_t xReleaseAfterSend;
+	/* The code does not expect both of these to be equal to NULL at the same time. */
+	__CPROVER_assume(pxSocket != NULL || pxNetworkBuffer != NULL);
+	publicTCPReturnPacket(pxSocket, pxNetworkBuffer, ulLen, xReleaseAfterSend);
+}

--- a/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/tools/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "queue.h"

--- a/tools/cbmc/proofs/utility/memory_assignments.c
+++ b/tools/cbmc/proofs/utility/memory_assignments.c
@@ -1,0 +1,24 @@
+#define ensure_memory_is_valid( px, length ) (px != NULL) && __CPROVER_w_ok((px), length)
+
+/* Implementation of safe malloc which returns NULL if the requested size is 0.
+ Warning: The behavior of malloc(0) is platform dependent.
+ It is possible for malloc(0) to return an address without allocating memory.*/
+void *safeMalloc(size_t xWantedSize) {
+        return nondet_bool() ? malloc(xWantedSize) : NULL;
+}
+
+/* Memory assignment for FreeRTOS_Socket_t */
+FreeRTOS_Socket_t * ensure_FreeRTOS_Socket_t_is_allocated () {
+	FreeRTOS_Socket_t *pxSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	if (ensure_memory_is_valid(pxSocket, sizeof(FreeRTOS_Socket_t))) {
+		pxSocket->u.xTCP.rxStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.txStream = safeMalloc(sizeof(StreamBuffer_t));
+		pxSocket->u.xTCP.pxPeerSocket = safeMalloc(sizeof(FreeRTOS_Socket_t));
+	}
+	return pxSocket;
+}
+
+/* Memory assignment for FreeRTOS_Network_Buffer */
+NetworkBufferDescriptor_t * ensure_FreeRTOS_NetworkBuffer_is_allocated () {
+	return safeMalloc(sizeof(NetworkBufferDescriptor_t));
+}


### PR DESCRIPTION
Add TCP memory safety proofs originally written by Debasmita Lohar and now rebased against the current master branch.  

Review this request one commit at a time.  This pull request changes a lot of files, but each commit introduces a single proof at a time.   I have verified that the proofs work against the current master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.