### PR TITLE
Update board metadata per silicon partner request.

### DIFF
--- a/vendors/infineon/boards/xmc4800_iotkit/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_iotkit/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 
-afr_set_board_metadata(ID "Infineon-XMC4800-IoT-Kit")
+afr_set_board_metadata(ID "Infineon-XMC4800-IoT-Connectivity-Kit ")
 afr_set_board_metadata(DISPLAY_NAME "XMC4800 IoT Connectivity Kit")
 afr_set_board_metadata(DESCRIPTION "Development kit for ARM Cortex-M4 based XMC4800 MCU")
 afr_set_board_metadata(VENDOR_NAME "Infineon")

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
@@ -21,9 +21,9 @@ endif()
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 
-afr_set_board_metadata(ID "Infineon-XMC4800-IoT-Kit-Plus-OPTIGA-Trust-X")
-afr_set_board_metadata(DISPLAY_NAME "XMC4800 IoT Connectivity Kit Plus OPTIGA(TM) Trust X")
-afr_set_board_metadata(DESCRIPTION "Development kit for ARM Cortex-M4 based XMC4800 MCU")
+afr_set_board_metadata(ID "Infineon-XMC4800-IoT-Connectivity-Kit-With-OPTIGA-Trust-X")
+afr_set_board_metadata(DISPLAY_NAME "XMC4800 IoT Connectivity Kit with OPTIGA Trust X")
+afr_set_board_metadata(DESCRIPTION "Development kit for ARM Cortex-M4 based XMC4800 MCU with OPTIGA Trust X secure element")
 afr_set_board_metadata(VENDOR_NAME "Infineon")
 afr_set_board_metadata(FAMILY_NAME "XMC4x00")
 afr_set_board_metadata(CODE_SIGNER "null")


### PR DESCRIPTION
Infineon has requested updates to the display string metadata of its two Amazon FreeRTOS qualified boards.