### PR TITLE
Reduce HTTPS Client Async Download Demo memory for Nuvoton

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/.gitignore
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/.gitignore
@@ -1,0 +1,5 @@
+# Ignore auto-generated UVision IDE files.
+**/obj/*
+**/lst/*
+*.uvopt
+*.uvgui.*

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
@@ -35,9 +35,9 @@
 #define AWS_IOT_DEMO_SHADOW_UPDATE_COUNT        ( 20 )   /* Number of updates to publish. */
 #define AWS_IOT_DEMO_SHADOW_UPDATE_PERIOD_MS    ( 3000 ) /* Period of Shadow updates. */
 
-/* The Nuvoton NuMaker-IoT-M487 has limited memory. This is limited because of large
+/* The Nuvoton NuMaker-IoT-M487 has memory limitations. This is limited because of large
  * static variables declared in some physical layer libraries. Lower the number of buffers
- * used for the HTTPS Client asynchronous download demo. */
+ * used for the HTTPS Client asynchronous download demo some buffer sizes. */
 #define IOT_HTTPS_DEMO_MAX_ASYNC_REQUESTS       ( 1 )
 #define IOT_DEMO_HTTPS_RESP_USER_BUFFER_SIZE    ( 768 )
 #define IOT_DEMO_HTTPS_RESP_BODY_BUFFER_SIZE    ( 256 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
@@ -35,6 +35,13 @@
 #define AWS_IOT_DEMO_SHADOW_UPDATE_COUNT        ( 20 )   /* Number of updates to publish. */
 #define AWS_IOT_DEMO_SHADOW_UPDATE_PERIOD_MS    ( 3000 ) /* Period of Shadow updates. */
 
+/* The Nuvoton NuMaker-IoT-M487 has limited memory. This is limited because of large
+ * static variables declared in some physical layer libraries. Lower the number of buffers
+ * used for the HTTPS Client asynchronous download demo. */
+#define IOT_HTTPS_DEMO_MAX_ASYNC_REQUESTS       ( 1 )
+#define IOT_DEMO_HTTPS_RESP_USER_BUFFER_SIZE    ( 768 )
+#define IOT_DEMO_HTTPS_REQ_USER_BUFFER_SIZE     ( 400 )
+
 /* Library logging configuration. IOT_LOG_LEVEL_GLOBAL provides a global log
  * level for all libraries; the library-specific settings override the global
  * setting. If both the library-specific and global settings are undefined,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
@@ -40,7 +40,7 @@
  * used for the HTTPS Client asynchronous download demo. */
 #define IOT_HTTPS_DEMO_MAX_ASYNC_REQUESTS       ( 1 )
 #define IOT_DEMO_HTTPS_RESP_USER_BUFFER_SIZE    ( 768 )
-#define IOT_DEMO_HTTPS_REQ_USER_BUFFER_SIZE     ( 400 )
+#define IOT_DEMO_HTTPS_RESP_BODY_BUFFER_SIZE    ( 256 )
 
 /* Library logging configuration. IOT_LOG_LEVEL_GLOBAL provides a global log
  * level for all libraries; the library-specific settings override the global


### PR DESCRIPTION
The Nuvoton NuMaker-IoT-M487 has limited memory due to static memory in the network layer and physical layer libraries. 
This PR updates the user configurations for the HTTPS Client Async Download Demo for Nuvoton's board ONLY. 
The user configuration updates the total number of requests in the pool to 1 and lowers the size of the request user buffer and the response body buffer. These buffers are static. 

https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/nuvoton/job/numaker_iot_m487_wifi-cmake/13/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/nuvoton/job/numaker_iot_m487_wifi-cmake/13/console
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.