### PR TITLE
Add IP memory safety proofs

### DIFF
--- a/tools/cbmc/proofs/IP/SendEventToIPTask/Makefile.json
+++ b/tools/cbmc/proofs/IP/SendEventToIPTask/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "SendEventToIPTask",
   "CBMCFLAGS": [

--- a/tools/cbmc/proofs/IP/SendEventToIPTask/Makefile.json
+++ b/tools/cbmc/proofs/IP/SendEventToIPTask/Makefile.json
@@ -1,0 +1,13 @@
+{
+  "ENTRY": "SendEventToIPTask",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+  	"--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ]
+}

--- a/tools/cbmc/proofs/IP/SendEventToIPTask/README.md
+++ b/tools/cbmc/proofs/IP/SendEventToIPTask/README.md
@@ -1,0 +1,13 @@
+This is the memory safety proof for xSendEventToIPTask, a function used
+for sending different events to IP-Task.  We have abstracted away queues.
+
+This proof is a work-in-progress.  Proof assumptions are described in
+the harness.  The proof also assumes the following functions are
+memory safe and have no side effects relevant to the memory safety of
+this function:
+
+* uxQueueMessagesWaiting
+* xQueueGenericSend
+
+The coverage is imperfect (97%) because xSendEventToIPTask always
+calls xSendEventStructToIPTask with xTimeout==0.

--- a/tools/cbmc/proofs/IP/SendEventToIPTask/SendEventToIPTask_harness.c
+++ b/tools/cbmc/proofs/IP/SendEventToIPTask/SendEventToIPTask_harness.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+// The harness test proceeds to call SendEventToIPTask with an unconstrained value
+void harness()
+{
+  eIPEvent_t eEvent;
+  xSendEventToIPTask( eEvent );
+}

--- a/tools/cbmc/proofs/IP/SendEventToIPTask/SendEventToIPTask_harness.c
+++ b/tools/cbmc/proofs/IP/SendEventToIPTask/SendEventToIPTask_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 #include <stdint.h>
 
 /* FreeRTOS includes. */


### PR DESCRIPTION
Add CBMC memory safety proof for SendEventToIPTask originally written by Adrian Palacios and now rebased against the current master branch.

I have verified that the proofs work against the current master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.