### PR TITLE
Add DHCP memory safety proofs

### DIFF
--- a/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_DHCP.h"
+
+/*
+ * CBMC automatically unwinds strlen on a fixed string
+ */
+const char * pcApplicationHostnameHook(void) {
+  return "hostname";
+}
+
+/*
+ * This stub allows us to overcome the unwinding error obtained
+ * in the do-while loop within function prvCreatePartDHCPMessage.
+ * The behaviour is similar to the original function, but failed allocations
+ * are not considered here (this is a safe assumption that avoids the error)
+ */
+void *FreeRTOS_GetUDPPayloadBuffer( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks )
+{
+  NetworkBufferDescriptor_t xNetworkBuffer;
+  void *pvReturn;
+
+  xNetworkBuffer.xDataLength = ipUDP_PAYLOAD_OFFSET_IPv4 + xRequestedSizeBytes;
+  xNetworkBuffer.pucEthernetBuffer = malloc( xNetworkBuffer.xDataLength );
+  pvReturn = (void *) &( xNetworkBuffer.pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+  return pvReturn;
+}
+
+/*
+ * In this stub we allocate a buffer within the specified range
+ * Note that the values for BUFFER_SIZE and prvProcessDHCPReplies.0
+ * are correlated, and their current values have been adjusted in order
+ * to obtain maximum coverage in the shortest amount of time
+ */
+int32_t FreeRTOS_recvfrom(
+  Socket_t xSocket, void *pvBuffer, size_t xBufferLength,
+  BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress,
+  socklen_t *pxSourceAddressLength )
+{
+  __CPROVER_assert(xFlags & FREERTOS_ZERO_COPY, "I can only do ZERO_COPY");
+
+  size_t xBufferSize;
+  /* A DHCP message (min. size 241B) is preceded by the IP buffer padding (10B) and the UDP payload (42B) */
+  __CPROVER_assume(xBufferSize >= ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4);
+  /* The last field of a DHCP message (Options) is variable in length, but 6 additional bytes are enough */
+  /* to obtain maximum coverage with this proof. Hence, we have BUFFER_SIZE=299 */
+  __CPROVER_assume(xBufferSize <= BUFFER_SIZE);
+
+  /* The buffer gets allocated and we set the pointer past the UDP payload (i.e., start of DHCP message) */
+  *((char **)pvBuffer) = malloc(xBufferSize) + ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4;
+
+  return xBufferSize - ipUDP_PAYLOAD_OFFSET_IPv4 - ipBUFFER_PADDING;
+}
+
+/*
+ * The harness test proceeds to call DHCPProcess with an unconstrained value
+ */
+void harness()
+{
+  BaseType_t xReset;
+  vDHCPProcess( xReset );
+}

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 #include <stdint.h>
 
 /* FreeRTOS includes. */

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -34,10 +34,14 @@ void *FreeRTOS_GetUDPPayloadBuffer( size_t xRequestedSizeBytes, TickType_t xBloc
 }
 
 /*
- * In this stub we allocate a buffer within the specified range
- * Note that the values for BUFFER_SIZE and prvProcessDHCPReplies.0
- * are correlated, and their current values have been adjusted in order
- * to obtain maximum coverage in the shortest amount of time
+ * We stub out FreeRTOS_recvfrom to do nothing but return a buffer of
+ * arbitrary size (but size at most BUFFER_SIZE) containing arbitrary
+ * data.  We need to bound the size of the buffer in order to bound
+ * the number of iterations of the loop prvProcessDHCPReplies.0 that
+ * iterates over the buffer contents.  The bound BUFFER_SIZE is chosen
+ * to be large enough to ensure complete code coverage, and small
+ * enough to ensure CBMC terminates within a reasonable amount of
+ * time.
  */
 int32_t FreeRTOS_recvfrom(
   Socket_t xSocket, void *pvBuffer, size_t xBufferLength,

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
@@ -1,0 +1,17 @@
+{
+  "ENTRY": "DHCPProcess",
+  "CBMCFLAGS": "--unwind 4 --unwindset strlen.0:11,memcmp.0:7,prvProcessDHCPReplies.0:8 --nondet-static",
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto",
+    "$(FREERTOS)/freertos_kernel/tasks.goto"
+  ],
+# Minimal buffer size for maximum coverage, see harness for details.
+  "BUFFER_SIZE": 299,
+  "DEF":
+  [
+    "BUFFER_SIZE={BUFFER_SIZE}"
+  ]
+}

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "DHCPProcess",
   "CBMCFLAGS": "--unwind 4 --unwindset strlen.0:11,memcmp.0:7,prvProcessDHCPReplies.0:8 --nondet-static",

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/README.md
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/README.md
@@ -1,0 +1,28 @@
+This is the memory safety proof for DHCPProcess function, which is the
+function that triggers the DHCP protocol.
+
+The main stubs in this proof deal with buffer management, which assume
+that the buffer is large enough to accomodate a DHCP message plus a
+few additional bytes for options (which is the last, variable-sized
+field in a DHCP message). We have abstracted away sockets, concurrency
+and third-party code. For more details, please check the comments on
+the harness file.
+
+This proof is a work-in-progress.  Proof assumptions are described in
+the harness.  The proof also assumes the following functions are
+memory safe and have no side effects relevant to the memory safety of
+this function:
+
+* FreeRTOS_sendto
+* FreeRTOS_setsockopt
+* FreeRTOS_socket
+* ulRand
+* vARPSendGratuitous
+* vApplicationIPNetworkEventHook
+* vLoggingPrintf
+* vPortEnterCritical
+* vPortExitCritical
+* vReleaseNetworkBufferAndDescriptor
+* vSocketBind
+* vSocketClose
+

--- a/tools/cbmc/proofs/DHCP/IsDHCPSocket/IsDHCPSocket_harness.c
+++ b/tools/cbmc/proofs/DHCP/IsDHCPSocket/IsDHCPSocket_harness.c
@@ -1,3 +1,31 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
 #include <stdint.h>
 
 /* FreeRTOS includes. */
@@ -16,6 +44,6 @@ void harness()
 {
   Socket_t xSocket;
   BaseType_t xResult;
-  
+
   xResult = xIsDHCPSocket( xSocket );
 }

--- a/tools/cbmc/proofs/DHCP/IsDHCPSocket/IsDHCPSocket_harness.c
+++ b/tools/cbmc/proofs/DHCP/IsDHCPSocket/IsDHCPSocket_harness.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_DHCP.h"
+
+/*
+ * The harness test proceeds to call IsDHCPSocket with an unconstrained value
+ */
+void harness()
+{
+  Socket_t xSocket;
+  BaseType_t xResult;
+  
+  xResult = xIsDHCPSocket( xSocket );
+}

--- a/tools/cbmc/proofs/DHCP/IsDHCPSocket/Makefile.json
+++ b/tools/cbmc/proofs/DHCP/IsDHCPSocket/Makefile.json
@@ -1,0 +1,12 @@
+{
+  "ENTRY": "IsDHCPSocket",
+  "CBMCFLAGS":
+  [
+      "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto"
+  ]
+}

--- a/tools/cbmc/proofs/DHCP/IsDHCPSocket/Makefile.json
+++ b/tools/cbmc/proofs/DHCP/IsDHCPSocket/Makefile.json
@@ -1,3 +1,31 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
 {
   "ENTRY": "IsDHCPSocket",
   "CBMCFLAGS":

--- a/tools/cbmc/proofs/DHCP/IsDHCPSocket/README.md
+++ b/tools/cbmc/proofs/DHCP/IsDHCPSocket/README.md
@@ -1,0 +1,1 @@
+This is the memory safety proof for IsDCHPSocket.


### PR DESCRIPTION
Add DHCP memory safety proofs originally written by Adrian Palacios and now rebased against the current master branch.

Review this request one commit at a time. This pull request changes a lot of files, but each commit introduces a single proof at a time. I have verified that the proofs work against the current master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.