### PR TITLE
Fix buffer overflow in vARPGenerateRequestPacket.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c
@@ -589,6 +589,12 @@ void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffe
 {
 ARPPacket_t *pxARPPacket;
 
+        /* Buffer allocation ensures that buffers always have space
+	   for an ARP packet. See buffer allocation implementations 1
+	   and 2 under portable/BufferManagement. */
+        configASSERT( pxNetworkBuffer );
+        configASSERT( pxNetworkBuffer->xDataLength >= sizeof(ARPPacket_t) );
+
 	pxARPPacket = ( ARPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 
 	/* memcpy the const part of the header information into the correct


### PR DESCRIPTION
Check that Ethernet buffer has enough space for an ARP packet in vARPGenerateRequestPacket.

The check added by this pull request simply returns if there is not enough space, but some
logging or error handling should be done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.