### PR TITLE
Fix TLS tests to check for EC support defined to 1 (#1329)

### DIFF
--- a/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
+++ b/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
@@ -38,6 +38,9 @@
 #include "aws_clientcredential_keys.h"
 #include "iot_test_tls.h"
 
+/* Configuration includes. */
+#include "iot_test_pkcs11_config.h"
+
 /* Provisioning include. */
 #include "aws_dev_mode_key_provisioning.h"
 #include "iot_pkcs11.h"
@@ -82,7 +85,7 @@ TEST_GROUP_RUNNER( Full_TLS )
 {
     RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectDefault );
     #if ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED == 1 )
-        #ifdef pkcs11testEC_KEY_SUPPORT
+        #if ( pkcs11testEC_KEY_SUPPORT == 1 )
             RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectEC );
             RUN_TEST_CASE( Full_TLS, AFQP_TLS_ConnectBYOCCredentials );
         #endif


### PR DESCRIPTION
It's defined for all ports, but some ports define to 0.

Resolves TS-9313

Cherry picks PR #1329 which was already merged to master.

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.