### PR TITLE
fix: Re-architect Defender Library.

### DIFF
--- a/demos/defender/aws_iot_demo_defender.c
+++ b/demos/defender/aws_iot_demo_defender.c
@@ -1,6 +1,5 @@
 /*
- * Amazon FreeRTOS V201908.00
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -18,124 +17,63 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- * http://aws.amazon.com/freertos
- * http://www.FreeRTOS.org
  */
+
+/* Demo configuration includes. */
+#include "iot_config.h"
 
 /* Standard includes. */
 #include <stdio.h>
 #include <string.h>
 
-/* Demo configuration includes. */
-#include "aws_demo.h"
-#include "aws_demo_config.h"
-#include "aws_clientcredential.h"
-
 /* Demo logging include. */
 #include "iot_demo_logging.h"
-
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-
-/* Secure Socket includes. */
-#include "iot_secure_sockets.h"
 
 /* Platform includes for demo. */
 #include "platform/iot_clock.h"
 #include "platform/iot_network.h"
-#include "platform/iot_network_freertos.h"
 
 /* Defender includes. */
 #include "aws_iot_defender.h"
 
 /* Includes for initialization. */
 #include "iot_mqtt.h"
-
-/* Set to 1 to enable this demo to connect to echo server.
- * Then in the demo output, it is expected to see one more established TCP connection.
- */
-#define _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER    0
-
-static IotNetworkServerInfo_t _DEFENDER_SERVER_INFO = AWS_IOT_NETWORK_SERVER_INFO_AFR_INITIALIZER;
-static IotNetworkCredentials_t _AWS_IOT_CREDENTIALS = AWS_IOT_NETWORK_CREDENTIALS_AFR_INITIALIZER;
-
-#if _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER == 1
-    static Socket_t _createSocketToEchoServer();
-#endif
+#include "platform/iot_metrics.h"
 
 /**
- * @brief Runs the defender demo.
+ * @brief The keep-alive interval used for this demo.
  *
- * @return AWS_IOT_DEFENDER_SUCCESS on success, otherwise an error code indicating
- *         the cause of error.
+ * An MQTT ping request will be sent periodically at this interval.
  */
-static AwsIotDefenderError_t _defenderDemo( void );
+#define KEEP_ALIVE_SECONDS    ( 60 )
 
 /**
- * @brief Starts the defender agent.
- *
- * @return AWS_IOT_DEFENDER_SUCCESS on success, otherwise an error code indicating
- *         the cause of error.
+ * @brief The timeout for Defender and MQTT operations in this demo.
  */
-static AwsIotDefenderError_t _startDefender( void );
+#define TIMEOUT_MS            ( 5000 )
+
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Callback used to get notification of defender's events.
+ *
+ * @param[in] pCallbackContext context pointer passed by the application
+ * when callback is regiested in AwsIotDefender_Start()
+ *
+ * @param[im] pointer to AwsIotDefenderCallbackInfo_t containing status of
+ * publish
  */
-static void _defenderCallback( void * param1,
-                               AwsIotDefenderCallbackInfo_t * const pCallbackInfo );
-
-/*-----------------------------------------------------------*/
-
-int vStartDefenderDemo( bool awsIotMqttMode,
-                        const char * pIdentifier,
-                        void * pNetworkServerInfo,
-                        void * pNetworkCredentialInfo,
-                        const IotNetworkInterface_t * pNetworkInterface )
+static void _defenderCallback( void * pCallbackContext,
+                               AwsIotDefenderCallbackInfo_t * const pCallbackInfo )
 {
-    int status = EXIT_FAILURE;
-    IotMqttError_t mqttInitStatus;
-    AwsIotDefenderError_t defenderResult;
+    ( void ) pCallbackContext;
 
-    /* Unused parameters */
-    ( void ) awsIotMqttMode;
-    ( void ) pIdentifier;
-    ( void ) pNetworkServerInfo;
-    ( void ) pNetworkCredentialInfo;
-    ( void ) pNetworkInterface;
+    IotLogInfo( "User's callback is invoked on event: %s.", AwsIotDefender_EventType( pCallbackInfo->eventType ) );
 
-    /* Initialize the MQTT library. */
-    mqttInitStatus = IotMqtt_Init();
-
-    if( mqttInitStatus == IOT_MQTT_SUCCESS )
-    {
-        /* If the MQTT initialization was successful, run the demo. */
-        defenderResult = _defenderDemo();
-
-        if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
-        {
-            status = EXIT_SUCCESS;
-        }
-    }
-
-    return status;
-}
-
-/*-----------------------------------------------------------*/
-
-void _defenderCallback( void * param1,
-                        AwsIotDefenderCallbackInfo_t * const pCallbackInfo )
-{
-    ( void ) param1;
-
-    IotLogInfo( "User's callback is invoked on event %d.", pCallbackInfo->eventType );
-
-    /* Print out the sent metrics report if there is. */
+    /*  Callback info processing example . */
     if( pCallbackInfo->pMetricsReport != NULL )
     {
-        IotLogInfo( "\nPublished metrics report." );
+        IotLogInfo( "Published metrics report." );
     }
     else
     {
@@ -144,7 +82,7 @@ void _defenderCallback( void * param1,
 
     if( pCallbackInfo->pPayload != NULL )
     {
-        IotLogInfo( "\nReceived MQTT message." );
+        IotLogInfo( "Received MQTT message." );
     }
     else
     {
@@ -154,138 +92,216 @@ void _defenderCallback( void * param1,
 
 /*-----------------------------------------------------------*/
 
-static AwsIotDefenderError_t _defenderDemo( void )
+/**
+ * @brief Establish a new connection to the MQTT server for the Defender demo.
+ *
+ * @param[in] pIdentifier NULL-terminated MQTT client identifier. The Defender
+ * demo will use the Thing Name as the client identifier.
+ * @param[in] pNetworkServerInfo Passed to the MQTT connect function when
+ * establishing the MQTT connection.
+ * @param[in] pNetworkCredentialInfo Passed to the MQTT connect function when
+ * establishing the MQTT connection.
+ * @param[in] pNetworkInterface The network interface to use for this demo.
+ * @param[out] pMqttConnection Set to the handle to the new MQTT connection.
+ *
+ * @return `EXIT_SUCCESS` if the connection is successfully established; `EXIT_FAILURE`
+ * otherwise.
+ */
+static int _establishMqttConnection( const char * pIdentifier,
+                                     void * pNetworkServerInfo,
+                                     void * pNetworkCredentialInfo,
+                                     const IotNetworkInterface_t * pNetworkInterface,
+                                     IotMqttConnection_t * pMqttConnection )
 {
-    /* Expected remote IP of AWS IoT endpoint in defender metrics report. */
-    uint32_t expectedIp = 0;
-    char expectedIpBuffer[ 16 ] = "";
-    AwsIotDefenderError_t defenderResult;
+    int status = EXIT_SUCCESS;
+    IotMqttError_t connectStatus = IOT_MQTT_STATUS_PENDING;
+    IotMqttNetworkInfo_t networkInfo = IOT_MQTT_NETWORK_INFO_INITIALIZER;
+    IotMqttConnectInfo_t connectInfo = IOT_MQTT_CONNECT_INFO_INITIALIZER;
 
-    IotLogInfo( "----Device Defender Demo Start----.\r\n" );
-
-    #if _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER == 1
-        /* Create a socket connected to echo server. */
-        Socket_t socket = _createSocketToEchoServer();
-    #endif
-
-    /* Specify all metrics in "tcp connections" group */
-    defenderResult = AwsIotDefender_SetMetrics( AWS_IOT_DEFENDER_METRICS_TCP_CONNECTIONS,
-                                                AWS_IOT_DEFENDER_METRICS_ALL );
-
-    if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
+    if( pIdentifier == NULL )
     {
-        /* Set metrics report period to 5 minutes(300 seconds) */
-        defenderResult = AwsIotDefender_SetPeriod( 300 );
+        IotLogError( "Defender Thing Name must be provided." );
+
+        status = EXIT_FAILURE;
     }
 
-    if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
+    if( status == EXIT_SUCCESS )
     {
-        /* Start the defender agent. */
-        defenderResult = _startDefender();
+        /* Set the members of the network info not set by the initializer. This
+         * struct provided information on the transport layer to the MQTT connection. */
+        networkInfo.createNetworkConnection = true;
+        networkInfo.u.setup.pNetworkServerInfo = pNetworkServerInfo;
+        networkInfo.u.setup.pNetworkCredentialInfo = pNetworkCredentialInfo;
+        networkInfo.pNetworkInterface = pNetworkInterface;
 
-        if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
+        /* Set the members of the connection info not set by the initializer. */
+        connectInfo.awsIotMqttMode = true;
+        connectInfo.cleanSession = true;
+        connectInfo.keepAliveSeconds = KEEP_ALIVE_SECONDS;
+
+        /* AWS IoT recommends the use of the Thing Name as the MQTT client ID. */
+        connectInfo.pClientIdentifier = pIdentifier;
+        connectInfo.clientIdentifierLength = ( uint16_t ) strlen( pIdentifier );
+
+        IotLogInfo( "Defender Thing Name is %.*s (length %hu).",
+                    connectInfo.clientIdentifierLength,
+                    connectInfo.pClientIdentifier,
+                    connectInfo.clientIdentifierLength );
+
+        /* Establish the MQTT connection. */
+        connectStatus = IotMqtt_Connect( &networkInfo,
+                                         &connectInfo,
+                                         TIMEOUT_MS,
+                                         pMqttConnection );
+
+        if( connectStatus != IOT_MQTT_SUCCESS )
         {
-            /* Query DNS for the IP. */
-            expectedIp = SOCKETS_GetHostByName( clientcredentialMQTT_BROKER_ENDPOINT );
+            IotLogError( "MQTT CONNECT returned error %s.",
+                         IotMqtt_strerror( connectStatus ) );
 
-            /* Convert to string. */
-            SOCKETS_inet_ntoa( expectedIp, expectedIpBuffer );
-            IotLogInfo( "expected ip: %s", expectedIpBuffer );
-
-            /* Let it run for 3 seconds */
-            IotClock_SleepMs( 3000 );
-
-            /* Stop the defender agent. */
-            AwsIotDefender_Stop();
+            status = EXIT_FAILURE;
         }
     }
 
-    #if _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER == 1
-        /* Clean up the socket. */
-        SOCKETS_Shutdown( socket, SOCKETS_SHUT_RDWR );
-        SOCKETS_Close( socket );
-    #endif
-
-    IotLogInfo( "----Device Defender Demo End. Status: %d----.\r\n", defenderResult );
-
-    return defenderResult;
+    return status;
 }
-
 /*-----------------------------------------------------------*/
 
-static AwsIotDefenderError_t _startDefender( void )
+/**
+ * @brief The function that runs the Defender demo, called by the demo runner.
+ *
+ * @param[in] awsIotMqttMode Ignored for the Defender demo.
+ * @param[in] pIdentifier NULL-terminated Defender Thing Name.
+ * @param[in] pNetworkServerInfo Passed to the MQTT connect function when
+ * establishing the MQTT connection for Defender.
+ * @param[in] pNetworkCredentialInfo Passed to the MQTT connect function when
+ * establishing the MQTT connection for Defender.
+ * @param[in] pNetworkInterface The network interface to use for this demo.
+ *
+ * @return `EXIT_SUCCESS` if the demo completes successfully; `EXIT_FAILURE` otherwise.
+ */
+int RunDefenderDemo( bool awsIotMqttMode,
+                     const char * pIdentifier,
+                     void * pNetworkServerInfo,
+                     void * pNetworkCredentialInfo,
+                     const IotNetworkInterface_t * pNetworkInterface )
 {
-    const AwsIotDefenderCallback_t callback = { .function = _defenderCallback, .param1 = NULL };
-    AwsIotDefenderError_t defenderResult;
-
+    int status = EXIT_SUCCESS;
+    bool metricsInitStatus = false;
+    IotMqttError_t mqttStatus = IOT_MQTT_INIT_FAILED;
+    AwsIotDefenderError_t defenderResult = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
     AwsIotDefenderStartInfo_t startInfo = AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
+    const AwsIotDefenderCallback_t callback = { .function = _defenderCallback, .pCallbackContext = NULL };
+    IotMqttConnection_t mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
 
-    /* Set network information. */
-    startInfo.mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
-    startInfo.mqttNetworkInfo.createNetworkConnection = true;
-    startInfo.mqttNetworkInfo.u.setup.pNetworkServerInfo = &_DEFENDER_SERVER_INFO;
-    startInfo.mqttNetworkInfo.u.setup.pNetworkCredentialInfo = &_AWS_IOT_CREDENTIALS;
+    /* Unused parameters. */
+    ( void ) awsIotMqttMode;
 
-    /* Only set ALPN protocol if the connected port is 443. */
-    if( ( ( IotNetworkServerInfo_t * ) ( startInfo.mqttNetworkInfo.u.setup.pNetworkServerInfo ) )->port != 443 )
+    IotLogInfo( "----Device Defender Demo Start----" );
+
+    /* Check parameter(s). */
+    if( ( pIdentifier == NULL ) || ( pIdentifier[ 0 ] == '\0' ) )
     {
-        ( ( IotNetworkCredentials_t * ) ( startInfo.mqttNetworkInfo.u.setup.pNetworkCredentialInfo ) )->pAlpnProtos = NULL;
+        IotLogError( "The length of the Thing Name (identifier) must be nonzero." );
+        status = EXIT_FAILURE;
     }
 
-    /* Set network interface. */
-    startInfo.mqttNetworkInfo.pNetworkInterface = IOT_NETWORK_INTERFACE_AFR;
+    if( status == EXIT_SUCCESS )
+    {
+        /* Initialize the MQTT library. */
+        mqttStatus = IotMqtt_Init();
 
-    /* Set MQTT connection information. */
-    startInfo.mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
-    startInfo.mqttConnectionInfo.pClientIdentifier = clientcredentialIOT_THING_NAME;
-    startInfo.mqttConnectionInfo.clientIdentifierLength = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME );
+        if( mqttStatus != IOT_MQTT_SUCCESS )
+        {
+            IotLogError( "MQTT Initialization Failed." );
+            status = EXIT_FAILURE;
+        }
+    }
 
-    /* Set Defender callback. */
-    startInfo.callback = callback;
+    if( status == EXIT_SUCCESS )
+    {
+        /* Initialize Metrics. */
+        metricsInitStatus = IotMetrics_Init();
 
-    /* Invoke defender start API. */
-    defenderResult = AwsIotDefender_Start( &startInfo );
+        if( !metricsInitStatus )
+        {
+            IotLogError( "IOT Metrics Initialization Failed." );
+            status = EXIT_FAILURE;
+        }
+    }
 
-    return defenderResult;
+    if( status == EXIT_SUCCESS )
+    {
+        /* Specify all metrics in "tcp connections" group */
+        defenderResult =
+            AwsIotDefender_SetMetrics( AWS_IOT_DEFENDER_METRICS_TCP_CONNECTIONS, AWS_IOT_DEFENDER_METRICS_ALL );
+
+        if( defenderResult != AWS_IOT_DEFENDER_SUCCESS )
+        {
+            status = EXIT_FAILURE;
+        }
+    }
+
+    if( status == EXIT_SUCCESS )
+    {
+        /* Set metrics report period to 5 minutes(300 seconds) */
+        defenderResult = AwsIotDefender_SetPeriod( 300 );
+
+        if( defenderResult != AWS_IOT_DEFENDER_SUCCESS )
+        {
+            status = EXIT_FAILURE;
+        }
+    }
+
+    if( status == EXIT_SUCCESS )
+    {
+        /* Create MQTT Connection */
+        mqttStatus = _establishMqttConnection( pIdentifier,
+                                               pNetworkServerInfo,
+                                               pNetworkCredentialInfo,
+                                               pNetworkInterface,
+                                               &mqttConnection );
+
+        if( mqttStatus != IOT_MQTT_SUCCESS )
+        {
+            IotLogError( "Failed to Create MQTT Connection:%d", IotMqtt_strerror( mqttStatus ) );
+            IotMqtt_Cleanup();
+            defenderResult = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
+        }
+        else
+        {
+            /* Initialize start info and call defender Start API */
+            startInfo.pClientIdentifier = pIdentifier;
+            startInfo.clientIdentifierLength = ( uint16_t ) strlen( pIdentifier );
+            startInfo.callback = callback;
+            startInfo.mqttConnection = mqttConnection;
+            defenderResult = AwsIotDefender_Start( &startInfo );
+        }
+
+        if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
+        {
+            /* Let it run for 3 seconds */
+            IotClock_SleepMs( 3000 );
+            /* Stop the defender agent. */
+            AwsIotDefender_Stop();
+            /* Disconnect MQTT */
+            IotMqtt_Disconnect( mqttConnection, false );
+        }
+    }
+
+    /* Cleanup. */
+    if( metricsInitStatus )
+    {
+        IotMetrics_Cleanup();
+    }
+
+    if( mqttStatus == IOT_MQTT_SUCCESS )
+    {
+        IotMqtt_Cleanup();
+    }
+
+    IotLogInfo( "----Device Defender Demo End. Status: %s----.", AwsIotDefender_strerror( defenderResult ) );
+    return status;
 }
-
-/*-----------------------------------------------------------*/
-
-#if _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER == 1
-
-    static Socket_t _createSocketToEchoServer()
-    {
-        Socket_t socket;
-        SocketsSockaddr_t echoServerAddress;
-        int32_t error = 0;
-
-        /* Rx and Tx time outs are used to ensure the sockets do not wait too long for
-         * missing data. */
-        const TickType_t xReceiveTimeOut = pdMS_TO_TICKS( 2000 );
-        const TickType_t xSendTimeOut = pdMS_TO_TICKS( 2000 );
-
-        /* Echo requests are sent to the echo server.  The address of the echo
-         * server is configured by the constants configECHO_SERVER_ADDR0 to
-         * configECHO_SERVER_ADDR3 in FreeRTOSConfig.h. */
-        echoServerAddress.usPort = SOCKETS_htons( configTCP_ECHO_CLIENT_PORT );
-        echoServerAddress.ulAddress = SOCKETS_inet_addr_quick( configECHO_SERVER_ADDR0,
-                                                               configECHO_SERVER_ADDR1,
-                                                               configECHO_SERVER_ADDR2,
-                                                               configECHO_SERVER_ADDR3 );
-
-        socket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
-        configASSERT( socket != SOCKETS_INVALID_SOCKET );
-
-        /* Set a time out so a missing reply does not cause the task to block indefinitely. */
-        SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_RCVTIMEO, &xReceiveTimeOut, sizeof( xReceiveTimeOut ) );
-        SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_SNDTIMEO, &xSendTimeOut, sizeof( xSendTimeOut ) );
-
-        error = SOCKETS_Connect( socket, &echoServerAddress, sizeof( echoServerAddress ) );
-        configASSERT( error == 0 );
-
-        return socket;
-    }
-
-#endif /* if _DEMO_WITH_SOCKET_CONNECTED_TO_ECHO_SERVER == 1 */
 
 /*-----------------------------------------------------------*/

--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -79,7 +79,7 @@
         #define democonfigDEMO_PRIORITY     democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY
     #endif
 #elif defined( CONFIG_DEFENDER_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION              vStartDefenderDemo
+    #define DEMO_entryFUNCTION              RunDefenderDemo
 #elif defined( CONFIG_POSIX_DEMO_ENABLED )
     #define DEMO_entryFUNCTION              vStartPOSIXDemo
 #elif defined( CONFIG_OTA_UPDATE_DEMO_ENABLED )

--- a/libraries/c_sdk/aws/defender/include/aws_iot_defender.h
+++ b/libraries/c_sdk/aws/defender/include/aws_iot_defender.h
@@ -99,8 +99,16 @@
  * @brief Initializers of data handles.
  */
 /**@{ */
-#define AWS_IOT_DEFENDER_START_INFO_INITIALIZER \
-    { .mqttNetworkInfo = { 0 }                  \
+#define AWS_IOT_DEFENDER_CALLBACK_INITIALIZER \
+    {                                         \
+        .pCallbackContext = NULL,             \
+        .function = NULL                      \
+    }
+#define AWS_IOT_DEFENDER_START_INFO_INITIALIZER          \
+    { .pClientIdentifier = NULL,                         \
+      .clientIdentifierLength = 0,                       \
+      .mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER, \
+      .callback = AWS_IOT_DEFENDER_CALLBACK_INITIALIZER  \
     } /**< Initializer of #AwsIotDefenderCallbackInfo_t. */
 /**@} */
 
@@ -180,7 +188,7 @@ typedef struct AwsIotDefenderCallbackInfo
  */
 typedef struct AwsIotDefenderCallback
 {
-    void * param1;                                               /**< The first parameter to pass to the callback function(optional). */
+    void * pCallbackContext;                                     /**< The callback context for caller's use (optional). */
     void ( * function )( void *,
                          AwsIotDefenderCallbackInfo_t * const ); /**< Callback function signature(optional). */
 } AwsIotDefenderCallback_t;
@@ -191,47 +199,31 @@ typedef struct AwsIotDefenderCallback
  */
 typedef struct AwsIotDefenderStartInfo
 {
-    IotMqttNetworkInfo_t mqttNetworkInfo;    /**< MQTT Network info used by defender (required). */
-    IotMqttConnectInfo_t mqttConnectionInfo; /**< MQTT connection info used by defender (required). */
-    AwsIotDefenderCallback_t callback;       /**< Callback function parameter (optional). */
+    const char * pClientIdentifier;     /**< @brief MQTT client identifier. */
+    uint16_t clientIdentifierLength;    /**< @brief Length of #IotMqttConnectInfo_t.pClientIdentifier. */
+    IotMqttConnection_t mqttConnection; /**< MQTT connection used by defender (required). */
+    AwsIotDefenderCallback_t callback;  /**< Callback function parameter (optional). */
 } AwsIotDefenderStartInfo_t;
 
 /**
- * @functions_page{defender, Device Defender}
- * @functions_brief{Device Defender}
- * - @function_name{defender_function_setmetrics}
- * @function_brief{defender_function_setmetrics}
- * - @function_name{defender_function_start}
- * @function_brief{defender_function_start}
- * - @function_name{defender_function_stop}
- * @function_brief{defender_function_stop}
- * - @function_name{defender_function_setperiod}
- * @function_brief{defender_function_setperiod}
- * - @function_name{defender_function_getperiod}
- * @function_brief{defender_function_getperiod}
- * - @function_name{defender_function_strerror}
- * @function_brief{defender_function_strerror}
+ * @functionspage{defender,Device Defender library}
+ * - @functionname{defender_function_setmetrics}
+ * - @functionname{defender_function_start}
+ * - @functionname{defender_function_stop}
+ * - @functionname{defender_function_setperiod}
+ * - @functionname{defender_function_getperiod}
+ * - @functionname{defender_function_strerror}
+ * - @functionname{defender_function_EventType}
  */
 
 /**
- * @function_page{AwsIotDefender_SetMetrics,defender,setmetrics}
- * @function_snippet{defender,setmetrics,this}
- * @copydoc AwsIotDefender_SetMetrics
- * @function_page{AwsIotDefender_Start,defender,start}
- * @function_snippet{defender,start,this}
- * @copydoc AwsIotDefender_Start
- * @function_page{AwsIotDefender_Stop,defender,stop}
- * @function_snippet{defender,stop,this}
- * @copydoc AwsIotDefender_Stop
- * @function_page{AwsIotDefender_SetPeriod,defender,setperiod}
- * @function_snippet{defender,setperiod,this}
- * @copydoc AwsIotDefender_SetPeriod
- * @function_page{AwsIotDefender_GetPeriod,defender,getperiod}
- * @function_snippet{defender,getperiod,this}
- * @copydoc AwsIotDefender_GetPeriod
- * @function_page{AwsIotDefender_strerror,defender,strerror}
- * @function_snippet{defender,strerror,this}
- * @copydoc AwsIotDefender_strerror
+ * @functionpage{AwsIotDefender_SetMetrics,defender,setmetrics}
+ * @functionpage{AwsIotDefender_Start,defender,start}
+ * @functionpage{AwsIotDefender_Stop,defender,stop}
+ * @functionpage{AwsIotDefender_SetPeriod,defender,setperiod}
+ * @functionpage{AwsIotDefender_GetPeriod,defender,getperiod}
+ * @functionpage{AwsIotDefender_strerror,defender,strerror}
+ * @functionpage{AwsIotDefender_EventType,defender,EventType}
  */
 
 /**
@@ -278,9 +270,10 @@ AwsIotDefenderError_t AwsIotDefender_SetMetrics( AwsIotDefenderMetricsGroup_t me
  *
  * @code{c}
  *
- * // assume valid IotMqttNetworkInfo_t and IotMqttConnectInfo_t are created.
- * const IotMqttNetworkInfo_t _mqttNetworkInfo;
- * const IotMqttConnectInfo_t _mqttConnectionInfo;
+ * // assume valid IotMqttConnection_t is created and available.
+ * const IotMqttConnection_t _mqttConnection;
+ * // use AWS thing name as client identifier
+ * const char * pClientIdentifier = "AwsThingName";
  *
  * void logDefenderCallback( void * param1, AwsIotDefenderCallbackInfo_t * const pCallbackInfo )
  * {
@@ -307,13 +300,15 @@ AwsIotDefenderError_t AwsIotDefender_SetMetrics( AwsIotDefenderMetricsGroup_t me
  * void startDefender()
  * {
  *     // define a simple callback function which simply logs
- *     const AwsIotDefenderCallback_t callback = { .function = logDefenderCallback, .param1 = NULL };
+ *     const AwsIotDefenderCallback_t callback = { .function = logDefenderCallback, .pCallbackContext = NULL };
  *
  *     // define parameters of AwsIotDefender_Start function
+ *     // Note: This example assumes, connection is already established and metrics library is initialized.
  *     const AwsIotDefenderStartInfo_t startInfo =
  *     {
- *         .mqttNetworkInfo = _mqttNetworkInfo,
- *         .mqttConnectionInfo = _mqttConnectionInfo,
+ *         .pClientIdentifier = pClientIdentifier,
+ *         .clientIdentifierLength = strlen( pClientIdentifier ),
+ *         .mqttConnection = _mqttConnection,
  *         .callback = callback
  *     };
  *
@@ -402,4 +397,12 @@ uint32_t AwsIotDefender_GetPeriod( void );
 const char * AwsIotDefender_strerror( AwsIotDefenderError_t error );
 /* @[declare_defender_strerror] */
 
+/**
+ * @brief Return a string that describes #AwsIotDefenderEventType_t
+ *
+ * @return A string that describes given #AwsIotDefenderEventType_t
+ */
+/* @[declare_defender_EventType] */
+const char * AwsIotDefender_EventType( AwsIotDefenderEventType_t eventType );
+/* @[declare_defender_EventType] */
 #endif /* AWS_IOT_DEFENDER_H_ */

--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c
@@ -23,6 +23,11 @@
  * http://www.FreeRTOS.org
  */
 
+/* The config header is always included first. */
+#include "iot_config.h"
+/* Error handling include. */
+#include "private/iot_error.h"
+
 /* Defender internal include. */
 #include "private/aws_iot_defender_internal.h"
 
@@ -32,7 +37,8 @@
 /* Clock include. */
 #include "platform/iot_clock.h"
 
-#define WAIT_METRICS_JOB_MAX_SECONDS    ( 5 )
+#define WAIT_METRICS_JOB_MAX_SECONDS            ( 5 )
+#define MAX_DEFENDER_OUTSTANDING_PUBLISH_REQ    ( ( uint32_t ) 1 )
 
 #if WAIT_METRICS_JOB_MAX_SECONDS < AWS_IOT_DEFENDER_WAIT_SERVER_MAX_SECONDS
     #error "_WAIT_METRICS_JOB_MAX_SECONDS must be greater than AWS_IOT_DEFENDER_WAIT_SERVER_MAX_SECONDS."
@@ -51,25 +57,38 @@ void _rejectCallback( void * pArgument,
                       IotMqttCallbackParam_t * const pPublish );
 
 /**
- * Callback routine of _metricsPublishJob.
+ * subscribe to defender MQTT topics.
+ */
+static IotMqttError_t _metricsSubscribeRoutine();
+
+/**
+ * Publish to defender MQTT topic.
  */
 static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
                                     IotTaskPoolJob_t pJob,
                                     void * pUserContext );
 
-/* Callback routine of _disconnectJob. */
-static void _disconnectRoutine( IotTaskPool_t pTaskPool,
-                                IotTaskPoolJob_t pJob,
-                                void * pUserContext );
+/* Unsubscribe from defender MQTT topic. */
+static void _unsubscribeMqtt();
+
+/* Code to handle application callback */
+void _handleApplicationCallback( AwsIotDefenderEventType_t event,
+                                 IotMqttCallbackParam_t * const pPublish );
 
 
 /*------------------- Below are global variables. ---------------------------*/
+
+/* Restart defender state machine unless there is an error */
+
 
 /* Define global metrics and initialize metrics flags array to zero. */
 _defenderMetrics_t _AwsIotDefenderMetrics =
 {
     .metricsFlag = { 0 }
 };
+/* MQTT callback info for reporting accept or reject status for subscribe / unsubscribe */
+IotMqttCallbackInfo_t _acceptCallbackInfo = { .function = _acceptCallback, .pCallbackContext = NULL };
+IotMqttCallbackInfo_t _rejectCallbackInfo = { .function = _rejectCallback, .pCallbackContext = NULL };
 
 /**
  * Period between reports in milliseconds.
@@ -80,9 +99,7 @@ static uint32_t _periodMilliSecond = _defenderToMilliseconds( AWS_IOT_DEFENDER_D
 static IotTaskPoolJobStorage_t _metricsPublishJobStorage = IOT_TASKPOOL_JOB_STORAGE_INITIALIZER;
 static IotTaskPoolJob_t _metricsPublishJob = IOT_TASKPOOL_JOB_INITIALIZER;
 
-static IotTaskPoolJobStorage_t _disconnectJobStorage = IOT_TASKPOOL_JOB_STORAGE_INITIALIZER;
-static IotTaskPoolJob_t _disconnectJob = IOT_TASKPOOL_JOB_INITIALIZER;
-
+/* Semaphore to prevent stop during publish */
 static IotSemaphore_t _doneSem;
 
 /*
@@ -99,7 +116,7 @@ AwsIotDefenderStartInfo_t _startInfo = AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
 AwsIotDefenderError_t AwsIotDefender_SetMetrics( AwsIotDefenderMetricsGroup_t metricsGroup,
                                                  uint32_t metrics )
 {
-    if( metricsGroup >= DEFENDER_METRICS_GROUP_COUNT )
+    if( metricsGroup >= ( AwsIotDefenderMetricsGroup_t ) DEFENDER_METRICS_GROUP_COUNT )
     {
         IotLogError( "Input metrics group is invalid. Please use AwsIotDefenderMetricsGroup_t data type." );
 
@@ -129,21 +146,21 @@ AwsIotDefenderError_t AwsIotDefender_SetMetrics( AwsIotDefenderMetricsGroup_t me
 
 AwsIotDefenderError_t AwsIotDefender_Start( AwsIotDefenderStartInfo_t * pStartInfo )
 {
-    if( pStartInfo == NULL )
-    {
-        IotLogError( "Input start info is invalid." );
+    IotTaskPoolError_t taskPoolError = IOT_TASKPOOL_SUCCESS;
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
 
-        return AWS_IOT_DEFENDER_INVALID_INPUT;
+    IOT_FUNCTION_ENTRY( AwsIotDefenderError_t, AWS_IOT_DEFENDER_SUCCESS );
+
+    if( ( pStartInfo == NULL ) || ( pStartInfo->mqttConnection == IOT_MQTT_CONNECTION_INITIALIZER ) )
+    {
+        IotLogError( "Input startInfo is invalid." );
+        IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_DEFENDER_INVALID_INPUT );
     }
 
     /* Assert system task pool is pre-created! */
     AwsIotDefender_Assert( IOT_SYSTEM_TASKPOOL != NULL );
 
-    AwsIotDefenderError_t defenderError = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
-
-    IotTaskPoolError_t taskPoolError = IOT_TASKPOOL_SUCCESS;
-
-    /* Silence warnings when asserts are disabled. */
+    /* Silence warnigns when asserts are disabled. */
     ( void ) taskPoolError;
 
     /* Initialize flow control states to false. */
@@ -153,46 +170,73 @@ AwsIotDefenderError_t AwsIotDefender_Start( AwsIotDefenderStartInfo_t * pStartIn
 
     if( !_started )
     {
+        /* Get the pointers to the encoder function tables. */
+        #if AWS_IOT_DEFENDER_FORMAT == AWS_IOT_DEFENDER_FORMAT_CBOR
+            _pAwsIotDefenderDecoder = &_IotSerializerCborDecoder;
+            _pAwsIotDefenderEncoder = &_IotSerializerCborEncoder;
+        #else
+            _pAwsIotDefenderDecoder = IotSerializer_GetJsonDecoder();
+            _pAwsIotDefenderEncoder = IotSerializer_GetJsonEncoder();
+        #endif
+
         /* copy input start info into global variable _startInfo */
         _startInfo = *pStartInfo;
 
-        defenderError = AwsIotDefenderInternal_BuildTopicsNames();
+        status = AwsIotDefenderInternal_BuildTopicsNames();
 
-        buildTopicsNamesSuccess = ( defenderError == AWS_IOT_DEFENDER_SUCCESS );
+        buildTopicsNamesSuccess = ( status == AWS_IOT_DEFENDER_SUCCESS );
 
         if( buildTopicsNamesSuccess )
         {
             /* Create a binary semaphore with initial value 1. */
-            doneSemaphoreCreateSuccess = IotSemaphore_Create( &_doneSem, 1, 1 );
+            doneSemaphoreCreateSuccess = IotSemaphore_Create( &_doneSem, MAX_DEFENDER_OUTSTANDING_PUBLISH_REQ, 1 );
+        }
+        else
+        {
+            status = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
         }
 
         if( doneSemaphoreCreateSuccess )
         {
             metricsMutexCreateSuccess = IotMutex_Create( &_AwsIotDefenderMetrics.mutex, false );
         }
+        else
+        {
+            status = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
+        }
 
         if( metricsMutexCreateSuccess )
         {
-            /* Create disconnect job. */
-            taskPoolError = IotTaskPool_CreateJob( _disconnectRoutine, NULL, &_disconnectJobStorage, &_disconnectJob );
-            AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
+            /*  Subscribe to Metrics Publish topic */
+            mqttError = _metricsSubscribeRoutine();
 
-            /* Create metrics job. */
+            if( mqttError != IOT_MQTT_SUCCESS )
+            {
+                status = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
+            }
+        }
+        else
+        {
+            status = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
+        }
+
+        if( status == AWS_IOT_DEFENDER_SUCCESS )
+        {
+            /* Create metrics publish job, which will periodically publish metrics */
             taskPoolError = IotTaskPool_CreateJob( _metricsPublishRoutine, NULL, &_metricsPublishJobStorage, &_metricsPublishJob );
+            /* Silence warnigns when asserts are disabled. */
+            ( void ) taskPoolError;
             AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
-
-            /* Schedule metrics job. */
+            /* Schedule Publish Job */
             taskPoolError = IotTaskPool_Schedule( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, 0 );
             AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
-
-            /* Everything is good. Declare success. */
             _started = true;
-            defenderError = AWS_IOT_DEFENDER_SUCCESS;
+            status = AWS_IOT_DEFENDER_SUCCESS;
             IotLogInfo( "Defender agent has successfully started." );
         }
 
         /* Do the cleanup jobs if not success. */
-        if( defenderError != AWS_IOT_DEFENDER_SUCCESS )
+        if( status != AWS_IOT_DEFENDER_SUCCESS )
         {
             /* reset _startInfo to empty; otherwise next time defender might start with incorrect information. */
             _startInfo = ( AwsIotDefenderStartInfo_t ) AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
@@ -212,15 +256,15 @@ AwsIotDefenderError_t AwsIotDefender_Start( AwsIotDefenderStartInfo_t * pStartIn
                 IotMutex_Destroy( &_AwsIotDefenderMetrics.mutex );
             }
 
-            IotLogError( "Defender agent failed to start due to error %s.", AwsIotDefender_strerror( defenderError ) );
+            IotLogError( "Defender agent failed to start due to error %s.", AwsIotDefender_strerror( status ) );
         }
     }
     else
     {
-        defenderError = AWS_IOT_DEFENDER_ALREADY_STARTED;
+        IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_DEFENDER_ALREADY_STARTED );
     }
 
-    return defenderError;
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
 
 /*-----------------------------------------------------------*/
@@ -230,54 +274,60 @@ void AwsIotDefender_Stop( void )
     if( !_started )
     {
         IotLogWarn( "Defender has not started yet." );
-
-        return;
     }
-
-    /* First thing to do: wait for all the metrics processing to be done. */
-    IotSemaphore_Wait( &_doneSem );
-
-    IotTaskPoolJobStatus_t status;
-    IotTaskPoolError_t taskPoolError = IotTaskPool_TryCancel( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, &status );
-
-    /* If cancel failed, let it sleep for a while and hope everything finishes. */
-    if( taskPoolError != IOT_TASKPOOL_SUCCESS )
+    else
     {
-        IotLogWarn( "Failed to cancel metrics publish job with return code %d and status %d.", taskPoolError, status );
-        IotClock_SleepMs( WAIT_METRICS_JOB_MAX_SECONDS * 1000 );
+        /* Wait for all the metrics processing to be done, if there are outstanding requests */
+        IotSemaphore_Wait( &_doneSem );
+
+        IotTaskPoolJobStatus_t status;
+        IotTaskPoolError_t taskPoolError = IotTaskPool_TryCancel( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, &status );
+
+        /* If cancel failed, let it sleep for a while and hope everything finishes. */
+        if( taskPoolError != IOT_TASKPOOL_SUCCESS )
+        {
+            IotLogWarn( "Failed to cancel metrics publish job with return code %d and status %d.", taskPoolError, status );
+            IotClock_SleepMs( WAIT_METRICS_JOB_MAX_SECONDS * 1000 );
+        }
+
+        /* Unsubscribe MQTT */
+        IotLogInfo( "Unsubscribing from MQTT topics" );
+        _unsubscribeMqtt();
+
+        /* Destroy metrics' mutex. */
+        IotMutex_Destroy( &_AwsIotDefenderMetrics.mutex );
+
+        /* Post so that taken semaphore is returned */
+        IotSemaphore_Post( &_doneSem );
+        /* Destroy 'done' semaphore. */
+        IotSemaphore_Destroy( &_doneSem );
+
+        /* Delete topics names. */
+        AwsIotDefenderInternal_DeleteTopicsNames();
+
+        /* Delete report if it was created */
+        AwsIotDefenderInternal_DeleteReport();
+
+        /* Reset _startInfo to empty; otherwise next time defender might start with incorrect information. */
+        _startInfo = ( AwsIotDefenderStartInfo_t ) AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
+
+        /* Reset _periodMilliSecond to default value. */
+        _periodMilliSecond = _defenderToMilliseconds( AWS_IOT_DEFENDER_DEFAULT_PERIOD_SECONDS );
+
+        /* Reset metrics flag array to 0. */
+        memset( _AwsIotDefenderMetrics.metricsFlag, 0, sizeof( _AwsIotDefenderMetrics.metricsFlag ) );
+
+        /* Set to not started. */
+        _started = false;
+
+        IotLogInfo( "Defender agent has stopped." );
     }
-
-    /* Destroy metrics' mutex. */
-    IotMutex_Destroy( &_AwsIotDefenderMetrics.mutex );
-
-    /* Destroy 'done' semaphore. */
-    IotSemaphore_Destroy( &_doneSem );
-
-    /* Delete topics names. */
-    AwsIotDefenderInternal_DeleteTopicsNames();
-
-    /* Reset _startInfo to empty; otherwise next time defender might start with incorrect information. */
-    _startInfo = ( AwsIotDefenderStartInfo_t ) AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
-
-    /* Reset _periodMilliSecond to default value. */
-    _periodMilliSecond = _defenderToMilliseconds( AWS_IOT_DEFENDER_DEFAULT_PERIOD_SECONDS );
-
-    /* Reset metrics flag array to 0. */
-    memset( _AwsIotDefenderMetrics.metricsFlag, 0, sizeof( _AwsIotDefenderMetrics.metricsFlag ) );
-
-    /* Set to not started. */
-    _started = false;
-
-    IotLogInfo( "Defender agent has stopped." );
 }
 
 /*-----------------------------------------------------------*/
 
 AwsIotDefenderError_t AwsIotDefender_SetPeriod( uint32_t periodSeconds )
 {
-    /* Input period cannot be too long, which will cause integer overflow. */
-    AwsIotDefender_Assert( periodSeconds < _defenderToSeconds( UINT32_MAX ) );
-
     AwsIotDefenderError_t defenderError = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
 
     /* period can not be too short unless this is test mode. */
@@ -345,158 +395,139 @@ const char * AwsIotDefender_strerror( AwsIotDefenderError_t error )
 }
 
 /*-----------------------------------------------------------*/
-static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
-                                    IotTaskPoolJob_t pJob,
-                                    void * pUserContext )
+
+const char * AwsIotDefender_EventType( AwsIotDefenderEventType_t eventType )
 {
-    /* Unused parameter; silence the compiler. */
-    ( void ) pTaskPool;
-    ( void ) pJob;
-    ( void ) pUserContext;
+    const char * pEvent = NULL;
 
-    IotLogDebug( "Metrics publish job starts." );
-
-    if( !IotSemaphore_TryWait( &_doneSem ) )
+    /* Convert defent event to string  */
+    switch( eventType )
     {
-        IotLogWarn( "Defender has been stopped or the previous metrics is in process. No further action." );
+        case AWS_IOT_DEFENDER_METRICS_ACCEPTED:
+            pEvent = "Defender Metrics accepted";
+            break;
 
-        return;
+        case AWS_IOT_DEFENDER_METRICS_REJECTED:
+            pEvent = "Defender Metrics rejected";
+            break;
+
+        case AWS_IOT_DEFENDER_FAILURE_MQTT:
+            pEvent = "Defender MQTT operation failed";
+            break;
+
+        case AWS_IOT_DEFENDER_FAILURE_METRICS_REPORT: /**< Defender failed to create metrics report. */
+            pEvent = "Defender failed to create metrics Report";
+            break;
+
+        default:
+            pEvent = "Defender Unknown Event";
     }
 
-    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
-
-    bool mqttConnected = false;
-    bool reportCreated = false;
-
-    const IotMqttCallbackInfo_t acceptCallbackInfo = { .function = _acceptCallback, .pCallbackContext = NULL };
-    const IotMqttCallbackInfo_t rejectCallbackInfo = { .function = _rejectCallback, .pCallbackContext = NULL };
-
-    /* Step 1: connect to MQTT. */
-    mqttError = AwsIotDefenderInternal_MqttConnect();
-
-    if( mqttError == IOT_MQTT_SUCCESS )
-    {
-        mqttConnected = true;
-
-        /* Step 2: subscribe to accept/reject MQTT topics. */
-        mqttError = AwsIotDefenderInternal_MqttSubscribe( acceptCallbackInfo,
-                                                          rejectCallbackInfo );
-
-        if( mqttError == IOT_MQTT_SUCCESS )
-        {
-            /* Step 3: create serialized metrics report. */
-            reportCreated = AwsIotDefenderInternal_CreateReport();
-
-            /* If Report is created successfully. */
-            if( reportCreated )
-            {
-                /* Step 4: publish report to defender topic. */
-                mqttError = AwsIotDefenderInternal_MqttPublish( AwsIotDefenderInternal_GetReportBuffer(),
-                                                                AwsIotDefenderInternal_GetReportBufferSize() );
-
-                if( mqttError == IOT_MQTT_SUCCESS )
-                {
-                    IotLogDebug( "Metrics report has been published successfully." );
-                }
-            }
-        }
-    }
-
-    /* If no MQTT error and report has been created, it indicates everything is good. */
-    if( ( mqttError == IOT_MQTT_SUCCESS ) && reportCreated )
-    {
-        IotTaskPoolError_t taskPoolError = IotTaskPool_CreateJob( _disconnectRoutine, NULL, &_disconnectJobStorage, &_disconnectJob );
-
-        /* Silence warnings when asserts are disabled. */
-        ( void ) taskPoolError;
-        AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
-
-        IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL,
-                                      _disconnectJob,
-                                      _defenderToMilliseconds( AWS_IOT_DEFENDER_WAIT_SERVER_MAX_SECONDS ) );
-    }
-    else
-    {
-        AwsIotDefenderEventType_t eventType;
-
-        /* Set event type to only two possible categories. */
-        if( mqttError != IOT_MQTT_SUCCESS )
-        {
-            eventType = AWS_IOT_DEFENDER_FAILURE_MQTT;
-            IotLogError( "Failed to perform MQTT operations, with error %s.", IotMqtt_strerror( mqttError ) );
-        }
-        else
-        {
-            eventType = AWS_IOT_DEFENDER_FAILURE_METRICS_REPORT;
-            /* As of today, no memory is the only reason to fail metrics report creation. */
-            IotLogError( "Failed to create metrics report due to no memory." );
-        }
-
-        /* Invoke user's callback if there is. */
-        if( _startInfo.callback.function != NULL )
-        {
-            AwsIotDefenderCallbackInfo_t callbackInfo;
-
-            callbackInfo.eventType = eventType;
-
-            /* No message to be given to user's callback */
-            callbackInfo.pPayload = NULL;
-            callbackInfo.payloadLength = 0;
-
-            /* It is possible the report buffer is NULL and size is 0. */
-            callbackInfo.pMetricsReport = AwsIotDefenderInternal_GetReportBuffer();
-            callbackInfo.metricsReportLength = AwsIotDefenderInternal_GetReportBufferSize();
-
-            _startInfo.callback.function( _startInfo.callback.param1, &callbackInfo );
-        }
-
-        /* Clean up resources conditionally. */
-        if( reportCreated )
-        {
-            AwsIotDefenderInternal_DeleteReport();
-        }
-
-        if( mqttConnected )
-        {
-            AwsIotDefenderInternal_MqttDisconnect();
-        }
-
-        IotSemaphore_Post( &_doneSem );
-    }
-
-    IotLogDebug( "Metrics publish job ends." );
+    return pEvent;
 }
 
 /*-----------------------------------------------------------*/
 
-static void _disconnectRoutine( IotTaskPool_t pTaskPool,
-                                IotTaskPoolJob_t pJob,
-                                void * pUserContext )
+static IotMqttError_t _metricsSubscribeRoutine()
 {
-    /* Unused parameter; silence the compiler. */
+    IotLogDebug( "Metrics Subscribe starts." );
+
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
+
+    /* Subscribe to accept/reject MQTT topics. */
+    mqttError = AwsIotDefenderInternal_MqttSubscribe();
+
+    if( mqttError != IOT_MQTT_SUCCESS )
+    {
+        IotLogError( "Failed to perform MQTT operations, with error %s.", IotMqtt_strerror( mqttError ) );
+        _unsubscribeMqtt();
+        /* IotSemaphore_Post( &_doneSem ); */
+    }
+
+    return mqttError;
+}
+
+/*-----------------------------------------------------------*/
+
+static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
+                                    IotTaskPoolJob_t pJob,
+                                    void * pUserContext )
+{
+    /* Unsed parameter; silence the compiler. */
     ( void ) pTaskPool;
     ( void ) pJob;
     ( void ) pUserContext;
 
-    IotLogDebug( "Disconnect job starts." );
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
+    bool reportCreated = false;
+    IotTaskPoolError_t taskPoolError = IOT_TASKPOOL_SUCCESS;
 
-    AwsIotDefenderInternal_DeleteReport();
-    AwsIotDefenderInternal_MqttDisconnect();
-    /* Re-create metrics job. */
-    IotTaskPoolError_t taskPoolError = IotTaskPool_CreateJob( _metricsPublishRoutine, NULL, &_metricsPublishJobStorage, &_metricsPublishJob );
+    if( !IotSemaphore_TryWait( &_doneSem ) )
+    {
+        IotLogError( "Defender has been stopped or the previous metrics is in process. No further action." );
+    }
+    else
+    {
+        /* Create serialized metrics report. */
+        reportCreated = AwsIotDefenderInternal_CreateReport();
 
-    /* Silence warnings when asserts are disabled. */
-    ( void ) taskPoolError;
+        /* If Report is created successfully. */
+        if( reportCreated )
+        {
+            /* Publish report to defender topic. */
+            mqttError = AwsIotDefenderInternal_MqttPublish( AwsIotDefenderInternal_GetReportBuffer(),
+                                                            AwsIotDefenderInternal_GetReportBufferSize() );
 
-    AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
+            if( mqttError == IOT_MQTT_SUCCESS )
+            {
+                IotLogDebug( "Metrics report has been published successfully." );
+            }
+            else
+            {
+                IotLogError( "Failed to perform MQTT publish, with error %s.", IotMqtt_strerror( mqttError ) );
+            }
+        }
+        else
+        {
+            IotLogError( "Failed to create report" );
+        }
 
-    /* Re-schedule metrics job with period as deferred interval. */
-    taskPoolError = IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, _periodMilliSecond );
-    AwsIotDefender_Assert( taskPoolError == IOT_TASKPOOL_SUCCESS );
+        if( ( mqttError != IOT_MQTT_SUCCESS ) || ( !reportCreated ) )
+        {
+            if( reportCreated )
+            {
+                AwsIotDefenderInternal_DeleteReport();
+            }
 
-    IotSemaphore_Post( &_doneSem );
+            _unsubscribeMqtt();
+            /* Invoke user's callback if there is. */
+            _handleApplicationCallback( AWS_IOT_DEFENDER_FAILURE_MQTT, NULL );
+        }
+        else
+        {
+            /* Re-schedule metrics job with period as deferred interval. */
+            taskPoolError = IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, _periodMilliSecond );
+        }
 
-    IotLogDebug( "Disconnect job ends." );
+        /* Give Done semaphore so AwsIotDefender_Stop() can proceed */
+        IotSemaphore_Post( &_doneSem );
+    }
+
+    IotLogDebug( "Publish job ends." );
+}
+
+/*-----------------------------------------------------------*/
+
+void _unsubscribeMqtt()
+{
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
+
+    mqttError = AwsIotDefenderInternal_MqttUnSubscribe();
+
+    if( mqttError != IOT_MQTT_SUCCESS )
+    {
+        IotLogError( "Unsubscribe failed for defender agent" );
+    }
 }
 
 /*-----------------------------------------------------------*/
@@ -513,20 +544,9 @@ void _acceptCallback( void * pArgument,
     AwsIotDefender_Assert( pPublish->u.message.info.pPayload );
 
     /* Invoke user's callback with accept event. */
-    AwsIotDefenderCallbackInfo_t callbackInfo;
-
-    if( _startInfo.callback.function != NULL )
-    {
-        callbackInfo.eventType = AWS_IOT_DEFENDER_METRICS_ACCEPTED;
-
-        callbackInfo.pMetricsReport = AwsIotDefenderInternal_GetReportBuffer();
-        callbackInfo.metricsReportLength = AwsIotDefenderInternal_GetReportBufferSize();
-
-        callbackInfo.pPayload = pPublish->u.message.info.pPayload;
-        callbackInfo.payloadLength = pPublish->u.message.info.payloadLength;
-
-        _startInfo.callback.function( _startInfo.callback.param1, &callbackInfo );
-    }
+    _handleApplicationCallback( AWS_IOT_DEFENDER_METRICS_ACCEPTED, pPublish );
+    /* Delete report if exists */
+    AwsIotDefenderInternal_DeleteReport();
 }
 
 /*-----------------------------------------------------------*/
@@ -542,18 +562,39 @@ void _rejectCallback( void * pArgument,
     AwsIotDefender_Assert( pPublish->u.message.info.pPayload );
 
     /* Invoke user's callback with rejected event. */
+    _handleApplicationCallback( AWS_IOT_DEFENDER_METRICS_REJECTED, pPublish );
+    /* Delete report if exists */
+    AwsIotDefenderInternal_DeleteReport();
+}
+
+/*-----------------------------------------------------------*/
+
+void _handleApplicationCallback( AwsIotDefenderEventType_t event,
+                                 IotMqttCallbackParam_t * const pPublish )
+{
+    /* Invoke user's callback with  event. */
     AwsIotDefenderCallbackInfo_t callbackInfo;
 
     if( _startInfo.callback.function != NULL )
     {
-        callbackInfo.eventType = AWS_IOT_DEFENDER_METRICS_REJECTED;
+        callbackInfo.eventType = event;
 
         callbackInfo.pMetricsReport = AwsIotDefenderInternal_GetReportBuffer();
         callbackInfo.metricsReportLength = AwsIotDefenderInternal_GetReportBufferSize();
 
-        callbackInfo.pPayload = pPublish->u.message.info.pPayload;
-        callbackInfo.payloadLength = pPublish->u.message.info.payloadLength;
+        if( pPublish == NULL )
+        {
+            callbackInfo.pPayload = NULL;
+            callbackInfo.payloadLength = 0;
+        }
+        else
+        {
+            callbackInfo.pPayload = pPublish->u.message.info.pPayload;
+            callbackInfo.payloadLength = pPublish->u.message.info.payloadLength;
+        }
 
-        _startInfo.callback.function( _startInfo.callback.param1, &callbackInfo );
+        _startInfo.callback.function( _startInfo.callback.pCallbackContext, &callbackInfo );
     }
 }
+
+/*-----------------------------------------------------------*/

--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c
@@ -72,6 +72,9 @@ static uint32_t _metricsFlagSnapshot[ DEFENDER_METRICS_GROUP_COUNT ];
 /* Report id integer. */
 static uint64_t _AwsIotDefenderReportId = 0;
 
+const IotSerializerEncodeInterface_t * _pAwsIotDefenderEncoder = NULL;
+const IotSerializerDecodeInterface_t * _pAwsIotDefenderDecoder = NULL;
+
 /*---------------------- Helper Functions -------------------------*/
 
 static void _assertSuccess( IotSerializerError_t error );
@@ -118,7 +121,7 @@ size_t AwsIotDefenderInternal_GetReportBufferSize( void )
 {
     /* Encoder might over-calculate the needed size. Therefor encoded size might be smaller than buffer size: _report.size. */
     return _report.pDataBuffer == NULL ? 0
-           : _defenderEncoder.getEncodedSize( &_report.object, _report.pDataBuffer );
+           : _pAwsIotDefenderEncoder->getEncodedSize( &_report.object, _report.pDataBuffer );
 }
 
 /*-----------------------------------------------------------*/
@@ -145,10 +148,10 @@ bool AwsIotDefenderInternal_CreateReport( void )
     _serialize();
 
     /* Get the calculated required size. */
-    dataSize = _defenderEncoder.getExtraBufferSizeNeeded( pEncoderObject );
+    dataSize = _pAwsIotDefenderEncoder->getExtraBufferSizeNeeded( pEncoderObject );
 
     /* Clean the encoder object handle. */
-    _defenderEncoder.destroy( pEncoderObject );
+    _pAwsIotDefenderEncoder->destroy( pEncoderObject );
 
     /* Allocate memory once. */
     pReportBuffer = AwsIotDefender_MallocReport( dataSize * sizeof( uint8_t ) );
@@ -179,7 +182,7 @@ bool AwsIotDefenderInternal_CreateReport( void )
 void AwsIotDefenderInternal_DeleteReport( void )
 {
     /* Destroy the encoder object. */
-    _defenderEncoder.destroy( &( _report.object ) );
+    _pAwsIotDefenderEncoder->destroy( &( _report.object ) );
 
     /* Free the memory of data buffer. */
     AwsIotDefender_FreeReport( _report.pDataBuffer );
@@ -219,34 +222,34 @@ static void _serialize( void )
     uint8_t metricsGroupCount = 0;
     uint32_t i = 0;
 
-    serializerError = _defenderEncoder.init( pEncoderObject, _report.pDataBuffer, _report.size );
+    serializerError = _pAwsIotDefenderEncoder->init( pEncoderObject, _report.pDataBuffer, _report.size );
     assertNoError( serializerError );
 
     /* Create the outermost map with 2 keys: "header", "metrics". */
-    serializerError = _defenderEncoder.openContainer( pEncoderObject, &reportMap, 2 );
+    serializerError = _pAwsIotDefenderEncoder->openContainer( pEncoderObject, &reportMap, 2 );
     assertNoError( serializerError );
 
     /* Create the "header" map with 2 keys: "report_id", "version". */
-    serializerError = _defenderEncoder.openContainerWithKey( &reportMap,
-                                                             HEADER_TAG,
-                                                             &headerMap,
-                                                             2 );
+    serializerError = _pAwsIotDefenderEncoder->openContainerWithKey( &reportMap,
+                                                                     HEADER_TAG,
+                                                                     &headerMap,
+                                                                     2 );
     assertNoError( serializerError );
 
     /* Append key-value pair of "report_Id" which uses clock time. */
-    serializerError = _defenderEncoder.appendKeyValue( &headerMap,
-                                                       REPORTID_TAG,
-                                                       IotSerializer_ScalarSignedInt( ( int64_t ) _AwsIotDefenderReportId ) );
+    serializerError = _pAwsIotDefenderEncoder->appendKeyValue( &headerMap,
+                                                               REPORTID_TAG,
+                                                               IotSerializer_ScalarSignedInt( ( int64_t ) _AwsIotDefenderReportId ) );
     assertNoError( serializerError );
 
     /* Append key-value pair of "version". */
-    serializerError = _defenderEncoder.appendKeyValue( &headerMap,
-                                                       VERSION_TAG,
-                                                       IotSerializer_ScalarTextString( VERSION_1_0 ) );
+    serializerError = _pAwsIotDefenderEncoder->appendKeyValue( &headerMap,
+                                                               VERSION_TAG,
+                                                               IotSerializer_ScalarTextString( VERSION_1_0 ) );
     assertNoError( serializerError );
 
     /* Close the "header" map. */
-    serializerError = _defenderEncoder.closeContainer( &reportMap, &headerMap );
+    serializerError = _pAwsIotDefenderEncoder->closeContainer( &reportMap, &headerMap );
     assertNoError( serializerError );
 
     /* Count how many metrics groups user specified. */
@@ -256,10 +259,10 @@ static void _serialize( void )
     }
 
     /* Create the "metrics" map with number of keys as the number of metrics groups. */
-    serializerError = _defenderEncoder.openContainerWithKey( &reportMap,
-                                                             METRICS_TAG,
-                                                             &metricsMap,
-                                                             metricsGroupCount );
+    serializerError = _pAwsIotDefenderEncoder->openContainerWithKey( &reportMap,
+                                                                     METRICS_TAG,
+                                                                     &metricsMap,
+                                                                     metricsGroupCount );
     assertNoError( serializerError );
 
     for( i = 0; i < DEFENDER_METRICS_GROUP_COUNT; i++ )
@@ -281,11 +284,11 @@ static void _serialize( void )
     }
 
     /* Close the "metrics" map. */
-    serializerError = _defenderEncoder.closeContainer( &reportMap, &metricsMap );
+    serializerError = _pAwsIotDefenderEncoder->closeContainer( &reportMap, &metricsMap );
     assertNoError( serializerError );
 
     /* Close the "report" map. */
-    serializerError = _defenderEncoder.closeContainer( pEncoderObject, &reportMap );
+    serializerError = _pAwsIotDefenderEncoder->closeContainer( pEncoderObject, &reportMap );
     assertNoError( serializerError );
 }
 
@@ -335,30 +338,30 @@ static void _serializeTcpConnections( void * param1,
                                                      : _assertSuccess;
 
     /* Create the "tcp_connections" map with 1 key "established_connections" */
-    serializerError = _defenderEncoder.openContainerWithKey( pMetricsObject,
-                                                             TCP_CONN_TAG,
-                                                             &tcpConnectionMap,
-                                                             1 );
+    serializerError = _pAwsIotDefenderEncoder->openContainerWithKey( pMetricsObject,
+                                                                     TCP_CONN_TAG,
+                                                                     &tcpConnectionMap,
+                                                                     1 );
     assertNoError( serializerError );
 
     /* if user specify any metrics under "established_connections" */
     if( hasEstablishedConnections )
     {
         /* Create the "established_connections" map with "total" and/or "connections". */
-        serializerError = _defenderEncoder.openContainerWithKey( &tcpConnectionMap,
-                                                                 EST_CONN_TAG,
-                                                                 &establishedMap,
-                                                                 hasConnections + hasTotal );
+        serializerError = _pAwsIotDefenderEncoder->openContainerWithKey( &tcpConnectionMap,
+                                                                         EST_CONN_TAG,
+                                                                         &establishedMap,
+                                                                         hasConnections + hasTotal );
         assertNoError( serializerError );
 
         /* if user specify any metrics under "connections" and there are at least one connection */
         if( hasConnections )
         {
             /* create array "connections" under "established_connections" */
-            serializerError = _defenderEncoder.openContainerWithKey( &establishedMap,
-                                                                     CONN_TAG,
-                                                                     &connectionsArray,
-                                                                     total );
+            serializerError = _pAwsIotDefenderEncoder->openContainerWithKey( &establishedMap,
+                                                                             CONN_TAG,
+                                                                             &connectionsArray,
+                                                                             total );
             assertNoError( serializerError );
 
             IotContainers_ForEach( pTcpConnectionsMetricsList, pListIterator )
@@ -366,9 +369,9 @@ static void _serializeTcpConnections( void * param1,
                 IotSerializerEncoderObject_t connectionMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
 
                 /* open a map under "connections" */
-                serializerError = _defenderEncoder.openContainer( &connectionsArray,
-                                                                  &connectionMap,
-                                                                  hasRemoteAddr );
+                serializerError = _pAwsIotDefenderEncoder->openContainer( &connectionsArray,
+                                                                          &connectionMap,
+                                                                          hasRemoteAddr );
                 assertNoError( serializerError );
 
                 /* add remote address */
@@ -376,32 +379,32 @@ static void _serializeTcpConnections( void * param1,
                 {
                     pMetricsTcpConnection = IotLink_Container( IotMetricsTcpConnection_t, pListIterator, link );
 
-                    serializerError = _defenderEncoder.appendKeyValue( &connectionMap, REMOTE_ADDR_TAG,
-                                                                       IotSerializer_ScalarTextString( pMetricsTcpConnection->pRemoteAddress ) );
+                    serializerError = _pAwsIotDefenderEncoder->appendKeyValue( &connectionMap, REMOTE_ADDR_TAG,
+                                                                               IotSerializer_ScalarTextString( pMetricsTcpConnection->pRemoteAddress ) );
                     assertNoError( serializerError );
                 }
 
-                serializerError = _defenderEncoder.closeContainer( &connectionsArray, &connectionMap );
+                serializerError = _pAwsIotDefenderEncoder->closeContainer( &connectionsArray, &connectionMap );
                 assertNoError( serializerError );
             }
 
-            serializerError = _defenderEncoder.closeContainer( &establishedMap, &connectionsArray );
+            serializerError = _pAwsIotDefenderEncoder->closeContainer( &establishedMap, &connectionsArray );
             assertNoError( serializerError );
         }
 
         if( hasTotal )
         {
-            serializerError = _defenderEncoder.appendKeyValue( &establishedMap,
-                                                               TOTAL_TAG,
-                                                               IotSerializer_ScalarSignedInt( total ) );
+            serializerError = _pAwsIotDefenderEncoder->appendKeyValue( &establishedMap,
+                                                                       TOTAL_TAG,
+                                                                       IotSerializer_ScalarSignedInt( total ) );
             assertNoError( serializerError );
         }
 
-        serializerError = _defenderEncoder.closeContainer( &tcpConnectionMap, &establishedMap );
+        serializerError = _pAwsIotDefenderEncoder->closeContainer( &tcpConnectionMap, &establishedMap );
         assertNoError( serializerError );
     }
 
-    serializerError = _defenderEncoder.closeContainer( pMetricsObject, &tcpConnectionMap );
+    serializerError = _pAwsIotDefenderEncoder->closeContainer( pMetricsObject, &tcpConnectionMap );
     assertNoError( serializerError );
 }
 

--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c
@@ -23,6 +23,7 @@
  * http://www.FreeRTOS.org
  */
 
+#include <stdio.h>
 #include <string.h>
 
 /* Defender internal include. */
@@ -37,16 +38,20 @@
 
 #define TOPIC_SUFFIX_REJECTED    TOPIC_SUFFIX_PUBLISH "/rejected"
 
+/*-----------------------------------------------------------*/
+
+extern IotMqttCallbackInfo_t _acceptCallbackInfo;
+extern IotMqttCallbackInfo_t _rejectCallbackInfo;
 extern AwsIotDefenderStartInfo_t _startInfo;
 
-/* defender internally manages network and mqtt connection */
-static IotMqttConnection_t _mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
-
 static char * _pPublishTopic = NULL;
+static size_t _publishTopicLength = 0;
 
 static char * _pAcceptTopic = NULL;
+static size_t _acceptTopicLength = 0;
 
 static char * _pRejectTopic = NULL;
+static size_t _rejectTopicLength = 0;
 
 /*-----------------------------------------------------------*/
 
@@ -54,13 +59,14 @@ AwsIotDefenderError_t AwsIotDefenderInternal_BuildTopicsNames( void )
 {
     AwsIotDefenderError_t returnedError = AWS_IOT_DEFENDER_SUCCESS;
 
-    const char * pThingName = _startInfo.mqttConnectionInfo.pClientIdentifier;
-    uint16_t thingNameLength = _startInfo.mqttConnectionInfo.clientIdentifierLength;
+    const char * pThingName = _startInfo.pClientIdentifier;
+    uint16_t thingNameLength = _startInfo.clientIdentifierLength;
+    size_t topicPrefixLength = strlen( TOPIC_PREFIX );
 
     /* Calculate topics lengths. Plus one for string terminator. */
-    size_t publishTopicLength = strlen( TOPIC_PREFIX ) + thingNameLength + strlen( TOPIC_SUFFIX_PUBLISH ) + 1;
-    size_t acceptTopicLength = strlen( TOPIC_PREFIX ) + thingNameLength + strlen( TOPIC_SUFFIX_ACCEPTED ) + 1;
-    size_t rejectTopicLength = strlen( TOPIC_PREFIX ) + thingNameLength + strlen( TOPIC_SUFFIX_REJECTED ) + 1;
+    size_t publishTopicLength = topicPrefixLength + thingNameLength + strlen( TOPIC_SUFFIX_PUBLISH ) + 1;
+    size_t acceptTopicLength = topicPrefixLength + thingNameLength + strlen( TOPIC_SUFFIX_ACCEPTED ) + 1;
+    size_t rejectTopicLength = topicPrefixLength + thingNameLength + strlen( TOPIC_SUFFIX_REJECTED ) + 1;
 
     /* Allocate memory for each of them. */
     char * pPublishTopic = AwsIotDefender_MallocTopic( publishTopicLength * sizeof( char ) );
@@ -82,17 +88,24 @@ AwsIotDefenderError_t AwsIotDefenderInternal_BuildTopicsNames( void )
         _pAcceptTopic = pAcceptTopic;
         _pRejectTopic = pRejectTopic;
 
-        strcpy( _pPublishTopic, TOPIC_PREFIX );
-        strncat( _pPublishTopic, pThingName, thingNameLength );
-        strcat( _pPublishTopic, TOPIC_SUFFIX_PUBLISH );
+        snprintf( _pPublishTopic, publishTopicLength, "%s%s%s",
+                  TOPIC_PREFIX,
+                  pThingName,
+                  TOPIC_SUFFIX_PUBLISH );
 
-        strcpy( _pAcceptTopic, TOPIC_PREFIX );
-        strncat( _pAcceptTopic, pThingName, thingNameLength );
-        strcat( _pAcceptTopic, TOPIC_SUFFIX_ACCEPTED );
+        snprintf( _pAcceptTopic, acceptTopicLength, "%s%s%s",
+                  TOPIC_PREFIX,
+                  pThingName,
+                  TOPIC_SUFFIX_ACCEPTED );
 
-        strcpy( _pRejectTopic, TOPIC_PREFIX );
-        strncat( _pRejectTopic, pThingName, thingNameLength );
-        strcat( _pRejectTopic, TOPIC_SUFFIX_REJECTED );
+        snprintf( _pRejectTopic, rejectTopicLength, "%s%s%s",
+                  TOPIC_PREFIX,
+                  pThingName,
+                  TOPIC_SUFFIX_REJECTED );
+
+        _publishTopicLength = publishTopicLength - 1;
+        _acceptTopicLength = acceptTopicLength - 1;
+        _rejectTopicLength = rejectTopicLength - 1;
     }
 
     return returnedError;
@@ -108,37 +121,30 @@ void AwsIotDefenderInternal_DeleteTopicsNames( void )
     _pPublishTopic = NULL;
     _pAcceptTopic = NULL;
     _pRejectTopic = NULL;
+
+    _publishTopicLength = 0;
+    _acceptTopicLength = 0;
+    _rejectTopicLength = 0;
 }
 
 /*-----------------------------------------------------------*/
 
-IotMqttError_t AwsIotDefenderInternal_MqttConnect( void )
-{
-    return IotMqtt_Connect( &_startInfo.mqttNetworkInfo,
-                            &_startInfo.mqttConnectionInfo,
-                            _defenderToMilliseconds( AWS_IOT_DEFENDER_MQTT_CONNECT_TIMEOUT_SECONDS ),
-                            &_mqttConnection );
-}
-
-/*-----------------------------------------------------------*/
-
-IotMqttError_t AwsIotDefenderInternal_MqttSubscribe( IotMqttCallbackInfo_t acceptCallback,
-                                                     IotMqttCallbackInfo_t rejectCallback )
+IotMqttError_t AwsIotDefenderInternal_MqttSubscribe( void )
 {
     /* subscribe to two topics: accept and reject. */
     IotMqttSubscription_t subscriptions[ 2 ] = { IOT_MQTT_SUBSCRIPTION_INITIALIZER, IOT_MQTT_SUBSCRIPTION_INITIALIZER };
 
     subscriptions[ 0 ].qos = IOT_MQTT_QOS_0;
     subscriptions[ 0 ].pTopicFilter = _pAcceptTopic;
-    subscriptions[ 0 ].topicFilterLength = ( uint16_t ) strlen( _pAcceptTopic );
-    subscriptions[ 0 ].callback = acceptCallback;
+    subscriptions[ 0 ].topicFilterLength = ( uint16_t ) _acceptTopicLength;
+    subscriptions[ 0 ].callback = _acceptCallbackInfo;
 
     subscriptions[ 1 ].qos = IOT_MQTT_QOS_0;
     subscriptions[ 1 ].pTopicFilter = _pRejectTopic;
-    subscriptions[ 1 ].topicFilterLength = ( uint16_t ) strlen( _pRejectTopic );
-    subscriptions[ 1 ].callback = rejectCallback;
+    subscriptions[ 1 ].topicFilterLength = ( uint16_t ) _rejectTopicLength;
+    subscriptions[ 1 ].callback = _rejectCallbackInfo;
 
-    return IotMqtt_TimedSubscribe( _mqttConnection,
+    return IotMqtt_TimedSubscribe( _startInfo.mqttConnection,
                                    subscriptions,
                                    2,
                                    0,
@@ -154,11 +160,11 @@ IotMqttError_t AwsIotDefenderInternal_MqttPublish( uint8_t * pData,
 
     publishInfo.qos = IOT_MQTT_QOS_0;
     publishInfo.pTopicName = _pPublishTopic;
-    publishInfo.topicNameLength = ( uint16_t ) strlen( _pPublishTopic );
+    publishInfo.topicNameLength = ( uint16_t ) _publishTopicLength;
     publishInfo.pPayload = pData;
     publishInfo.payloadLength = dataLength;
-
-    return IotMqtt_TimedPublish( _mqttConnection,
+    /* Publish Defender Report */
+    return IotMqtt_TimedPublish( _startInfo.mqttConnection,
                                  &publishInfo,
                                  0,
                                  _defenderToMilliseconds( AWS_IOT_DEFENDER_MQTT_PUBLISH_TIMEOUT_SECONDS ) );
@@ -166,7 +172,26 @@ IotMqttError_t AwsIotDefenderInternal_MqttPublish( uint8_t * pData,
 
 /*-----------------------------------------------------------*/
 
-void AwsIotDefenderInternal_MqttDisconnect( void )
+IotMqttError_t AwsIotDefenderInternal_MqttUnSubscribe( void )
 {
-    IotMqtt_Disconnect( _mqttConnection, false );
+    /* unsubscribe to two topics: accept and reject. */
+    IotMqttSubscription_t subscriptions[ 2 ] = { IOT_MQTT_SUBSCRIPTION_INITIALIZER, IOT_MQTT_SUBSCRIPTION_INITIALIZER };
+
+    subscriptions[ 0 ].qos = IOT_MQTT_QOS_0;
+    subscriptions[ 0 ].pTopicFilter = _pAcceptTopic;
+    subscriptions[ 0 ].topicFilterLength = ( uint16_t ) _acceptTopicLength;
+    subscriptions[ 0 ].callback = _acceptCallbackInfo;
+
+    subscriptions[ 1 ].qos = IOT_MQTT_QOS_0;
+    subscriptions[ 1 ].pTopicFilter = _pRejectTopic;
+    subscriptions[ 1 ].topicFilterLength = ( uint16_t ) _rejectTopicLength;
+    subscriptions[ 1 ].callback = _rejectCallbackInfo;
+
+    return IotMqtt_TimedUnsubscribe( _startInfo.mqttConnection,
+                                     subscriptions,
+                                     2,
+                                     0,
+                                     _defenderToMilliseconds( AWS_IOT_DEFENDER_MQTT_SUBSCRIBE_TIMEOUT_SECONDS ) );
 }
+
+/*-----------------------------------------------------------*/

--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c
@@ -36,8 +36,15 @@
 /* Defender agent's status, initialized with eDefenderRepInit. */
 static DefenderReportStatus_t _status = eDefenderRepInit;
 
-static IotNetworkServerInfo_t _AWS_IOT_SERVER_INFO = AWS_IOT_NETWORK_SERVER_INFO_AFR_INITIALIZER;
-static IotNetworkCredentials_t _AWS_IOT_CREDENTIALS = AWS_IOT_NETWORK_CREDENTIALS_AFR_INITIALIZER;
+static IotNetworkServerInfo_t _serverInfo = AWS_IOT_NETWORK_SERVER_INFO_AFR_INITIALIZER;
+static IotNetworkCredentials_t _credential = AWS_IOT_NETWORK_CREDENTIALS_AFR_INITIALIZER;
+static IotMqttConnection_t _mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
+static bool _mqttConnectionStarted = false;
+
+/*-----------------------------------------------------------*/
+
+static IotMqttError_t _startMqttConnection( void );
+static void _stopMqttConnection( void );
 
 /*-----------------------------------------------------------*/
 
@@ -141,35 +148,40 @@ DefenderErr_t DEFENDER_ConnectionTimeoutSet( uint32_t ulTimeoutMs )
 DefenderErr_t DEFENDER_Start( void )
 {
     /* Register an internal callback. */
-    const AwsIotDefenderCallback_t callback = { .function = _defenderCallback, .param1 = NULL };
-
+    const AwsIotDefenderCallback_t callback = { .function = _defenderCallback, .pCallbackContext = NULL };
+    DefenderErr_t defError = eDefenderErrSuccess;
     AwsIotDefenderStartInfo_t startInfo = AWS_IOT_DEFENDER_START_INFO_INITIALIZER;
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
 
-    /* Set network information. */
-    startInfo.mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
-    startInfo.mqttNetworkInfo.createNetworkConnection = true;
-    startInfo.mqttNetworkInfo.u.setup.pNetworkServerInfo = &_AWS_IOT_SERVER_INFO;
-    startInfo.mqttNetworkInfo.u.setup.pNetworkCredentialInfo = &_AWS_IOT_CREDENTIALS;
-
-    /* Only set ALPN protocol if the connected port is 443. */
-    if( ( ( IotNetworkServerInfo_t * ) ( startInfo.mqttNetworkInfo.u.setup.pNetworkServerInfo ) )->port != 443 )
+    if( _serverInfo.port != 443 )
     {
-        ( ( IotNetworkCredentials_t * ) ( startInfo.mqttNetworkInfo.u.setup.pNetworkCredentialInfo ) )->pAlpnProtos = NULL;
+        _credential.pAlpnProtos = NULL;
     }
 
-    /* Set network interface. */
-    startInfo.mqttNetworkInfo.pNetworkInterface = IOT_NETWORK_INTERFACE_AFR;
+    /* Set network information. */
+    startInfo.mqttConnection = _mqttConnection;
+    startInfo.pClientIdentifier = clientcredentialIOT_THING_NAME;
+    startInfo.clientIdentifierLength = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME );
 
-    /* Set MQTT connection information. */
-    startInfo.mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
-    startInfo.mqttConnectionInfo.pClientIdentifier = clientcredentialIOT_THING_NAME;
-    startInfo.mqttConnectionInfo.clientIdentifierLength = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME );
+    /* Start MQTT connection */
+    mqttError = _startMqttConnection();
 
-    /* Set Defender callback. */
-    startInfo.callback = callback;
+    if( mqttError == IOT_MQTT_SUCCESS )
+    {
+        startInfo.mqttConnection = _mqttConnection;
 
-    /* Invoke defender start API. */
-    return _toDefenderErr( AwsIotDefender_Start( &startInfo ) );
+        /* Set Defender callback. */
+        startInfo.callback = callback;
+
+        /* Invoke defender start API. */
+        defError = _toDefenderErr( AwsIotDefender_Start( &startInfo ) );
+    }
+    else
+    {
+        defError = eDefenderErrOther;
+    }
+
+    return defError;
 }
 
 /*-----------------------------------------------------------*/
@@ -177,6 +189,7 @@ DefenderErr_t DEFENDER_Start( void )
 DefenderErr_t DEFENDER_Stop( void )
 {
     AwsIotDefender_Stop();
+    _stopMqttConnection();
 
     /* No failure cases. */
     return eDefenderErrSuccess;
@@ -263,4 +276,51 @@ char const * DEFENDER_ReportStatusAsString( DefenderReportStatus_t eStatusNum )
     }
 
     return "Invalid value";
+}
+
+static IotMqttError_t _startMqttConnection( void )
+{
+    IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
+    IotMqttNetworkInfo_t mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
+    IotMqttConnectInfo_t mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
+
+    if( !_mqttConnectionStarted )
+    {
+        mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
+        mqttNetworkInfo.createNetworkConnection = true;
+        mqttNetworkInfo.u.setup.pNetworkServerInfo = &_serverInfo;
+        mqttNetworkInfo.u.setup.pNetworkCredentialInfo = &_credential;
+
+        mqttNetworkInfo.pNetworkInterface = IOT_NETWORK_INTERFACE_AFR;
+
+        mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
+
+        /* Set MQTT connection information. */
+        mqttConnectionInfo.pClientIdentifier = clientcredentialIOT_THING_NAME;
+        mqttConnectionInfo.clientIdentifierLength = ( uint16_t ) strlen( clientcredentialIOT_THING_NAME );
+
+        mqttError = IotMqtt_Connect( &mqttNetworkInfo,
+                                     &mqttConnectionInfo,
+                                     1000,
+                                     &_mqttConnection );
+
+        if( mqttError == IOT_MQTT_SUCCESS )
+        {
+            _mqttConnectionStarted = true;
+        }
+    }
+
+    return mqttError;
+}
+
+/*-----------------------------------------------------------*/
+
+static void _stopMqttConnection( void )
+{
+    if( _mqttConnectionStarted )
+    {
+        IotMqtt_Disconnect( _mqttConnection, false );
+        _mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
+        _mqttConnectionStarted = false;
+    }
 }

--- a/libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h
+++ b/libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h
@@ -57,12 +57,15 @@
  */
 #if AWS_IOT_DEFENDER_ENABLE_ASSERTS == 1
     #ifndef AwsIotDefender_Assert
-        #include <assert.h>
-        #define AwsIotDefender_Assert( expression )    assert( expression )
+        #ifdef Iot_DefaultAssert
+            #define AwsIotDefender_Assert( expression )    Iot_DefaultAssert( expression )
+        #else
+            #error "Asserts are enabled for Defender, but AwsIotDefender_Assert is not defined"
+        #endif
     #endif
-#else
+#else /* if AWS_IOT_DEFENDER_ENABLE_ASSERTS == 1 */
     #define AwsIotDefender_Assert( expression )
-#endif
+#endif /* if AWS_IOT_DEFENDER_ENABLE_ASSERTS == 1 */
 
 /* Configure logs for Defender functions. */
 #ifdef AWS_IOT_LOG_LEVEL_DEFENDER
@@ -113,24 +116,37 @@
  */
     #define AwsIotDefender_FreeTopic       Iot_FreeMessageBuffer
 #else /* if IOT_STATIC_MEMORY_ONLY */
-    #include <stdlib.h>
-
     #ifndef AwsIotDefender_MallocReport
-        #define AwsIotDefender_MallocReport    malloc
+        #ifdef Iot_DefaultMalloc
+            #define AwsIotDefender_MallocReport    Iot_DefaultMalloc
+        #else
+            #error "No malloc function defined for AwsIotDefender_MallocReport"
+        #endif
     #endif
 
     #ifndef AwsIotDefender_FreeReport
-        #define AwsIotDefender_FreeReport    free
+        #ifdef Iot_DefaultFree
+            #define AwsIotDefender_FreeReport    Iot_DefaultFree
+        #else
+            #error "No free function defined for AwsIotDefender_FreeReport"
+        #endif
     #endif
 
     #ifndef AwsIotDefender_MallocTopic
-        #define AwsIotDefender_MallocTopic    malloc
+        #ifdef Iot_DefaultMalloc
+            #define AwsIotDefender_MallocTopic    Iot_DefaultMalloc
+        #else
+            #error "No malloc function defined for AwsIotDefender_MallocTopic"
+        #endif
     #endif
 
     #ifndef AwsIotDefender_FreeTopic
-        #define AwsIotDefender_FreeTopic    free
+        #ifdef Iot_DefaultFree
+            #define AwsIotDefender_FreeTopic    Iot_DefaultFree
+        #else
+            #error "No free function defined for AwsIotDefender_FreeTopic"
+        #endif
     #endif
-
 #endif /* if IOT_STATIC_MEMORY_ONLY */
 
 /**
@@ -236,20 +252,9 @@
  * Define encoder/decoder based on configuration AWS_IOT_DEFENDER_FORMAT.
  */
 #if AWS_IOT_DEFENDER_FORMAT == AWS_IOT_DEFENDER_FORMAT_CBOR
-
-    #define DEFENDER_FORMAT     "cbor"
-    #define _defenderEncoder    _IotSerializerCborEncoder       /**< Global defined in iot_serializer.h . */
-    #define _defenderDecoder    _IotSerializerCborDecoder       /**< Global defined in iot_serializer.h . */
-
-#elif AWS_IOT_DEFENDER_FORMAT == AWS_IOT_DEFENDER_FORMAT_JSON
-
-    #define DEFENDER_FORMAT     "json"
-    #define _defenderEncoder    _IotSerializerJsonEncoder       /**< Global defined in iot_serializer.h . */
-    #define _defenderDecoder    _IotSerializerJsonDecoder       /**< Global defined in iot_serializer.h . */
-
+    #define DEFENDER_FORMAT    "cbor"
 #else /* if AWS_IOT_DEFENDER_FORMAT == AWS_IOT_DEFENDER_FORMAT_CBOR */
-    #error "AWS_IOT_DEFENDER_FORMAT must be either AWS_IOT_DEFENDER_FORMAT_CBOR or AWS_IOT_DEFENDER_FORMAT_JSON."
-
+    #error "AWS_IOT_DEFENDER_FORMAT must be AWS_IOT_DEFENDER_FORMAT_CBOR"
 #endif /* if AWS_IOT_DEFENDER_FORMAT == AWS_IOT_DEFENDER_FORMAT_CBOR */
 
 /**
@@ -318,15 +323,10 @@ AwsIotDefenderError_t AwsIotDefenderInternal_BuildTopicsNames( void );
 void AwsIotDefenderInternal_DeleteTopicsNames( void );
 
 /**
- * Connect to AWS with MQTT.
- */
-IotMqttError_t AwsIotDefenderInternal_MqttConnect( void );
-
-/**
  * Subscribe accept/reject defender topics.
  */
-IotMqttError_t AwsIotDefenderInternal_MqttSubscribe( IotMqttCallbackInfo_t acceptCallback,
-                                                     IotMqttCallbackInfo_t rejectCallback );
+
+IotMqttError_t AwsIotDefenderInternal_MqttSubscribe( void );
 
 /**
  * Publish metrics data to defender topic.
@@ -335,12 +335,16 @@ IotMqttError_t AwsIotDefenderInternal_MqttPublish( uint8_t * pData,
                                                    size_t dataLength );
 
 /**
- * Disconnect with AWS MQTT.
+ * Unsubscribe accept/reject defender topics.
  */
-void AwsIotDefenderInternal_MqttDisconnect( void );
+IotMqttError_t AwsIotDefenderInternal_MqttUnSubscribe( void );
+
 
 /*----------------- Below this line are INTERNAL global variables --------------------*/
 
 extern _defenderMetrics_t _AwsIotDefenderMetrics;
+
+extern const IotSerializerEncodeInterface_t * _pAwsIotDefenderEncoder;
+extern const IotSerializerDecodeInterface_t * _pAwsIotDefenderDecoder;
 
 #endif /* ifndef AWS_IOT_DEFENDER_INTERNAL_H_ */


### PR DESCRIPTION
Use shared MQTT connection and remove sync call from taskpool.

Before this change, Defender library created and maintained its own
MQTT connection. Use of shared MQTT connection will save memory and
processing time.
Defender library used taskpool task which made blocking calls to
MQTT library. Because MQTT library also uses taskpool, blocking calls
may cause deadlock if limited number of taskpool tasks are available.
This change removes blocking calls from taskpool context.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.