### PR TITLE
 Make CBMC script make_type_header_files.py run under Python 3.5

### DIFF
--- a/tools/cbmc/proofs/make_type_header_files.py
+++ b/tools/cbmc/proofs/make_type_header_files.py
@@ -98,7 +98,7 @@ def make_header_file(goto_binary, fyle, target_folder):
         res = subprocess.run(drop_header_cmd,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
-                             text=True,
+                             universal_newlines=True,
                              cwd=tmpdir)
         if res.returncode:
             logging.error("Dumping type header for file '%s' failed", fyle)


### PR DESCRIPTION
Make CBMC script make_type_header_files.py run under Python 3.5

The script is used to prepare the source tree for CBMC proofs of the
queue API.  The script was written using the text keyword argument to
subprocess.run which was added in Python 3.7 "as a more understandable
alias of universal_newlines."  CBMC CI uses Python 3.5.  This patch just uses 
the original keyword argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.