### PR TITLE
Fix CBMC memory safety proof for ProcessDHCPReplies.

### DIFF
--- a/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
@@ -30,7 +30,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.goto",
     "$(FREERTOS)/freertos_kernel/event_groups.goto",
     "$(FREERTOS)/freertos_kernel/list.goto"


### PR DESCRIPTION
The Makefile.json was building DNS and not DHCP, so ProcessDHCPReplies
was not being tested.  This error was probably introduced during the
transition to the Makefile.json build flow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.