### PR TITLE
Fix missing reference tags in https client doxygen docs.

### DIFF
--- a/libraries/c_sdk/standard/https/include/iot_https_client.h
+++ b/libraries/c_sdk/standard/https/include/iot_https_client.h
@@ -390,7 +390,7 @@ IotHttpsReturnCode_t IotHttpsClient_InitializeRequest( IotHttpsRequestHandle_t *
  * the entity body. These 2 characters are accounted for in #requestUserBufferMinimumSize.
  *
  * The remaining length, after the header is added, is printed to the system configured standard debug output when
- * IOT_LOG_LEVEL_HTTPS is set to IOT_LOG_DEBUG in iot_config.h.
+ * @ref IOT_LOG_LEVEL_HTTPS is set to @ref IOT_LOG_DEBUG in iot_config.h.
  *
  * For an asynchronous request, this function can be invoked before the request is sent with
  * @ref https_client_function_sendasync, or during #IotHttpsClientCallbacks_t.appendHeaderCallback. It is
@@ -530,7 +530,7 @@ IotHttpsReturnCode_t IotHttpsClient_WriteRequestBody( IotHttpsRequestHandle_t re
  * to fit the headers received, then headers that don't fit will be thrown away. Please see
  * #responseUserBufferMinimumSize for information about sizing the #IotHttpsResponseInfo_t.userBuffer.
  * To receive feedback on headers discarded, debug logging must be turned on in iot_config.h by setting
- * @ref IOT_LOG_LEVEL_HTTPS to IOT_LOG_DEBUG.
+ * @ref IOT_LOG_LEVEL_HTTPS to @ref IOT_LOG_DEBUG.
  *
  * Multiple threads must not call this function for the same #IotHttpsRequestHandle_t. Multiple threads can call this
  * function for a different #IotHttpsRequestHandle_t, even on the same #IotHttpsConnectionHandle_t. An application must

--- a/libraries/c_sdk/standard/https/include/types/iot_https_types.h
+++ b/libraries/c_sdk/standard/https/include/types/iot_https_types.h
@@ -776,7 +776,7 @@ typedef struct IotHttpsConnectionInfo
      *
      * This contains the interface to connect, disconnect, send data, and receive data from the network.
      *
-     * In Amazon FreeRTOS this should be of the type IotNetworkInterface_t.
+     * In Amazon FreeRTOS this should be of the type @ref IotNetworkInterface_t.
      */
     IOT_HTTPS_NETWORK_INTERFACE_TYPE pNetworkInterface;
 } IotHttpsConnectionInfo_t;


### PR DESCRIPTION
Fix a few notable missing reference tags in https client doxygen docs.
These are just the ones in the header files.
When the HTTPS Client moves to the CSDK, doxygen generation will be able to get the acquire the tags desired.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.