### PR TITLE
Fixed esp32 project link to http_parser

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/amazon-freertos-common/component.mk
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/amazon-freertos-common/component.mk
@@ -52,7 +52,7 @@ COMPONENT_SRCDIRS := $(AMAZON_FREERTOS_SDK_DIR)/standard/mqtt/src \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/pkcs11/mbedtls \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/platform/freertos \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/secure_sockets/freertos_plus_tcp \
-        $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http-parser \
+        $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http_parser \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/jsmn \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/tinycbor \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/pkcs11 \
@@ -67,7 +67,7 @@ COMPONENT_ADD_INCLUDEDIRS := $(AMAZON_FREERTOS_ARF_PLUS_DIR)/standard/freertos_p
                              $(AMAZON_FREERTOS_ARF_PLUS_DIR)/standard/freertos_plus_tcp/source/portable/Compiler/GCC \
                              $(AMAZON_FREERTOS_SDK_DIR)/standard/ble/include \
                              $(AMAZON_FREERTOS_SDK_DIR)/standard/https/include \
-                             $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http-parser \
+                             $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http_parser \
                              $(AMAZON_FREERTOS_3RD_PARTY_DIR)/jsmn \
                              $(AMAZON_FREERTOS_3RD_PARTY_DIR)/tinycbor \
                              $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/platform/freertos/include \

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
@@ -52,7 +52,7 @@ COMPONENT_SRCDIRS := $(AMAZON_FREERTOS_SDK_DIR)/standard/mqtt/src \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/pkcs11/mbedtls \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/platform/freertos \
         $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/secure_sockets/freertos_plus_tcp \
-        $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http-parser \
+        $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http_parser \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/jsmn \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/tinycbor \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/pkcs11 \
@@ -67,7 +67,7 @@ COMPONENT_ADD_INCLUDEDIRS := $(AMAZON_FREERTOS_ARF_PLUS_DIR)/standard/freertos_p
                              $(AMAZON_FREERTOS_ARF_PLUS_DIR)/standard/freertos_plus_tcp/source/portable/Compiler/GCC \
                              $(AMAZON_FREERTOS_SDK_DIR)/standard/ble/include \
                              $(AMAZON_FREERTOS_SDK_DIR)/standard/https/include \
-                             $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http-parser \
+                             $(AMAZON_FREERTOS_3RD_PARTY_DIR)/http_parser \
                              $(AMAZON_FREERTOS_3RD_PARTY_DIR)/jsmn \
                              $(AMAZON_FREERTOS_3RD_PARTY_DIR)/tinycbor \
                              $(AMAZON_FREERTOS_ABSTRACTIONS_DIR)/platform/freertos/include \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fix http_parser link in esp32 project file. #1263 

https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/espressif/job/esp32_devkitc-ide/45/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.