### PR TITLE
docs: Improve documentation in iot header files

### DIFF
--- a/libraries/abstractions/common_io/include/iot_perfcounter.h
+++ b/libraries/abstractions/common_io/include/iot_perfcounter.h
@@ -42,6 +42,10 @@
 /**
  * @defgroup iot_perfcounter PerfCounter HAL APIs
  * @{
+ * @brief   The perf counter is generally used to measure the cycles (usually processor clock cycles )
+ *          taken between 2 places in code. perfcounters can be implemented using cycle counters if
+ *          the processor supports, or any generic timer that is granular enough to measure the time
+ *          between 2 points in code.
  */
 
 /**
@@ -63,7 +67,7 @@ uint64_t iot_perfcounter_get_value(void);
  *          performance counters are running at. This can be used to determine the
  *          time delta between two perfcounter values returned by valling iot_perfcounter_get_value()
  *
- * @return  returns the frequency of the performance counter.
+ * @return  returns the frequency of the performance counter as a uint32 value.
  *          This can be used to deterime the period between perfcounter
  *          increments.
  */

--- a/libraries/abstractions/common_io/include/iot_pwm.h
+++ b/libraries/abstractions/common_io/include/iot_pwm.h
@@ -79,7 +79,7 @@ typedef struct IotPwmDescriptor   * IotPwmHandle_t;
  * @return
  *   - Handle to PWM interface on success
  *   - NULL if
- *      - invalide instance
+ *      - invalid instance
  *      - instance already open
  */
 IotPwmHandle_t iot_pwm_open( int32_t lPwmInstance );

--- a/libraries/abstractions/common_io/include/iot_pwm.h
+++ b/libraries/abstractions/common_io/include/iot_pwm.h
@@ -39,10 +39,10 @@
 /**
  * @brief Return values used by PWM driver.
  */
-#define IOT_PWM_SUCCESS                   ( 0 )
-#define IOT_PWM_INVALID_VALUE             ( 1 )
-#define IOT_PWM_NOT_CONFIGURED            ( 2 )
-#define IOT_PWM_FUNCTION_NOT_SUPPORTED    ( 3 )
+#define IOT_PWM_SUCCESS                   ( 0 )    /*!< PWM operation completed successfully. */
+#define IOT_PWM_INVALID_VALUE             ( 1 )    /*!< At least one parameter is invalid. */
+#define IOT_PWM_NOT_CONFIGURED            ( 2 )    /*!< PWM must be configured prior to start. */
+#define IOT_PWM_FUNCTION_NOT_SUPPORTED    ( 3 )    /*!< PWM operation not supported. */
 
 
 /**
@@ -52,7 +52,9 @@ typedef struct IotPwmConfig
 {
     uint32_t ulPwmFrequency; /*!< PWM frequency */
     uint8_t ucPwmDutyCycle;  /*!< PWM duty cycle */
-    uint8_t ucPwmChannel;    /*!< PWM output channel.*/
+    uint8_t ucPwmChannel;    /*!< PWM output channel.  Depending on individual HW implementations,
+                                  each pwm controller may have one or more channels, where the
+                                  output signal can be directed.  */
 } IotPwmConfig_t;
 
 /**
@@ -74,7 +76,11 @@ typedef struct IotPwmDescriptor   * IotPwmHandle_t;
  * @param[in]   lPwmInstance   The instance of the PWM to initialize.
                                 PWM is output only.
  *
- * @return Handle to PWM interface on success, or NULL on failure.
+ * @return
+ *   - Handle to PWM interface on success
+ *   - NULL if
+ *      - invalide instance
+ *      - instance already open
  */
 IotPwmHandle_t iot_pwm_open( int32_t lPwmInstance );
 
@@ -86,8 +92,9 @@ IotPwmHandle_t iot_pwm_open( int32_t lPwmInstance );
  *                          iot_pwm_open
  * @param[in]   xConfig     PWM configuration to be setup.
  *
- * @return  returns IOT_PWM_SUCCESS on success or returns
- *          one of IOT_PWM_INVALID_VALUE on error.
+ * @return
+ *   - IOT_PWM_SUCCESS on success
+ *   - IOT_PWM_INVALID_VALUE if pxPwmHandle == NULL or invalid config setting
  */
 int32_t iot_pwm_set_config( IotPwmHandle_t const pxPwmHandle,
                             const IotPwmConfig_t xConfig );
@@ -98,20 +105,25 @@ int32_t iot_pwm_set_config( IotPwmHandle_t const pxPwmHandle,
  * @param[in]   pxPwmHandle  Handle to PWM driver returned in
  *                          iot_pwm_open
  *
- * @return  returns pointer to current PWM configuration on success,
- *          or returns NULL
+ * @return
+ *   - pointer to current PWM configuration on success
+ *   - NULL if pxPwmHandle == NULL
  */
 IotPwmConfig_t * iot_pwm_get_config( IotPwmHandle_t const pxPwmHandle );
 
 /*!
  * @brief   Start the PWM hardware. PWM configuration must be
- *          set before PWM is started.
+ *          set before PWM is started.  PWM signal availability
+ *          on the configured output based on the PWMChannel configured
+ *          in iot_pwm_set_config().
  *
  * @param[in]   pxPwmHandle  Handle to PWM driver returned in
  *                          iot_pwm_open
  *
- * @return  returns IOT_PWM_SUCCESS on success or returns
- *          one of IOT_PWM_INVALID_VALUE on error.
+ * @return
+ *   - IOT_PWM_SUCCESS on success
+ *   - IOT_PWM_INVALID_VALUE if pxPwmHandle == NULL
+ *   - IOT_PWM_NOT_CONFIGURED if iot_pwm_set_config hasn't been called.
  */
 int32_t iot_pwm_start( IotPwmHandle_t const pxPwmHandle );
 
@@ -121,8 +133,9 @@ int32_t iot_pwm_start( IotPwmHandle_t const pxPwmHandle );
  * @param[in]   pxPwmHandle  Handle to PWM driver returned in
  *                          iot_pwm_open
  *
- * @return  returns IOT_PWM_SUCCESS on success or returns
- *          one of IOT_PWM_INVALID_VALUE on error.
+ * @return
+ *   - IOT_PWM_SUCCESS on success
+ *   - IOT_PWM_INVALID_VALUE if pxPwmHandle == NULL
  */
 int32_t iot_pwm_stop( IotPwmHandle_t const pxPwmHandle );
 
@@ -132,8 +145,12 @@ int32_t iot_pwm_stop( IotPwmHandle_t const pxPwmHandle );
  * @param[in]   pxPwmHandle  Handle to PWM driver returned in
  *                          iot_pwm_open
  *
- * @return  returns IOT_PWM_SUCCESS on success or returns
- *          one of IOT_PWM_INVALID_VALUE on error.
+ * @return
+ *   - IOT_PWM_SUCCESS on success
+ *   - IOT_PWM_INVALID_VALUE if
+ *      - pxPwmHandle == NULL
+ *      - not in open state (already closed).
+
  */
 int32_t iot_pwm_close( IotPwmHandle_t const pxPwmHandle );
 

--- a/libraries/abstractions/common_io/include/iot_reset.h
+++ b/libraries/abstractions/common_io/include/iot_reset.h
@@ -41,8 +41,9 @@
 /**
  * Return values used by reset driver
  */
-#define IOT_RESET_SUCCESS                   ( 0 )
-#define IOT_RESET_FUNCTION_NOT_SUPPORTED    ( 1 )
+#define IOT_RESET_SUCCESS                   ( 0 )    /**< Reset operation completed successfully. */
+#define IOT_RESET_FUNCTION_NOT_SUPPORTED    ( 1 )    /**< Reset function not supported. */
+#define IOT_RESET_INVALID_VALUE             ( 2 )    /**< At least one parameter is invalid. */
 
 typedef enum
 {
@@ -81,8 +82,9 @@ void iot_reset_reboot( IotResetBootFlag_t xResetBootFlag );
  *          If the target does not support shutdown of the device, IOT_RESET_FUNCTION_NOT_SUPPORTED
  *          is returned to the user.
  *
- * @return  does not return and device shutdown on success, or returns one of
- *          IOT_RESET_FUNCTION_NOT_SUPPORTED
+ * @return
+ *   - does not return and device shutdown on success
+ *   - IOT_RESET_FUNCTION_NOT_SUPPORTED if shutdown not supported.
  */
 int32_t iot_reset_shutdown();
 
@@ -94,7 +96,10 @@ int32_t iot_reset_shutdown();
  *
  * @param[out]   xResetReason  One of the reset reasons specified in IotResetReason_t types
  *
- * @return  returns one of IOT_RESET_SUCCESS or IOT_RESET_FUNCTION_NOT_SUPPORTED
+ * @return
+ *   - IOT_RESET_SUCCESS on success.
+ *   - IOT_RESET_FUNCTION_NOT_SUPPORTED if not supported.
+ *   - IOT_RESET_INVALID_VALUE if xREsetReason == NULL
  */
 int32_t iot_get_reset_reason(IotResetReason_t  * xResetReason);
 


### PR DESCRIPTION
Improve documentation in PerfCounter, PWM, and Reset header files

Why:  Need to clarify return values of all of the APIs, as well as
improve overall documentation to make usage clearer.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.