### PR TITLE
add missing console metadata

### DIFF
--- a/vendors/infineon/boards/xmc4800_iotkit/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_iotkit/CMakeLists.txt
@@ -33,7 +33,7 @@ afr_set_board_metadata(RECOMMENDED_IDE "DAVE")
 afr_set_board_metadata(IDE_DAVE_NAME "DAVE")
 afr_set_board_metadata(IDE_DAVE_COMPILER "GCC")
 afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")
-
+afr_set_board_metadata(IS_ACTIVE "TRUE")
 afr_set_board_metadata(IDE_DAVE_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/infineon/xmc4800_iotkit/dave4/aws_demos")
 afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${AFR_ROOT_DIR}/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files")
 

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
@@ -34,7 +34,7 @@ afr_set_board_metadata(RECOMMENDED_IDE "DAVE")
 afr_set_board_metadata(IDE_DAVE_NAME "DAVE")
 afr_set_board_metadata(IDE_DAVE_COMPILER "GCC")
 afr_set_board_metadata(KEY_IMPORT_PROVISIONING "FALSE")
-
+afr_set_board_metadata(IS_ACTIVE "TRUE")
 afr_set_board_metadata(IDE_DAVE_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos")
 afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${AFR_ROOT_DIR}/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files")
 

--- a/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
+++ b/vendors/nxp/boards/lpc54018iotmodule/CMakeLists.txt
@@ -38,7 +38,7 @@ afr_set_board_metadata(IDE_IAREmbeddedWorkbench_COMPILER "IAR")
 afr_set_board_metadata(IDE_MCUXpresso_NAME "MCUXpresso")
 afr_set_board_metadata(IDE_MCUXpresso_COMPILER "GCC")
 afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")
-
+afr_set_board_metadata(IS_ACTIVE "TRUE")
 afr_set_board_metadata(IDE_IAREmbeddedWorkbench_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/nxp/lpc54018iotmodule/iar/aws_demos")
 afr_set_board_metadata(IDE_MCUXpresso_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_demos")
 afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${AFR_ROOT_DIR}/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files")


### PR DESCRIPTION
add missing metadata "IS_ACTIVE" required by console for the following boards.

infineon:
  xmc4800_plus_optiga_trust_x
  xmc4800_iotkit

nxp:
  lpc54018iotmodule

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.