### PR TITLE
Consistent key import policy handling for OPTIGA

### DIFF
--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -38,6 +38,7 @@
 #include "iot_crypto.h"
 #include "aws_clientcredential.h"
 #include "iot_default_root_certificates.h"
+#include "iot_pkcs11_config.h"
 #include "iot_pkcs11.h"
 #include "aws_dev_mode_key_provisioning.h"
 #include "iot_test_pkcs11_config.h"

--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.cproject
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_demos/.cproject
@@ -82,7 +82,6 @@
 									<listOptionValue builtIn="false" value="MBEDTLS_ECDH_COMPUTE_SHARED_ALT"/>
 									<listOptionValue builtIn="false" value="MBEDTLS_ECDH_GEN_PUBLIC_ALT"/>
 									<listOptionValue builtIn="false" value="PAL_OS_HAS_EVENT_INIT"/>
-									<listOptionValue builtIn="false" value="pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED=0"/>
 								</option>
 								<option id="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std.189927906" name="Language standard" superClass="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std" useByScannerDiscovery="false" value="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std.c99" valueType="enumerated"/>
 								<inputType id="org.eclipse.cdt.cross.arm.gnu.sourcery.windows.c.compiler.base.input.62519071" superClass="org.eclipse.cdt.cross.arm.gnu.sourcery.windows.c.compiler.base.input"/>

--- a/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.cproject
+++ b/projects/infineon/xmc4800_plus_optiga_trust_x/dave4/aws_tests/.cproject
@@ -93,7 +93,6 @@
 									<listOptionValue builtIn="false" value="MBEDTLS_ECDH_COMPUTE_SHARED_ALT"/>
 									<listOptionValue builtIn="false" value="MBEDTLS_ECDH_GEN_PUBLIC_ALT"/>
 									<listOptionValue builtIn="false" value="PAL_OS_HAS_EVENT_INIT"/>
-									<listOptionValue builtIn="false" value="pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED=0"/>
 								</option>
 								<option id="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.warnings.nocommon.1711033944" name="No common (-fno-common)" superClass="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.warnings.nocommon" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std.84952347" name="Language standard" superClass="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std" useByScannerDiscovery="false" value="org.eclipse.cdt.cross.arm.gnu.c.compiler.option.misc.std.c99" valueType="enumerated"/>

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
@@ -46,13 +46,12 @@ afr_mcu_port(compiler)
 #Set defined symbols for compiler and assembler
 set( defined_symbols
      XMC4800_F100x2048
-	 USE_CMDLIB_WITH_RTOS
+     USE_CMDLIB_WITH_RTOS
      MBEDTLS_ECDSA_SIGN_ALT
      MBEDTLS_ECDSA_VERIFY_ALT
      MBEDTLS_ECDH_COMPUTE_SHARED_ALT
      MBEDTLS_ECDH_GEN_PUBLIC_ALT
      PAL_OS_HAS_EVENT_INIT
-	 pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED=0
 )
 
 # Compiler defined symbols.

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -25,7 +25,7 @@
 
 /**
  * @file aws_test_pkcs11_config.h
- * @brief Port-specific variables for PKCS11 tests. 
+ * @brief Port-specific variables for PKCS11 tests.
  */
 #ifndef _AWS_TEST_PKCS11_CONFIG_H_
 #define _AWS_TEST_PKCS11_CONFIG_H_
@@ -36,7 +36,7 @@
  * Each task consumes both stack and heap space, which may cause memory allocation
  * failures if too many tasks are created.
  */
-#define pkcs11testMULTI_THREAD_TASK_COUNT     ( 2 )
+#define pkcs11testMULTI_THREAD_TASK_COUNT             ( 2 )
 
 /**
  * @brief The number of iterations of the test that will run in multithread tests.
@@ -45,7 +45,7 @@
  * boards. Ensure that pkcs11testEVENT_GROUP_TIMEOUT is long enough to accommodate
  * all iterations of the loop.
  */
-#define pkcs11testMULTI_THREAD_LOOP_COUNT     ( 10 )
+#define pkcs11testMULTI_THREAD_LOOP_COUNT             ( 10 )
 
 /**
  * @brief
@@ -53,32 +53,32 @@
  * All tasks of the SignVerifyRoundTrip_MultitaskLoop test must finish within
  * this timeout, or the test will fail.
  */
-#define pkcs11testEVENT_GROUP_TIMEOUT_MS      ( pdMS_TO_TICKS( 1000000UL ) )
+#define pkcs11testEVENT_GROUP_TIMEOUT_MS              ( pdMS_TO_TICKS( 1000000UL ) )
 
 /**
  * @brief The index of the slot that should be used to open sessions for PKCS #11 tests.
  */
-#define pkcs11testSLOT_NUMBER                 ( 0 )
+#define pkcs11testSLOT_NUMBER                         ( 0 )
 
 /*
  * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testRSA_KEY_SUPPORT             ( 0 )
+#define pkcs11testRSA_KEY_SUPPORT                     ( 0 )
 
 /*
  * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testEC_KEY_SUPPORT              ( 1 )
+#define pkcs11testEC_KEY_SUPPORT                      ( 1 )
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT       ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT          ( 0 )
 
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT    ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 1 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.
@@ -87,7 +87,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "0xE0F2"
+#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS    "0xE0F2"
 
 /**
  * @brief The PKCS #11 label for device public key.
@@ -96,7 +96,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "0xF1D2"
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     "0xF1D2"
 
 /**
  * @brief The PKCS #11 label for the device certificate.
@@ -105,7 +105,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS       "0xE0E2"
+#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS    "0xE0E2"
 
 /**
  * @brief The PKCS #11 label for the object to be used for code verification.
@@ -116,7 +116,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_CODE_VERIFICATION_KEY            pkcs11configLABEL_CODE_VERIFICATION_KEY
+#define pkcs11testLABEL_CODE_VERIFICATION_KEY         pkcs11configLABEL_CODE_VERIFICATION_KEY
 
 /**
  * @brief The PKCS #11 label for Just-In-Time-Provisioning.
@@ -129,13 +129,13 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_JITP_CERTIFICATE                 pkcs11configLABEL_JITP_CERTIFICATE
+#define pkcs11testLABEL_JITP_CERTIFICATE              pkcs11configLABEL_JITP_CERTIFICATE
 
 /**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
+#define pkcs11testLABEL_ROOT_CERTIFICATE              pkcs11configLABEL_ROOT_CERTIFICATE
 
 #endif /* _AWS_TEST_PKCS11_CONFIG_H_ */


### PR DESCRIPTION
The purpose of this change is to ensure that the Infineon OPTIGA Trust X projects, including IDE and cmake, set key import policy via the same configuration headers.