### PR TITLE
Link Local Fallback and UDP Verbosity Fixes

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
@@ -995,7 +995,11 @@ size_t xOptionsLength = sizeof( ucDHCPDiscoverOptions );
 		xNetworkAddressing.ulBroadcastAddress = ( xDHCPData.ulOfferedIPAddress & xNetworkAddressing.ulNetMask ) |  ~xNetworkAddressing.ulNetMask;
 
 		/* Close socket to ensure packets don't queue on it. not needed anymore as DHCP failed. but still need timer for ARP testing. */
-		vSocketClose( xDHCPData.xDHCPSocket );
+		if( xDHCPData.xDHCPSocket != NULL )
+		{
+			/* Close socket to ensure packets don't queue on it. */
+			vSocketClose( xDHCPData.xDHCPSocket );
+		}
 		xDHCPData.xDHCPSocket = NULL;
 		xDHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000ul + ( ipconfigRAND32() & 0x3fful ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
@@ -999,8 +999,9 @@ size_t xOptionsLength = sizeof( ucDHCPDiscoverOptions );
 		{
 			/* Close socket to ensure packets don't queue on it. */
 			vSocketClose( xDHCPData.xDHCPSocket );
+		    xDHCPData.xDHCPSocket = NULL;
 		}
-		xDHCPData.xDHCPSocket = NULL;
+
 		xDHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000ul + ( ipconfigRAND32() & 0x3fful ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
 
 		xARPHadIPClash = pdFALSE;	   /* reset flag that shows if have ARP clash. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_1.c
@@ -280,13 +280,14 @@ UBaseType_t uxCount;
 					pxReturn->pxNextBuffer = NULL;
 				}
 				#endif /* ipconfigUSE_LINKED_RX_MESSAGES */
-
+#if( ipconfigUSE_TCP_WIN != 0 )
 				if( xTCPWindowLoggingLevel > 3 )
 				{
 					FreeRTOS_debug_printf( ( "BUF_GET[%ld]: %p (%p)\n",
 						bIsValidNetworkDescriptor( pxReturn ),
 						pxReturn, pxReturn->pucEthernetBuffer ) );
 				}
+#endif
 			}
 			iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
 		}
@@ -390,11 +391,13 @@ BaseType_t xListItemAlreadyInFreeList;
 	{
 		xSemaphoreGive( xNetworkBufferSemaphore );
 		prvShowWarnings();
+#if( ipconfigUSE_TCP_WIN != 0 )
 		if( xTCPWindowLoggingLevel > 3 )
 			FreeRTOS_debug_printf( ( "BUF_PUT[%ld]: %p (%p) (now %lu)\n",
 				bIsValidNetworkDescriptor( pxNetworkBuffer ),
 				pxNetworkBuffer, pxNetworkBuffer->pucEthernetBuffer,
 				uxGetNumberOfFreeNetworkBuffers( ) ) );
+#endif
 	}
 	iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
 }

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_1.c
@@ -280,14 +280,6 @@ UBaseType_t uxCount;
 					pxReturn->pxNextBuffer = NULL;
 				}
 				#endif /* ipconfigUSE_LINKED_RX_MESSAGES */
-#if( ipconfigUSE_TCP_WIN != 0 )
-				if( xTCPWindowLoggingLevel > 3 )
-				{
-					FreeRTOS_debug_printf( ( "BUF_GET[%ld]: %p (%p)\n",
-						bIsValidNetworkDescriptor( pxReturn ),
-						pxReturn, pxReturn->pucEthernetBuffer ) );
-				}
-#endif
 			}
 			iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
 		}
@@ -391,13 +383,6 @@ BaseType_t xListItemAlreadyInFreeList;
 	{
 		xSemaphoreGive( xNetworkBufferSemaphore );
 		prvShowWarnings();
-#if( ipconfigUSE_TCP_WIN != 0 )
-		if( xTCPWindowLoggingLevel > 3 )
-			FreeRTOS_debug_printf( ( "BUF_PUT[%ld]: %p (%p) (now %lu)\n",
-				bIsValidNetworkDescriptor( pxNetworkBuffer ),
-				pxNetworkBuffer, pxNetworkBuffer->pucEthernetBuffer,
-				uxGetNumberOfFreeNetworkBuffers( ) ) );
-#endif
 	}
 	iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
 }


### PR DESCRIPTION
Link Local Fallback and UDP Verbosity Fixes

Description
-----------
- FreeRTOS_DHCP can crash when trying to close a NULL socket
- TCP window debugging messages cause compile problems when TCP is unused

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.