### PR TITLE
Feature/common io

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_cli.c
+++ b/libraries/abstractions/common_io/test/test_iot_cli.c
@@ -46,14 +46,18 @@ ace_status_t runIotTests(int32_t argc, const char** argv) {
 }
 
 const aceCli_moduleCmd_t iot_tests_cli_sub[] = {
-                            {"test", "<num>\n\t0: all\n\t1: uart\n\t2: flash\n\t"
+                            {"test", "<num>\n\t0: all\n\t"
+                            "1: uart <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_AssistedIotUARTReadWriteSync\n\t\t2: AFQP_AssistedIotUARTBaudChange\n\t\t3: AFQP_AssistedIotUARTReadWriteAsync\n\t"
+                            "2: flash\n\t"
                             "3: wdog <num> \n\t\t0: All Non-Reset tests\n\t\t1: Bite-Reset test\n\t\t2: ResetReason Test\n\t"
                             "4: rtc\n\t"
                             "5: gpio <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_AssistedIotGpioModeWritePushPullTrue\n\t\t2: AFQP_AssistedIotGpioModeWritePushPullFalse\n\t\t3: AFQP_AssistedIotGpioModeWriteOpenDrainTrue\n\t\t4: AFQP_AssistedIotGpioModeWriteOpenDrainFalse\n\t\t5: AFQP_AssistedIotGpioModeReadTrue\n\t\t6: AFQP_AssistedIotGpioModeReadFalse\n\t"
                             "6: timer\n\t"
                             "7: adc <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_IotAdcPrintReadSample\n\t"
                             "8: reset <num>\n\t\t0: Shutdown\n\t\t1: RebootZero\n\t\t2: RebootNonZero"
-                            "\n\t9: perfcounter\n\t10: pwm\n\t11: i2c\n\t12: tsensor\n\t13: power\n\t14: battery"
+                            "\n\t9: perfcounter\n\t10: pwm\n\t11: i2c\n\t12: tsensor"
+                            "\n\t13: power <num>\n\t\t0: All tests excludes VddOff test\n\t\t1: Run VddOff test"
+                            "\n\t14: battery"
                             "\n\t15: efuse\n\t"
                             "16: spi <num> \n\t\t0: All Independent tests\n\t\t1: Read Sync Master\n\t\t"
                             "2: Write Sync Master\n\t\t3: Transfer Sync Master\n\t\t4: Read ASync Master\n\t\t"

--- a/libraries/abstractions/common_io/test/test_iot_main.c
+++ b/libraries/abstractions/common_io/test/test_iot_main.c
@@ -42,13 +42,30 @@
 /* Board config includes. */
 #include "test_iot_internal.h"
 
-static void RUN_TEST_IOT_UART(void)
+static void RUN_TEST_IOT_UART(int testCaseIndex)
 {
     int i;
     for(i = 0; i < UART_TEST_SET; i++)
     {
         SET_TEST_IOT_UART_CONFIG(i);
-        RUN_TEST_GROUP( TEST_IOT_UART );
+            switch (testCaseIndex)
+            {
+                case 0:
+                    RUN_TEST_GROUP( TEST_IOT_UART );
+                    break;
+                case 1:
+                    RUN_TEST_CASE( TEST_IOT_UART, AFQP_AssistedIotUARTWriteReadSync );
+                    break;
+                case 2:
+                    RUN_TEST_CASE( TEST_IOT_UART, AFQP_AssistedIotUARTBaudChange );
+                    break;
+                case 3:
+                    RUN_TEST_CASE( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync );
+                    break;
+                default:
+                    printf("Invalid UART test case\n");
+                    return;
+        }
     }
 }
 
@@ -494,7 +511,7 @@ void RunIotTests(int testIndex, int testCaseIndex)
             RUN_TEST_IOT_ALL_GROUP();
             break;
         case 1:
-            RUN_TEST_IOT_UART();
+            RUN_TEST_IOT_UART(0);
             break;
         case 2:
             RUN_TEST_IOT_FLASH();

--- a/libraries/abstractions/common_io/test/test_iot_spi.c
+++ b/libraries/abstractions/common_io/test/test_iot_spi.c
@@ -38,6 +38,7 @@
 
 /* Driver includes */
 #include "iot_spi.h"
+#include "test_iot_internal.h"
 
 /* FreeRTOS includes */
 #include "FreeRTOS.h"

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -39,29 +39,32 @@
 
 /*-----------------------------------------------------------*/
 /* Test Defines */
-#define testIotUART_DEFAULT_SEMPAHORE_DELAY            ( 5000 )                                                       /** Amount of time a function waits for every callback to finish. */
+#define testIotUART_DEFAULT_SEMPAHORE_DELAY            ( 60 )                                                       /** Amount of time a function waits for every callback to finish. */
 #define testIotUART_TEST_BAUD_RATE                     ( 38400 )                                                    /** Alternative baud rate to test. */
 #define testIotUART_TEST_BAUD_RATE_DEFAULT             ( IOT_UART_BAUD_RATE_DEFAULT )                               /** Default baud rate. */
 #define testIotUART_BAUD_RATE_STRING                   ( "Baudrate: 38400\n" )                                      /** Signal external device to change to different baudrate. */
 #define testIotUART_BAUD_RATE_DEFAULT_STRING           ( "Baudrate: 115200\n" )                                     /** Signal external device to revert back to default baudrate. */
 #define testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH       ( sizeof( testIotUART_BAUD_RATE_STRING ) - 1 )
 #define testIotUART_BAUD_RATE_BUFFER_DEFAULT_LENGTH    ( sizeof( testIotUART_BAUD_RATE_DEFAULT_STRING ) - 1 )
-#define testIotUART_WRITE_BUFFER_STRING                ( "Test for write async\n" )
-#define testIotUART_READ_BUFFER_STRING                 ( "Test for read async\n" )
-#define testIotUART_WRITE_BUFFER_LENGTH                ( sizeof( testIotUART_WRITE_BUFFER_STRING ) - 1 )
-#define testIotUART_READ_BUFFER_LENGTH                 ( sizeof( testIotUART_READ_BUFFER_STRING ) - 1 )
-#define testBufferSize                                 32
+#define testIotUART_BUFFER_STRING                      ( "Test for UART read-write\n" )
+#define testIotUART_BUFFER_LENGTH                      ( sizeof( testIotUART_BUFFER_STRING ) - 1 )
+
+#define testIotUART_BAUD_RATE_FAST             ( 115200 )
+#define testIotUART_BAUD_RATE_SLOW             ( 9600 )
+#define testIotUARTBUFFERSIZE                  ( 32 )
+#define testIotUART_BUFFER_LENGTH_LARGE        ( 200 )
+#define testIotUART_DELAY                      ( 1000 )
 /*-----------------------------------------------------------*/
 
 /*-----------------------------------------------------------*/
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint8_t ustestIotUartPort = 0;         /** Default UART port for testing */
-uint32_t ultestIotUartFlowControl = 0; /** Default UART flow control for testing */
-uint32_t ultestIotUartParity = 0;      /** Default UART parity for testing */
-uint32_t ultestIotUartWordLength = 0;  /** Default UART port for testing */
-uint32_t ultestIotUartStopBits = 0;    /** Default UART stop bits for testing */
+uint8_t ustestIotUartPort = 0; /** Default UART port for testing */
+uint32_t ultestIotUartFlowControl = 0;
+uint32_t ultestIotUartParity = 0;
+uint32_t ultestIotUartWordLength = 0;
+uint32_t ultestIotUartStopBits = 0;
 
 /*-----------------------------------------------------------*/
 /* Static Globals */
@@ -70,7 +73,19 @@ static SemaphoreHandle_t xtestIotUARTSemaphore = NULL;
 static StaticSemaphore_t xtestIotUARTCompleted;
 
 /**
- * @brief Application/POSIX defined callback for asynchronous read/write operation on
+ * This function sets the fast Baud rate.
+ */
+static  void    iot_uart_fast_setting(IotUARTConfig_t *pxConfig)
+{
+    pxConfig->ulBaudrate   = testIotUART_BAUD_RATE_FAST;
+    pxConfig->ulFlowControl= 0;
+    pxConfig->ulParity     = 0;
+    pxConfig->ulStopbits   = 0;
+    pxConfig->ulWordlength = 3;
+}
+
+/**
+ * @brief Application/POSIX defined callback for asynchronous write operation on
  * UART for testing the loopback function.
  * This callback function releases a semaphore every time it is called.
  */
@@ -79,15 +94,17 @@ static void prvReadWriteCallback( IotUARTOperationStatus_t xOpStatus,
 {
     BaseType_t xHigherPriorityTaskWoken;
 
-    TEST_ASSERT_EQUAL( ( xOpStatus ), eUartCompleted );
+    TEST_ASSERT_EQUAL( (xOpStatus), eUartCompleted );
     TEST_ASSERT_EQUAL( pvParams, NULL );
     xSemaphoreGiveFromISR( xtestIotUARTSemaphore, &xHigherPriorityTaskWoken );
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
+
 /*-----------------------------------------------------------*/
 
 /* Define Test Group. */
 TEST_GROUP( TEST_IOT_UART );
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -95,7 +112,10 @@ TEST_GROUP( TEST_IOT_UART );
  */
 TEST_SETUP( TEST_IOT_UART )
 {
+    xtestIotUARTSemaphore = xSemaphoreCreateCountingStatic( 10, 0, &xtestIotUARTCompleted );
+    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotUARTSemaphore );
 }
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -104,32 +124,367 @@ TEST_SETUP( TEST_IOT_UART )
 TEST_TEAR_DOWN( TEST_IOT_UART )
 {
 }
-/*-----------------------------------------------------------*/
 
+/*-----------------------------------------------------------*/
 /**
  * @brief Function to define which tests to execute as part of this group.
  */
 TEST_GROUP_RUNNER( TEST_IOT_UART )
 {
-    xtestIotUARTSemaphore = xSemaphoreCreateCountingStatic( 10, 0, &xtestIotUARTCompleted );
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotUARTSemaphore );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_IoctlFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_ReadSyncFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_ReadAsyncFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_WriteSyncFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_WriteAsyncFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUART_OpenCloseCancelFuzzing );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteReadSync );
     RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback );
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy ) ;
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTBaudChange ) ;
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet ) ;
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlGetRxTxBytes ) ;
-    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTCancel ) ;
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlFuzzing );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTReadSyncFuzzing );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTReadAsyncFuzzing );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteSyncFuzzing );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteAsyncFuzzing );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTCancel );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy )
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTWriteSyncReadAsyncLoopbackTest );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet );
+    RUN_TEST_CASE( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing );
 }
 /*-----------------------------------------------------------*/
 
+/*-----------------------------------------------------------*/
 /**
+ * hardware loopback. The Tx and Rx pin on the vendor board are shorted with a
+ * connector and the test is run by transmitting some bytes on write sync and checking
+ * if same characters are read synchronously.
+ */
+TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteReadSync )
+{
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+    uint8_t cpBufferRead[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+    IotUARTHandle_t xUartHandle;
+    int32_t lRead, lWrite, lClose;
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        lRead = iot_uart_read_sync( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+
+        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to check UART Ioctl API specifications.
+ */
+TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lClose, lTransferAmount;
+    IotUARTConfig_t pvgetConfigBuffer, pvConfigBuffer, pvOriginalConfig;
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+
+        /* Save original UART config */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvOriginalConfig );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_NOT_EQUAL( testIotUART_TEST_BAUD_RATE, pvOriginalConfig.ulBaudrate );
+        TEST_ASSERT_NOT_EQUAL( testIotUART_TEST_BAUD_RATE, pvgetConfigBuffer.ulBaudrate );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        /* Test changing baudrate config */
+        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE;
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvgetConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_EQUAL( testIotUART_TEST_BAUD_RATE, pvgetConfigBuffer.ulBaudrate );
+
+        /* Test changing control flow config */
+        pvConfigBuffer.ulFlowControl = ultestIotUartFlowControl;
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartFlowControl, pvOriginalConfig.ulFlowControl );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartFlowControl, pvgetConfigBuffer.ulFlowControl );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvgetConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_EQUAL( ultestIotUartFlowControl, pvgetConfigBuffer.ulFlowControl );
+
+        /* Test changing stop bit config */
+        pvConfigBuffer.ulStopbits = ultestIotUartStopBits;
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartStopBits, pvOriginalConfig.ulStopbits );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartStopBits, pvgetConfigBuffer.ulStopbits );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvgetConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_EQUAL( ultestIotUartStopBits, pvgetConfigBuffer.ulStopbits );
+
+        /* Test changing Wordlength config */
+        pvConfigBuffer.ulWordlength = ultestIotUartWordLength;
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartWordLength, pvOriginalConfig.ulWordlength );
+        TEST_ASSERT_NOT_EQUAL( ultestIotUartWordLength, pvgetConfigBuffer.ulWordlength );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvgetConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_EQUAL( ultestIotUartWordLength, pvgetConfigBuffer.ulWordlength );
+
+        /* Set config back to original */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvOriginalConfig );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        /* Getting transfer byte amount only works on an operation in flight. */
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetRxNoOfbytes, &lTransferAmount );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to check if UART can be configured to a different baudrate.
+ *  Works by signal external device to change to a new baudrate. Sending and recieving a message.
+ *  Then signals to return back to default baudrate.
+ *-----------------------------------------------------------*/
+ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTBaudChange )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lWrite, lRead, lClose;
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+    uint8_t cpBufferRead[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_STRING, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        /* Signal other device to change to new baudrate */
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        IotUARTConfig_t pvConfigBuffer;
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE;
+
+        /* Configure a different baudrate */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        /* Wait for other UART to change baudrate. */
+        vTaskDelay( pdMS_TO_TICKS( testIotUART_DELAY ) );
+
+        memset( cpBuffer, 0, testIotUARTBUFFERSIZE );
+        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        lRead = iot_uart_read_sync( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+
+        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
+
+        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_DEFAULT_STRING, testIotUART_BAUD_RATE_BUFFER_DEFAULT_LENGTH );
+
+        /* Signal other device to revert to original baudrate */
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BAUD_RATE_BUFFER_DEFAULT_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT;
+
+        /* Reset baudrate back to default */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &pvConfigBuffer );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+        /* Wait for other UART to change baudrate. */
+        vTaskDelay( pdMS_TO_TICKS( testIotUART_DELAY ) );
+
+        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        lRead = iot_uart_read_sync( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+
+        /* Baudrate reverted succesfully */
+        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test function to test the asynchronous read/write with UART by doing a
+ * hardware loopback. The Tx and Rx pin on the vendor board are shorted with a
+ * connector and the test is run by transmitting some bytes on write async and checking
+ * if same characters are read asynchronously.
+ * This test also checks if we are getting Tx bytes in flight.
+ */
+TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lWrite, lClose, lRead, lTransferAmount;
+
+    uint8_t cpBuffer[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
+    uint8_t cpBufferRead[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
+    uint8_t uStringCompare = 1;
+
+    strncpy( (char*)cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_GREATER_THAN( 0, lTransferAmount  );
+
+        lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+
+        /* Delay for 1 sec. */
+        vTaskDelay(testIotUART_DELAY);
+
+        uStringCompare = memcmp( cpBuffer, cpBufferRead, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( 0, uStringCompare );
+    }
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * This is Assisted Test function to test the asynchronous read/write with UART by doing a
+ * loopback with RPI3. The Tx and Rx pin on the vendor board are connected to RX and TX of
+ * RPI3. Test is run by transmitting some bytes on write async and checking
+ * if same characters are read asynchronously on RPI3. Validation happens on RPI3
+ * This test also checks if we are getting Tx bytes in flight.
+ */
+TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lWrite, lClose, lRead, lTransferAmount_1, lTransferAmount_2;
+    uint8_t i;
+    uint8_t cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE + 1 ] = { 0 };
+    uint8_t cpBufferRead[ testIotUART_BUFFER_LENGTH_LARGE + 1 ] = { 0 };
+    uint8_t uStringCompare = 1;
+
+    for (i = 0; i < testIotUART_BUFFER_LENGTH_LARGE; i++)
+    {
+        cpBufferLarge[i] = 0xAA;
+    }
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lWrite = iot_uart_write_async( xUartHandle, cpBufferLarge, testIotUART_BUFFER_LENGTH_LARGE );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount_1 );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_GREATER_THAN( 0, lTransferAmount_1  );
+
+        /* Delay for 1 sec. */
+        vTaskDelay(testIotUART_DELAY);
+
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount_2 );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+        TEST_ASSERT_GREATER_THAN( lTransferAmount_1, lTransferAmount_2  );
+
+        /* Delay for 1 sec. */
+        vTaskDelay(testIotUART_DELAY);
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test function to test the asynchronous read/write with UART by doing a
+ * hardware loopback. The Tx and Rx pin on the vendor board are shorted with a
+ * connector and the test is run by transmitting some bytes on write sync and checking
+ * if same characters are read asynchronously.
+ * This test also checks if we are getting Rx bytes in flight.
+ */
+TEST( TEST_IOT_UART, AFQP_IotUARTWriteSyncReadAsyncLoopbackTest )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lWrite, lClose, lRead, lTransferAmount;
+    BaseType_t xCallbackReturn;
+
+    uint8_t cpBuffer[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
+    uint8_t cpBufferRead[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
+    uint8_t uStringCompare = 1;
+
+    strncpy( (char*)cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+    iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
+
+    lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+
+    xCallbackReturn = xSemaphoreTake( xtestIotUARTSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+    TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
+
+    lIoctl = iot_uart_ioctl( xUartHandle, eGetRxNoOfbytes, &lTransferAmount );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
+
+    uStringCompare = memcmp( cpBuffer, cpBufferRead, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( 0, uStringCompare );
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*
  * @brief Test function to test the asynchronous read with UART by doing a
  * hardware loopback. The Tx and Rx pin on the vendor board are shorted with a
  * connector and the test is run by transmitting some bytes on write async and checking
@@ -137,73 +492,267 @@ TEST_GROUP_RUNNER( TEST_IOT_UART )
  */
 TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
 {
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-    uint8_t cpBufferRead[ testBufferSize ] = { 0 };
+    IotUARTHandle_t xUartHandle;
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+    uint8_t cpBufferRead[ testIotUARTBUFFERSIZE ] = { 0 };
 
-    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_READ_BUFFER_STRING, testIotUART_READ_BUFFER_LENGTH );
-    IotUARTHandle_t xOpen;
+    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     int32_t lRead, lWrite, lClose;
     BaseType_t xCallbackReturn;
     uint8_t ucPort = ustestIotUartPort;
 
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
+    xUartHandle = iot_uart_open( ucPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
     {
-        iot_uart_set_callback( xOpen, prvReadWriteCallback, NULL );
+        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
 
-        lWrite = iot_uart_write_async( xOpen, cpBuffer, testIotUART_READ_BUFFER_LENGTH );
+        lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
         xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
         TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
-        lRead = iot_uart_read_async( xOpen, cpBufferRead, testIotUART_READ_BUFFER_LENGTH );
+        lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
 
         xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
         TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
-        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_READ_BUFFER_LENGTH ) );
+        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
     }
 
-    lClose = iot_uart_close( xOpen );
+    lClose = iot_uart_close( xUartHandle );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 }
 /*-----------------------------------------------------------*/
 
+/*-----------------------------------------------------------*/
 /**
- * hardware loopback. The Tx and Rx pin on the vendor board are shorted with a
- * connector and the test is run by transmitting some bytes on write sync and checking
- * if same characters are read synchronously.
- */
-TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadSync )
+ * @brief Test Function to test iot_uart_cancel
+ *
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
 {
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-    uint8_t cpBufferRead[ testBufferSize ] = { 0 };
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lWrite, lClose, lCancel;
+    BaseType_t xCallbackReturn;
 
-    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_WRITE_BUFFER_STRING, testIotUART_WRITE_BUFFER_LENGTH );
-    IotUARTHandle_t xOpen;
-    int32_t lRead, lWrite, lClose;
-    uint8_t ucPort = ustestIotUartPort;
+    uint8_t cSmallBuf[ 2 ] = { 'H', 'I' };
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+    uint8_t uSmallBuflen = sizeof ( cSmallBuf ) / sizeof ( uint8_t );
 
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
+    strncpy( (char*)cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
     if( TEST_PROTECT() )
     {
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
+        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
+
+        lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
-        lRead = iot_uart_read_sync( xOpen, cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
+        lCancel = iot_uart_cancel( xUartHandle );
+        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lCancel );
 
-        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH ) );
+        /* Wait to make sure operation was really canceled. */
+        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdFALSE, xCallbackReturn );
     }
 
-    lClose = iot_uart_close( xOpen );
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    lWrite = iot_uart_write_async( xUartHandle, cSmallBuf, uSmallBuflen );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
+
+    /* Since  cSmallBuf is small buffer, write is already complete. Hence nothing to cancel */
+    lCancel = iot_uart_cancel( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_NOTHING_TO_CANCEL, lCancel );
+
+    lClose = iot_uart_close( xUartHandle );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 }
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to fuzz iot_uart_write_async
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncFuzzing )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lClose, lWrite;
+
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    strncpy( (char*)cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+    lWrite = iot_uart_write_async( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lWrite = iot_uart_write_async( xUartHandle, NULL, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+
+        lWrite = iot_uart_write_async( xUartHandle, cpBuffer, 0 );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to fuzz iot_uart_write_sync
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTWriteSyncFuzzing )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lClose, lWrite;
+
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    strncpy( (char*)cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
+
+    lWrite = iot_uart_write_sync( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lWrite = iot_uart_write_sync( xUartHandle, NULL, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+
+        lWrite = iot_uart_write_sync( xUartHandle, cpBuffer, 0 );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to fuzz iot_uart_read_async
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTReadAsyncFuzzing )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lClose, lRead;
+
+    uint8_t cpBufferRead[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    lRead = iot_uart_read_async( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lRead = iot_uart_read_async( xUartHandle, NULL, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+
+        lRead = iot_uart_read_async( xUartHandle, cpBufferRead, 0 );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Test Function to fuzz iot_uart_read_sync
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTReadSyncFuzzing )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lClose, lRead;
+
+    uint8_t cpBufferRead[ testIotUARTBUFFERSIZE ] = { 0 };
+
+    lRead = iot_uart_read_sync( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
+    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        lRead = iot_uart_read_sync( xUartHandle, NULL, testIotUART_BUFFER_LENGTH );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+
+        lRead = iot_uart_read_sync( xUartHandle, cpBufferRead, 0 );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
+/*-----------------------------------------------------------*/
+ /* @brief Test Function to fuzz iot_uart_ioctl
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTIoctlFuzzing )
+{
+    IotUARTHandle_t xUartHandle;
+    int32_t lIoctl, lClose;
+    IotUARTConfig_t xUartConfigTest;
+
+    /* Call iot_uart_ioctl with NULL handle. Expect IOT_UART_INVALID_VALUE */
+    lIoctl = iot_uart_ioctl( NULL, eUartSetConfig, &xUartConfigTest);
+    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
+
+    if( TEST_PROTECT() )
+    {
+        /* Call iot_uart_ioctl with valid handle, but with invalid enum (-1) request.Expect IOT_UART_INVALID_VALUE */
+        lIoctl = iot_uart_ioctl( xUartHandle, -1, &xUartConfigTest );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+        /* Call iot_uart_ioctl with enum eUartSetConfig, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, NULL );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+        /* Call iot_uart_ioctl with enum eUartGetConfig, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartGetConfig, NULL );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+        /* Call iot_uart_ioctl with enum eGetTxNoOfbytes, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, NULL );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+
+        /* Call iot_uart_ioctl with enum eGetRxNoOfbytes, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
+        lIoctl = iot_uart_ioctl( xUartHandle, eGetRxNoOfbytes, NULL );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
+    }
+
+    lClose = iot_uart_close( xUartHandle );
+    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
+}
+/*-----------------------------------------------------------*/
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -212,458 +761,58 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadSync )
  */
 TEST( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy )
 {
-    IotUARTHandle_t xOpen;
+    IotUARTHandle_t xUartHandle;
     int32_t lIoctl, lWrite, lClose;
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-    uint8_t ucPort = ustestIotUartPort;
+    BaseType_t xCallbackReturn;
+    uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
 
-    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_WRITE_BUFFER_STRING, testIotUART_WRITE_BUFFER_LENGTH );
+    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     IotUARTConfig_t xUartConfig = { .ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT };
 
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
     {
-        lWrite = iot_uart_write_async( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
+        lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &xUartConfig );
+        lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &xUartConfig );
         TEST_ASSERT_EQUAL( IOT_UART_BUSY, lIoctl );
     }
 
-    lClose = iot_uart_close( xOpen );
+    lClose = iot_uart_close( xUartHandle );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 }
 /*-----------------------------------------------------------*/
 
-/**
- * @brief Test Function to check if UART can be configured to a different baudrate.
- *  Works by signal external device to change to a new baudrate. Sending and recieving a message.
- *  Then signals to return back to default baudrate.
- */
-TEST( TEST_IOT_UART, AFQP_IotUARTBaudChange )
-{
-    IotUARTHandle_t xOpen;
-    int32_t lIoctl, lWrite, lRead, lClose;
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-    uint8_t cpBufferRead[ testBufferSize ] = { 0 };
-
-    uint8_t ucPort = ustestIotUartPort;
-
-    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_STRING, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        /* Signal other device to change to new baudrate */
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        IotUARTConfig_t pvConfigBuffer;
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE;
-
-        /* Configure a different baudrate */
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        /* Wait for other UART to change baudrate. */
-        vTaskDelay( pdMS_TO_TICKS( 1000 ) );
-
-        memset( cpBuffer, 0, testBufferSize );
-        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_WRITE_BUFFER_STRING, testIotUART_WRITE_BUFFER_LENGTH );
-
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        lRead = iot_uart_read_sync( xOpen, cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
-
-        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH ) );
-
-        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_DEFAULT_STRING, testIotUART_BAUD_RATE_BUFFER_DEFAULT_LENGTH );
-
-        /* Signal other device to revert to original baudrate */
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, testIotUART_BAUD_RATE_BUFFER_DEFAULT_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT;
-
-        /* Reset baudrate back to default */
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        /* Wait for other UART to change baudrate. */
-        vTaskDelay( pdMS_TO_TICKS( 1000 ) );
-
-        strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_WRITE_BUFFER_STRING, testIotUART_WRITE_BUFFER_LENGTH );
-
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        lRead = iot_uart_read_sync( xOpen, cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
-
-        /* Baudrate reverted succesfully */
-        TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_WRITE_BUFFER_LENGTH ) );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
 /*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to check UART Ioctl API specifications.
- */
-TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
+ /* @brief Test Function to fuzz iot_uart_open and iot_uart_close
+*-----------------------------------------------------------*/
+TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
 {
-    IotUARTHandle_t xOpen;
-    int32_t lIoctl, lClose, lTransferAmount;
-    IotUARTConfig_t pvConfigBuffer, pvOriginalConfig;
-    uint8_t ucPort = ustestIotUartPort;
-
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        /* Save original UART config */
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvOriginalConfig );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        /* Test changing baudrate config */
-        pvConfigBuffer.ulBaudrate = testIotUART_TEST_BAUD_RATE;
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        TEST_ASSERT_EQUAL( testIotUART_TEST_BAUD_RATE, pvConfigBuffer.ulBaudrate );
-
-        /* Test changing control flow config */
-        pvConfigBuffer.ulFlowControl = ultestIotUartFlowControl;
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        TEST_ASSERT_EQUAL( ultestIotUartFlowControl, pvConfigBuffer.ulFlowControl );
-
-        /* Test changing stop bit config */
-        pvConfigBuffer.ulStopbits = ultestIotUartStopBits;
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        TEST_ASSERT_EQUAL( ultestIotUartStopBits, pvConfigBuffer.ulStopbits );
-
-        /* Test changing stop bit config */
-        pvConfigBuffer.ulWordlength = ultestIotUartWordLength;
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, &pvConfigBuffer );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-        TEST_ASSERT_EQUAL( ultestIotUartWordLength, pvConfigBuffer.ulWordlength );
-
-        /* Set config back to original */
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, &pvOriginalConfig );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        lIoctl = iot_uart_ioctl( xOpen, eGetTxNoOfbytes, &lTransferAmount );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        lIoctl = iot_uart_ioctl( xOpen, eGetRxNoOfbytes, &lTransferAmount );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to check if getting Tx and Rx bytes in flight.
- */
-TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetRxTxBytes )
-{
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-
-    strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_WRITE_BUFFER_STRING, testIotUART_WRITE_BUFFER_LENGTH );
-    IotUARTHandle_t xOpen;
-    int32_t lWrite, lClose, lTransferAmount, lIoctl;
-    BaseType_t xCallbackReturn;
-    uint8_t ucPort = ustestIotUartPort;
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        lWrite = iot_uart_write_async( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        lIoctl = iot_uart_ioctl( xOpen, eGetTxNoOfbytes, &lTransferAmount );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-
-        /* Need to assure that write operation finishes before calling read. */
-        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
-
-        lWrite = iot_uart_read_async( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        lIoctl = iot_uart_ioctl( xOpen, eGetRxNoOfbytes, &lTransferAmount );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to cancel an asynchronous operation in flight.
- */
-TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
-{
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-
-    IotUARTHandle_t xOpen;
-    int32_t lWrite, lCancel, lClose;
-    uint8_t ucPort = ustestIotUartPort;
-    BaseType_t xCallbackReturn;
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        iot_uart_set_callback( xOpen, prvReadWriteCallback, NULL );
-
-        lWrite = iot_uart_write_async( xOpen, cpBuffer, testIotUART_WRITE_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
-
-        lCancel = iot_uart_cancel( xOpen );
-        TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lCancel );
-
-        /* Wait to make sure operation was really canceled. */
-        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
-        TEST_ASSERT_EQUAL( pdFALSE, xCallbackReturn );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_write_async
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_WriteAsyncFuzzing )
-{
-    IotUARTHandle_t xOpen;
-    uint8_t ucPort = ustestIotUartPort;
-    int32_t lClose, lWrite;
-
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-
-    strncpy( cpBuffer, testIotUART_READ_BUFFER_STRING, testIotUART_READ_BUFFER_LENGTH );
-
-    lWrite = iot_uart_write_async( NULL, cpBuffer, testIotUART_READ_BUFFER_LENGTH );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-    
-    if( TEST_PROTECT() )
-    {
-        lWrite = iot_uart_write_async( xOpen, NULL, testIotUART_READ_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-
-        lWrite = iot_uart_write_async( xOpen, cpBuffer, 0 );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_write_sync
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_WriteSyncFuzzing )
-{
-    IotUARTHandle_t xOpen;
-    uint8_t ucPort = ustestIotUartPort;
-    int32_t lClose, lWrite;
-
-    uint8_t cpBuffer[ testBufferSize ] = { 0 };
-
-    strncpy( cpBuffer, testIotUART_READ_BUFFER_STRING, testIotUART_READ_BUFFER_LENGTH );
-
-    lWrite = iot_uart_write_sync( NULL, cpBuffer, testIotUART_READ_BUFFER_LENGTH );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        lWrite = iot_uart_write_sync( xOpen, NULL, testIotUART_READ_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-
-        lWrite = iot_uart_write_sync( xOpen, cpBuffer, 0 );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
-    }
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_read_async
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_ReadAsyncFuzzing )
-{
-    IotUARTHandle_t xOpen;
-    uint8_t ucPort = ustestIotUartPort;
-    int32_t lClose, lRead;
-
-    uint8_t cpBufferRead[ 32 ] = { 0 };
-
-    lRead = iot_uart_read_async( NULL, cpBufferRead, testIotUART_READ_BUFFER_LENGTH );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        lRead = iot_uart_read_async( xOpen, NULL, testIotUART_READ_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-
-        lRead = iot_uart_read_async( xOpen, cpBufferRead, 0 );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_read_sync
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_ReadSyncFuzzing )
-{
-    IotUARTHandle_t xOpen;
-    uint8_t ucPort = ustestIotUartPort;
-    int32_t lClose, lRead;
-
-    uint8_t cpBufferRead[ 32 ] = { 0 };
-
-    lRead = iot_uart_read_sync( NULL, cpBufferRead, testIotUART_READ_BUFFER_LENGTH );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        lRead = iot_uart_read_sync( xOpen, NULL, testIotUART_READ_BUFFER_LENGTH );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-
-        lRead = iot_uart_read_sync( xOpen, cpBufferRead, 0 );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
-    }
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_ioctl
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_IoctlFuzzing )
-{
-    IotUARTHandle_t xOpen;
-    int32_t lIoctl, lClose;
-    uint8_t ucPort = ustestIotUartPort;
-    IotUARTConfig_t localUARTconfig_test;
-
-    /* Call iot_uart_ioctl with NULL handle. Expect IOT_UART_INVALID_VALUE */
-    lIoctl = iot_uart_ioctl( NULL, eUartSetConfig, &localUARTconfig_test );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
-
-    if( TEST_PROTECT() )
-    {
-        /* Call iot_uart_ioctl with valid handle, but with invalid enum (-1) request.Expect IOT_UART_INVALID_VALUE */
-        lIoctl = iot_uart_ioctl( xOpen, -1, &localUARTconfig_test );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-
-        /* Call iot_uart_ioctl with enum eUartSetConfig, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
-        lIoctl = iot_uart_ioctl( xOpen, eUartSetConfig, NULL );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-
-        /* Call iot_uart_ioctl with enum eUartGetConfig, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
-        lIoctl = iot_uart_ioctl( xOpen, eUartGetConfig, NULL );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-
-        /* Call iot_uart_ioctl with enum eGetTxNoOfbytes, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
-        lIoctl = iot_uart_ioctl( xOpen, eGetTxNoOfbytes, NULL );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-
-        /* Call iot_uart_ioctl with enum eGetRxNoOfbytes, and NULL buffer.Expect IOT_UART_INVALID_VALUE */
-        lIoctl = iot_uart_ioctl( xOpen, eGetRxNoOfbytes, NULL );
-        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
-    }
-
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Test Function to fuzz iot_uart_open,
- * iot_uart_cancel and iot_uart_close
- *-----------------------------------------------------------*/
-TEST( TEST_IOT_UART, AFQP_IotUART_OpenCloseCancelFuzzing )
-{
-    IotUARTHandle_t xOpen, xOpen2;
+    IotUARTHandle_t xUartHandle_1, xUartHandle_2, xUartHandle_3;
     int32_t lClose, lCancel;
-    uint8_t ucPort = ustestIotUartPort;
 
-    xOpen = iot_uart_open( -1 );
-    TEST_ASSERT_EQUAL( NULL, xOpen );
+    xUartHandle_1 = iot_uart_open( -1 );
+    TEST_ASSERT_EQUAL( NULL, xUartHandle_1 );
 
     lClose = iot_uart_close( NULL );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lClose );
 
-    xOpen = iot_uart_open( ucPort );
-    TEST_ASSERT_NOT_EQUAL( NULL, xOpen );
+    xUartHandle_2 = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle_2 );
 
-    xOpen2 = iot_uart_open( ucPort );
-    TEST_ASSERT_EQUAL( NULL, xOpen2 );
+    xUartHandle_3 = iot_uart_open( ustestIotUartPort );
+    TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
 
     lCancel = iot_uart_cancel( NULL );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lCancel );
 
-    lClose = iot_uart_close( xOpen );
+    lClose = iot_uart_close( xUartHandle_2 );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 
-    lClose = iot_uart_close( xOpen );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lClose );
+    lClose = iot_uart_close( xUartHandle_2 );
+    TEST_ASSERT_EQUAL( NULL, lClose );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
FWPLATFORM-1251: MTK Test Failure:SPI tests fail since we are using same SPI instance for STARLITE and MTK. [1/1]

Description
-----------
Adding "test_iot_internal.h" to includes, to make the SPI instance configurable, respective to boards.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.