### PR TITLE
Modify PKCS #11 GenerateRandom to return entropy & CRYPTO layer to ma…

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3789,10 +3789,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     return xResult;
 }
 
-extern int renamed_mbedtls_hardware_poll( void * data,
-                                          unsigned char * output,
-                                          size_t len,
-                                          size_t * olen );
+extern int ulPortGetEntropyFromHardware( void * data,
+                                         unsigned char * output,
+                                         size_t len,
+                                         size_t * olen );
 
 /**
  * @brief Generate cryptographically random bytes.
@@ -3825,7 +3825,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( xResult == CKR_OK )
     {
-        lMbedResult = renamed_mbedtls_hardware_poll( NULL, pucRandomData, ulRandomLen, &olen );
+        lMbedResult = ulPortGetEntropyFromHardware( NULL, pucRandomData, ulRandomLen, &olen );
     }
 
     if( ( lMbedResult != 0 ) || ( olen != ulRandomLen ) )

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3856,6 +3856,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
                                                    &pucRandomData[ totalBytes ],
                                                    ulRandomLen - totalBytes,
                                                    &olen );
+
+            if( lResult != 0 )
+            {
+                break;
+            }
+
             totalBytes += olen;
             lLoops++;
         }

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3869,7 +3869,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( ( lResult != 0 ) || ( totalBytes != ulRandomLen ) )
     {
-        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes %d\r\n ", lResult, olen ) );
+        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes Generated %d, Bytes Requested %d\r\n ", lResult, olen, ulRandomLen) );
         xResult = CKR_FUNCTION_FAILED;
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3864,6 +3864,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
             totalBytes += olen;
             lLoops++;
+            PKCS11_PRINT(("loop#: %d, requested bytes: %d, total bytes: %d, olen: %d\r\n", lLoops, ulRandomLen, totalBytes, olen));
+            vPortDelay(100);
         }
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3830,7 +3830,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( ( lResult != 0 ) || ( olen != ulRandomLen ) )
     {
-        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes %d\r\n ", lResult, olen ) )
+        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes %d\r\n ", lResult, olen ) );
         xResult = CKR_FUNCTION_FAILED;
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3864,8 +3864,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
             totalBytes += olen;
             lLoops++;
-            PKCS11_PRINT(("loop#: %d, requested bytes: %d, total bytes: %d, olen: %d\r\n", lLoops, ulRandomLen, totalBytes, olen));
-            vPortDelay(100);
         }
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3864,6 +3864,13 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
             totalBytes += olen;
             lLoops++;
+
+            /* If no entropy was returned, give the hardware time
+             * to generate additional entropy. */
+            if( olen == 0 )
+            {
+                vTaskDelay( 1 );
+            }
         }
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3869,7 +3869,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( ( lResult != 0 ) || ( totalBytes != ulRandomLen ) )
     {
-        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes Generated %d, Bytes Requested %d\r\n ", lResult, olen, ulRandomLen) );
+        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes Generated %d, Bytes Requested %d\r\n ", lResult, olen, ulRandomLen ) );
         xResult = CKR_FUNCTION_FAILED;
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3069,7 +3069,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE xSession,
                                                       ulDataLen,
                                                       pxSignatureBuffer,
                                                       ( size_t * ) &xExpectedInputLength,
-                                                      CRYPTO_GenerateRandomBytesMbedTls,
+                                                      CRYPTO_GetRandomBytes,
                                                       NULL );
 
                     if( lMbedTLSResult != CKR_OK )
@@ -3728,7 +3728,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     {
         if( 0 != mbedtls_ecp_gen_key( MBEDTLS_ECP_DP_SECP256R1,
                                       mbedtls_pk_ec( xCtx ),
-                                      CRYPTO_GenerateRandomBytesMbedTls,
+                                      CRYPTO_GetRandomBytes,
                                       NULL ) )
         {
             xResult = CKR_FUNCTION_FAILED;

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3861,7 +3861,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
         }
     }
 
-    if( ( lResult != 0 ) || ( olen != ulRandomLen ) )
+    if( ( lResult != 0 ) || ( totalBytes != ulRandomLen ) )
     {
         PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes %d\r\n ", lResult, olen ) );
         xResult = CKR_FUNCTION_FAILED;

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3789,10 +3789,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     return xResult;
 }
 
-extern int ulPortGetEntropyFromHardware( void * data,
-                                         unsigned char * output,
-                                         size_t len,
-                                         size_t * olen );
+extern int lPortGetEntropyFromHardware( void * data,
+                                        unsigned char * output,
+                                        size_t len,
+                                        size_t * olen );
 
 /**
  * @brief Generate cryptographically random bytes.
@@ -3812,7 +3812,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
                                                 CK_ULONG ulRandomLen )
 {
     CK_RV xResult = CKR_OK;
-    int lMbedResult = 0;
+    int lResult = 0;
     size_t olen;
 
     xResult = PKCS11_SESSION_VALID_AND_MODULE_INITIALIZED( xSession );
@@ -3825,11 +3825,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( xResult == CKR_OK )
     {
-        lMbedResult = ulPortGetEntropyFromHardware( NULL, pucRandomData, ulRandomLen, &olen );
+        lResult = lPortGetEntropyFromHardware( NULL, pucRandomData, ulRandomLen, &olen );
     }
 
-    if( ( lMbedResult != 0 ) || ( olen != ulRandomLen ) )
+    if( ( lResult != 0 ) || ( olen != ulRandomLen ) )
     {
+        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes %d\r\n ", lResult, olen ) )
         xResult = CKR_FUNCTION_FAILED;
     }
 

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -109,7 +109,7 @@ TEST_GROUP( Full_PKCS11_RSA );
 /* The EC test group is for tests that require elliptic curve keys. */
 TEST_GROUP( Full_PKCS11_EC );
 
-/* #define PKCS11_TEST_MEMORY_LEAK */
+/*#define PKCS11_TEST_MEMORY_LEAK */
 #ifdef PKCS11_TEST_MEMORY_LEAK
     BaseType_t xHeapBefore;
     BaseType_t xHeapAfter;
@@ -1041,9 +1041,8 @@ static void prvGenerateRandomMultiThreadTask( void * pvParameters )
 
     for( xCount = 0; xCount < pkcs11testMULTI_THREAD_LOOP_COUNT; xCount++ )
     {
-        xResult = pxGlobalFunctionList->C_GenerateRandom( xSession,
-                                                          xRandomData,
-                                                          sizeof( xRandomData ) );
+        /* TS-9475 */
+        xResult = CRYPTO_GetRandomBytes( NULL, xRandomData, sizeof( xRandomData ) );
 
         if( xResult != CKR_OK )
         {

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -635,32 +635,21 @@ static CK_RV prvSocketsGetCryptoSession( SemaphoreHandle_t * pxSessionLock,
 uint32_t ulRand( void )
 {
     CK_RV xResult = 0;
-    SemaphoreHandle_t xSessionLock = NULL;
-    CK_SESSION_HANDLE xPkcs11Session = 0;
-    CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
+
     uint32_t ulRandomValue = 0;
 
-    xResult = prvSocketsGetCryptoSession( &xSessionLock,
-                                          &xPkcs11Session,
-                                          &pxPkcs11FunctionList );
 
-    if( 0 == xResult )
-    {
-        /* Request a sequence of cryptographically random byte values using
-         * PKCS#11. */
-        xResult = pxPkcs11FunctionList->C_GenerateRandom( xPkcs11Session,
-                                                          ( CK_BYTE_PTR ) &ulRandomValue,
-                                                          sizeof( ulRandomValue ) );
-    }
+    xResult = CRYPTO_GetRandomBytes( &ulRandomValue, sizeof( ulRandomValue ) );
 
     /* Check if any of the API calls failed. */
-    if( 0 != xResult )
+    if ( CKR_OK != xResult )
     {
         ulRandomValue = 0;
     }
 
     return ulRandomValue;
 }
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -695,9 +684,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
         if( CK_FALSE == xKeyIsInitialized )
         {
             /* One-time initialization, per boot, of the random seed. */
-            xResult = pxPkcs11FunctionList->C_GenerateRandom( xPkcs11Session,
-                                                              ( CK_BYTE_PTR ) &ullKey,
-                                                              sizeof( ullKey ) );
+            xResult = CRYPTO_GetRandomBytes( &ullKey, sizeof( ullKey ) );
 
             if( xResult == CKR_OK )
             {

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -642,7 +642,7 @@ uint32_t ulRand( void )
     xResult = CRYPTO_GetRandomBytes( &ulRandomValue, sizeof( ulRandomValue ) );
 
     /* Check if any of the API calls failed. */
-    if ( CKR_OK != xResult )
+    if( CKR_OK != xResult )
     {
         ulRandomValue = 0;
     }

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -638,8 +638,7 @@ uint32_t ulRand( void )
 
     uint32_t ulRandomValue = 0;
 
-
-    xResult = CRYPTO_GetRandomBytes( &ulRandomValue, sizeof( ulRandomValue ) );
+    xResult = CRYPTO_GetRandomBytes( NULL, &ulRandomValue, sizeof( ulRandomValue ) );
 
     /* Check if any of the API calls failed. */
     if( CKR_OK != xResult )
@@ -684,7 +683,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
         if( CK_FALSE == xKeyIsInitialized )
         {
             /* One-time initialization, per boot, of the random seed. */
-            xResult = CRYPTO_GetRandomBytes( &ullKey, sizeof( ullKey ) );
+            xResult = CRYPTO_GetRandomBytes( NULL, &ullKey, sizeof( ullKey ) );
 
             if( xResult == CKR_OK )
             {

--- a/libraries/freertos_plus/standard/crypto/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/crypto/CMakeLists.txt
@@ -19,6 +19,7 @@ afr_module_include_dirs(
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PRIVATE 3rdparty::mbedtls
+    PRIVATE AFR::pkcs11
 )
 
 # Crypto test

--- a/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
+++ b/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
@@ -77,24 +77,12 @@ void CRYPTO_ConfigureDRBG( void );
 #define cryptoASYMMETRIC_ALGORITHM_ECDSA    2
 
 
-/**
- * @brief Callback that wraps CRYPTO_GetRandomBytes for
- * replacement of mbedTLS f_rng().
- *
- * @param[in] pvCtx Caller context, which is ignored.
- * @param[in] pucRandom Byte array to fill with random data.
- * @param[in] xRandomLength Length of byte array.
- *
- * @return Zero on success.
- */
-int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
-                                       unsigned char * pucRandom,
-                                       size_t xRandomLength );
-
 
 /**
  * @brief Generate random bytes.
  *
+ * @param[in] pvContext           Pointer to a context for compatibility with other crypto
+ *                                libraries.  This input is ignored in this port.
  * @param[out] pRandomBytes       Pointer to the location where random bytes will be
  *                                placed.  This memory should be allocated by the caller.
  * @param[in] length              Number of random bytes to be generated.  pRandomBytes
@@ -103,7 +91,8 @@ int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
  * @return 0 on success, otherwise error.
  *
  */
-int CRYPTO_GetRandomBytes( uint8_t * pRandomBytes,
+int CRYPTO_GetRandomBytes( void * pvContext,
+                           uint8_t * pRandomBytes,
                            size_t length );
 
 

--- a/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
+++ b/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
@@ -28,6 +28,11 @@
 
 #include "FreeRTOS.h"
 
+/*
+ * Error codes
+ */
+#define CRYPTO_ERROR_RNG             0x3000
+
 /**
  * @brief Commonly used buffer sizes for storing cryptographic hash computation
  * results.
@@ -95,11 +100,11 @@ int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
  * @param[in] length              Number of random bytes to be generated.  pRandomBytes
  *                                must be at least length bytes long.
  *
- * @return CKR_OK on success, otherwise error.
+ * @return 0 on success, otherwise error.
  *
  */
-CK_RV CRYPTO_GetRandomBytes( CK_BYTE_PTR pRandomBytes,
-                             CK_ULONG length );
+int CRYPTO_GetRandomBytes( uint8_t * pRandomBytes,
+                           size_t length );
 
 
 /**

--- a/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
+++ b/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
@@ -57,12 +57,50 @@ void CRYPTO_ConfigureThreading( void );
 void CRYPTO_ConfigureHeap( void );
 
 /**
+ * @brief Initializes the CRYPTO-maintained DRBG.
+ *
+ */
+void CRYPTO_ConfigureDRBG( void );
+
+
+/**
  * @brief Library-independent cryptographic algorithm identifiers.
  */
 #define cryptoHASH_ALGORITHM_SHA1           1
 #define cryptoHASH_ALGORITHM_SHA256         2
 #define cryptoASYMMETRIC_ALGORITHM_RSA      1
 #define cryptoASYMMETRIC_ALGORITHM_ECDSA    2
+
+
+/**
+ * @brief Callback that wraps CRYPTO_GetRandomBytes for
+ * replacement of mbedTLS f_rng().
+ *
+ * @param[in] pvCtx Caller context, which is ignored.
+ * @param[in] pucRandom Byte array to fill with random data.
+ * @param[in] xRandomLength Length of byte array.
+ *
+ * @return Zero on success.
+ */
+int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
+                                       unsigned char * pucRandom,
+                                       size_t xRandomLength );
+
+
+/**
+ * @brief Generate random bytes.
+ *
+ * @param[out] pRandomBytes       Pointer to the location where random bytes will be
+ *                                placed.  This memory should be allocated by the caller.
+ * @param[in] length              Number of random bytes to be generated.  pRandomBytes
+ *                                must be at least length bytes long.
+ *
+ * @return CKR_OK on success, otherwise error.
+ *
+ */
+CK_RV CRYPTO_GetRandomBytes( CK_BYTE_PTR pRandomBytes,
+                             CK_ULONG length );
+
 
 /**
  * @brief Initializes digital signature verification.

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -316,18 +316,18 @@ int mbedtls_hardware_poll( void * data,
 
     xResult = C_GetFunctionList( &pxFunctionList );
 
-    if ( xResult == CKR_OK )
+    if( xResult == CKR_OK )
     {
         xResult = xInitializePkcs11Session( &xSession );
     }
 
-    if ( xResult == CKR_OK )
+    if( xResult == CKR_OK )
     {
         xSessionOpened = CK_TRUE;
         xResult = pxFunctionList->C_GenerateRandom( xSession, output, len );
     }
 
-    if ( xSessionOpened == CK_TRUE )
+    if( xSessionOpened == CK_TRUE )
     {
         xResult = pxFunctionList->C_CloseSession( xSession );
     }
@@ -335,16 +335,7 @@ int mbedtls_hardware_poll( void * data,
     return lStatus;
 }
 
-/**
- * @brief Callback that wraps CRYPTO_GetRandomBytes for
- * replacement of mbedTLS f_rng().
- *
- * @param[in] pvCtx Caller context, which is ignored.
- * @param[in] pucRandom Byte array to fill with random data.
- * @param[in] xRandomLength Length of byte array.
- *
- * @return Zero on success.
- */
+
 int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
                                        unsigned char * pucRandom,
                                        size_t xRandomLength )

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -336,28 +336,13 @@ int mbedtls_hardware_poll( void * data,
 }
 
 
-int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
-                                       unsigned char * pucRandom,
-                                       size_t xRandomLength )
-{
-    ( void ) pvCtx; /*lint !e9087 !e9079 Allow casting void* to other types. */
-    int xResult;
 
-    xResult = CRYPTO_GetRandomBytes( pucRandom, xRandomLength );
-
-    if( xResult != CKR_OK )
-    {
-        CRYPTO_PRINT( ( "ERROR: Failed to generate random bytes %d \r\n", xResult ) );
-        xResult = 0xa1e8a;
-    }
-
-    return xResult;
-}
-
-
-int CRYPTO_GetRandomBytes( uint8_t * pRandomBytes,
+int CRYPTO_GetRandomBytes( void * pvCtx,
+                           uint8_t * pRandomBytes,
                            size_t length )
 {
+    ( void ) pvCtx; /*lint !e9087 !e9079 Allow casting void* to other types. */
+
     int lResult = 0;
 
     if( ( NULL == pRandomBytes ) ||

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -358,6 +358,12 @@ int CRYPTO_GetRandomBytes( void * pvCtx,
         lResult = CRYPTO_ERROR_RNG;
     }
 
+    if( xDrbg.xIsInitialized != CK_TRUE )
+    {
+        CRYPTO_PRINT( ( "ERROR: DRBG is not initialized \r\n" ) );
+        lResult = CRYPTO_ERROR_RNG;
+    }
+
     if( lResult == 0 )
     {
         lResult = mbedtls_ctr_drbg_random( &xDrbg.xMbedDrbgCtx, pRandomBytes, length );

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -332,6 +332,12 @@ int mbedtls_hardware_poll( void * data,
         xResult = pxFunctionList->C_CloseSession( xSession );
     }
 
+    if( xResult == CKR_OK )
+    {
+        lStatus = 0;
+        *olen = len;
+    }
+
     return lStatus;
 }
 

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -354,8 +354,9 @@ int CRYPTO_GenerateRandomBytesMbedTls( void * pvCtx,
     return xResult;
 }
 
-CK_RV CRYPTO_GetRandomBytes( CK_BYTE_PTR pRandomBytes,
-                             CK_ULONG length )
+
+int CRYPTO_GetRandomBytes( uint8_t * pRandomBytes,
+                           size_t length )
 {
     int lResult = 0;
 
@@ -363,7 +364,7 @@ CK_RV CRYPTO_GetRandomBytes( CK_BYTE_PTR pRandomBytes,
         ( length == 0 ) )
     {
         CRYPTO_PRINT( ( "ERROR: Invalid inputs to CRYPTO_GetRandomBytes \r\n" ) );
-        lResult = CKR_ARGUMENTS_BAD;
+        lResult = CRYPTO_ERROR_RNG;
     }
 
     if( lResult == 0 )
@@ -373,7 +374,7 @@ CK_RV CRYPTO_GetRandomBytes( CK_BYTE_PTR pRandomBytes,
         if( lResult != 0 )
         {
             CRYPTO_PRINT( ( "ERROR: DRBG failed %d \r\n", lResult ) );
-            lResult = CKR_FUNCTION_FAILED;
+            lResult = CRYPTO_ERROR_RNG;
         }
     }
 

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -734,7 +734,7 @@ BaseType_t TLS_Connect( void * pvContext )
         mbedtls_ssl_conf_authmode( &pxCtx->xMbedSslConfig, MBEDTLS_SSL_VERIFY_REQUIRED );
 
         /* Set the RNG callback. */
-        mbedtls_ssl_conf_rng( &pxCtx->xMbedSslConfig, &CRYPTO_GenerateRandomBytesMbedTls, NULL ); /*lint !e546 Nothing wrong here. */
+        mbedtls_ssl_conf_rng( &pxCtx->xMbedSslConfig, &CRYPTO_GetRandomBytes, NULL ); /*lint !e546 Nothing wrong here. */
 
         /* Set issuer certificate. */
         mbedtls_ssl_conf_ca_chain( &pxCtx->xMbedSslConfig, &pxCtx->xMbedX509CA, NULL );

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -176,35 +176,6 @@ static int prvNetworkRecv( void * pvContext,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Callback that wraps PKCS#11 for pseudo-random number generation.
- *
- * @param[in] pvCtx Caller context.
- * @param[in] pucRandom Byte array to fill with random data.
- * @param[in] xRandomLength Length of byte array.
- *
- * @return Zero on success.
- */
-static int prvGenerateRandomBytes( void * pvCtx,
-                                   unsigned char * pucRandom,
-                                   size_t xRandomLength )
-{
-    TLSContext_t * pxCtx = ( TLSContext_t * ) pvCtx; /*lint !e9087 !e9079 Allow casting void* to other types. */
-    BaseType_t xResult;
-
-    xResult = pxCtx->pxP11FunctionList->C_GenerateRandom( pxCtx->xP11Session, pucRandom, xRandomLength );
-
-    if( xResult != CKR_OK )
-    {
-        TLS_PRINT( ( "ERROR: Failed to generate random bytes %d \r\n", xResult ) );
-        xResult = TLS_ERROR_RNG;
-    }
-
-    return xResult;
-}
-
-/*-----------------------------------------------------------*/
-
-/**
  * @brief Callback that enforces a worst-case expiration check on TLS server
  * certificates.
  *
@@ -763,7 +734,7 @@ BaseType_t TLS_Connect( void * pvContext )
         mbedtls_ssl_conf_authmode( &pxCtx->xMbedSslConfig, MBEDTLS_SSL_VERIFY_REQUIRED );
 
         /* Set the RNG callback. */
-        mbedtls_ssl_conf_rng( &pxCtx->xMbedSslConfig, &prvGenerateRandomBytes, pxCtx ); /*lint !e546 Nothing wrong here. */
+        mbedtls_ssl_conf_rng( &pxCtx->xMbedSslConfig, &CRYPTO_GenerateRandomBytesMbedTls, NULL ); /*lint !e546 Nothing wrong here. */
 
         /* Set issuer certificate. */
         mbedtls_ssl_conf_ca_chain( &pxCtx->xMbedSslConfig, &pxCtx->xMbedX509CA, NULL );

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -61,7 +61,7 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -61,10 +61,10 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
+int ulPortGetEntropyFromHardware( void * data,
+                                  unsigned char * output,
+                                  size_t len,
+                                  size_t * olen )
 {
 
 #ifdef WLAN_FIRMWARE_PRNG_SEED

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -61,7 +61,7 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -61,10 +61,10 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
+int ulPortGetEntropyFromHardware( void * data,
+                                  unsigned char * output,
+                                  size_t len,
+                                  size_t * olen )
 {
 
 #ifdef WLAN_FIRMWARE_PRNG_SEED

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
@@ -39,7 +39,7 @@
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     optiga_lib_status_t status;

--- a/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
@@ -39,7 +39,7 @@
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     optiga_lib_status_t status;

--- a/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
@@ -39,7 +39,7 @@
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     optiga_lib_status_t status;

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -318,7 +318,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 /*-----------------------------------------------------------*/
 
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -318,7 +318,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 /*-----------------------------------------------------------*/
 
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -318,7 +318,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 /*-----------------------------------------------------------*/
 
 
-int renamed_mbedtls_hardware_poll( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -346,7 +346,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 #include <string.h>
 #include <hal_trng.h>
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -346,7 +346,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 #include <string.h>
 #include <hal_trng.h>
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -346,7 +346,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 #include <string.h>
 #include <hal_trng.h>
 
-int renamed_mbedtls_hardware_poll( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ typedef struct
  */
 static P11KeyConfig_t P11ConfigSave;
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen );
@@ -373,7 +373,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ typedef struct
  */
 static P11KeyConfig_t P11ConfigSave;
 
-int renamed_mbedtls_hardware_poll( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen );
@@ -373,7 +373,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int renamed_mbedtls_hardware_poll( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ typedef struct
  */
 static P11KeyConfig_t P11ConfigSave;
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen );
@@ -373,7 +373,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -213,7 +213,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
  
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
@@ -47,7 +47,7 @@
 #endif
 
 
-int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     status_t result = kStatus_Success;
 

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
@@ -47,7 +47,7 @@
 #endif
 
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+int renamed_mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     status_t result = kStatus_Success;
 

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
@@ -47,7 +47,7 @@
 #endif
 
 
-int ulPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     status_t result = kStatus_Success;
 

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
@@ -30,7 +30,7 @@
 
 /*-----------------------------------------------------------*/
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
@@ -30,7 +30,7 @@
 
 /*-----------------------------------------------------------*/
 
-int renamed_mbedtls_hardware_poll( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
@@ -30,7 +30,7 @@
 
 /*-----------------------------------------------------------*/
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/pc/boards/windows/aws_tests/application_code/main.c
+++ b/vendors/pc/boards/windows/aws_tests/application_code/main.c
@@ -145,6 +145,9 @@ int main( void )
         0,
         0 );
 
+    /* Initialize AWS system libraries. */
+    SYSTEM_Init();
+
     /* Initialize the network interface.
      *
      ***NOTE*** Tasks that use the network are created in the network event hook
@@ -173,8 +176,6 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     /* If the network has just come up...*/
     if( ( eNetworkEvent == eNetworkUp ) && ( xTasksAlreadyCreated == pdFALSE ) )
     {
-        /* Initialize AWS system libraries. */
-        SYSTEM_Init();
 
         vDevModeKeyProvisioning();
 

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
@@ -48,11 +48,11 @@
 #define testrunnerFULL_MQTT_ALPN_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED       0
 #define testrunnerFULL_MQTTv4_ENABLED                 0
-#define testrunnerFULL_PKCS11_ENABLED                 0
+#define testrunnerFULL_PKCS11_ENABLED                 1
 #define testrunnerFULL_POSIX_ENABLED                  0
 #define testrunnerFULL_SHADOW_ENABLED                 0
 #define testrunnerFULL_SHADOWv4_ENABLED               0
-#define testrunnerFULL_TCP_ENABLED                    1
+#define testrunnerFULL_TCP_ENABLED                    0
 #define testrunnerFULL_TLS_ENABLED                    0
 #define testrunnerFULL_MEMORYLEAK_ENABLED             0
 #define testrunnerFULL_OTA_CBOR_ENABLED               0

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
@@ -48,11 +48,11 @@
 #define testrunnerFULL_MQTT_ALPN_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED       0
 #define testrunnerFULL_MQTTv4_ENABLED                 0
-#define testrunnerFULL_PKCS11_ENABLED                 1
+#define testrunnerFULL_PKCS11_ENABLED                 0
 #define testrunnerFULL_POSIX_ENABLED                  0
 #define testrunnerFULL_SHADOW_ENABLED                 0
 #define testrunnerFULL_SHADOWv4_ENABLED               0
-#define testrunnerFULL_TCP_ENABLED                    0
+#define testrunnerFULL_TCP_ENABLED                    1
 #define testrunnerFULL_TLS_ENABLED                    0
 #define testrunnerFULL_MEMORYLEAK_ENABLED             0
 #define testrunnerFULL_OTA_CBOR_ENABLED               0

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -15,7 +15,7 @@ void get_random_number(uint8_t *data, uint32_t len);
 /******************************************************************************
 Functions : hardware entropy collector(repeatedly called until enough gathered)
 ******************************************************************************/
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -15,7 +15,7 @@ void get_random_number(uint8_t *data, uint32_t len);
 /******************************************************************************
 Functions : hardware entropy collector(repeatedly called until enough gathered)
 ******************************************************************************/
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -15,7 +15,7 @@ void get_random_number(uint8_t *data, uint32_t len);
 /******************************************************************************
 Functions : hardware entropy collector(repeatedly called until enough gathered)
 ******************************************************************************/
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -19,15 +19,15 @@ int lPortGetEntropyFromHardware( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);
-    R_INTERNAL_NOT_USED(len);
 
     uint32_t random_number = 0;
+    size_t num_bytes = ( len < 4 ) ? len : 4;
 
-    get_random_number((uint8_t *)&random_number, sizeof(uint32_t));
+    get_random_number( ( uint8_t * ) &random_number, num_bytes );
     *olen = 0;
 
-    memcpy(output, &random_number, sizeof(uint32_t));
-    *olen = sizeof(uint32_t);
+    memcpy( output, &random_number, num_bytes );
+    *olen = num_bytes;
 
     return 0;
 }

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
@@ -49,11 +49,11 @@
 #include "main.h"
 #include "stm32l4xx_hal.h"
 
-int ulPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
+int lPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
@@ -49,11 +49,11 @@
 #include "main.h"
 #include "stm32l4xx_hal.h"
 
-int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
+int renamed_mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
@@ -49,11 +49,11 @@
 #include "main.h"
 #include "stm32l4xx_hal.h"
 
-int renamed_mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
+int ulPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
@@ -48,11 +48,11 @@
 #include <string.h>
 #include "main.h"
 
-int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
+int renamed_mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int mbedtls_hardware_poll( void *data,
+int renamed_mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
@@ -48,11 +48,11 @@
 #include <string.h>
 #include "main.h"
 
-int renamed_mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
+int ulPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int renamed_mbedtls_hardware_poll( void *data,
+int ulPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
@@ -48,11 +48,11 @@
 #include <string.h>
 #include "main.h"
 
-int ulPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
+int lPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int ulPortGetEntropyFromHardware( void *data,
+int lPortGetEntropyFromHardware( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -657,10 +657,10 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 
 /*-----------------------------------------------------------*/
 
-int mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
+int ulPortGetEntropyFromHardware( void * data,
+                                  unsigned char * output,
+                                  size_t len,
+                                  size_t * olen )
 {
     int lStatus = MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
 

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -657,7 +657,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 
 /*-----------------------------------------------------------*/
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -38,97 +38,99 @@
 
 
 /**
-* @brief Writes a file to local storage.
-*
-* Port-specific file write for crytographic information.
-*
-* @param[in] pxLabel       Label of the object to be saved.
-* @param[in] pucData       Data buffer to be written to file
-* @param[in] ulDataSize    Size (in bytes) of data to be saved.
-*
-* @return The file handle of the object that was stored.
-*/
+ * @brief Writes a file to local storage.
+ *
+ * Port-specific file write for crytographic information.
+ *
+ * @param[in] pxLabel       Label of the object to be saved.
+ * @param[in] pucData       Data buffer to be written to file
+ * @param[in] ulDataSize    Size (in bytes) of data to be saved.
+ *
+ * @return The file handle of the object that was stored.
+ */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        uint8_t * pucData,
+                                        uint32_t ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = 0;
+
     return xHandle;
 }
 
 /**
-* @brief Translates a PKCS #11 label into an object handle.
-*
-* Port-specific object handle retrieval.
-*
-*
-* @param[in] pLabel         Pointer to the label of the object
-*                           who's handle should be found.
-* @param[in] usLength       The length of the label, in bytes.
-*
-* @return The object handle if operation was successful.
-* Returns eInvalidHandle if unsuccessful.
-*/
+ * @brief Translates a PKCS #11 label into an object handle.
+ *
+ * Port-specific object handle retrieval.
+ *
+ *
+ * @param[in] pLabel         Pointer to the label of the object
+ *                           who's handle should be found.
+ * @param[in] usLength       The length of the label, in bytes.
+ *
+ * @return The object handle if operation was successful.
+ * Returns eInvalidHandle if unsuccessful.
+ */
 CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+                                        uint8_t usLength )
 {
     CK_OBJECT_HANDLE xHandle = 0;
+
     return xHandle;
 }
 
 /**
-* @brief Gets the value of an object in storage, by handle.
-*
-* Port-specific file access for cryptographic information.
-*
-* This call dynamically allocates the buffer which object value
-* data is copied into.  PKCS11_PAL_GetObjectValueCleanup()
-* should be called after each use to free the dynamically allocated
-* buffer.
-*
-* @sa PKCS11_PAL_GetObjectValueCleanup
-*
-* @param[in] pcFileName    The name of the file to be read.
-* @param[out] ppucData     Pointer to buffer for file data.
-* @param[out] pulDataSize  Size (in bytes) of data located in file.
-* @param[out] pIsPrivate   Boolean indicating if value is private (CK_TRUE)
-*                          or exportable (CK_FALSE)
-*
-* @return CKR_OK if operation was successful.  CKR_KEY_HANDLE_INVALID if
-* no such object handle was found, CKR_DEVICE_MEMORY if memory for
-* buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
-* error.
-*/
+ * @brief Gets the value of an object in storage, by handle.
+ *
+ * Port-specific file access for cryptographic information.
+ *
+ * This call dynamically allocates the buffer which object value
+ * data is copied into.  PKCS11_PAL_GetObjectValueCleanup()
+ * should be called after each use to free the dynamically allocated
+ * buffer.
+ *
+ * @sa PKCS11_PAL_GetObjectValueCleanup
+ *
+ * @param[in] pcFileName    The name of the file to be read.
+ * @param[out] ppucData     Pointer to buffer for file data.
+ * @param[out] pulDataSize  Size (in bytes) of data located in file.
+ * @param[out] pIsPrivate   Boolean indicating if value is private (CK_TRUE)
+ *                          or exportable (CK_FALSE)
+ *
+ * @return CKR_OK if operation was successful.  CKR_KEY_HANDLE_INVALID if
+ * no such object handle was found, CKR_DEVICE_MEMORY if memory for
+ * buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
+ * error.
+ */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                 uint8_t ** ppucData,
+                                 uint32_t * pulDataSize,
+                                 CK_BBOOL * pIsPrivate )
 {
     CK_RV xReturn = CKR_OK;
+
     return xReturn;
 }
 
 
 /**
-* @brief Cleanup after PKCS11_GetObjectValue().
-*
-* @param[in] pucData       The buffer to free.
-*                          (*ppucData from PKCS11_PAL_GetObjectValue())
-* @param[in] ulDataSize    The length of the buffer to free.
-*                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
-*/
+ * @brief Cleanup after PKCS11_GetObjectValue().
+ *
+ * @param[in] pucData       The buffer to free.
+ *                          (*ppucData from PKCS11_PAL_GetObjectValue())
+ * @param[in] ulDataSize    The length of the buffer to free.
+ *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
+ */
 void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+                                       uint32_t ulDataSize )
 {
-    
 }
 
 /*-----------------------------------------------------------*/
 
-int renamed_mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
+int ulPortGetEntropyFromHardware( void * data,
+                                  unsigned char * output,
+                                  size_t len,
+                                  size_t * olen )
 {
     /* FIX ME. */
     return 0;

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -125,7 +125,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int mbedtls_hardware_poll( void * data,
+int renamed_mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -127,7 +127,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -333,7 +333,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 }
 
 
-int int ulPortGetEntropyFromHardware( void * data,
+int ulPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )                        

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -333,10 +333,10 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 }
 
 
-int mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
+int int ulPortGetEntropyFromHardware( void * data,
+                                  unsigned char * output,
+                                  size_t len,
+                                  size_t * olen )                        
 {
     ( void ) data;
 

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -333,7 +333,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 }
 
 
-int ulPortGetEntropyFromHardware( void * data,
+int lPortGetEntropyFromHardware( void * data,
                                   unsigned char * output,
                                   size_t len,
                                   size_t * olen )                        


### PR DESCRIPTION
…intain DRBG

In order to maintain consistency with Secure Elements and reduce the number of bus
crosses when randomness is required, this commit modifies PKCS #11 C_GenerateRandom
to return entropy, rather than to return random numbers from a DRBG.

The DRBG is now maintained in the CRYPTO layer, and all applications requiring randomness
should now call CRYPTO_GetRandomBytes, or if suppling the f_rng to mbedTLS,
CRYPTO_GenerateRandomBytesMbedTls with a NULL context.

Test Run:

https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/233/

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.