### PR TITLE
Fix compiler warnings and add mbedtls configuration to FreeRTOS IoT file.

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -41,9 +41,11 @@
 #include "iot_init.h"
 
 /* Remove dependency to MQTT */
-#define MQTT_DEMO_TYPE_ENABLED    ( defined( CONFIG_MQTT_DEMO_ENABLED ) || defined( CONFIG_SHADOW_DEMO_ENABLED ) || defined( CONFIG_DEFENDER_DEMO_ENABLED ) || defined( CONFIG_OTA_UPDATE_DEMO_ENABLED ) )
+#if ( defined( CONFIG_MQTT_DEMO_ENABLED ) || defined( CONFIG_SHADOW_DEMO_ENABLED ) || defined( CONFIG_DEFENDER_DEMO_ENABLED ) || defined( CONFIG_OTA_UPDATE_DEMO_ENABLED ) )
+    #define MQTT_DEMO_TYPE_ENABLED   
+#endif
 
-#if MQTT_DEMO_TYPE_ENABLED
+#if defined( MQTT_DEMO_TYPE_ENABLED )
     #include "iot_mqtt.h"
 #endif
 

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -78,7 +78,7 @@ static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
 
         return ret;
     }
-#endif /* if MQTT_DEMO_TYPE_ENABLED */
+#endif /* if defined( MQTT_DEMO_TYPE_ENABLED ) */
 
 /*-----------------------------------------------------------*/
 

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -42,7 +42,7 @@
 
 /* Remove dependency to MQTT */
 #if ( defined( CONFIG_MQTT_DEMO_ENABLED ) || defined( CONFIG_SHADOW_DEMO_ENABLED ) || defined( CONFIG_DEFENDER_DEMO_ENABLED ) || defined( CONFIG_OTA_UPDATE_DEMO_ENABLED ) )
-    #define MQTT_DEMO_TYPE_ENABLED   
+    #define MQTT_DEMO_TYPE_ENABLED
 #endif
 
 #if defined( MQTT_DEMO_TYPE_ENABLED )

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -57,7 +57,7 @@ static IotSemaphore_t demoNetworkSemaphore;
 /* Variable used to indicate the connected network. */
 static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
 
-#if MQTT_DEMO_TYPE_ENABLED
+#if defined( MQTT_DEMO_TYPE_ENABLED )
     #if BLE_ENABLED
         extern const IotMqttSerializer_t IotBleMqttSerializer;
     #endif

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -752,7 +752,7 @@ static CK_RV prvExportPublicKey( CK_SESSION_HANDLE xSession,
     };
     uint8_t pucUnusedKeyTag[] = { 0x04, 0x41 };
 
-    /* This variable is used only for it's size. This gets rid of compiler warnings. */
+    /* This variable is used only for its size. This gets rid of compiler warnings. */
     ( void ) pucUnusedKeyTag;
 
     xResult = C_GetFunctionList( &pxFunctionList );

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -143,7 +143,7 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
     {
         lMbedResult = mbedtls_mpi_write_binary( &( pxKeyPair->d ), pxD, EC_D_LENGTH );
 
-        if( lMbedResult != 0)
+        if( lMbedResult != 0 )
         {
             DEV_MODE_KEY_PROVISIONING_PRINT( ( "Failed to parse EC private key components. \r\n" ) );
             xResult = CKR_ATTRIBUTE_VALUE_INVALID;
@@ -176,9 +176,9 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
         };
 
         xResult = pxFunctionList->C_CreateObject( xSession,
-                                                    ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
-                                                    sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
-                                                    pxObjectHandle );
+                                                  ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
+                                                  sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                                  pxObjectHandle );
     }
 
     if( pxD != NULL )
@@ -753,7 +753,7 @@ static CK_RV prvExportPublicKey( CK_SESSION_HANDLE xSession,
     uint8_t pucUnusedKeyTag[] = { 0x04, 0x41 };
 
     /* This variable is used only for it's size. This gets rid of compiler warnings. */
-    ( void )pucUnusedKeyTag;
+    ( void ) pucUnusedKeyTag;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -1164,7 +1164,7 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Retrieve the size of the file specified in the S3 pre-signed URL. */
-    if( _IotHttpsDemo_GetS3ObjectFileSize( &fileSize,
+    if( _IotHttpsDemo_GetS3ObjectFileSize( ( uint32_t* )( &fileSize ),
                                            _connHandle,
                                            pPath,
                                            strlen( pPath ),

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -1164,7 +1164,7 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Retrieve the size of the file specified in the S3 pre-signed URL. */
-    if( _IotHttpsDemo_GetS3ObjectFileSize( ( uint32_t* )( &fileSize ),
+    if( _IotHttpsDemo_GetS3ObjectFileSize( ( uint32_t * ) ( &fileSize ),
                                            _connHandle,
                                            pPath,
                                            strlen( pPath ),

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -1298,7 +1298,7 @@ CK_RV prvGetExistingKeyComponent( CK_OBJECT_HANDLE_PTR pxPalHandle,
 
     if( *pxPalHandle != CK_INVALID_HANDLE )
     {
-        xResult = PKCS11_PAL_GetObjectValue( *pxPalHandle, &pucData, ( uint32_t* )&xDataLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( *pxPalHandle, &pucData, ( uint32_t * ) &xDataLength, &xIsPrivate );
 
         if( xResult == CKR_OK )
         {

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -1087,10 +1087,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_CloseSession )( CK_SESSION_HANDLE xSession )
             vSemaphoreDelete( pxSession->xVerifyMutex );
         }
 
-        if( NULL != &pxSession->xSHA256Context )
-        {
-            mbedtls_sha256_free( &pxSession->xSHA256Context );
-        }
+        mbedtls_sha256_free( &pxSession->xSHA256Context );
 
         vPortFree( pxSession );
     }
@@ -1301,7 +1298,7 @@ CK_RV prvGetExistingKeyComponent( CK_OBJECT_HANDLE_PTR pxPalHandle,
 
     if( *pxPalHandle != CK_INVALID_HANDLE )
     {
-        xResult = PKCS11_PAL_GetObjectValue( *pxPalHandle, &pucData, &xDataLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( *pxPalHandle, &pucData, ( uint32_t* )&xDataLength, &xIsPrivate );
 
         if( xResult == CKR_OK )
         {
@@ -2021,7 +2018,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_CreateObject )( CK_SESSION_HANDLE xSession,
                                               CK_OBJECT_HANDLE_PTR pxObject )
 { /*lint !e9072 It's OK to have different parameter name. */
     CK_RV xResult = PKCS11_SESSION_VALID_AND_MODULE_INITIALIZED( xSession );
-    P11SessionPtr_t pxSession = prvSessionPointerFromHandle( xSession );
     CK_OBJECT_CLASS xClass;
 
     if( ( NULL == pxTemplate ) ||

--- a/libraries/c_sdk/standard/common/iot_device_metrics.c
+++ b/libraries/c_sdk/standard/common/iot_device_metrics.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "iot_config.h"
 

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -30,10 +30,10 @@
 
 /* mbedTLS includes. */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
+#if !defined( MBEDTLS_CONFIG_FILE )
+    #include "mbedtls/config.h"
 #else
-#include MBEDTLS_CONFIG_FILE
+    #include MBEDTLS_CONFIG_FILE
 #endif
 
 #include "mbedtls/platform.h"

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -29,7 +29,13 @@
 #include "iot_crypto.h"
 
 /* mbedTLS includes. */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #include "mbedtls/platform.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/sha1.h"


### PR DESCRIPTION
Fix compiler warnings and add mbedtls configuration to FreeRTOS IoT file.

Description
-----------
- The first commit addresses issue #1366 
  I have done a grep of #include "mbedtls/config" and iot_crypo.c is the ONLY file where this is present in Amazon FreeRTOS.
- The second commit addresses issue #1367 + other build warnings found when compiling MCUExpresso, UVision, and IAR.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.