### PR TITLE
Working CMake for ECC608 (with current folder structure)

### DIFF
--- a/libraries/c_sdk/standard/common/CMakeLists.txt
+++ b/libraries/c_sdk/standard/common/CMakeLists.txt
@@ -6,7 +6,7 @@ set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
 
 # TODO, this is a workaround to remove iot_logging_task_dynamic_buffers.c from common, because
 # winsim use a different logging implementation.
-if(NOT AFR_BOARD STREQUAL "pc.windows")
+if(NOT AFR_BOARD MATCHES "pc.windows|microchip.secure_element")
     set(aws_logging_task "${src_dir}/logging/iot_logging_task_dynamic_buffers.c")
 endif()
 

--- a/vendors/microchip/boards/secure_element/CMakeLists.txt
+++ b/vendors/microchip/boards/secure_element/CMakeLists.txt
@@ -1,0 +1,166 @@
+set(mchp_dir "${AFR_VENDORS_DIR}/microchip")
+set(harmony_dir "${mchp_dir}/harmony/v2.05")
+
+set(afr_ports_dir "${CMAKE_CURRENT_LIST_DIR}/ports")
+set(board_demos_dir "${CMAKE_CURRENT_LIST_DIR}/aws_demos")
+set(board_tests_dir "${CMAKE_CURRENT_LIST_DIR}/aws_tests")
+
+if(AFR_IS_TESTING)
+    set(board_dir "${board_tests_dir}")
+else()
+    set(board_dir "${board_demos_dir}")
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+if("${AFR_BOARD_NAME}" STREQUAL "secure_element")
+    include("${CMAKE_CURRENT_LIST_DIR}/secure_element.cmake")
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+afr_mcu_port(compiler)
+
+target_compile_definitions(
+    AFR::compiler::mcu_port
+    INTERFACE
+        __free_rtos__
+        _CONSOLE
+        _CRT_SECURE_NO_WARNINGS
+)
+
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE "/MP" "/wd4210" "/wd4127" "/wd4244" "/wd4310"
+)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS portable layers
+# -------------------------------------------------------------------------------------------------
+# Normally the portable layer for kernel should be vendor's driver code.
+afr_mcu_port(kernel)
+target_sources(
+    AFR::kernel::mcu_port
+    INTERFACE
+        "${AFR_KERNEL_DIR}/portable/MSVC-MingW/port.c"
+        "${AFR_KERNEL_DIR}/portable/MSVC-MingW/portmacro.h"
+        "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
+)
+target_include_directories(
+    AFR::kernel::mcu_port
+    INTERFACE
+        "${AFR_KERNEL_DIR}/portable/MSVC-MingW"
+        "${board_dir}/config_files"
+        "${board_dir}/application_code"
+        # Need aws_clientcredential.h
+        "$<IF:${AFR_IS_TESTING},${AFR_TESTS_DIR},${AFR_DEMOS_DIR}>/include"
+)
+target_link_libraries(
+    AFR::kernel::mcu_port
+    INTERFACE
+        3rdparty::tracealyzer_recorder
+)
+
+# POSIX
+afr_mcu_port(posix)
+target_sources(
+    AFR::posix::mcu_port
+    INTERFACE "${afr_ports_dir}/posix/FreeRTOS_POSIX_portable.h"
+)
+target_include_directories(
+    AFR::posix::mcu_port
+    INTERFACE "${afr_ports_dir}/posix"
+)
+target_link_libraries(
+    AFR::posix::mcu_port
+    INTERFACE AFR::freertos_plus_posix
+)
+
+# PKCS11
+afr_mcu_port(pkcs11_implementation)
+target_sources(
+    AFR::pkcs11_implementation::mcu_port
+    INTERFACE
+        "${AFR_VENDORS_DIR}/microchip/secure_elements/lib"
+)
+
+# FreeRTOS Plus TCP
+afr_mcu_port(freertos_plus_tcp)
+target_sources(
+    AFR::freertos_plus_tcp::mcu_port
+    INTERFACE
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.c"
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/NetworkInterface/WinPCap/NetworkInterface.c"
+)
+target_include_directories(
+    AFR::freertos_plus_tcp::mcu_port
+    INTERFACE
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/Compiler/MSVC"
+)
+target_link_libraries(
+    AFR::freertos_plus_tcp::mcu_port
+    INTERFACE 3rdparty::win_pcap
+)
+
+# Secure sockets
+afr_mcu_port(secure_sockets)
+target_link_libraries(
+    AFR::secure_sockets::mcu_port
+    INTERFACE AFR::secure_sockets_freertos_plus_tcp
+)
+
+# OTA
+afr_mcu_port(ota)
+target_sources(
+    AFR::ota::mcu_port
+    INTERFACE "${afr_ports_dir}/ota/aws_ota_pal.c"
+)
+target_link_libraries(
+    AFR::ota::mcu_port
+    INTERFACE AFR::crypto
+)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS demos and tests
+# -------------------------------------------------------------------------------------------------
+# TODO, remove network manager src.
+afr_glob_src(network_manager_src DIRECTORY "${AFR_DEMOS_DIR}/network_manager")
+afr_glob_src(config_files DIRECTORY "${board_dir}/config_files")
+
+# Build an OTA test that only builds on Windows.
+afr_module_sources(
+    test_ota
+    INTERFACE
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/test/aws_test_ota_cbor.c"
+)
+
+if(AFR_IS_TESTING)
+    set(exe_target aws_tests)
+else()
+    set(exe_target aws_demos)
+    set(extra_src ${network_manager_src})
+endif()
+
+add_executable(
+    ${exe_target}
+    "${board_dir}/application_code/main.c"
+    "${board_demos_dir}/application_code/aws_demo_logging.c"
+    "${board_demos_dir}/application_code/aws_demo_logging.h"
+    "${board_demos_dir}/application_code/aws_entropy_hardware_poll.c"
+    "${board_demos_dir}/application_code/aws_run-time-stats-utils.c"
+    ${extra_src}
+)
+target_include_directories(
+    ${exe_target}
+    PRIVATE
+        "${board_demos_dir}/application_code"
+)
+target_link_libraries(
+    ${exe_target}
+    PRIVATE
+        AFR::freertos_plus_tcp
+        AFR::utils
+        AFR::dev_mode_key_provisioning
+)

--- a/vendors/microchip/boards/secure_element/CMakeLists.txt
+++ b/vendors/microchip/boards/secure_element/CMakeLists.txt
@@ -118,7 +118,6 @@ target_sources(
     AFR::pkcs11_implementation::mcu_port
     INTERFACE
         "${ecc608_pkcs11_src}"
-        "${afr_ports_dir}/pkcs11/iot_pkcs11_pal.c"
         "${afr_ports_dir}/pkcs11/iot_pkcs11_secure_element.c"
 )
 

--- a/vendors/microchip/boards/secure_element/CMakeLists.txt
+++ b/vendors/microchip/boards/secure_element/CMakeLists.txt
@@ -41,12 +41,44 @@ target_compile_options(
 # -------------------------------------------------------------------------------------------------
 # Normally the portable layer for kernel should be vendor's driver code.
 afr_mcu_port(kernel)
+
+# ECC608 source files
+afr_glob_src(ecc608_src DIRECTORY ${ecc608_dir}/lib)
+afr_glob_src(ecc608_atacert_src RECURSE DIRECTORY ${ecc608_dir}/lib/atcacert)
+afr_glob_src(ecc608_basic_src RECURSE DIRECTORY ${ecc608_dir}/lib/basic)
+afr_glob_src(ecc608_crypto_src RECURSE DIRECTORY ${ecc608_dir}/lib/crypto)
+afr_glob_src(ecc608_host_src RECURSE DIRECTORY ${ecc608_dir}/lib/host)
+afr_glob_src(ecc608_pkcs11_src RECURSE DIRECTORY ${ecc608_dir}/lib/pkcs11)
+
+set(
+    ecc608_hid_src
+    "${ecc608_dir}/third_party/hidapi/windows/hid.c"
+)
+set(
+    ecc608_hal_src
+        "${ecc608_dir}/lib/hal/atca_hal.c"
+        "${ecc608_dir}/lib/hal/hal_all_platforms_kit_hidapi.c"
+        "${ecc608_dir}/lib/hal/hal_freertos.c"
+        "${ecc608_dir}/lib/hal/hal_windows.c"
+        "${ecc608_dir}/lib/hal/kit_protocol.c"
+        "${ecc608_dir}/lib/hal/atca_hal.h"
+        "${ecc608_dir}/lib/hal/hal_all_platforms_kit_hidapi.h"
+        "${ecc608_dir}/lib/hal/kit_phy.h"
+        "${ecc608_dir}/lib/hal/kit_protocol.h"
+)
 target_sources(
     AFR::kernel::mcu_port
     INTERFACE
         "${AFR_KERNEL_DIR}/portable/MSVC-MingW/port.c"
         "${AFR_KERNEL_DIR}/portable/MSVC-MingW/portmacro.h"
         "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
+        "${ecc608_src}"
+        "${ecc608_atacert_src}"
+        "${ecc608_basic_src}"
+        "${ecc608_crypto_src}"
+        "${ecc608_hal_src}"
+        "${ecc608_hid_src}"
+        "${ecc608_host_src}"
 )
 target_include_directories(
     AFR::kernel::mcu_port
@@ -54,6 +86,8 @@ target_include_directories(
         "${AFR_KERNEL_DIR}/portable/MSVC-MingW"
         "${board_dir}/config_files"
         "${board_dir}/application_code"
+        "${ecc608_dir}/lib"
+        "${ecc608_dir}/third_party/hidapi/hidapi"
         # Need aws_clientcredential.h
         "$<IF:${AFR_IS_TESTING},${AFR_TESTS_DIR},${AFR_DEMOS_DIR}>/include"
 )
@@ -78,15 +112,14 @@ target_link_libraries(
     INTERFACE AFR::freertos_plus_posix
 )
 
-# ECC608 Secure Element
-add_subdirectory("${mchp_dir}/secure_elements/lib")
-
 # PKCS11
 afr_mcu_port(pkcs11_implementation)
 target_sources(
     AFR::pkcs11_implementation::mcu_port
     INTERFACE
-        "${mchp_dir}/secure_elements/lib/pkcs11/pkcs11_main.c"
+        "${ecc608_pkcs11_src}"
+        "${afr_ports_dir}/pkcs11/iot_pkcs11_pal.c"
+        "${afr_ports_dir}/pkcs11/iot_pkcs11_secure_element.c"
 )
 
 # FreeRTOS Plus TCP
@@ -130,7 +163,6 @@ target_link_libraries(
 # -------------------------------------------------------------------------------------------------
 # TODO, remove network manager src.
 afr_glob_src(network_manager_src DIRECTORY "${AFR_DEMOS_DIR}/network_manager")
-afr_glob_src(config_files DIRECTORY "${board_dir}/config_files")
 
 # Build an OTA test that only builds on Windows.
 afr_module_sources(
@@ -149,8 +181,8 @@ endif()
 add_executable(
     ${exe_target}
     "${board_dir}/application_code/main.c"
+    "${board_demos_dir}/application_code/atca_cert_chain.c"
     "${board_demos_dir}/application_code/aws_demo_logging.c"
-    "${board_demos_dir}/application_code/aws_demo_logging.h"
     "${board_demos_dir}/application_code/aws_entropy_hardware_poll.c"
     "${board_demos_dir}/application_code/aws_run-time-stats-utils.c"
     ${extra_src}
@@ -166,4 +198,5 @@ target_link_libraries(
         AFR::freertos_plus_tcp
         AFR::utils
         AFR::dev_mode_key_provisioning
+        setupapi.lib
 )

--- a/vendors/microchip/boards/secure_element/CMakeLists.txt
+++ b/vendors/microchip/boards/secure_element/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(mchp_dir "${AFR_VENDORS_DIR}/microchip")
-set(harmony_dir "${mchp_dir}/harmony/v2.05")
+set(ecc608_dir "${mchp_dir}/secure_elements")
 
 set(afr_ports_dir "${CMAKE_CURRENT_LIST_DIR}/ports")
 set(board_demos_dir "${CMAKE_CURRENT_LIST_DIR}/aws_demos")
@@ -78,12 +78,15 @@ target_link_libraries(
     INTERFACE AFR::freertos_plus_posix
 )
 
+# ECC608 Secure Element
+add_subdirectory("${mchp_dir}/secure_elements/lib")
+
 # PKCS11
 afr_mcu_port(pkcs11_implementation)
 target_sources(
     AFR::pkcs11_implementation::mcu_port
     INTERFACE
-        "${AFR_VENDORS_DIR}/microchip/secure_elements/lib"
+        "${mchp_dir}/secure_elements/lib/pkcs11/pkcs11_main.c"
 )
 
 # FreeRTOS Plus TCP

--- a/vendors/microchip/boards/secure_element/secure_element.cmake
+++ b/vendors/microchip/boards/secure_element/secure_element.cmake
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+afr_set_board_metadata(ID "ECC608-With-Windows-Simulator")
+afr_set_board_metadata(DISPLAY_NAME "ECC608 With Windows Simulator")
+afr_set_board_metadata(DESCRIPTION "ECC608 With Windows Simulator")
+afr_set_board_metadata(VENDOR_NAME "Microchip")
+afr_set_board_metadata(FAMILY_NAME "ECC608")
+afr_set_board_metadata(CODE_SIGNER "AmazonFreeRTOS-Default")
+afr_set_board_metadata(SUPPORTED_IDE "VisualStudio")
+afr_set_board_metadata(RECOMMENDED_IDE "VisualStudio")
+afr_set_board_metadata(IDE_VisualStudio_NAME "Visual Studio")
+afr_set_board_metadata(IDE_VisualStudio_COMPILER "MSVC")
+afr_set_board_metadata(IS_ACTIVE "TRUE")
+
+afr_set_board_metadata(IDE_VisualStudio_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/microchip/secure_element/visual_studio/aws_demos")
+afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}/aws_demos/config_files")

--- a/vendors/microchip/boards/secure_element/secure_element.cmake
+++ b/vendors/microchip/boards/secure_element/secure_element.cmake
@@ -1,17 +1,18 @@
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
-afr_set_board_metadata(ID "ECC608-With-Windows-Simulator")
-afr_set_board_metadata(DISPLAY_NAME "ECC608 With Windows Simulator")
-afr_set_board_metadata(DESCRIPTION "ECC608 With Windows Simulator")
+afr_set_board_metadata(ID "Microchip-ATECC608A-with-Windows-Simulator")
+afr_set_board_metadata(DISPLAY_NAME "Microchip ATECC608A with Windows Simulator")
+afr_set_board_metadata(DESCRIPTION " Microchip ATECC608A secure element with Windows Simulator ")
 afr_set_board_metadata(VENDOR_NAME "Microchip")
-afr_set_board_metadata(FAMILY_NAME "ECC608")
+afr_set_board_metadata(FAMILY_NAME "ATECC608A")
 afr_set_board_metadata(CODE_SIGNER "AmazonFreeRTOS-Default")
 afr_set_board_metadata(SUPPORTED_IDE "VisualStudio")
 afr_set_board_metadata(RECOMMENDED_IDE "VisualStudio")
 afr_set_board_metadata(IDE_VisualStudio_NAME "Visual Studio")
 afr_set_board_metadata(IDE_VisualStudio_COMPILER "MSVC")
 afr_set_board_metadata(IS_ACTIVE "TRUE")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "FALSE")
 
 afr_set_board_metadata(IDE_VisualStudio_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/microchip/secure_element/visual_studio/aws_demos")
 afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}/aws_demos/config_files")

--- a/vendors/microchip/manifest.cmake
+++ b/vendors/microchip/manifest.cmake
@@ -1,6 +1,7 @@
 set(
     AFR_MANIFEST_SUPPORTED_BOARDS
     curiosity_pic32mzef
+    secure_element
     CACHE INTERNAL "Supported boards list."
 )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

This PR has a working CMake file for the ECC608+WinSim port. Since the naming is not decided, this is to be merged to mchp/ecc608, not master.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.