### PR TITLE
style: Documentation and spelling error in RTC API

### DIFF
--- a/libraries/abstractions/common_io/include/iot_rtc.h
+++ b/libraries/abstractions/common_io/include/iot_rtc.h
@@ -46,22 +46,22 @@
 /**
  * @brief Return values used by RTC driver
  */
-#define IOT_RTC_SUCCESS                   ( 0 )
-#define IOT_RTC_INVALID_VALUE             ( 1 )
-#define IOT_RTC_NOT_STARTED               ( 2 )
-#define IOT_RTC_GET_FAILED                ( 3 )
-#define IOT_RTC_SET_FAILED                ( 4 )
-#define IOT_RTC_FUNCTION_NOT_SUPPORTED    ( 5 )
+#define IOT_RTC_SUCCESS                   ( 0 )    /*!< RTC operation completed successfully. */
+#define IOT_RTC_INVALID_VALUE             ( 1 )    /*!< At least one parameter is invalid. */
+#define IOT_RTC_NOT_STARTED               ( 2 )    /*!< RTC not started. */
+#define IOT_RTC_GET_FAILED                ( 3 )    /*!< RTC get operation failed. */
+#define IOT_RTC_SET_FAILED                ( 4 )    /*!< RTC set operation failed. */
+#define IOT_RTC_FUNCTION_NOT_SUPPORTED    ( 5 )    /*!< RTC operation not supported. */
 
 /**
  * @brief RTC driver status values
  */
 typedef enum
 {
-    eRtcTimerStopped,
-    eRtcTimerRunning,
-    eRtcTimerAlaramTriggered,
-    eRtcTimerWakeupTriggered,
+    eRtcTimerStopped,              /*!< RTC Timer status: stopped. */
+    eRtcTimerRunning,              /*!< RTC Timer status: running. */
+    eRtcTimerAlarmTriggered,       /*!< RTC Timer status: alarm triggered. */
+    eRtcTimerWakeupTriggered,      /*!< RTC Timer status: wakeup triggered. */
 } IotRtcStatus_t;
 
 /**
@@ -122,7 +122,11 @@ typedef void ( * IotRtcCallback_t)( IotRtcStatus_t xStatus, void * pvUserContext
  *
  * @param[in]   lRtcInstance   The instance of the RTC timer to initialize.
  *
- * @return  returns the handle IotRtcHandle_t on success, or NULL on failure.
+ * @return
+ *   - the handle IotRtcHandle_t on success
+ *   - NULL if
+ *      - already open
+ *      - invalid instance
  */
 IotRtcHandle_t iot_rtc_open( int32_t lRtcInstance );
 
@@ -130,13 +134,15 @@ IotRtcHandle_t iot_rtc_open( int32_t lRtcInstance );
  * @brief   iot_rtc_set_callback is used to set the callback to be called when alarmTime triggers.
  *          The caller must set the Alarm time using IOCTL to get the callback.
  *
+ * @note Single callback is used for both rtc_alarm, and rtc_wakeup features.
+ * @note Newly set callback overrides the one previously set
+ * @note This callback is per handle. Each instance has its own callback.
+ *
  * @param[in]   pxRtcHandle  handle to RTC driver returned in
  *                          iot_rtc_open()
  * @param[in]   xCallback   callback function to be called.
  * @param[in]   pvUserContext   user context to be passed when callback is called.
  *
- * @return  returns IOT_RTC_SUCCESS on success or returns
- *          one of IOT_RTC_INVALID_VALUE, IOT_RTC_NOT_STARTED on error.
  */
 void iot_rtc_set_callback( IotRtcHandle_t const pxRtcHandle,
                            IotRtcCallback_t xCallback,
@@ -152,9 +158,14 @@ void iot_rtc_set_callback( IotRtcHandle_t const pxRtcHandle,
  * @param[in]   xRequest    configuration request of type IotRtcIoctlRequest_t
  * @param[in,out] pvBuffer  buffer holding RTC set and get values.
  *
- * @return  returns IOT_RTC_SUCCESS on success or returns
- *          one of IOT_RTC_INVALID_VALUE, IOT_RTC_NOT_STARTED on error
- *          or IOT_RTC_FUNCTION_NOT_SUPPORTED.
+ * @return
+ *   - IOT_RTC_SUCCESS on success
+ *   - IOT_RTC_INVALID_VALUE if
+ *      - pxRtcHandle == NULL
+ *      - xRequest is invalid
+ *      - pvBuffer == NULL (excluding eCancelRtcAlarm, eCancelRtcWakeup)
+     - IOT_RTC_NOT_STARTED on error
+ *   - IOT_RTC_FUNCTION_NOT_SUPPORTED if feature not supported.
  */
 int32_t iot_rtc_ioctl( IotRtcHandle_t const pxRtcHandle,
                        IotRtcIoctlRequest_t xRequest,
@@ -168,8 +179,10 @@ int32_t iot_rtc_ioctl( IotRtcHandle_t const pxRtcHandle,
  * @param[in]   pxDatetime  pointer to IotRtcDatetime_t structure to set the date&time
  *                          to be set in RTC counter.
  *
- * @return  returns IOT_RTC_SUCCESS on success or returns
- *          one of IOT_RTC_INVALID_VALUE, IOT_RTC_SET_FAILED on error.
+ * @return
+ *   - IOT_RTC_SUCCESS on success
+ *   - IOT_RTC_INVALID_VALUE if pxRtcHandle == NULL or pxDatetime == NULL
+ *   - IOT_RTC_SET_FAILED on error.
  */
 int32_t iot_rtc_set_datetime( IotRtcHandle_t const pxRtcHandle,
                               const IotRtcDatetime_t * pxDatetime );
@@ -183,8 +196,10 @@ int32_t iot_rtc_set_datetime( IotRtcHandle_t const pxRtcHandle,
  * @param[in]   pxDatetime  pointer to IotRtcDatetime_t structure to get the date&time
  *                          from RTC counter.
  *
- * @return  returns IOT_RTC_SUCCESS on success or returns
- *          one of IOT_RTC_INVALID_VALUE, IOT_RTC_NOT_STARTED on error.
+ * @return
+ *   - IOT_RTC_SUCCESS on success
+ *   - IOT_RTC_INVALID_VALUE if pxRtcHandle == NULL or pxDatetime == NULL
+ *   - IOT_RTC_NOT_STARTED on error
  */
 int32_t iot_rtc_get_datetime( IotRtcHandle_t const pxRtcHandle,
                               IotRtcDatetime_t * pxDatetime );
@@ -195,8 +210,11 @@ int32_t iot_rtc_get_datetime( IotRtcHandle_t const pxRtcHandle,
  *
  * @param[in]   pxRtcHandle  handle to RTC interface.
  *
- * @return  returns IOT_RTC_SUCCESS on success or returns
- *          one of IOT_RTC_INVALID_VALUE on error.
+ * @return
+ *   - IOT_RTC_SUCCESS on success
+ *   - IOT_RTC_INVALID_VALUE if
+ *      - pxRtcHandle == NULL
+ *      - not in open state (already closed).
  */
 int32_t iot_rtc_close( IotRtcHandle_t const pxRtcHandle );
 

--- a/libraries/abstractions/common_io/test/test_iot_rtc.c
+++ b/libraries/abstractions/common_io/test/test_iot_rtc.c
@@ -355,8 +355,8 @@ TEST( TEST_IOT_RTC, AFQP_IotRtcSetGetAlarm )
                                  eGetRtcStatus,
                                  ( void * const ) &lStatus);
     TEST_ASSERT_EQUAL( IOT_RTC_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eRtcTimerAlaramTriggered,
-                       lStatus & eRtcTimerAlaramTriggered );
+    TEST_ASSERT_EQUAL( eRtcTimerAlarmTriggered,
+                       lStatus & eRtcTimerAlarmTriggered );
 
     lRetVal = iot_rtc_close( xRtcHandle );
     TEST_ASSERT_EQUAL( IOT_RTC_SUCCESS, lRetVal );


### PR DESCRIPTION
Fixing a spelling error in RTC API plus documentation additions

Why:  While making documentation improvements to the RTC APIs,
I found that there was a mis-spelling in one of the enums.  I've
corrected that, along with making many documentation improvements.

@qiutongs , @lundinc2 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.