### PR TITLE
Fixing timer task priority on Marvell

### DIFF
--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
@@ -108,7 +108,7 @@ unsigned long portWMSDK_GET_RUN_TIME_COUNTER_VALUE(void);
 
 /*  Software timer definitions. */
 #define configUSE_TIMERS			1
-#define configTIMER_TASK_PRIORITY		( 4 )
+#define configTIMER_TASK_PRIORITY		( configMAX_PRIORITIES - 1  )
 #define configTIMER_QUEUE_LENGTH		5
 #define configTIMER_TASK_STACK_DEPTH		( configMINIMAL_STACK_SIZE )
 

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
@@ -111,7 +111,7 @@ unsigned long portWMSDK_GET_RUN_TIME_COUNTER_VALUE(void);
 
 /*  Software timer definitions. */
 #define configUSE_TIMERS		1
-#define configTIMER_TASK_PRIORITY	( 4 )
+#define configTIMER_TASK_PRIORITY	( configMAX_PRIORITIES - 1  )
 #define configTIMER_QUEUE_LENGTH	5
 #define configTIMER_TASK_STACK_DEPTH	( configMINIMAL_STACK_SIZE )
 


### PR DESCRIPTION
Description
-----------
PR #1163 has incorrectly reverted timer task priority fix, and we are seeing hard fault in task pool test group. (When timer task priority is lower than task pool priority, timer deletion and timer triggering are executed in wrong order.) Reapplying previous fix. 

After this PR is merged to master, will cherry pick it into release candidate.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.