### PR TITLE
Update IotNetworkAfr_Create() to give error feedback on connection.

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -382,7 +382,7 @@ IotNetworkError_t IotNetworkAfr_Create( void * pConnectionInfo,
 
     if( socketStatus != SOCKETS_ERROR_NONE )
     {
-        IotLogError( "Failed to establish new connection." );
+        IotLogError( "Failed to establish new connection. Socket status: %d.", socketStatus );
         IOT_SET_AND_GOTO_CLEANUP( IOT_NETWORK_SYSTEM_ERROR );
     }
 
@@ -395,7 +395,7 @@ IotNetworkError_t IotNetworkAfr_Create( void * pConnectionInfo,
 
     if( socketStatus != SOCKETS_ERROR_NONE )
     {
-        IotLogError( "Failed to set socket receive timeout." );
+        IotLogError( "Failed to set socket receive timeout. Socket status %d.", socketStatus );
         IOT_SET_AND_GOTO_CLEANUP( IOT_NETWORK_SYSTEM_ERROR );
     }
 


### PR DESCRIPTION
Update IotNetworkAfr_Create() to give error feedback on connection.

This helpful for example to know that FreeRTOS+TCP timed out with a -116 error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.