### PR TITLE
Ble Hal tests: Clear events from previous test case

### DIFF
--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -503,6 +503,7 @@ BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
                                              void * pxMessage,
                                              size_t xMessageLength,
                                              uint32_t timeoutMs );
+void IotTestBleHal_ClearEventQueue( void );
 
 void IotTestBleHal_BLEManagerInit( void );
 void IotTestBleHal_BLEEnable( bool bEnable );

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -228,6 +228,8 @@ TEST( Full_BLE, BLE_Connection_Mode1Level2 )
     BLETESTPairingStateChangedCallback_t xPairingStateChangedEvent;
     BLETESTsspRequestCallback_t xSSPrequestEvent;
 
+    IotTestBleHal_ClearEventQueue();
+
     IotTestBleHal_StartAdvertisement();
     IotTestBleHal_WaitConnection( true );
 

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -1689,14 +1689,13 @@ BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
     return xStatus;
 }
 
-void  IotTestBleHal_ClearEventQueue( void )
+void IotTestBleHal_ClearEventQueue( void )
 {
     IotMutex_Lock( &threadSafetyMutex );
 
     IotListDouble_RemoveAll( &eventQueueHead, IotTest_Free, offsetof( BLEHALEventsInternals_t, eventList ) );
 
     IotMutex_Unlock( &threadSafetyMutex );
-
 }
 
 void prvIndicationSentCb( uint16_t usConnId,

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -457,13 +457,7 @@ void IotTestBleHal_BLESetUp()
 
 void IotTestBleHal_BLEFree( void )
 {
-    IotMutex_Lock( &threadSafetyMutex );
-
-    /* Get the event associated to the callback */
-    IotListDouble_RemoveAll( &eventQueueHead, IotTest_Free, offsetof( BLEHALEventsInternals_t, eventList ) );
-
-    IotMutex_Unlock( &threadSafetyMutex );
-
+    IotTestBleHal_ClearEventQueue();
     IotMutex_Destroy( &threadSafetyMutex );
     IotSemaphore_Destroy( &eventSemaphore );
 }
@@ -1695,6 +1689,15 @@ BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
     return xStatus;
 }
 
+void  IotTestBleHal_ClearEventQueue( void )
+{
+    IotMutex_Lock( &threadSafetyMutex );
+
+    IotListDouble_RemoveAll( &eventQueueHead, IotTest_Free, offsetof( BLEHALEventsInternals_t, eventList ) );
+
+    IotMutex_Unlock( &threadSafetyMutex );
+
+}
 
 void prvIndicationSentCb( uint16_t usConnId,
                           BTStatus_t xStatus )


### PR DESCRIPTION
Clear events from the previous test case

Description
-----------
Some test cases don't check for all ble events in the queue. These pending ble events can cause the following test cases to fail.

Added a helper to clear the event queue before running the test case.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.