### PR TITLE
style: Fixing spelling error on IotRtcStatus_t enum.

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_rtc.c
+++ b/libraries/abstractions/common_io/test/test_iot_rtc.c
@@ -355,8 +355,8 @@ TEST( TEST_IOT_RTC, AFQP_IotRtcSetGetAlarm )
                                  eGetRtcStatus,
                                  ( void * const ) &lStatus);
     TEST_ASSERT_EQUAL( IOT_RTC_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eRtcTimerAlaramTriggered,
-                       lStatus & eRtcTimerAlaramTriggered );
+    TEST_ASSERT_EQUAL( eRtcTimerAlarmTriggered,
+                       lStatus & eRtcTimerAlarmTriggered );
 
     lRetVal = iot_rtc_close( xRtcHandle );
     TEST_ASSERT_EQUAL( IOT_RTC_SUCCESS, lRetVal );


### PR DESCRIPTION
Fixing spelling error on IotRtcStatus_t enum.

Why:  because alarm was spelled wrong.
This is related to PR 1391
@lundinc2 @qiutongs 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.