### PR TITLE
Remove 2 unused functions from +TCP stream buffer

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h
@@ -157,31 +157,6 @@ size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
 	}
 }
 /*-----------------------------------------------------------*/
-static portINLINE BaseType_t xStreamBufferIsEmpty( const StreamBuffer_t *pxBuffer );
-static portINLINE BaseType_t xStreamBufferIsEmpty( const StreamBuffer_t *pxBuffer )
-{
-BaseType_t xReturn;
-
-	/* True if no item is available */
-	if( pxBuffer->uxHead == pxBuffer->uxTail )
-	{
-		xReturn = pdTRUE;
-	}
-	else
-	{
-		xReturn = pdFALSE;
-	}
-	return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-static portINLINE BaseType_t xStreamBufferIsFull( const StreamBuffer_t *pxBuffer );
-static portINLINE BaseType_t xStreamBufferIsFull( const StreamBuffer_t *pxBuffer )
-{
-	/* True if the available space equals zero. */
-	return ( BaseType_t ) ( uxStreamBufferGetSpace( pxBuffer ) == 0u );
-}
-/*-----------------------------------------------------------*/
 
 static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t *pxBuffer, const size_t uxLeft, const size_t uxRight );
 static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t *pxBuffer, const size_t uxLeft, const size_t uxRight )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -43,23 +43,6 @@ Includes   <System Includes> , "Project Includes"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
 
-/* Renesas */
-#define STREAM_BUFFER_H // Prevent from including stream_buffer.h in platform.h in r_ether_rx_if.h
-// because we need FreeRTOS_Stream_Buffer.h but stream_buffer.h has following incompatibilities at least.
-//
-// stream_buffer.h(628):W0520147:Declaration is incompatible with "BaseType_t xStreamBufferIsFull(const StreamBuffer_t *)" (declared at line 179 of FreeRTOS_Stream_Buffer.h)
-// stream_buffer.h(648):W0520147:Declaration is incompatible with "BaseType_t xStreamBufferIsEmpty(const StreamBuffer_t *)" (declared at line 161 of FreeRTOS_Stream_Buffer.h)
-//
-// lib\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h
-//
-// static portINLINE BaseType_t xStreamBufferIsFull( const StreamBuffer_t *pxBuffer );
-// static portINLINE BaseType_t xStreamBufferIsEmpty( const StreamBuffer_t *pxBuffer );
-//
-// lib\include\stream_buffer.h
-//
-// BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;
-// BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;
-//
 #include "r_ether_rx_if.h"
 #include "r_pinset.h"
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The FreeRTOS+TCP library has its own implementation of a stream buffer in `FreeRTOS_Stream_Buffer.c`.
Its implementation differs in some ways from the kernel library `stream_buffer.c`.
Two helper functions are defined in both modules: `xStreamBufferIsFull()` and `xStreamBufferIsEmpty()`.

In many projects, this went unnoticed because the FreeRTOS+TCP versions are never used in any of the sources.

I propose to remove the two unused declarations from `FreeRTOS_Stream_Buffer.c` :

~~~c
static portINLINE BaseType_t xStreamBufferIsEmpty( const StreamBuffer_t *pxBuffer );
static portINLINE BaseType_t xStreamBufferIsFull( const StreamBuffer_t *pxBuffer );
~~~

The [Renesas Network Interface](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c) mentions this conflict.
It defines `STREAM_BUFFER_H` to avoid the inclusion of `stream_buffer.h`. That is not necessary anymore after this patch.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.