### PR TITLE
Fix FreeRTOS+TCP rand32 mapping in ESP32.

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -105,8 +105,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * number generation is performed via this macro to allow applications to use their
  * own random number generation method.  For example, it might be possible to
  * generate a random number by sampling noise on an analogue input. */
-extern int rand();
-#define ipconfigRAND32()    rand()
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -105,8 +105,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * number generation is performed via this macro to allow applications to use their
  * own random number generation method.  For example, it might be possible to
  * generate a random number by sampling noise on an analogue input. */
-extern int rand();
-#define ipconfigRAND32()    rand()
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK


### PR DESCRIPTION
- This was mapping to c std rand() and therefore the same numbers were being output each board reset.
- ulRand() defined in the secure sockets port for FreeRTOS+TCP maps to the ESP32 hardware entropy logic.

This fixes issue #1357 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.