### PR TITLE
disable network in demo cleanup code so that demo can be re-run

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -283,6 +283,7 @@ static int _initialize( demoContext_t * pContext )
  */
 static void _cleanup( void )
 {
+    AwsIotNetworkManager_DisableNetwork( configENABLED_NETWORKS );
     /* Remove network manager subscription */
     AwsIotNetworkManager_RemoveSubscription( subscription );
     IotSemaphore_Destroy( &demoNetworkSemaphore );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
disable network in demo cleanup code so that demo can be re-run

Related issue: https://github.com/aws/amazon-freertos/issues/1380

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.