### PR TITLE
Don't check for ECDSA support if it's disabled in static configuration.

### DIFF
--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -788,24 +788,21 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
         configPRINTF( ( "The PKCS #11 module supports RSA signing.\r\n" ) );
     }
 
-    /* Check for ECDSA support. */
-    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
-    TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
+    /* Check for ECDSA support, if applicable. */
+    #if ( 1 == pkcs11testEC_KEY_SUPPORT )
+        xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
+        TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
 
-    if( CKR_OK == xResult )
-    {
-        TEST_ASSERT_TRUE( 0 != ( ( CKF_SIGN | CKF_VERIFY ) & MechanismInfo.flags ) );
+        if( CKR_OK == xResult )
+        {
+            TEST_ASSERT_TRUE( 0 != ( ( CKF_SIGN | CKF_VERIFY ) & MechanismInfo.flags ) );
 
-        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
-                          MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
+            TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
+                              MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
 
-        /* Check consistency with static configuration. */
-        #if ( 0 == pkcs11testEC_KEY_SUPPORT )
-            TEST_FAIL_MESSAGE( "Static and runtime configuration for key generation support are inconsistent." );
-        #endif
-
-        configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
-    }
+            configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
+        }
+    #endif /* if ( 1 == pkcs11testEC_KEY_SUPPORT ) */
 
     /* Check for elliptic-curve key generation support. */
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_EC_KEY_PAIR_GEN, &MechanismInfo );
@@ -822,8 +819,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
         configPRINTF( ( "The PKCS #11 module supports elliptic-curve key generation.\r\n" ) );
     }
 
-    /* SHA-256 support is required, but we don't need to write it to the console,
-     * since it doesn't impact the execution sequence for IDT. */
+    /* SHA-256 support is required. */
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_SHA256, &MechanismInfo );
     TEST_ASSERT_TRUE( CKR_OK == xResult );
     TEST_ASSERT_TRUE( 0 != ( CKF_DIGEST & MechanismInfo.flags ) );

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -789,20 +789,23 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     }
 
     /* Check for ECDSA support, if applicable. */
-    #if ( 1 == pkcs11testEC_KEY_SUPPORT )
-        xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
-        TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
+    xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
+    TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
 
-        if( CKR_OK == xResult )
-        {
-            TEST_ASSERT_TRUE( 0 != ( ( CKF_SIGN | CKF_VERIFY ) & MechanismInfo.flags ) );
+    if( CKR_OK == xResult )
+    {
+        TEST_ASSERT_TRUE( 0 != ( ( CKF_SIGN | CKF_VERIFY ) & MechanismInfo.flags ) );
 
-            TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
-                              MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
+        TEST_ASSERT_TRUE( MechanismInfo.ulMaxKeySize >= pkcs11ECDSA_P256_KEY_BITS &&
+                          MechanismInfo.ulMinKeySize <= pkcs11ECDSA_P256_KEY_BITS );
 
-            configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
-        }
-    #endif /* if ( 1 == pkcs11testEC_KEY_SUPPORT ) */
+        /* Check consistency with static configuration. */
+        #if ( 0 == pkcs11testEC_KEY_SUPPORT )
+            TEST_FAIL_MESSAGE( "Static and runtime configuration for key generation support are inconsistent." );
+        #endif
+
+        configPRINTF( ( "The PKCS #11 module supports ECDSA.\r\n" ) );
+    }
 
     /* Check for elliptic-curve key generation support. */
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_EC_KEY_PAIR_GEN, &MechanismInfo );

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
@@ -44,19 +44,19 @@
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
  */
-#define configPKCS11_DEFAULT_USER_PIN    "0000"
+#define configPKCS11_DEFAULT_USER_PIN                      "0000"
 
 /**
  * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
  * attribute.
  */
-#define pkcs11configMAX_LABEL_LENGTH     32
+#define pkcs11configMAX_LABEL_LENGTH                       32
 
 /**
  * @brief Maximum number of token objects that can be stored
  * by the PKCS #11 module.
  */
-#define pkcs11configMAX_NUM_OBJECTS      6
+#define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
  * @brief Set to 1 if a PAL destroy object is implemented.
@@ -127,5 +127,14 @@
  * @see aws_default_root_certificates.h
  */
 #define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
+
+/**
+ * @brief Disable ECDSA crypto algorithm (i.e. mechanism) support in this
+ * PKCS #11 module.
+ *
+ * Set this to 1 when the host doesn't support ECDSA for network authentication
+ * (e.g. in the TLS protocol implementation).
+ */
+#define pkcs11configSUPPRESS_ECDSA_MECHANISM               1
 
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -25,7 +25,7 @@
 
 /**
  * @file iot_test_pkcs11_config.h
- * @brief Port-specific variables for PKCS11 tests. 
+ * @brief Port-specific variables for PKCS11 tests.
  */
 
 #ifndef _AWS_TEST_PKCS11_CONFIG_H_
@@ -37,7 +37,7 @@
  * Each task consumes both stack and heap space, which may cause memory allocation
  * failures if too many tasks are created.
  */
-#define pkcs11testMULTI_THREAD_TASK_COUNT    ( 2 )
+#define pkcs11testMULTI_THREAD_TASK_COUNT             ( 2 )
 
 /**
  * @brief The number of iterations in SignVerifyRoundTrip_MultitaskLoop.
@@ -46,7 +46,7 @@
  * boards. Ensure that pkcs11testEVENT_GROUP_TIMEOUT is long enough to accommodate
  * all iterations of the loop.
  */
-#define pkcs11testMULTI_THREAD_LOOP_COUNT    ( 10 )
+#define pkcs11testMULTI_THREAD_LOOP_COUNT             ( 10 )
 
 /**
  * @brief
@@ -54,32 +54,32 @@
  * All tasks of the SignVerifyRoundTrip_MultitaskLoop test must finish within
  * this timeout, or the test will fail.
  */
-#define pkcs11testEVENT_GROUP_TIMEOUT_MS    ( pdMS_TO_TICKS( 1000000UL ) )
+#define pkcs11testEVENT_GROUP_TIMEOUT_MS              ( pdMS_TO_TICKS( 1000000UL ) )
 
 /**
  * @brief The index of the slot that should be used to open sessions for PKCS #11 tests.
  */
-#define pkcs11testSLOT_NUMBER                 ( 0 )
+#define pkcs11testSLOT_NUMBER                         ( 0 )
 
 /*
  * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testRSA_KEY_SUPPORT             ( 1 )
+#define pkcs11testRSA_KEY_SUPPORT                     ( 1 )
 
 /*
  * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testEC_KEY_SUPPORT              ( 0 )
+#define pkcs11testEC_KEY_SUPPORT                      ( 0 )
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT       ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT          ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )
 
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT    ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 0 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.
@@ -88,7 +88,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
+#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS    pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for device public key.
@@ -97,7 +97,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for the device certificate.
@@ -106,7 +106,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS       pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS
+#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS    pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for the object to be used for code verification.
@@ -117,7 +117,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_CODE_VERIFICATION_KEY            pkcs11configLABEL_CODE_VERIFICATION_KEY
+#define pkcs11testLABEL_CODE_VERIFICATION_KEY         pkcs11configLABEL_CODE_VERIFICATION_KEY
 
 /**
  * @brief The PKCS #11 label for Just-In-Time-Provisioning.
@@ -130,12 +130,12 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_JITP_CERTIFICATE                 pkcs11configLABEL_JITP_CERTIFICATE
+#define pkcs11testLABEL_JITP_CERTIFICATE              pkcs11configLABEL_JITP_CERTIFICATE
 
 /**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
+#define pkcs11testLABEL_ROOT_CERTIFICATE              pkcs11configLABEL_ROOT_CERTIFICATE
 #endif /* _AWS_TEST_PKCS11_CONFIG_H_ */


### PR DESCRIPTION
If ECDSA support has been disabled via static configuration, the PKCS #11 test module should completely skip test cases that involve that cryptosystem.