### PR TITLE
Revert "Modify PKCS #11 GenerateRandom to return entropy & CRYPTO lay…

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -112,9 +112,11 @@ typedef struct P11ObjectList_t
 /* PKCS #11 Module Object */
 typedef struct P11Struct_t
 {
-    CK_BBOOL xIsInitialized;     /* Indicates whether PKCS #11 module has been initialized with a call to C_Initialize. */
-    P11ObjectList_t xObjectList; /* List of PKCS #11 objects that have been found/created since module initialization.
-                                  * The array position indicates the "App Handle"  */
+    CK_BBOOL xIsInitialized;                     /* Indicates whether PKCS #11 module has been initialized with a call to C_Initialize. */
+    mbedtls_ctr_drbg_context xMbedDrbgCtx;       /* CTR-DRBG context for PKCS #11 module - used to generate pseudo-random numbers. */
+    mbedtls_entropy_context xMbedEntropyContext; /* Entropy context for PKCS #11 module - used to collect entropy for RNG. */
+    P11ObjectList_t xObjectList;                 /* List of PKCS #11 objects that have been found/created since module initialization.
+                                                  * The array position indicates the "App Handle"  */
 } P11Struct_t, * P11Context_t;
 
 /* The global PKCS #11 module object.
@@ -263,7 +265,23 @@ CK_RV prvMbedTLS_Initialize( void )
         memset( &xP11Context, 0, sizeof( xP11Context ) );
         xP11Context.xObjectList.xMutex = xSemaphoreCreateMutex();
 
-        xP11Context.xIsInitialized = CK_TRUE;
+        CRYPTO_Init();
+        /* Initialize the entropy source and DRBG for the PKCS#11 module */
+        mbedtls_entropy_init( &xP11Context.xMbedEntropyContext );
+        mbedtls_ctr_drbg_init( &xP11Context.xMbedDrbgCtx );
+
+        if( 0 != mbedtls_ctr_drbg_seed( &xP11Context.xMbedDrbgCtx,
+                                        mbedtls_entropy_func,
+                                        &xP11Context.xMbedEntropyContext,
+                                        NULL,
+                                        0 ) )
+        {
+            xResult = CKR_FUNCTION_FAILED;
+        }
+        else
+        {
+            xP11Context.xIsInitialized = CK_TRUE;
+        }
     }
 
     return xResult;
@@ -679,6 +697,16 @@ CK_DECLARE_FUNCTION( CK_RV, C_Finalize )( CK_VOID_PTR pvReserved )
 
     if( xResult == CKR_OK )
     {
+        if( NULL != &xP11Context.xMbedEntropyContext )
+        {
+            mbedtls_entropy_free( &xP11Context.xMbedEntropyContext );
+        }
+
+        if( NULL != &xP11Context.xMbedDrbgCtx )
+        {
+            mbedtls_ctr_drbg_free( &xP11Context.xMbedDrbgCtx );
+        }
+
         vSemaphoreDelete( xP11Context.xObjectList.xMutex );
 
         xP11Context.xIsInitialized = CK_FALSE;
@@ -3065,8 +3093,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE xSession,
                                                       ulDataLen,
                                                       pxSignatureBuffer,
                                                       ( size_t * ) &xExpectedInputLength,
-                                                      CRYPTO_GetRandomBytes,
-                                                      NULL );
+                                                      mbedtls_ctr_drbg_random,
+                                                      &xP11Context.xMbedDrbgCtx );
 
                     if( lMbedTLSResult != CKR_OK )
                     {
@@ -3724,8 +3752,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     {
         if( 0 != mbedtls_ecp_gen_key( MBEDTLS_ECP_DP_SECP256R1,
                                       mbedtls_pk_ec( xCtx ),
-                                      CRYPTO_GetRandomBytes,
-                                      NULL ) )
+                                      mbedtls_ctr_drbg_random,
+                                      &xP11Context.xMbedDrbgCtx ) )
         {
             xResult = CKR_FUNCTION_FAILED;
         }
@@ -3785,32 +3813,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     return xResult;
 }
 
-
-/**
- * @brief Obtain entropy data.
- *
- * For mbedTLS-based implementations, this is
- * a wrapper of mbedtls_hardware_poll()
- *
- * @note Note that if the port using NVM seeding,
- * lPortGetEntropyFromHardware() would need to map to
- * mbedtls_nv_seed_poll() wrapper instead of
- * mbedtls_hardware_poll() wrapper.
- *
- * @param[in] data      Unused in current implementation.
- *                      Implementation should be able to
- *                      accept NULL for this input.
- * @param[out] output   Location that random bytes should be
- *                      placed.
- * @param[len] len      Number of bytes requested.
- * @param[in/out] olen  Updated to contain the actual number of
- *                      bytes returned.
- */
-extern int lPortGetEntropyFromHardware( void * data,
-                                        unsigned char * output,
-                                        size_t len,
-                                        size_t * olen );
-
 /**
  * @brief Generate cryptographically random bytes.
  *
@@ -3828,13 +3830,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
                                                 CK_BYTE_PTR pucRandomData,
                                                 CK_ULONG ulRandomLen )
 {
-#define ENTROPY_MAX_LOOPS    256
-
     CK_RV xResult = CKR_OK;
-    int lResult = 0;
-    size_t olen = 0;
-    int lLoops = 0;
-    int totalBytes = 0;
+    int lMbedResult = 0;
 
     xResult = PKCS11_SESSION_VALID_AND_MODULE_INITIALIZED( xSession );
 
@@ -3846,34 +3843,13 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE xSession,
 
     if( xResult == CKR_OK )
     {
-        while( ( lLoops < ENTROPY_MAX_LOOPS ) && ( totalBytes < ulRandomLen ) )
+        lMbedResult = mbedtls_ctr_drbg_random( &xP11Context.xMbedDrbgCtx, pucRandomData, ulRandomLen );
+
+        if( lMbedResult != 0 )
         {
-            lResult = lPortGetEntropyFromHardware( NULL,
-                                                   &pucRandomData[ totalBytes ],
-                                                   ulRandomLen - totalBytes,
-                                                   &olen );
-
-            if( lResult != 0 )
-            {
-                break;
-            }
-
-            totalBytes += olen;
-            lLoops++;
-
-            /* If no entropy was returned, give the hardware time
-             * to generate additional entropy. */
-            if( olen == 0 )
-            {
-                vTaskDelay( 1 );
-            }
+            PKCS11_PRINT( ( "ERROR: DRBG failed %d \r\n", lMbedResult ) );
+            xResult = CKR_FUNCTION_FAILED;
         }
-    }
-
-    if( ( lResult != 0 ) || ( totalBytes != ulRandomLen ) )
-    {
-        PKCS11_PRINT( ( "ERROR: Failed to get entropy from hardware. Error %d, Bytes Generated %d, Bytes Requested %d\r\n ", lResult, olen, ulRandomLen ) );
-        xResult = CKR_FUNCTION_FAILED;
     }
 
     return xResult;

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -110,7 +110,7 @@ TEST_GROUP( Full_PKCS11_RSA );
 /* The EC test group is for tests that require elliptic curve keys. */
 TEST_GROUP( Full_PKCS11_EC );
 
-/*#define PKCS11_TEST_MEMORY_LEAK */
+/* #define PKCS11_TEST_MEMORY_LEAK */
 #ifdef PKCS11_TEST_MEMORY_LEAK
     BaseType_t xHeapBefore;
     BaseType_t xHeapAfter;
@@ -1042,8 +1042,9 @@ static void prvGenerateRandomMultiThreadTask( void * pvParameters )
 
     for( xCount = 0; xCount < pkcs11testMULTI_THREAD_LOOP_COUNT; xCount++ )
     {
-        /* TS-9475 */
-        xResult = CRYPTO_GetRandomBytes( NULL, xRandomData, sizeof( xRandomData ) );
+        xResult = pxGlobalFunctionList->C_GenerateRandom( xSession,
+                                                          xRandomData,
+                                                          sizeof( xRandomData ) );
 
         if( xResult != CKR_OK )
         {

--- a/libraries/freertos_plus/standard/crypto/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/crypto/CMakeLists.txt
@@ -19,7 +19,6 @@ afr_module_include_dirs(
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PRIVATE 3rdparty::mbedtls
-    PRIVATE AFR::pkcs11
 )
 
 # Crypto test

--- a/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
+++ b/libraries/freertos_plus/standard/crypto/include/iot_crypto.h
@@ -28,11 +28,6 @@
 
 #include "FreeRTOS.h"
 
-/*
- * Error codes
- */
-#define CRYPTO_ERROR_RNG             0x3000
-
 /**
  * @brief Commonly used buffer sizes for storing cryptographic hash computation
  * results.
@@ -62,39 +57,12 @@ void CRYPTO_ConfigureThreading( void );
 void CRYPTO_ConfigureHeap( void );
 
 /**
- * @brief Initializes the CRYPTO-maintained DRBG.
- *
- */
-void CRYPTO_ConfigureDRBG( void );
-
-
-/**
  * @brief Library-independent cryptographic algorithm identifiers.
  */
 #define cryptoHASH_ALGORITHM_SHA1           1
 #define cryptoHASH_ALGORITHM_SHA256         2
 #define cryptoASYMMETRIC_ALGORITHM_RSA      1
 #define cryptoASYMMETRIC_ALGORITHM_ECDSA    2
-
-
-
-/**
- * @brief Generate random bytes.
- *
- * @param[in] pvContext           Pointer to a context for compatibility with other crypto
- *                                libraries.  This input is ignored in this port.
- * @param[out] pRandomBytes       Pointer to the location where random bytes will be
- *                                placed.  This memory should be allocated by the caller.
- * @param[in] length              Number of random bytes to be generated.  pRandomBytes
- *                                must be at least length bytes long.
- *
- * @return 0 on success, otherwise error.
- *
- */
-int CRYPTO_GetRandomBytes( void * pvContext,
-                           uint8_t * pRandomBytes,
-                           size_t length );
-
 
 /**
  * @brief Initializes digital signature verification.

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -27,7 +27,6 @@
 #include "FreeRTOS.h"
 #include "FreeRTOSIPConfig.h"
 #include "iot_crypto.h"
-#include "iot_pkcs11.h"
 
 /* mbedTLS includes. */
 
@@ -42,9 +41,6 @@
 #include "mbedtls/sha1.h"
 #include "mbedtls/pk.h"
 #include "mbedtls/x509_crt.h"
-#include "mbedtls/ctr_drbg.h"
-#include "mbedtls/entropy.h"
-
 /* Threading mutex implementations for mbedTLS. */
 #include "mbedtls/threading.h"
 #include "threading_alt.h"
@@ -250,7 +246,6 @@ void CRYPTO_Init( void )
 {
     CRYPTO_ConfigureHeap();
     CRYPTO_ConfigureThreading();
-    CRYPTO_ConfigureDRBG();
 }
 
 /**
@@ -265,16 +260,6 @@ void CRYPTO_ConfigureHeap( void )
 }
 
 
-typedef struct CryptoDRBG_t
-{
-    CK_BBOOL xIsInitialized;                     /* Indicates whether PKCS #11 module has been initialized with a call to C_Initialize. */
-    mbedtls_ctr_drbg_context xMbedDrbgCtx;       /* CTR-DRBG context for PKCS #11 module - used to generate pseudo-random numbers. */
-    mbedtls_entropy_context xMbedEntropyContext; /* Entropy context for PKCS #11 module - used to collect entropy for RNG. */
-} CryptoDRBG_t;
-
-CryptoDRBG_t xDrbg;
-
-
 void CRYPTO_ConfigureThreading( void )
 {
     /* Configure mbedtls to use FreeRTOS mutexes. */
@@ -283,107 +268,6 @@ void CRYPTO_ConfigureThreading( void )
                                aws_mbedtls_mutex_lock,
                                aws_mbedtls_mutex_unlock );
 }
-
-
-void CRYPTO_ConfigureDRBG( void )
-{
-    int lMbedResult = 0;
-
-    /* Initialize the entropy source and DRBG for the CRYPTO module */
-    mbedtls_entropy_init( &xDrbg.xMbedEntropyContext );
-    mbedtls_ctr_drbg_init( &xDrbg.xMbedDrbgCtx );
-
-    if( 0 != mbedtls_ctr_drbg_seed( &xDrbg.xMbedDrbgCtx,
-                                    mbedtls_entropy_func,
-                                    &xDrbg.xMbedEntropyContext,
-                                    NULL,
-                                    0 ) )
-    {
-        CRYPTO_PRINT( ( "Failed to seed DRBG" ) );
-    }
-    else
-    {
-        xDrbg.xIsInitialized = CK_TRUE;
-    }
-}
-
-
-
-int mbedtls_hardware_poll( void * data,
-                           unsigned char * output,
-                           size_t len,
-                           size_t * olen )
-{
-    int lStatus = MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
-    CK_RV xSession = CK_INVALID_HANDLE;
-    CK_RV xResult = CKR_OK;
-    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-    CK_BBOOL xSessionOpened = CK_FALSE;
-
-    xResult = C_GetFunctionList( &pxFunctionList );
-
-    if( xResult == CKR_OK )
-    {
-        xResult = xInitializePkcs11Session( &xSession );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xSessionOpened = CK_TRUE;
-        xResult = pxFunctionList->C_GenerateRandom( xSession, output, len );
-    }
-
-    if( xSessionOpened == CK_TRUE )
-    {
-        xResult = pxFunctionList->C_CloseSession( xSession );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        lStatus = 0;
-        *olen = len;
-    }
-
-    return lStatus;
-}
-
-
-
-int CRYPTO_GetRandomBytes( void * pvCtx,
-                           uint8_t * pRandomBytes,
-                           size_t length )
-{
-    ( void ) pvCtx; /*lint !e9087 !e9079 Allow casting void* to other types. */
-
-    int lResult = 0;
-
-    if( ( NULL == pRandomBytes ) ||
-        ( length == 0 ) )
-    {
-        CRYPTO_PRINT( ( "ERROR: Invalid inputs to CRYPTO_GetRandomBytes \r\n" ) );
-        lResult = CRYPTO_ERROR_RNG;
-    }
-
-    if( xDrbg.xIsInitialized != CK_TRUE )
-    {
-        CRYPTO_PRINT( ( "ERROR: DRBG is not initialized \r\n" ) );
-        lResult = CRYPTO_ERROR_RNG;
-    }
-
-    if( lResult == 0 )
-    {
-        lResult = mbedtls_ctr_drbg_random( &xDrbg.xMbedDrbgCtx, pRandomBytes, length );
-
-        if( lResult != 0 )
-        {
-            CRYPTO_PRINT( ( "ERROR: DRBG failed %d \r\n", lResult ) );
-            lResult = CRYPTO_ERROR_RNG;
-        }
-    }
-
-    return lResult;
-}
-
 
 /**
  * @brief Creates signature verification context.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -63,10 +63,10 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int lPortGetEntropyFromHardware( void * data,
-                                  unsigned char * output,
-                                  size_t len,
-                                  size_t * olen )
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
 {
 
 #ifdef WLAN_FIRMWARE_PRNG_SEED

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/hw_poll.c
@@ -63,10 +63,10 @@ extern uint32_t ulSeed;
 static uint32_t ulPrgnSeedDone = 0;
 #endif
 
-int lPortGetEntropyFromHardware( void * data,
-                                  unsigned char * output,
-                                  size_t len,
-                                  size_t * olen )
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
 {
 
 #ifdef WLAN_FIRMWARE_PRNG_SEED

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/mbedtls/port/esp_hardware.c
@@ -11,7 +11,7 @@
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
 extern int os_get_random(unsigned char *buf, size_t len);
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     os_get_random(output, len);

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/application_code/infineon_code/entropy_hardware_alt.c
@@ -19,7 +19,7 @@
 #include "xmc_common.h"
 #include "mbedtls/entropy_poll.h"
 
-int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
   (void)data;
 

--- a/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/examples/mbedtls_port/trustx_random.c
@@ -39,7 +39,7 @@
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     optiga_lib_status_t status;

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -322,7 +322,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 /*-----------------------------------------------------------*/
 
 
-int lPortGetEntropyFromHardware( void * data,
+int mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -346,7 +346,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 #include <string.h>
 #include <hal_trng.h>
 
-int lPortGetEntropyFromHardware( void * data,
+int mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ typedef struct
  */
 static P11KeyConfig_t P11ConfigSave;
 
-int lPortGetEntropyFromHardware( void * data,
+int mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen );
@@ -373,7 +373,7 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 
 /*-----------------------------------------------------------*/
 
-int lPortGetEntropyFromHardware( void * data,
+int mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -216,7 +216,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
 
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c
@@ -216,7 +216,7 @@ static BaseType_t trng_init()
  * Get len bytes of entropy from the hardware RNG.
  */
 
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
     /* Enabling ADC and sampling the internal voltage to come out one random seed,

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/hw_poll.c
@@ -47,7 +47,7 @@
 #endif
 
 
-int lPortGetEntropyFromHardware(void *data, unsigned char *output, size_t len, size_t *olen)
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     status_t result = kStatus_Success;
 

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_entropy_hardware_poll.c
@@ -30,7 +30,7 @@
 
 /*-----------------------------------------------------------*/
 
-int lPortGetEntropyFromHardware( void * data,
+int mbedtls_hardware_poll( void * data,
                            unsigned char * output,
                            size_t len,
                            size_t * olen )

--- a/vendors/pc/boards/windows/aws_tests/application_code/main.c
+++ b/vendors/pc/boards/windows/aws_tests/application_code/main.c
@@ -145,9 +145,6 @@ int main( void )
         0,
         0 );
 
-    /* Initialize AWS system libraries. */
-    SYSTEM_Init();
-
     /* Initialize the network interface.
      *
      ***NOTE*** Tasks that use the network are created in the network event hook
@@ -176,6 +173,8 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     /* If the network has just come up...*/
     if( ( eNetworkEvent == eNetworkUp ) && ( xTasksAlreadyCreated == pdFALSE ) )
     {
+        /* Initialize AWS system libraries. */
+        SYSTEM_Init();
 
         vDevModeKeyProvisioning();
 

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -15,19 +15,19 @@ void get_random_number(uint8_t *data, uint32_t len);
 /******************************************************************************
 Functions : hardware entropy collector(repeatedly called until enough gathered)
 ******************************************************************************/
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);
+    R_INTERNAL_NOT_USED(len);
 
     uint32_t random_number = 0;
-    size_t num_bytes = ( len < 4 ) ? len : 4;
 
-    get_random_number( ( uint8_t * ) &random_number, num_bytes );
+    get_random_number((uint8_t *)&random_number, sizeof(uint32_t));
     *olen = 0;
 
-    memcpy( output, &random_number, num_bytes );
-    *olen = num_bytes;
+    memcpy(output, &random_number, sizeof(uint32_t));
+    *olen = sizeof(uint32_t);
 
     return 0;
 }

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
@@ -49,11 +49,11 @@
 #include "main.h"
 #include "stm32l4xx_hal.h"
 
-int lPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
+int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
@@ -48,11 +48,11 @@
 #include <string.h>
 #include "main.h"
 
-int lPortGetEntropyFromHardware( void *data, unsigned char *output, size_t len, size_t *olen );
+int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
 
 
-int lPortGetEntropyFromHardware( void *data,
+int mbedtls_hardware_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen )
 {
   HAL_StatusTypeDef status = HAL_OK;

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -657,10 +657,10 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 
 /*-----------------------------------------------------------*/
 
-int lPortGetEntropyFromHardware( void * data,
-                                  unsigned char * output,
-                                  size_t len,
-                                  size_t * olen )
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
 {
     int lStatus = MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
 

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -38,99 +38,97 @@
 
 
 /**
- * @brief Writes a file to local storage.
- *
- * Port-specific file write for crytographic information.
- *
- * @param[in] pxLabel       Label of the object to be saved.
- * @param[in] pucData       Data buffer to be written to file
- * @param[in] ulDataSize    Size (in bytes) of data to be saved.
- *
- * @return The file handle of the object that was stored.
- */
+* @brief Writes a file to local storage.
+*
+* Port-specific file write for crytographic information.
+*
+* @param[in] pxLabel       Label of the object to be saved.
+* @param[in] pucData       Data buffer to be written to file
+* @param[in] ulDataSize    Size (in bytes) of data to be saved.
+*
+* @return The file handle of the object that was stored.
+*/
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+    uint8_t * pucData,
+    uint32_t ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = 0;
-
     return xHandle;
 }
 
 /**
- * @brief Translates a PKCS #11 label into an object handle.
- *
- * Port-specific object handle retrieval.
- *
- *
- * @param[in] pLabel         Pointer to the label of the object
- *                           who's handle should be found.
- * @param[in] usLength       The length of the label, in bytes.
- *
- * @return The object handle if operation was successful.
- * Returns eInvalidHandle if unsuccessful.
- */
+* @brief Translates a PKCS #11 label into an object handle.
+*
+* Port-specific object handle retrieval.
+*
+*
+* @param[in] pLabel         Pointer to the label of the object
+*                           who's handle should be found.
+* @param[in] usLength       The length of the label, in bytes.
+*
+* @return The object handle if operation was successful.
+* Returns eInvalidHandle if unsuccessful.
+*/
 CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+    uint8_t usLength )
 {
     CK_OBJECT_HANDLE xHandle = 0;
-
     return xHandle;
 }
 
 /**
- * @brief Gets the value of an object in storage, by handle.
- *
- * Port-specific file access for cryptographic information.
- *
- * This call dynamically allocates the buffer which object value
- * data is copied into.  PKCS11_PAL_GetObjectValueCleanup()
- * should be called after each use to free the dynamically allocated
- * buffer.
- *
- * @sa PKCS11_PAL_GetObjectValueCleanup
- *
- * @param[in] pcFileName    The name of the file to be read.
- * @param[out] ppucData     Pointer to buffer for file data.
- * @param[out] pulDataSize  Size (in bytes) of data located in file.
- * @param[out] pIsPrivate   Boolean indicating if value is private (CK_TRUE)
- *                          or exportable (CK_FALSE)
- *
- * @return CKR_OK if operation was successful.  CKR_KEY_HANDLE_INVALID if
- * no such object handle was found, CKR_DEVICE_MEMORY if memory for
- * buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
- * error.
- */
+* @brief Gets the value of an object in storage, by handle.
+*
+* Port-specific file access for cryptographic information.
+*
+* This call dynamically allocates the buffer which object value
+* data is copied into.  PKCS11_PAL_GetObjectValueCleanup()
+* should be called after each use to free the dynamically allocated
+* buffer.
+*
+* @sa PKCS11_PAL_GetObjectValueCleanup
+*
+* @param[in] pcFileName    The name of the file to be read.
+* @param[out] ppucData     Pointer to buffer for file data.
+* @param[out] pulDataSize  Size (in bytes) of data located in file.
+* @param[out] pIsPrivate   Boolean indicating if value is private (CK_TRUE)
+*                          or exportable (CK_FALSE)
+*
+* @return CKR_OK if operation was successful.  CKR_KEY_HANDLE_INVALID if
+* no such object handle was found, CKR_DEVICE_MEMORY if memory for
+* buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
+* error.
+*/
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+    uint8_t ** ppucData,
+    uint32_t * pulDataSize,
+    CK_BBOOL * pIsPrivate )
 {
     CK_RV xReturn = CKR_OK;
-
     return xReturn;
 }
 
 
 /**
- * @brief Cleanup after PKCS11_GetObjectValue().
- *
- * @param[in] pucData       The buffer to free.
- *                          (*ppucData from PKCS11_PAL_GetObjectValue())
- * @param[in] ulDataSize    The length of the buffer to free.
- *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
- */
+* @brief Cleanup after PKCS11_GetObjectValue().
+*
+* @param[in] pucData       The buffer to free.
+*                          (*ppucData from PKCS11_PAL_GetObjectValue())
+* @param[in] ulDataSize    The length of the buffer to free.
+*                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
+*/
 void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+    uint32_t ulDataSize )
 {
+    
 }
 
 /*-----------------------------------------------------------*/
 
-int lPortGetEntropyFromHardware( void * data,
-                                  unsigned char * output,
-                                  size_t len,
-                                  size_t * olen )
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
 {
     /* FIX ME. */
     return 0;

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -333,10 +333,10 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 }
 
 
-int lPortGetEntropyFromHardware( void * data,
-                                  unsigned char * output,
-                                  size_t len,
-                                  size_t * olen )                        
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
 {
     ( void ) data;
 


### PR DESCRIPTION
…er to ma… (#1372)"

This reverts commit d1200dd03510659ea4905a3213440073b45488e4.

# Conflicts:
#	vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code/entropy_hardware_poll.c
#	vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code/entropy_hardware_poll.c

Conflicts resolved by using master, but manually changing lPortGetEntropyFromHardware
to mbedtls_hardware_poll manually.

<!--- Title -->

Tests:
Tests, IDE: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/255/
-rb nuvoton: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/nuvoton/job/numaker_iot_m487_wifi-ide/67/
Tests, CMake: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_cmake/162/console

Dmeos, IDE: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/256/console
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/260/console
rb cyp: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/cypress/job/cypress54-ide/77/console
Demos, Cmake: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_cmake/163/
rb pc: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/pc/job/windows-cmake/62/console
rb nuvo: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/nuvoton/job/numaker_iot_m487_wifi-cmake/48/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.