### PR TITLE
Prevent overflow of Renesas RNG buffer

### DIFF
--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -21,7 +21,7 @@ int mbedtls_hardware_poll( void *data,
     R_INTERNAL_NOT_USED(data);
 
     uint32_t random_number = 0;
-    size_t num_bytes = ( len < 4 ) ? len : 4;
+    size_t num_bytes = ( len < sizeof( uint32_t ) ) ? len : sizeof( uint32_t );
 
     get_random_number( ( uint8_t * ) &random_number, sizeof( uint32_t ) );
     *olen = 0;

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -19,15 +19,15 @@ int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);
-    R_INTERNAL_NOT_USED(len);
 
     uint32_t random_number = 0;
+    size_t num_bytes = ( len < 4 ) ? len : 4;
 
-    get_random_number((uint8_t *)&random_number, sizeof(uint32_t));
+    get_random_number( ( uint8_t * ) &random_number, sizeof( uint32_t ) );
     *olen = 0;
 
-    memcpy(output, &random_number, sizeof(uint32_t));
-    *olen = sizeof(uint32_t);
+    memcpy( output, &random_number, num_bytes );
+    *olen = num_bytes;
 
     return 0;
 }


### PR DESCRIPTION
When data requested is not a multiple of 4 bytes,
mbedtls_hardware_poll could have overflowed the output
buffer.

<!--- Title -->

Tests
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/262/console
Rebuild after PR feedback:
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/274/console (all tests pass)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.