### PR TITLE
Add test that private keys are not extractable

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2163,6 +2163,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
         {
             xResult = PKCS11_PAL_GetObjectValue( xPalHandle, &pxObjectValue, &ulLength, &xIsPrivate );
         }
+        else
+        {
+            xResult = CKR_OBJECT_HANDLE_INVALID;
+        }
     }
 
     /* Determine what kind of object we are dealing with. */

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2293,6 +2293,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
 
                     break;
 
+                case CKA_PRIVATE_EXPONENT:
+
+                    xResult = CKR_ATTRIBUTE_SENSITIVE;
+
+                    break;
+
                 case CKA_EC_PARAMS:
 
                     /* TODO: Add check that is key, is ec key. */

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1265,7 +1265,7 @@ TEST( Full_PKCS11_RSA, AFQP_CreateObjectGetAttributeValue )
     CK_OBJECT_HANDLE xCertificateHandle;
     CK_ATTRIBUTE xTemplate;
     CK_BYTE xCertificateValue[ CERTIFICATE_VALUE_LENGTH ];
-    CK_BYTE xKeyComponent[ (pkcs11RSA_2048_MODULUS_BITS / 8) + 1 ] = { 0 };
+    CK_BYTE xKeyComponent[ ( pkcs11RSA_2048_MODULUS_BITS / 8 ) + 1 ] = { 0 };
 
     prvProvisionRsaTestCredentials( &xPrivateKeyHandle, &xCertificateHandle );
 
@@ -1825,7 +1825,7 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     xTemplate.ulValueLen = sizeof( xPrivateKeyBuffer );
     xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xPrivateKeyBuffer, &xTemplate, 1 );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_ATTRIBUTE_SENSITIVE, xResult, "Wrong error code retrieving private key" );
-    TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE( 0, xPrivateKeyBuffer, sizeof(xPrivateKeyBuffer), "Private key bytes returned when they should not be" );
+    TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE( 0, xPrivateKeyBuffer, sizeof( xPrivateKeyBuffer ), "Private key bytes returned when they should not be" );
 
     /* Check that public key point can be retrieved for public key. */
     xTemplate.type = CKA_EC_POINT;

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1265,6 +1265,7 @@ TEST( Full_PKCS11_RSA, AFQP_CreateObjectGetAttributeValue )
     CK_OBJECT_HANDLE xCertificateHandle;
     CK_ATTRIBUTE xTemplate;
     CK_BYTE xCertificateValue[ CERTIFICATE_VALUE_LENGTH ];
+    CK_BYTE xKeyComponent[ (pkcs11RSA_2048_MODULUS_BITS / 8) + 1 ] = { 0 };
 
     prvProvisionRsaTestCredentials( &xPrivateKeyHandle, &xCertificateHandle );
 
@@ -1282,6 +1283,14 @@ TEST( Full_PKCS11_RSA, AFQP_CreateObjectGetAttributeValue )
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to get RSA certificate value" );
     TEST_ASSERT_EQUAL_MESSAGE( CERTIFICATE_VALUE_LENGTH, xTemplate.ulValueLen, "GetAttributeValue returned incorrect length of RSA certificate value" );
     /* TODO: Check byte array */
+
+    /* Check that the private key cannot be retrieved. */
+    xTemplate.type = CKA_PRIVATE_EXPONENT;
+    xTemplate.pValue = xKeyComponent;
+    xTemplate.ulValueLen = sizeof( xKeyComponent );
+    xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xPrivateKeyHandle, &xTemplate, 1 );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_ATTRIBUTE_SENSITIVE, xResult, "Incorrect error code retrieved when trying to obtain private key." );
+    TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE( 0, xKeyComponent, sizeof( xKeyComponent ), "Private key bytes returned when they should not be." );
 }
 
 
@@ -1719,7 +1728,7 @@ TEST( Full_PKCS11_EC, AFQP_Sign )
 
 /*
  * 1. Generates an Elliptic Curve P256 key pair
- * 2. Calls GetAttributeValue to check generated key attirbutes
+ * 2. Calls GetAttributeValue to check generated key & that private key is not extractable.
  * 3. Constructs the public key using values from GetAttributeValue calls
  * 4. Uses private key to perform a sign operation
  * 5. Verifies the signature using mbedTLS library and reconstructed public key
@@ -1738,6 +1747,7 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     CK_MECHANISM xMechanism;
     CK_BYTE xSignature[ pkcs11RSA_2048_SIGNATURE_LENGTH ] = { 0 };
     CK_BYTE xEcPoint[ 256 ] = { 0 };
+    CK_BYTE xPrivateKeyBuffer[ 32 ] = { 0 };
     CK_BYTE xEcParams[ 11 ] = { 0 };
     CK_KEY_TYPE xKeyType;
     CK_ULONG xSignatureLength;
@@ -1808,6 +1818,14 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Error getting attribute value of EC Parameters." );
     TEST_ASSERT_EQUAL_MESSAGE( sizeof( ucSecp256r1Oid ), xTemplate.ulValueLen, "Length of ECParameters identifier incorrect in GetAttributeValue" );
     TEST_ASSERT_EQUAL_INT8_ARRAY_MESSAGE( ucSecp256r1Oid, xEcParams, xTemplate.ulValueLen, "EcParameters did not match P256 OID." );
+
+    /* Check that the private key cannot be retrieved. */
+    xTemplate.type = CKA_VALUE;
+    xTemplate.pValue = xPrivateKeyBuffer;
+    xTemplate.ulValueLen = sizeof( xPrivateKeyBuffer );
+    xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xPrivateKeyBuffer, &xTemplate, 1 );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_ATTRIBUTE_SENSITIVE, xResult, "Wrong error code retrieving private key" );
+    TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE( 0, xPrivateKeyBuffer, sizeof(xPrivateKeyBuffer), "Private key bytes returned when they should not be" );
 
     /* Check that public key point can be retrieved for public key. */
     xTemplate.type = CKA_EC_POINT;

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1823,7 +1823,7 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     xTemplate.type = CKA_VALUE;
     xTemplate.pValue = xPrivateKeyBuffer;
     xTemplate.ulValueLen = sizeof( xPrivateKeyBuffer );
-    xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xPrivateKeyBuffer, &xTemplate, 1 );
+    xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xPrivateKeyHandle, &xTemplate, 1 );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_ATTRIBUTE_SENSITIVE, xResult, "Wrong error code retrieving private key" );
     TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE( 0, xPrivateKeyBuffer, sizeof( xPrivateKeyBuffer ), "Private key bytes returned when they should not be" );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Adds test that RSA and EC private keys cannot be extracted.
Updates C_GetAttributeValue to return the correct error code when RSA private key is queried. (Previously returned CKR_ATTRIBUTE_TYPE_INVALID).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/268/console
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.