### PR TITLE
modify IotNetworkAfr_Close in iot_network_freertos.c to fixed crash issue

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -634,7 +634,7 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
 
     /* Call Secure Sockets shutdown function to close connection. */
     socketStatus = SOCKETS_Shutdown( pNetworkConnection->socket,
-                                     SOCKETS_SHUT_RDWR );
+                                     SOCKETS_SHUT_WR );
 
     if( socketStatus != SOCKETS_ERROR_NONE )
     {


### PR DESCRIPTION

mqtt create a thread for receive data in block mode, so when mqtt close the socket, the receiving thread might be blocked, we should not shutdown RX in this situation, notify receiving thread shutdown RX would be more safe

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

- the socket of mqtt works in full duplex mode with two threads, one for TX and another for RX(passive), the TX thread should change the socket to half duplex mode and wait, other than close the socket directly

- it is a critical issue with lwip porting, while freertos_plus_tcp porting works well, since there is a eSOCKET_CLOSED event triger in FreeRTOS_recv

```
BaseType_t FreeRTOS_recv( Socket_t xSocket, void *pvBuffer, size_t xBufferLength, BaseType_t xFlags )
{
   ...
                /* Block until there is a down-stream event. */
                xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup,
                    eSOCKET_RECEIVE | eSOCKET_CLOSED | eSOCKET_INTR,
                    pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
   ...
}
```

- the PR referred to #1436 

Checklist:
----------
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [+] I have tested my changes. No regression in existing tests.
- [+] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.