### PR TITLE
Add bootloader project to Nordic CMake

### DIFF
--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -46,6 +46,20 @@ afr_module_dependencies(
         AFR::serializer
 )
 
+# BLE test
+afr_test_module()
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        "${test_dir}/iot_test_ble_end_to_end.c"
+)
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        AFR::ble
+)
+
+
 afr_module(NAME ble_wifi_provisioning)
 
 afr_module_sources(
@@ -69,17 +83,15 @@ afr_module_dependencies(
         AFR::wifi
 )
 
-# BLE test
-afr_test_module()
+#BLE Wifi provisioning test
+afr_test_module(ble_wifi_provisioning)
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
-        "${test_dir}/iot_test_ble_end_to_end.c"
         "${test_dir}/iot_test_wifi_provisioning.c"
 )
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE
-        AFR::ble
         AFR::ble_wifi_provisioning
 )

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -174,7 +174,6 @@ static void RunTests( void )
     #endif
 
     #if ( testrunnerFULL_BLE_ENABLED == 1 )
-        RUN_TEST_GROUP( MQTT_Unit_BLE_Serialize );
         RUN_TEST_GROUP( Full_BLE );
     #endif
 
@@ -191,6 +190,7 @@ static void RunTests( void )
     #endif
 
     #if ( testrunnerFULL_BLE_END_TO_END_TEST_ENABLED == 1 )
+        RUN_TEST_GROUP( MQTT_Unit_BLE_Serialize );
         RUN_TEST_GROUP( Full_BLE_END_TO_END_MQTT );
         RUN_TEST_GROUP( Full_BLE_END_TO_END_SHADOW );
     #endif

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -218,9 +218,10 @@ bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
 
                 if( bleEnabled == false )
                 {
-                    bleEnabled = pdTRUE;
-                    bInitializeSucceeded = _BLEEnable();
+                    bleEnabled = _BLEEnable();
                 }
+
+                bInitializeSucceeded = bleEnabled;
                 break;
         #endif
         #if !defined( WIFI_SUPPORTED ) || ( WIFI_SUPPORTED != 0 )

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -478,8 +478,11 @@ else()
     set(exe_target aws_demos)
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/bootloader.cmake")
+
 # Do not add demos or tests if they're turned off.
 if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
+	
     set( application_src
         "${board_dir}/application_code/main.c"
         "${board_dir}/application_code/nordic_code/SEGGER_HardFaultHandler.c"
@@ -501,28 +504,60 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
         -section-placement-macros
         "FLASH_PH_START=0x0$<SEMICOLON>FLASH_PH_SIZE=0x100000$<SEMICOLON>RAM_PH_START=0x20000000$<SEMICOLON>RAM_PH_SIZE=0x40000$<SEMICOLON>FLASH_START=0x27000$<SEMICOLON>FLASH_SIZE=0xda000$<SEMICOLON>RAM_START=0x200046F8$<SEMICOLON>RAM_SIZE=0x3B908"
     )
-    add_custom_command(
-        TARGET ${exe_target} PRE_LINK
-        COMMAND VERBATIM "${AFR_COMPILER_DIR}/../../../bin/mkld" ${mkld_flags} "${CMAKE_BINARY_DIR}/${exe_target}.ld"
+
+
+    # -------------------------------------------------------------------------------------------------
+    # Additional build configurations
+    # -------------------------------------------------------------------------------------------------
+
+    set( mkld_flags
+         -memory-map-segments "FLASH RX 0x0 0x100000$<SEMICOLON>RAM RWX 0x20000000 0x40000"
+         -section-placement-file "${nrf52840_dir}/flash_placement.xml"
+         -check-segment-overflow
+         -symbols "__STACKSIZE__=8192$<SEMICOLON>__STACKSIZE_PROCESS__=0$<SEMICOLON>__HEAPSIZE__=8192"
+         -section-placement-macros
+         "FLASH_PH_START=0x0$<SEMICOLON>FLASH_PH_SIZE=0x100000$<SEMICOLON>RAM_PH_START=0x20000000$<SEMICOLON>RAM_PH_SIZE=0x40000$<SEMICOLON>FLASH_START=0x27000$<SEMICOLON>FLASH_SIZE=0xda000$<SEMICOLON>RAM_START=0x200046F8$<SEMICOLON>RAM_SIZE=0x3B908"
     )
 
-    find_program(gcc_objectcopy arm-none-eabi-objcopy)
-    find_program(gcc_size arm-none-eabi-size)
+    function(nrf52840_build)
+        set( build_target ${ARGV0} )
+        set( build_mkld_flags ${${ARGV1}} )
+        add_custom_command(
+            TARGET ${build_target}
+            PRE_LINK
+            COMMAND VERBATIM "${AFR_COMPILER_DIR}/../../../bin/mkld" ${build_mkld_flags} "${CMAKE_BINARY_DIR}/${build_target}.ld"
+        )
 
-    if(NOT gcc_objectcopy )
-        message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
-    endif()
+        find_program(gcc_objectcopy arm-none-eabi-objcopy)
+        find_program(gcc_size arm-none-eabi-size)
 
-    set(output_file "$<TARGET_FILE_DIR:${exe_target}>/${exe_target}.hex")
+        if(NOT gcc_objectcopy )
+            message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
+        endif()
 
-    add_custom_command(
-        TARGET ${exe_target} POST_BUILD
-        COMMAND "${gcc_objectcopy}" -O ihex "$<TARGET_FILE:${exe_target}>" "${output_file}"
-        COMMAND "${gcc_size}" "$<TARGET_FILE:${exe_target}>"
+        set(output_file "$<TARGET_FILE_DIR:${build_target}>/${build_target}.hex")
+
+        add_custom_command(
+            TARGET ${build_target} POST_BUILD
+            COMMAND "${gcc_objectcopy}" -O ihex "$<TARGET_FILE:${build_target}>" "${output_file}"
+            COMMAND "${gcc_size}" "$<TARGET_FILE:${build_target}>"
+        )
+
+        add_custom_command(
+            TARGET ${build_target} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E copy "${output_file}" "${CMAKE_BINARY_DIR}"
+        )
+
+    endfunction()
+
+    nrf52840_build(
+        bootloader
+        bootloader_mkld_flags
     )
 
-    add_custom_command(
-        TARGET ${exe_target} POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy "${output_file}" "${CMAKE_BINARY_DIR}"
+    nrf52840_build(
+        ${exe_target}
+        mkld_flags
     )
+
 endif()

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -482,7 +482,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/bootloader.cmake")
 
 # Do not add demos or tests if they're turned off.
 if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
-	
+
     set( application_src
         "${board_dir}/application_code/main.c"
         "${board_dir}/application_code/nordic_code/SEGGER_HardFaultHandler.c"
@@ -528,7 +528,7 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
             COMMAND VERBATIM "${AFR_COMPILER_DIR}/../../../bin/mkld" ${build_mkld_flags} "${CMAKE_BINARY_DIR}/${build_target}.ld"
         )
 
-        find_program(gcc_objectcopy arm-none-eabi-objcopy)
+        find_program(gcc_objectcopy objcopy)
         find_program(gcc_size arm-none-eabi-size)
 
         if(NOT gcc_objectcopy )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/bootloader/asn1utility.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/bootloader/asn1utility.c
@@ -28,9 +28,8 @@
  * @brief ASN1 utility implementation.
  */
 
-#include "asn1.h"
+#include "mbedtls/asn1.h"
 #include "string.h"
-#include <tinycrypt/ecc.h>
 #include "asn1utility.h"
 
 

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/bootloader/asn1utility.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/bootloader/asn1utility.h
@@ -31,7 +31,7 @@
 #ifndef _ASN1UTILITY_H_
 #define _ASN1UTILITY_H_
 
-#include <tinycrypt/ecc.h>
+#include <stdint.h>
 
 /**
  * @brief asn1_getBigInteger.

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/bootloader/asn1utility.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/bootloader/asn1utility.c
@@ -28,9 +28,8 @@
  * @brief ASN1 utility implementation.
  */
 
-#include "asn1.h"
+#include "mbedtls/asn1.h"
 #include "string.h"
-#include <tinycrypt/ecc.h>
 #include "asn1utility.h"
 
 

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/bootloader/asn1utility.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/bootloader/asn1utility.h
@@ -31,7 +31,7 @@
 #ifndef _ASN1UTILITY_H_
 #define _ASN1UTILITY_H_
 
-#include <tinycrypt/ecc.h>
+#include <stdint.h>
 
 /**
  * @brief asn1_getBigInteger.

--- a/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
+++ b/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
@@ -1,0 +1,250 @@
+#--------------------------------------------------------------------------------------------------
+# This cmake file is included from the project cmakefile to build bootloader
+#=-------------------------------------------------------------------------------------------------
+
+add_executable( bootloader )
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+
+set(defined_symbols
+   __SIZEOF_WCHAR_T=4
+   __ARM_ARCH_7EM__
+   __SES_ARM
+   __ARM_ARCH_FPV4_SP_D16__
+   __SES_VERSION=41600
+   NDEBUG
+   BOARD_PCA10056
+   CONFIG_GPIO_AS_PINRESET
+   FLOAT_ABI_HARD
+   INITIALIZE_USER_SECTIONS
+   NO_VTOR_CONFIG
+   NRF52840_XXAA
+   NRF_DFU_SETTINGS_VERSION=1
+   SVC_INTERFACE_CALL_AS_NORMAL_FUNCTION
+)
+
+target_compile_definitions(
+    bootloader
+    PRIVATE
+    ${defined_symbols}
+)
+
+set(c_flags
+    "-fmessage-length=0"
+    "-fno-diagnostics-show-caret"
+    "-mcpu=cortex-m4"
+    "-mlittle-endian"
+    "-mfloat-abi=hard"
+    "-mfpu=fpv4-sp-d16"
+    "-mthumb"
+    "-mtp=soft"
+    "-munaligned-access"
+    "-nostdinc"
+    "-quiet"
+    "-std=gnu99"
+    "-g3"
+    "-gpubnames"
+    "-fomit-frame-pointer"
+    "-fno-dwarf2-cfi-asm"
+    "-fno-builtin"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-fshort-enums"
+    "-fno-common"
+ )
+
+# Compiler flags
+target_compile_options(
+    bootloader
+    PRIVATE
+    $<$<NOT:$<COMPILE_LANGUAGE:ASM>>:${c_flags}>
+)
+
+
+set(
+    asm_flags
+    "-fmessage-length=0"
+    "-fno-diagnostics-show-caret"
+    "-E"
+    "-mcpu=cortex-m4"
+    "-mlittle-endian"
+    "-mfloat-abi=hard"
+    "-mfpu=fpv4-sp-d16"
+    "-mthumb"
+    "-nostdinc"
+    "-quiet"
+    "-lang-asm"
+)
+
+target_compile_options(
+    bootloader
+    PRIVATE
+    $<$<COMPILE_LANGUAGE:ASM>:${asm_flags}>
+)
+
+set(linker_flags
+    "-X"
+    "--omagic"
+    "-eReset_Handler"
+    "--defsym=__vfprintf=__vfprintf_long_long"
+    "--defsym=__vfscanf=__vfscanf_long_long"
+    "--gc-sections"
+    "-EL"
+    "-T${CMAKE_BINARY_DIR}/bootloader.ld"
+    "-Map"
+    "${CMAKE_BINARY_DIR}/bootloader.map"
+    "-u_vectors"
+    "--emit-relocs"
+)
+
+# Linker flags
+target_link_options(
+    bootloader
+    PRIVATE
+    ${linker_flags}
+)
+
+target_link_libraries(
+  bootloader
+  PRIVATE
+  "${nrf5_sdk}/external/nrf_cc310_bl/lib/libnrf_cc310_bl_0.9.10.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+  "${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+)
+
+# bootloader src
+set( 
+    bootloader_src
+    "${board_dir}/bootloader/asn1utility.c"
+    "${board_dir}/bootloader/crypto.c"
+    "${board_dir}/bootloader/main.c"
+    "${board_dir}/bootloader/utils.c"
+    "${AFR_COMPILER_DIR}/../../../source/thumb_crt0.s"
+    "${nrf5_sdk}/components/boards/boards.c"
+    "${nrf5_sdk}/modules/nrfx/mdk/ses_startup_nrf_common.s"
+    "${nrf5_sdk}/modules/nrfx/mdk/ses_startup_nrf52840.s"
+    "${nrf5_sdk}/modules/nrfx/mdk/system_nrf52840.c"
+    "${nrf5_sdk}/components/drivers_nrf/nrf_soc_nosd/nrf_nvic.c"
+    "${nrf5_sdk}/components/drivers_nrf/nrf_soc_nosd/nrf_soc.c"
+    "${nrf5_sdk}/modules/nrfx/drivers/src/prs/nrfx_prs.c"
+    "${nrf5_sdk}/components/libraries/util/app_error_weak.c"
+    "${nrf5_sdk}/components/libraries/util/app_util_platform.c"
+    "${nrf5_sdk}/components/libraries/util/nrf_assert.c"
+    "${nrf5_sdk}/components/libraries/crc32/crc32.c"
+    "${nrf5_sdk}/components/libraries/mem_manager/mem_manager.c"
+    "${nrf5_sdk}/components/libraries/atomic/nrf_atomic.c"
+    "${nrf5_sdk}/components/libraries/balloc/nrf_balloc.c"
+    "${nrf5_sdk}/components/libraries/bootloader/nrf_bootloader_info.c"
+    "${nrf5_sdk}/components/libraries/memobj/nrf_memobj.c"
+    "${nrf5_sdk}/components/libraries/queue/nrf_queue.c"
+    "${nrf5_sdk}/components/libraries/strerror/nrf_strerror.c"
+    "${nrf5_sdk}/components/libraries/log/src/nrf_log_frontend.c"
+    "${nrf5_sdk}/components/libraries/log/src/nrf_log_str_formatter.c"
+    "${nrf5_sdk}/components/softdevice/common/nrf_sdh.c"
+    "${nrf5_sdk}/modules/nrfx/hal/nrf_nvmc.c"
+    "${AFR_3RDPARTY_DIR}/mbedtls/library/base64.c"
+    "${AFR_3RDPARTY_DIR}/mbedtls/library/asn1parse.c"
+    "${nrf5_sdk}/components/libraries/crypto/nrf_crypto_ecc.c"
+    "${nrf5_sdk}/components/libraries/crypto/nrf_crypto_ecdsa.c"
+    "${nrf5_sdk}/components/libraries/crypto/nrf_crypto_hash.c"
+    "${nrf5_sdk}/components/libraries/crypto/nrf_crypto_init.c"
+    "${nrf5_sdk}/components/libraries/crypto/nrf_crypto_shared.c"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl/cc310_bl_backend_ecc.c"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl/cc310_bl_backend_ecdsa.c"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl/cc310_bl_backend_hash.c"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl/cc310_bl_backend_init.c"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl/cc310_bl_backend_shared.c"
+)
+
+set(
+    bootloader_inc
+    "${board_dir}/bootloader"
+    "${board_dir}/bootloader/pca10056/config"
+    "${nrf5_sdk}/components/boards"
+    "${nrf5_sdk}/components/libraries/atomic"
+    "${nrf5_sdk}/components/libraries/balloc"
+    "${nrf5_sdk}/components/libraries/bootloader"
+    "${nrf5_sdk}/components/libraries/bootloader/dfu"
+    "${nrf5_sdk}/components/libraries/bootloader/serial_dfu"
+    "${nrf5_sdk}/components/libraries/crc32"
+    "${nrf5_sdk}/components/libraries/crypto"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cc310_bl"
+    "${nrf5_sdk}/components/libraries/crypto/backend/cifra"
+    "${nrf5_sdk}/components/libraries/crypto/backend/mbedtls"
+    "${nrf5_sdk}/components/libraries/crypto/backend/micro_ecc"
+    "${nrf5_sdk}/components/libraries/crypto/backend/nrf_hw"
+    "${nrf5_sdk}/components/libraries/crypto/backend/nrf_sw"
+    "${nrf5_sdk}/components/libraries/crypto/backend/oberon"
+    "${nrf5_sdk}/components/libraries/delay"
+    "${nrf5_sdk}/components/libraries/experimental_section_vars"
+    "${nrf5_sdk}/components/libraries/fstorage"
+    "${nrf5_sdk}/components/libraries/log"
+    "${nrf5_sdk}/components/libraries/log/src"
+    "${nrf5_sdk}/components/libraries/mem_manager"
+    "${nrf5_sdk}/components/libraries/memobj"
+    "${nrf5_sdk}/components/libraries/mutex"
+    "${nrf5_sdk}/components/libraries/queue"
+    "${nrf5_sdk}/components/libraries/ringbuf"
+    "${nrf5_sdk}/components/libraries/scheduler"
+    "${nrf5_sdk}/components/libraries/slip"
+    "${nrf5_sdk}/components/libraries/stack_info"
+    "${nrf5_sdk}/components/libraries/strerror"
+    "${nrf5_sdk}/components/libraries/util"
+    "${nrf5_sdk}/components/softdevice/s140/headers"
+    "${nrf5_sdk}/components/softdevice/mbr/nrf52840/headers"
+    "${nrf5_sdk}/components/toolchain/cmsis/include"
+    "${nrf5_sdk}/external/fprintf"
+    "${nrf5_sdk}/external/nano-pb"
+    "${nrf5_sdk}/external/nrf_cc310/include"
+    "${nrf5_sdk}/external/nrf_cc310_bl/include"
+    "${nrf5_sdk}/external/nrf_oberon"
+    "${nrf5_sdk}/external/nrf_oberon/include"
+    "${nrf5_sdk}/integration/nrfx"
+    "${nrf5_sdk}/integration/nrfx/legacy"
+    "${nrf5_sdk}/modules/nrfx"
+    "${nrf5_sdk}/modules/nrfx/drivers/include"
+    "${nrf5_sdk}/modules/nrfx/hal"
+    "${nrf5_sdk}/modules/nrfx/mdk"
+    "${AFR_3RDPARTY_DIR}/mbedtls/include"
+    #TODO: Remove depedency on "aws_ota_codesigner_certificate.h"  from crypto.c in tests.
+    "${AFR_DEMOS_DIR}/include"
+)
+
+target_sources(
+    bootloader
+    PRIVATE
+    ${bootloader_src}
+)
+target_include_directories(
+    bootloader
+    PRIVATE
+    $<$<NOT:$<COMPILE_LANGUAGE:ASM>>:${bootloader_inc}>
+)
+
+target_link_libraries(
+    bootloader
+    PRIVATE
+)
+
+# -------------------------------------------------------------------------------------------------
+# Additional build configurations
+# -------------------------------------------------------------------------------------------------
+
+set(
+    bootloader_mkld_flags
+    -memory-map-segments "FLASH RX 0x0 0x100000$<SEMICOLON>RAM RWX 0x20000000 0x40000$<SEMICOLON>uicr_bootloader_start_address RX 0x10001014 0x4$<SEMICOLON>mbr_params_page RX 0x000FE000 0x1000$<SEMICOLON>bootloader_settings_page RX 0x000FF000 0x1000$<SEMICOLON>uicr_mbr_params_page RX 0x10001018 0x4"
+    -section-placement-file "${nrf52840_dir}/bootloader_flash_placement.xml"
+    -check-segment-overflow
+    -symbols "__STACKSIZE__=2048$<SEMICOLON>__STACKSIZE_PROCESS__=0$<SEMICOLON>__HEAPSIZE__=0"
+    -section-placement-macros
+    "FLASH_PH_START=0x0$<SEMICOLON>FLASH_PH_SIZE=0x100000$<SEMICOLON>RAM_PH_START=0x20000000$<SEMICOLON>RAM_PH_SIZE=0x40000$<SEMICOLON>FLASH_START=0xF8000$<SEMICOLON>FLASH_SIZE=0x6000$<SEMICOLON>RAM_START=0x20000008$<SEMICOLON>RAM_SIZE=0x3fff8"
+)

--- a/vendors/nordic/boards/nrf52840-dk/bootloader_flash_placement.xml
+++ b/vendors/nordic/boards/nrf52840-dk/bootloader_flash_placement.xml
@@ -1,0 +1,57 @@
+<!DOCTYPE Linker_Placement_File>
+<Root name="Flash Section Placement">
+  <MemorySegment name="FLASH" start="$(FLASH_PH_START)" size="$(FLASH_PH_SIZE)">
+    <ProgramSection load="no" name=".reserved_flash" start="$(FLASH_PH_START)" size="$(FLASH_START)-$(FLASH_PH_START)" />
+    <ProgramSection alignment="0x100" load="Yes" name=".vectors" start="$(FLASH_START)" />
+    <ProgramSection alignment="4" load="Yes" name=".init" />
+    <ProgramSection alignment="4" load="Yes" name=".init_rodata" />
+    <ProgramSection alignment="4" load="Yes" name=".text" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".crypto_data" inputsections="*(SORT(.crypto_data*))" address_symbol="__start_crypto_data" end_symbol="__stop_crypto_data" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".dfu_trans" inputsections="*(SORT(.dfu_trans*))" address_symbol="__start_dfu_trans" end_symbol="__stop_dfu_trans" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".fs_data"  inputsections="*(.fs_data*)" runin=".fs_data_run"/>
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_filter_data"  inputsections="*(SORT(.log_filter_data*))" runin=".log_filter_data_run"/>
+    <ProgramSection alignment="4" load="Yes" name=".dtors" />
+    <ProgramSection alignment="4" load="Yes" name=".ctors" />
+    <ProgramSection alignment="4" load="Yes" name=".rodata" />
+    <ProgramSection alignment="4" load="Yes" name=".ARM.exidx" address_symbol="__exidx_start" end_symbol="__exidx_end" />
+    <ProgramSection alignment="4" load="Yes" runin=".fast_run" name=".fast" />
+    <ProgramSection alignment="4" load="Yes" runin=".data_run" name=".data" />
+    <ProgramSection alignment="4" load="Yes" runin=".tdata_run" name=".tdata" />
+  </MemorySegment>
+  <MemorySegment name="RAM" start="$(RAM_PH_START)" size="$(RAM_PH_SIZE)">
+    <ProgramSection load="no" name=".reserved_ram" start="$(RAM_PH_START)" size="$(RAM_START)-$(RAM_PH_START)" />
+    <ProgramSection alignment="0x100" load="No" name=".vectors_ram" start="$(RAM_START)" address_symbol="__app_ram_start__"/>
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run" address_symbol="__start_nrf_sections_run" />
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".fs_data_run" address_symbol="__start_fs_data" end_symbol="__stop_fs_data" />
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_dynamic_data_run" address_symbol="__start_log_dynamic_data" end_symbol="__stop_log_dynamic_data" />
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_filter_data_run" address_symbol="__start_log_filter_data" end_symbol="__stop_log_filter_data" />
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run_end" address_symbol="__end_nrf_sections_run" />
+    <ProgramSection alignment="4" load="No" name=".fast_run" />
+    <ProgramSection alignment="4" load="No" name=".data_run" />
+    <ProgramSection alignment="4" load="No" name=".tdata_run" />
+    <ProgramSection alignment="4" load="No" name=".bss" />
+    <ProgramSection alignment="4" load="No" name=".tbss" />
+    <ProgramSection alignment="4" load="No" name=".non_init" />
+    <ProgramSection alignment="4" size="__HEAPSIZE__" load="No" name=".heap" />
+    <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
+    <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
+  </MemorySegment>
+  <MemorySegment name="mbr_params_page" start="0x000FE000" size="0x1000">
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".mbr_params_page" address_symbol="__start_mbr_params_page" end_symbol="__stop_mbr_params_page" start = "0x000FE000" size="0x1000" />
+  </MemorySegment>
+  <MemorySegment name="bootloader_settings_page" start="0x000FF000" size="0x1000">
+    <ProgramSection alignment="4" keep="Yes" load="No" name=".bootloader_settings_page" address_symbol="__start_bootloader_settings_page" end_symbol="__stop_bootloader_settings_page" start = "0x000FF000" size="0x1000" />
+  </MemorySegment>
+  <MemorySegment name="uicr_bootloader_start_address" start="0x10001014" size="0x4">
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".uicr_bootloader_start_address" address_symbol="__start_uicr_bootloader_start_address" end_symbol="__stop_uicr_bootloader_start_address" start = "0x10001014" size="0x4" />
+  </MemorySegment>
+  <MemorySegment name="uicr_mbr_params_page" start="0x10001018" size="0x4">
+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".uicr_mbr_params_page" address_symbol="__start_uicr_mbr_params_page" end_symbol="__stop_uicr_mbr_params_page" start = "0x10001018" size="0x4" />
+  </MemorySegment>
+</Root>


### PR DESCRIPTION
Add bootloader project to nordic cmake

Description
-----------
Nordic has separate bootloader project which needs to be built along with demos and test projects

* Added bootloader CMakefile and include it from demos and test projects.
* Ran Nordic tests with CMake.
* Separated BLE WiFi provisioning test files  from BLE  CMake to not get included for Nordic.
* Fix header file dependencies in Nordic application code
* Move MQTT serializer tests for BLE under BLE end-to-end group.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.