### PR TITLE
test: Adding unit tests for iot_i2s APIs

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_cli.c
+++ b/libraries/abstractions/common_io/test/test_iot_cli.c
@@ -32,6 +32,8 @@
 #include "ace_cli.h"
 #include <ace/aceCli.h>
 
+
+extern int32_t ltestIotI2SReadSize;
 ace_status_t runIotTests(int32_t argc, const char** argv) {
     if (argc < 1)
     {
@@ -41,6 +43,10 @@ ace_status_t runIotTests(int32_t argc, const char** argv) {
 
     int testIndex = ((int)atoi(argv[0]));
     int testCaseIndex = ((int)atoi(argv[1]));
+
+    if( argc == 3 ) {
+       ltestIotI2SReadSize = ((int)atoi(argv[2]));
+    }
     RunIotTests(testIndex, testCaseIndex);
     return ACE_STATUS_OK;
 }
@@ -53,18 +59,33 @@ const aceCli_moduleCmd_t iot_tests_cli_sub[] = {
                             "4: rtc\n\t"
                             "5: gpio <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_AssistedIotGpioModeWritePushPullTrue\n\t\t2: AFQP_AssistedIotGpioModeWritePushPullFalse\n\t\t3: AFQP_AssistedIotGpioModeWriteOpenDrainTrue\n\t\t4: AFQP_AssistedIotGpioModeWriteOpenDrainFalse\n\t\t5: AFQP_AssistedIotGpioModeReadTrue\n\t\t6: AFQP_AssistedIotGpioModeReadFalse\n\t"
                             "6: timer\n\t"
-                            "7: adc <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_IotAdcPrintReadSample\n\t"
-                            "8: reset <num>\n\t\t0: Shutdown\n\t\t1: RebootZero\n\t\t2: RebootNonZero"
-                            "\n\t9: perfcounter\n\t10: pwm\n\t11: i2c\n\t12: tsensor"
-                            "\n\t13: power <num>\n\t\t0: All tests excludes VddOff test\n\t\t1: Run VddOff test"
-                            "\n\t14: battery"
-                            "\n\t15: efuse\n\t"
+                            "7: adc\n\t"
+                            "8: reset <num>\n\t\t0: Shutdown\n\t\t1: RebootZero\n\t\t2: RebootNonZero\n\t"
+                            "9: perfcounter\n\t"
+                            "10: pwm\n\t"
+                            "11: i2c\n\t"
+                            "12: tsensor\n\t"
+                            "13: power <num>\n\t\t0: All tests excludes VddOff test\n\t\t1: Run VddOff test\n\t"
+                            "14: battery\n\t"
+                            "15: efuse\n\t"
                             "16: spi <num> \n\t\t0: All Independent tests\n\t\t1: Read Sync Master\n\t\t"
                             "2: Write Sync Master\n\t\t3: Transfer Sync Master\n\t\t4: Read ASync Master\n\t\t"
                             "5: Write ASync Master\n\t\t6: Transfer ASync Master\n\t\t"
                             "10: Read Sync Slave\n\t\t11: Write Sync Slave\n\t\t12: Transfer Sync Slave"
                             "\n\t17: UsbDevice <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_IotUsbDeviceHidAttach\n\t\t2: AFQP_IotUsbDeviceHidDetach\n\t\t3: AFQP_IotUsbDeviceEndpointStall\n\t\t4: AFQP_IotUsbDeviceGetSpeed\n\t\t5: AFQP_IotUsbDeviceWriteAsync\n\t\t6: AFQP_IotUsbDeviceReadAsync\n\t\t7: AFQP_IotUsbDeviceWriteSync\n\t\t8: AFQP_IotUsbDeviceReadSync\n\t\t9: AFQP_IotUsbDeviceEndpointCancelTransfer\n\t\t10: AFQP_IotUsbDeviceIoctl\n\t"
-                            "18: UsbHost <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_IotUsbHostHidGeneric\n\t\t2: AFQP_IotUsbHostWriteAsync\n\t\t3: AFQP_IotUsbHostReadAsync\n\t",
+                            "18: UsbHost <num> \n\t\t0: All Independent tests\n\t\t1: AFQP_IotUsbHostHidGeneric\n\t\t2: AFQP_IotUsbHostWriteAsync\n\t\t3: AFQP_IotUsbHostReadAsync\n\t"
+                            "19: i2s <num> \n\t\t"
+                              "0: All Independent tests\n\t\t"
+                              "1: Read Sync Master\n\t\t"
+                              "2: Write Sync Master\n\t\t"
+                              "3: Read Async Master\n\t\t"
+                              "4: Write Async Master\n\t\t"
+                              "5: Write Async Read Async Loopback\n\t\t"
+                              "6: Write Sync Read Async Loopback\n\t\t"
+                              "7: Write Async Read Sync Loopback\n\t\t"
+                              "8: Write Sync Read Sync Loopback\n\t\t"
+                              "10: Read Sync Slave\n\t\t"
+                              "11: Write Sync Slave\n\t\t",
                             ACE_CLI_SET_LEAF, .command.func=&runIotTests},
                             ACE_CLI_NULL_MODULE
                             };

--- a/libraries/abstractions/common_io/test/test_iot_i2s.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2s.c
@@ -50,9 +50,9 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-int32_t ultestIotI2sInputInstance = 4;    /* Use Mic instance 4 */
-int32_t ultestIotI2sOutputInstance = 2;   /* Use Spkr instance 2 */
-int32_t ultestIotI2SReadSize = testIotI2S_BUF_SIZE;
+int32_t ltestIotI2sInputInstance = 4;    /* Use Mic instance 4 */
+int32_t ltestIotI2sOutputInstance = 2;   /* Use Spkr instance 2 */
+int32_t ltestIotI2SReadSize = testIotI2S_BUF_SIZE;
 /*-----------------------------------------------------------*/
 /* Static Globals */
 /*-----------------------------------------------------------*/
@@ -138,7 +138,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SOpenClose )
     int32_t lRetVal;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     /* Close instance */
@@ -163,30 +163,32 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadAsyncLoopback )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
-    /* Set a callback for async call */
-    iot_i2s_set_callback( xI2SMicHandle, prvI2SReadCallback, NULL);
-    iot_i2s_set_callback( xI2SSpkrHandle, prvI2SWriteCallback, NULL);
+    if( TEST_PROTECT() ) {
+       /* Set a callback for async call */
+       iot_i2s_set_callback( xI2SMicHandle, prvI2SReadCallback, NULL);
+       iot_i2s_set_callback( xI2SSpkrHandle, prvI2SWriteCallback, NULL);
 
-    lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, portMAX_DELAY);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, portMAX_DELAY);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
-       TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       /* Validate data was read correctly */
+       for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
+          TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       }
     }
 
     /* Close instance */
@@ -213,26 +215,28 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncReadAsyncLoopback )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
-    /* Set a callback for async call */
-    iot_i2s_set_callback( xI2SMicHandle, prvI2SReadCallback, NULL);
+    if( TEST_PROTECT() ) {
+       /* Set a callback for async call */
+       iot_i2s_set_callback( xI2SMicHandle, prvI2SReadCallback, NULL);
 
-    lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
-       TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       /* Validate data was read correctly */
+       for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
+          TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       }
     }
 
     /* Close instance */
@@ -259,20 +263,22 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadSyncLoopback )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
-    lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
-       TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       /* Validate data was read correctly */
+       for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
+          TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       }
     }
 
     /* Close instance */
@@ -299,20 +305,22 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncReadSyncLoopback )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
-    lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
-       TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       /* Validate data was read correctly */
+       for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
+          TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
+       }
     }
 
     /* Close instance */
@@ -333,16 +341,17 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadSync )
     int i;
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
 
-    //lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
-    lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, ultestIotI2SReadSize );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, ltestIotI2SReadSize );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=0; i<ultestIotI2SReadSize; i++) {
-       TEST_ASSERT_EQUAL( (i & 0xff), ucRxbuf[i] );
+       /* Validate data was read correctly */
+       for(i=0; i<ltestIotI2SReadSize; i++) {
+          TEST_ASSERT_EQUAL( (i & 0xff), ucRxbuf[i] );
+       }
     }
 
     /* Close instance */
@@ -366,11 +375,13 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSync )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
-    lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_write_sync( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SSpkrHandle );
@@ -388,19 +399,22 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsync )
     int i;
 
     /* Open i2s to initialize hardware */
-    xI2SMicHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SMicHandle );
 
     iot_i2s_set_callback( xI2SMicHandle, prvI2SReadCallback, NULL);
 
-    lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, ultestIotI2SReadSize );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_read_async( xI2SMicHandle, ucRxbuf, ltestIotI2SReadSize );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Validate data was read correctly */
-    for(i=0; i<ultestIotI2SReadSize; i++) {
-       TEST_ASSERT_EQUAL( (i & 0xff), ucRxbuf[i] );
+       /* Validate data was read correctly */
+       for(i=0; i<ltestIotI2SReadSize; i++) {
+          TEST_ASSERT_EQUAL( (i & 0xff), ucRxbuf[i] );
+       }
     }
 
     /* Close instance */
@@ -424,17 +438,19 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsync )
     }
 
     /* Open i2s to initialize hardware */
-    xI2SSpkrHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SSpkrHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SSpkrHandle );
 
     /* Set a callback for async call */
     iot_i2s_set_callback( xI2SSpkrHandle, prvI2SWriteCallback, NULL);
 
-    lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       lRetVal = iot_i2s_write_async( xI2SSpkrHandle, ucTxbuf, testIotI2S_BUF_SIZE );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, portMAX_DELAY);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, portMAX_DELAY);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SSpkrHandle );
@@ -455,7 +471,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SIoctl )
     uint32_t ulBusState;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     if( TEST_PROTECT() ) {
@@ -566,7 +582,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SCancelFail )
     int32_t lRetVal;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_cancel(xI2SHandle);
@@ -590,7 +606,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SCancelSuccess )
     uint8_t ucBuf[testIotI2S_BUF_SIZE];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     /* Set a callback for async call */
@@ -632,26 +648,28 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsyncIoctlBusy )
     IotI2sIoctlConfig_t xOrigConfig;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
-    /* Save off original config */
-    lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       /* Save off original config */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Set a callback for async call */
-    iot_i2s_set_callback( xI2SHandle, prvI2SReadCallback, NULL);
+       /* Set a callback for async call */
+       iot_i2s_set_callback( xI2SHandle, prvI2SReadCallback, NULL);
 
-    lRetVal = iot_i2s_read_async( xI2SHandle, uxRxbuf, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_async( xI2SHandle, uxRxbuf, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Try setting config while busy */
-    lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+       /* Try setting config while busy */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SHandle );
@@ -669,26 +687,28 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncIoctlBusy )
     IotI2sIoctlConfig_t xOrigConfig;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
-    /* Save off original config */
-    lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+    if( TEST_PROTECT() ) {
+       /* Save off original config */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Set a callback for async call */
-    iot_i2s_set_callback( xI2SHandle, prvI2SWriteCallback, NULL);
+       /* Set a callback for async call */
+       iot_i2s_set_callback( xI2SHandle, prvI2SWriteCallback, NULL);
 
-    lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
-    /* Try setting config while busy */
-    lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+       /* Try setting config while busy */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetConfig, &xOrigConfig );
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SHandle );
@@ -706,31 +726,33 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsyncTwice )
     uint8_t ucRxbuf2[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     /* Set a callback for async call */
     iot_i2s_set_callback( xI2SHandle, prvI2SReadCallback, NULL);
 
-    /* Test read_async() read_async */
-    lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf1, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
-    lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf2, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+    if( TEST_PROTECT() ) {
+       /* Test read_async() read_async */
+       lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf1, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf2, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
 
-    /* Test read_async() read_sync */
-    lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf1, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
-    lRetVal = iot_i2s_read_sync( xI2SHandle, ucRxbuf2, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+       /* Test read_async() read_sync */
+       lRetVal = iot_i2s_read_async( xI2SHandle, ucRxbuf1, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_read_sync( xI2SHandle, ucRxbuf2, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SHandle );
@@ -748,31 +770,33 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncTwice )
     uint8_t uxTxbuf2[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     /* Set a callback for async call */
     iot_i2s_set_callback( xI2SHandle, prvI2SWriteCallback, NULL);
 
-    /* test write_async write_async */
-    lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf1, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
-    lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf2, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+    if( TEST_PROTECT() ) {
+       /* test write_async write_async */
+       lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf1, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf2, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
 
-    /* test write_async write_sync */
-    lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf1, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
-    lRetVal = iot_i2s_write_sync( xI2SHandle, uxTxbuf2, testIotI2S_BUF_SIZE);
-    TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
+       /* test write_async write_sync */
+       lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf1, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       lRetVal = iot_i2s_write_sync( xI2SHandle, uxTxbuf2, testIotI2S_BUF_SIZE);
+       TEST_ASSERT_EQUAL( IOT_I2S_BUSY, lRetVal );
 
-    /*Wait for the callback. */
-    lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
-    TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+       /*Wait for the callback. */
+       lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, testIotI2S_DEFAULT_SEMAPHORE_DELAY);
+       TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
 
     /* Close instance */
     lRetVal = iot_i2s_close( xI2SHandle );
@@ -792,11 +816,11 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SOpenCloseFuzzing )
     TEST_ASSERT_EQUAL( NULL, xI2SHandle );
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     /* Open second i2s to initialize hardware.  Expect failure */
-    xI2SHandleFail = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandleFail = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_EQUAL( NULL, xI2SHandleFail );
 
     /* Close instance */
@@ -818,7 +842,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SIoctlFuzzing )
     IotI2SBusStatus_t xBusStatus;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_ioctl( NULL, eI2SGetBusState, &xBusStatus);
@@ -845,7 +869,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadSyncFuzzing )
     uint8_t uxRxbuf[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_read_sync( NULL, uxRxbuf, testIotI2S_BUF_SIZE);
@@ -857,7 +881,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadSyncFuzzing )
     lRetVal = iot_i2s_read_sync( xI2SHandle, uxRxbuf, 0);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
-    // read/write must be in increments of 4.
+    /* read/write must be in increments of 4. */
     lRetVal = iot_i2s_read_sync( xI2SHandle, uxRxbuf, 1);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
@@ -876,7 +900,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsyncFuzzing )
     uint8_t uxRxbuf[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_read_async( NULL, uxRxbuf, testIotI2S_BUF_SIZE);
@@ -888,7 +912,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsyncFuzzing )
     lRetVal = iot_i2s_read_async( xI2SHandle, uxRxbuf, 0);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
-    // read/write must be in increments of 4.
+    /* read/write must be in increments of 4. */
     lRetVal = iot_i2s_read_async( xI2SHandle, uxRxbuf, 1);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
@@ -907,7 +931,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncFuzzing )
     uint8_t uxTxbuf[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_write_sync( NULL, uxTxbuf, testIotI2S_BUF_SIZE);
@@ -919,7 +943,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncFuzzing )
     lRetVal = iot_i2s_write_sync( xI2SHandle, uxTxbuf, 0);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
-    // read/write must be in increments of 4.
+    /* read/write must be in increments of 4. */
     lRetVal = iot_i2s_write_sync( xI2SHandle, uxTxbuf, 1);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
@@ -938,7 +962,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncFuzzing )
     uint8_t uxTxbuf[ testIotI2S_BUF_SIZE ];
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sOutputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sOutputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_write_async( NULL, uxTxbuf, testIotI2S_BUF_SIZE);
@@ -950,7 +974,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncFuzzing )
     lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf, 0);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
-    // read/write must be in increments of 4.
+    /* read/write must be in increments of 4. */
     lRetVal = iot_i2s_write_async( xI2SHandle, uxTxbuf, 1);
     TEST_ASSERT_EQUAL( IOT_I2S_INVALID_VALUE, lRetVal );
 
@@ -968,7 +992,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SCancelFuzzing )
     int32_t lRetVal;
 
     /* Open i2s to initialize hardware */
-    xI2SHandle = iot_i2s_open( ultestIotI2sInputInstance );
+    xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2SHandle );
 
     lRetVal = iot_i2s_cancel( NULL );

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -1,28 +1,16 @@
 /*
- * Amazon FreeRTOS Common IO V1.0.0
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * AMAZON PROPRIETARY/CONFIDENTIAL
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * You may not use this file except in compliance with the terms and
+ * conditions set forth in the accompanying LICENSE.TXT file.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- * http://aws.amazon.com/freertos
- * http://www.FreeRTOS.org
+ * THESE MATERIALS ARE PROVIDED ON AN "AS IS" BASIS. AMAZON SPECIFICALLY
+ * DISCLAIMS, WITH RESPECT TO THESE MATERIALS, ALL WARRANTIES, EXPRESS,
+ * IMPLIED, OR STATUTORY, INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
  */
-
 /*******************************************************************************
  * IOT On-Target Unit Test
  * @File: test_iot_internal.h
@@ -37,7 +25,7 @@
  * Board specific UART config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_UART_CONFIG(int testSet);
 
@@ -45,7 +33,7 @@ void SET_TEST_IOT_UART_CONFIG(int testSet);
  * Board specific Flash config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_FLASH_CONFIG(int testSet);
 
@@ -53,7 +41,7 @@ void SET_TEST_IOT_FLASH_CONFIG(int testSet);
  * Board specific Watchdog config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_WATCHDOG_CONFIG(int testSet);
 
@@ -61,7 +49,7 @@ void SET_TEST_IOT_WATCHDOG_CONFIG(int testSet);
  * Board specific RTC config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_RTC_CONFIG(int testSet);
 
@@ -69,7 +57,7 @@ void SET_TEST_IOT_RTC_CONFIG(int testSet);
  * Board specific GPIO config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_GPIO_CONFIG(int testSet);
 
@@ -77,7 +65,7 @@ void SET_TEST_IOT_GPIO_CONFIG(int testSet);
  * Board specific Timer config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_TIMER_CONFIG(int testSet);
 
@@ -85,7 +73,7 @@ void SET_TEST_IOT_TIMER_CONFIG(int testSet);
  * Board specific ADC config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_ADC_CONFIG(int testSet);
 
@@ -93,7 +81,7 @@ void SET_TEST_IOT_ADC_CONFIG(int testSet);
  * Board specific Reset config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_RESET_CONFIG(int testSet);
 
@@ -101,7 +89,7 @@ void SET_TEST_IOT_RESET_CONFIG(int testSet);
  * Board specific Performance Counter config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_PERFCOUNTER_CONFIG(int testSet);
 
@@ -109,7 +97,7 @@ void SET_TEST_IOT_PERFCOUNTER_CONFIG(int testSet);
  * Board specific PWM config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_PWM_CONFIG(int testSet);
 
@@ -117,7 +105,7 @@ void SET_TEST_IOT_PWM_CONFIG(int testSet);
  * Board specific I2C config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_I2C_CONFIG(int testSet);
 
@@ -125,7 +113,7 @@ void SET_TEST_IOT_I2C_CONFIG(int testSet);
  * Board specific SPI config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_SPI_CONFIG(int testSet);
 
@@ -133,7 +121,7 @@ void SET_TEST_IOT_SPI_CONFIG(int testSet);
  * Board specific Power config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_POWER_CONFIG(int testSet);
 
@@ -141,7 +129,7 @@ void SET_TEST_IOT_POWER_CONFIG(int testSet);
  * Board specific SDIO config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_SDIO_CONFIG(int testSet);
 
@@ -149,6 +137,14 @@ void SET_TEST_IOT_SDIO_CONFIG(int testSet);
  * Board specific Temp Sensor config set
  *
  * @param: testSet: number of config set to be test
- * @returnNone
+ * @return None
  */
 void SET_TEST_IOT_TEMP_SENSOR_CONFIG(int testSet);
+
+/**
+ * Board specific I2S config set
+ *
+ * @param: testSet: number of config set to be test
+ * @return None
+ */
+void SET_TEST_IOT_I2S_CONFIG(int testSet);


### PR DESCRIPTION
Adding unit tests for the iot_i2s APIs

Why:  We need to have unit tests for the iot_i2s APIs so that
we can validate proper functionality.
This completes the addition of the tests added in PR 1426

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.