### PR TITLE
Implement LWIP_NETCONN_SEM_PER_THREAD and LWIP_NETCONN_FULLDUPLEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Contains bug fixes and enhancements in ESP NIMBLE stack.
 - Contains bug fixes in ESP Bluedroid stack.
 
+#### Enable lwIP full duplex feature
+- The same socket may be used by multiple tasks concurrently.
+
 ## 201908.00 08/26/2019
 
 ### New Features

--- a/libraries/3rdparty/lwip/src/include/lwip/sys.h
+++ b/libraries/3rdparty/lwip/src/include/lwip/sys.h
@@ -333,7 +333,7 @@ err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg);
  * @param timeout maximum time (in milliseconds) to wait for a message (0 = wait forever)
  * @return SYS_ARCH_TIMEOUT on timeout, any other value if a message has been received
  */
-u32_t sys_arch_mbox_fetch(volatile sys_mbox_t *mbox, void **msg, u32_t timeout);
+u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout);
 /* Allow port to override with a macro, e.g. special timeout for sys_arch_mbox_fetch() */
 #ifndef sys_arch_mbox_tryfetch
 /**
@@ -366,7 +366,7 @@ u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg);
  * 
  * @param mbox mbox to delete
  */
-void sys_mbox_free(volatile sys_mbox_t *mbox);
+void sys_mbox_free(sys_mbox_t *mbox);
 #define sys_mbox_fetch(mbox, msg) sys_arch_mbox_fetch(mbox, msg, 0)
 #ifndef sys_mbox_valid
 /**

--- a/libraries/3rdparty/lwip/src/portable/arch/lwipopts_freertos.h
+++ b/libraries/3rdparty/lwip/src/portable/arch/lwipopts_freertos.h
@@ -221,6 +221,23 @@
 #define LWIP_LOOPBACK_MAX_PBUFS 12
 
 
+/** LWIP_NETCONN_SEM_PER_THREAD==1: Use one (thread-local) semaphore per
+ * thread calling socket/netconn functions instead of allocating one
+ * semaphore per netconn (and per select etc.)
+ */
+#define LWIP_NETCONN_SEM_PER_THREAD     1
+
+/** LWIP_NETCONN_FULLDUPLEX==1: Enable code that allows reading from one thread,
+ * writing from a 2nd thread and closing from a 3rd thread at the same time.
+ * ATTENTION: Some requirements:
+ * - LWIP_NETCONN_SEM_PER_THREAD==1 is required to use one socket/netconn from
+ *   multiple threads at once
+ * - sys_mbox_free() has to unblock receive tasks waiting on recvmbox/acceptmbox
+ *   and prevent a task pending on this during/after deletion
+ */
+#define LWIP_NETCONN_FULLDUPLEX         1
+
+
 /*
    ------------------------------------
    ----------- Debug options ----------

--- a/libraries/3rdparty/lwip/src/portable/arch/sys_arch.c
+++ b/libraries/3rdparty/lwip/src/portable/arch/sys_arch.c
@@ -578,6 +578,46 @@ sys_thread_t xReturn;
     return xReturn;
 }
 
+#if LWIP_NETCONN_SEM_PER_THREAD
+#if configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0
+
+/*---------------------------------------------------------------------------*
+ * Routine:  sys_arch_netconn_sem_get
+ *---------------------------------------------------------------------------*
+ * Description:
+ *      Lookup the task-specific semaphore; create one if necessary.
+ *      The semaphore pointer lives in the 0th slot of the
+ *      TCB local storage array.  Once allocated, it is never released.
+ *---------------------------------------------------------------------------*/
+sys_sem_t *
+sys_arch_netconn_sem_get(void)
+{
+    void* ret;
+    TaskHandle_t task = xTaskGetCurrentTaskHandle();
+    configASSERT( task != NULL );
+
+    ret = pvTaskGetThreadLocalStoragePointer( task, 0 );
+    if( ret == NULL )
+    {
+        sys_sem_t *sem;
+        err_t err;
+        /* allocate memory for this semaphore */
+        sem = mem_malloc( sizeof( sys_sem_t ) );
+        configASSERT( sem != NULL );
+        err = sys_sem_new( sem, 0 );
+        configASSERT( err == ERR_OK );
+        configASSERT( sys_sem_valid( sem ) );
+        vTaskSetThreadLocalStoragePointer( task, 0, sem );
+        ret = sem;
+    }
+    return ret;
+}
+#else /* configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0 */
+#error LWIP_NETCONN_SEM_PER_THREAD needs configNUM_THREAD_LOCAL_STORAGE_POINTERS
+#endif /* configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0 */
+
+#endif /* LWIP_NETCONN_SEM_PER_THREAD */
+
 /*---------------------------------------------------------------------------*
  * Routine:  sys_arch_protect
  *---------------------------------------------------------------------------*

--- a/libraries/3rdparty/lwip/src/portable/arch/sys_arch.h
+++ b/libraries/3rdparty/lwip/src/portable/arch/sys_arch.h
@@ -59,6 +59,8 @@ typedef struct sys_mbox sys_mbox_t;
 #if LWIP_NETCONN_SEM_PER_THREAD
 sys_sem_t* sys_arch_netconn_sem_get(void);
 #define LWIP_NETCONN_THREAD_SEM_GET()   sys_arch_netconn_sem_get()
+#define LWIP_NETCONN_THREAD_SEM_ALLOC()
+#define LWIP_NETCONN_THREAD_SEM_FREE()
 #endif /* LWIP_NETCONN_SEM_PER_THREAD */
 
 #endif /* __ARCH_SYS_ARCH_H__ */

--- a/libraries/3rdparty/lwip/src/portable/arch/sys_arch.h
+++ b/libraries/3rdparty/lwip/src/portable/arch/sys_arch.h
@@ -56,6 +56,10 @@ typedef struct sys_mbox sys_mbox_t;
 #define sys_sem_valid( x ) ( ( ( *x ) == NULL) ? pdFALSE : pdTRUE )
 #define sys_sem_set_invalid( x ) ( ( *x ) = NULL )
 
+#if LWIP_NETCONN_SEM_PER_THREAD
+sys_sem_t* sys_arch_netconn_sem_get(void);
+#define LWIP_NETCONN_THREAD_SEM_GET()   sys_arch_netconn_sem_get()
+#endif /* LWIP_NETCONN_SEM_PER_THREAD */
 
 #endif /* __ARCH_SYS_ARCH_H__ */
 


### PR DESCRIPTION
These changes implement the minimum functionality necessary to enable lwIP's "full duplex" mode.  This mode "enables code that allows reading from one thread, writing from a 2nd thread and closing from a 3rd thread at the same time."

To keep the implementation self-contained, the per-task semaphore lookup function does the allocation on first use by a given task, and the semaphore is never freed.  This is compatible with the standard persistent task model.

This work is the companion of the code committed in https://github.com/aws/amazon-freertos/pull/1017/commits/e6dee5a266a2bbf01c1aef47ea40b55935c607b3 .

The TCP regression suite passes, including:
TEST(Full_TCP, AFQP_SOCKETS_Threadsafe_SameSocketDifferentTasks) PASS
TEST(Full_TCP, AFQP_SOCKETS_Threadsafe_DifferentSocketsDifferentTasks) PASS
