### PR TITLE
Fix OTA PAL test for Nordic

### DIFF
--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c
@@ -37,11 +37,16 @@
 #include "aws_ota_pal_test_access_declare.h"
 #include "aws_ota_pal.h"
 #include "aws_iot_ota_agent.h"
+
+#if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
 #include "iot_pkcs11.h"
 #include "iot_pkcs11_config.h"
+#include "aws_dev_mode_key_provisioning.h"
+#endif
+
 #include "aws_ota_codesigner_certificate.h"
 #include "aws_test_ota_config.h"
-#include "aws_dev_mode_key_provisioning.h"
+
 
 /* The Texas Instruments CC3220SF has special requirements on its file system security.
  * We enable code specially for testing the OTA PAL layer for this device. */
@@ -229,7 +234,7 @@ TEST( Full_OTA_PAL, prvPAL_CloseFile_ValidSignature )
         TEST_ASSERT_EQUAL_INT( kOTA_Err_None, xOtaStatus );
     }
 }
-
+ #if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
 CK_RV prvImportCodeSigningCertificate( const uint8_t * pucCertificate,
                                        size_t xCertificateLength,
                                        uint8_t * pucLabel )
@@ -277,6 +282,8 @@ CK_RV prvImportCodeSigningCertificate( const uint8_t * pucCertificate,
 
     return xResult;
 }
+
+#endif
 
 /**
  * @brief Test prvPAL_CloseFile with a valid signature and signature verification

--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c
@@ -39,9 +39,9 @@
 #include "aws_iot_ota_agent.h"
 
 #if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
-#include "iot_pkcs11.h"
-#include "iot_pkcs11_config.h"
-#include "aws_dev_mode_key_provisioning.h"
+    #include "iot_pkcs11.h"
+    #include "iot_pkcs11_config.h"
+    #include "aws_dev_mode_key_provisioning.h"
 #endif
 
 #include "aws_ota_codesigner_certificate.h"
@@ -234,56 +234,56 @@ TEST( Full_OTA_PAL, prvPAL_CloseFile_ValidSignature )
         TEST_ASSERT_EQUAL_INT( kOTA_Err_None, xOtaStatus );
     }
 }
- #if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
-CK_RV prvImportCodeSigningCertificate( const uint8_t * pucCertificate,
-                                       size_t xCertificateLength,
-                                       uint8_t * pucLabel )
-{
-    /* Find the certificate */
-    CK_OBJECT_HANDLE xHandle;
-    CK_RV xResult;
-    CK_FUNCTION_LIST_PTR xFunctionList;
-    CK_SLOT_ID xSlotId;
-    CK_ULONG xCount = 1;
-    CK_SESSION_HANDLE xSession;
-    CK_BBOOL xSessionOpen = CK_FALSE;
-
-    xResult = C_GetFunctionList( &xFunctionList );
-
-    if( CKR_OK == xResult )
+#if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
+    CK_RV prvImportCodeSigningCertificate( const uint8_t * pucCertificate,
+                                           size_t xCertificateLength,
+                                           uint8_t * pucLabel )
     {
-        xResult = xInitializePKCS11();
+        /* Find the certificate */
+        CK_OBJECT_HANDLE xHandle;
+        CK_RV xResult;
+        CK_FUNCTION_LIST_PTR xFunctionList;
+        CK_SLOT_ID xSlotId;
+        CK_ULONG xCount = 1;
+        CK_SESSION_HANDLE xSession;
+        CK_BBOOL xSessionOpen = CK_FALSE;
+
+        xResult = C_GetFunctionList( &xFunctionList );
+
+        if( CKR_OK == xResult )
+        {
+            xResult = xInitializePKCS11();
+        }
+
+        if( ( CKR_OK == xResult ) || ( CKR_CRYPTOKI_ALREADY_INITIALIZED == xResult ) )
+        {
+            xResult = xFunctionList->C_GetSlotList( CK_TRUE, &xSlotId, &xCount );
+        }
+
+        if( CKR_OK == xResult )
+        {
+            xResult = xFunctionList->C_OpenSession( xSlotId, CKF_SERIAL_SESSION, NULL, NULL, &xSession );
+        }
+
+        if( CKR_OK == xResult )
+        {
+            xSessionOpen = CK_TRUE;
+            xResult = xProvisionCertificate( xSession,
+                                             ( uint8_t * ) pucCertificate,
+                                             xCertificateLength,
+                                             pucLabel,
+                                             &xHandle );
+        }
+
+        if( xSessionOpen == CK_TRUE )
+        {
+            xResult = xFunctionList->C_CloseSession( xSession );
+        }
+
+        return xResult;
     }
 
-    if( ( CKR_OK == xResult ) || ( CKR_CRYPTOKI_ALREADY_INITIALIZED == xResult ) )
-    {
-        xResult = xFunctionList->C_GetSlotList( CK_TRUE, &xSlotId, &xCount );
-    }
-
-    if( CKR_OK == xResult )
-    {
-        xResult = xFunctionList->C_OpenSession( xSlotId, CKF_SERIAL_SESSION, NULL, NULL, &xSession );
-    }
-
-    if( CKR_OK == xResult )
-    {
-        xSessionOpen = CK_TRUE;
-        xResult = xProvisionCertificate( xSession,
-                                         ( uint8_t * ) pucCertificate,
-                                         xCertificateLength,
-                                         pucLabel,
-                                         &xHandle );
-    }
-
-    if( xSessionOpen == CK_TRUE )
-    {
-        xResult = xFunctionList->C_CloseSession( xSession );
-    }
-
-    return xResult;
-}
-
-#endif
+#endif /* if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 ) */
 
 /**
  * @brief Test prvPAL_CloseFile with a valid signature and signature verification

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -331,18 +331,9 @@ set(
     "${nrf5_sdk}/components"
     "${nrf5_sdk}/components/ble/common"
     "${nrf5_sdk}/components/boards"
-    "${nrf5_sdk}/components/device"
-    "${nrf5_sdk}/components/drivers_nrf/clock"
-    "${nrf5_sdk}/components/drivers_nrf/common"
-    "${nrf5_sdk}/components/drivers_nrf/delay"
-    "${nrf5_sdk}/components/drivers_nrf/gpiote"
     "${nrf5_sdk}/components/ble/nrf_ble_gatt"
     "${nrf5_sdk}/components/ble/ble_services/ble_nus"
     "${nrf5_sdk}/components/ble/nrf_ble_qwr"
-    "${nrf5_sdk}/components/drivers_nrf/hal"
-    "${nrf5_sdk}/components/drivers_nrf/rng"
-    "${nrf5_sdk}/components/drivers_nrf/timer"
-    "${nrf5_sdk}/components/drivers_nrf/wdt"
     "${nrf5_sdk}/components/libraries/atomic"
     "${nrf5_sdk}/components/libraries/balloc"
     "${nrf5_sdk}/components/libraries/bsp"
@@ -450,7 +441,6 @@ target_link_libraries(
     AFR::ota::mcu_port
     INTERFACE
         AFR::crypto
-        AFR::pkcs11
 )
 
 # POSIX


### PR DESCRIPTION
Fix OTA PAL test for Nordic

Description
-----------
Nordic doesn't have a PKCS11 port implementation yet, so the test for importing code signer certificate using PKCS11 should be disabled for Nordic. The test was guarded with config `otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 `  but not the private function. 
Added guard to the private function as well.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.