### PR TITLE
Renesas RNG and private key policy fixes

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2176,6 +2176,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
         {
             xResult = PKCS11_PAL_GetObjectValue( xPalHandle, &pxObjectValue, &ulLength, &xIsPrivate );
         }
+        else
+        {
+            xResult = CKR_OBJECT_HANDLE_INVALID;
+        }
     }
 
     /* Determine what kind of object we are dealing with. */
@@ -2303,6 +2307,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
                             memcpy( pxTemplate[ iAttrib ].pValue, &xPkcsKeyType, sizeof( CK_KEY_TYPE ) );
                         }
                     }
+
+                    break;
+
+                case CKA_PRIVATE_EXPONENT:
+
+                    xResult = CKR_ATTRIBUTE_SENSITIVE;
 
                     break;
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -853,8 +853,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID slotID,
     {
         { CKM_RSA_PKCS,        { 2048, 2048, CKF_SIGN              } },
         { CKM_RSA_X_509,       { 2048, 2048, CKF_VERIFY            } },
-        { CKM_ECDSA,           { 256,  256,  CKF_SIGN | CKF_VERIFY } },
-        { CKM_EC_KEY_PAIR_GEN, { 256,  256,  CKF_GENERATE_KEY_PAIR } },
+        #if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 )
+            { CKM_ECDSA,           { 256,  256,  CKF_SIGN | CKF_VERIFY } },
+            { CKM_EC_KEY_PAIR_GEN, { 256,  256,  CKF_GENERATE_KEY_PAIR } },
+        #endif
         { CKM_SHA256,          { 0,    0,    CKF_DIGEST            } }
     };
     uint32_t ulMech = 0;
@@ -1617,51 +1619,54 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
             xResult = CKR_HOST_MEMORY;
         }
     }
-    else if( xKeyType == CKK_EC ) /* CKK_EC = CKK_ECDSA. */
-    {
-        /* Key will be assembled in the mbedTLS key context and then exported to DER for storage. */
-        prvGetLabel( &pxLabel, pxTemplate, ulCount );
 
-        xResult = prvGetExistingKeyComponent( &xPalHandle, &xMbedContext, pxLabel );
-
-        if( xPalHandle == CK_INVALID_HANDLE )
+    #if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 )
+        else if( xKeyType == CKK_EC ) /* CKK_EC = CKK_ECDSA. */
         {
-            /* An mbedTLS key is comprised of 2 pieces of data- an "info" and a "context".
-             * Since a valid key was not found by prvGetExistingKeyComponent, we are going to initialize
-             * the structure so that the mbedTLS structures will look the same as they would if a key
-             * had been found, minus the public key component. */
+            /* Key will be assembled in the mbedTLS key context and then exported to DER for storage. */
+            prvGetLabel( &pxLabel, pxTemplate, ulCount );
 
-            /* If a key had been found by prvGetExistingKeyComponent, the keypair context
-             * would have been malloc'ed. */
-            pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+            xResult = prvGetExistingKeyComponent( &xPalHandle, &xMbedContext, pxLabel );
 
-            if( pxKeyPair != NULL )
+            if( xPalHandle == CK_INVALID_HANDLE )
             {
-                /* Initialize the info. */
-                xMbedContext.pk_info = &mbedtls_eckey_info;
+                /* An mbedTLS key is comprised of 2 pieces of data- an "info" and a "context".
+                 * Since a valid key was not found by prvGetExistingKeyComponent, we are going to initialize
+                 * the structure so that the mbedTLS structures will look the same as they would if a key
+                 * had been found, minus the public key component. */
 
-                /* Initialize the context. */
-                xMbedContext.pk_ctx = pxKeyPair;
-                mbedtls_ecp_keypair_init( pxKeyPair );
-                mbedtls_ecp_group_init( &pxKeyPair->grp );
-                /*/ * At this time, only P-256 curves are supported. * / */
-                mbedtls_ecp_group_load( &pxKeyPair->grp, MBEDTLS_ECP_DP_SECP256R1 );
+                /* If a key had been found by prvGetExistingKeyComponent, the keypair context
+                 * would have been malloc'ed. */
+                pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+
+                if( pxKeyPair != NULL )
+                {
+                    /* Initialize the info. */
+                    xMbedContext.pk_info = &mbedtls_eckey_info;
+
+                    /* Initialize the context. */
+                    xMbedContext.pk_ctx = pxKeyPair;
+                    mbedtls_ecp_keypair_init( pxKeyPair );
+                    mbedtls_ecp_group_init( &pxKeyPair->grp );
+                    /*/ * At this time, only P-256 curves are supported. * / */
+                    mbedtls_ecp_group_load( &pxKeyPair->grp, MBEDTLS_ECP_DP_SECP256R1 );
+                }
+                else
+                {
+                    xResult = CKR_HOST_MEMORY;
+                }
             }
-            else
-            {
-                xResult = CKR_HOST_MEMORY;
-            }
+
+            xResult = prvCreateEcPrivateKey( &xMbedContext,
+                                             &pxLabel,
+                                             pxTemplate,
+                                             ulCount,
+                                             pxObject );
         }
-
-        xResult = prvCreateEcPrivateKey( &xMbedContext,
-                                         &pxLabel,
-                                         pxTemplate,
-                                         ulCount,
-                                         pxObject );
-    }
+    #endif /* if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 ) */
     else
     {
-        xResult = CKR_TEMPLATE_INCONSISTENT;
+        xResult = CKR_MECHANISM_INVALID;
     }
 
     /* Convert back to DER and save to memory. */
@@ -1863,52 +1868,56 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
 
     if( xKeyType == CKK_RSA )
     {
+        xResult = CKR_ATTRIBUTE_TYPE_INVALID;
     }
-    else if( xKeyType == CKK_EC ) /* CKK_EC = CKK_ECDSA. */
-    {
-        prvGetLabel( &pxLabel, pxTemplate, ulCount );
 
-        xResult = prvGetExistingKeyComponent( &xPalHandle, &xMbedContext, pxLabel );
-
-        if( xPalHandle == CK_INVALID_HANDLE )
+    #if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 )
+        else if( xKeyType == CKK_EC ) /* CKK_EC = CKK_ECDSA. */
         {
-            /* An mbedTLS key is comprised of 2 pieces of data- an "info" and a "context".
-             * Since a valid key was not found by prvGetExistingKeyComponent, we are going to initialize
-             * the structure so that the mbedTLS structures will look the same as they would if a key
-             * had been found, minus the private key component. */
+            prvGetLabel( &pxLabel, pxTemplate, ulCount );
 
-            /* If a key had been found by prvGetExistingKeyComponent, the keypair context
-             * would have been malloc'ed. */
-            pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+            xResult = prvGetExistingKeyComponent( &xPalHandle, &xMbedContext, pxLabel );
 
-            if( pxKeyPair != NULL )
+            if( xPalHandle == CK_INVALID_HANDLE )
             {
-                /* Initialize the info. */
-                xMbedContext.pk_info = &mbedtls_eckey_info;
+                /* An mbedTLS key is comprised of 2 pieces of data- an "info" and a "context".
+                 * Since a valid key was not found by prvGetExistingKeyComponent, we are going to initialize
+                 * the structure so that the mbedTLS structures will look the same as they would if a key
+                 * had been found, minus the private key component. */
 
-                /* Initialize the context. */
-                xMbedContext.pk_ctx = pxKeyPair;
-                mbedtls_ecp_keypair_init( pxKeyPair );
-                mbedtls_ecp_group_init( &pxKeyPair->grp );
-                /*/ * At this time, only P-256 curves are supported. * / */
-                mbedtls_ecp_group_load( &pxKeyPair->grp, MBEDTLS_ECP_DP_SECP256R1 );
+                /* If a key had been found by prvGetExistingKeyComponent, the keypair context
+                 * would have been malloc'ed. */
+                pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+
+                if( pxKeyPair != NULL )
+                {
+                    /* Initialize the info. */
+                    xMbedContext.pk_info = &mbedtls_eckey_info;
+
+                    /* Initialize the context. */
+                    xMbedContext.pk_ctx = pxKeyPair;
+                    mbedtls_ecp_keypair_init( pxKeyPair );
+                    mbedtls_ecp_group_init( &pxKeyPair->grp );
+                    /*/ * At this time, only P-256 curves are supported. * / */
+                    mbedtls_ecp_group_load( &pxKeyPair->grp, MBEDTLS_ECP_DP_SECP256R1 );
+                }
+                else
+                {
+                    xResult = CKR_HOST_MEMORY;
+                }
             }
             else
             {
-                xResult = CKR_HOST_MEMORY;
+                xPrivateKeyFound = CK_TRUE;
             }
-        }
-        else
-        {
-            xPrivateKeyFound = CK_TRUE;
-        }
 
-        xResult = prvCreateECPublicKey( &xMbedContext, &pxLabel, pxTemplate, ulCount, pxObject );
-    }
+            xResult = prvCreateECPublicKey( &xMbedContext, &pxLabel, pxTemplate, ulCount, pxObject );
+        }
+    #endif /* if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 ) */
     else
     {
         PKCS11_PRINT( ( "Invalid key type %d \r\n", xKeyType ) );
-        xResult = CKR_TEMPLATE_INCONSISTENT;
+        xResult = CKR_MECHANISM_INVALID;
     }
 
     if( xResult == CKR_OK )
@@ -3705,18 +3714,31 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE xSession,
     CK_OBJECT_HANDLE xPalPublic = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE xPalPrivate = CK_INVALID_HANDLE;
 
-    if( ( pxPublicKeyTemplate == NULL ) ||
-        ( pxPrivateKeyTemplate == NULL ) ||
-        ( pxPublicKey == NULL ) ||
-        ( pxPrivateKey == NULL ) ||
-        ( pxMechanism == NULL ) )
+    #if ( pkcs11configSUPPRESS_ECDSA_MECHANISM == 1 )
+        if( xResult == CKR_OK )
+        {
+            xResult = CKR_MECHANISM_INVALID;
+        }
+    #endif
+
+    if( xResult == CKR_OK )
     {
-        xResult = CKR_ARGUMENTS_BAD;
+        if( ( pxPublicKeyTemplate == NULL ) ||
+            ( pxPrivateKeyTemplate == NULL ) ||
+            ( pxPublicKey == NULL ) ||
+            ( pxPrivateKey == NULL ) ||
+            ( pxMechanism == NULL ) )
+        {
+            xResult = CKR_ARGUMENTS_BAD;
+        }
     }
 
-    if( pucDerFile == NULL )
+    if( xResult == CKR_OK )
     {
-        xResult = CKR_HOST_MEMORY;
+        if( pucDerFile == NULL )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
     }
 
     if( xResult == CKR_OK )

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -788,7 +788,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
         configPRINTF( ( "The PKCS #11 module supports RSA signing.\r\n" ) );
     }
 
-    /* Check for ECDSA support. */
+    /* Check for ECDSA support, if applicable. */
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_ECDSA, &MechanismInfo );
     TEST_ASSERT_TRUE( CKR_OK == xResult || CKR_MECHANISM_INVALID == xResult );
 
@@ -822,8 +822,7 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
         configPRINTF( ( "The PKCS #11 module supports elliptic-curve key generation.\r\n" ) );
     }
 
-    /* SHA-256 support is required, but we don't need to write it to the console,
-     * since it doesn't impact the execution sequence for IDT. */
+    /* SHA-256 support is required. */
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_SHA256, &MechanismInfo );
     TEST_ASSERT_TRUE( CKR_OK == xResult );
     TEST_ASSERT_TRUE( 0 != ( CKF_DIGEST & MechanismInfo.flags ) );

--- a/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
+++ b/vendors/renesas/amazon_freertos_common/entropy_hardware_poll.c
@@ -19,15 +19,15 @@ int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
     R_INTERNAL_NOT_USED(data);
-    R_INTERNAL_NOT_USED(len);
 
     uint32_t random_number = 0;
+    size_t num_bytes = ( len < sizeof( uint32_t ) ) ? len : sizeof( uint32_t );
 
-    get_random_number((uint8_t *)&random_number, sizeof(uint32_t));
+    get_random_number( ( uint8_t * ) &random_number, sizeof( uint32_t ) );
     *olen = 0;
 
-    memcpy(output, &random_number, sizeof(uint32_t));
-    *olen = sizeof(uint32_t);
+    memcpy( output, &random_number, num_bytes );
+    *olen = num_bytes;
 
     return 0;
 }

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
@@ -44,19 +44,19 @@
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
  */
-#define configPKCS11_DEFAULT_USER_PIN    "0000"
+#define configPKCS11_DEFAULT_USER_PIN                      "0000"
 
 /**
  * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
  * attribute.
  */
-#define pkcs11configMAX_LABEL_LENGTH     32
+#define pkcs11configMAX_LABEL_LENGTH                       32
 
 /**
  * @brief Maximum number of token objects that can be stored
  * by the PKCS #11 module.
  */
-#define pkcs11configMAX_NUM_OBJECTS      6
+#define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
  * @brief Set to 1 if a PAL destroy object is implemented.
@@ -127,5 +127,14 @@
  * @see aws_default_root_certificates.h
  */
 #define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
+
+/**
+ * @brief Disable ECDSA crypto algorithm (i.e. mechanism) support in this
+ * PKCS #11 module.
+ *
+ * Set this to 1 when the host doesn't support ECDSA for network authentication
+ * (e.g. in the TLS protocol implementation).
+ */
+#define pkcs11configSUPPRESS_ECDSA_MECHANISM               1
 
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -25,7 +25,7 @@
 
 /**
  * @file iot_test_pkcs11_config.h
- * @brief Port-specific variables for PKCS11 tests. 
+ * @brief Port-specific variables for PKCS11 tests.
  */
 
 #ifndef _AWS_TEST_PKCS11_CONFIG_H_
@@ -37,7 +37,7 @@
  * Each task consumes both stack and heap space, which may cause memory allocation
  * failures if too many tasks are created.
  */
-#define pkcs11testMULTI_THREAD_TASK_COUNT    ( 2 )
+#define pkcs11testMULTI_THREAD_TASK_COUNT             ( 2 )
 
 /**
  * @brief The number of iterations in SignVerifyRoundTrip_MultitaskLoop.
@@ -46,7 +46,7 @@
  * boards. Ensure that pkcs11testEVENT_GROUP_TIMEOUT is long enough to accommodate
  * all iterations of the loop.
  */
-#define pkcs11testMULTI_THREAD_LOOP_COUNT    ( 10 )
+#define pkcs11testMULTI_THREAD_LOOP_COUNT             ( 10 )
 
 /**
  * @brief
@@ -54,32 +54,32 @@
  * All tasks of the SignVerifyRoundTrip_MultitaskLoop test must finish within
  * this timeout, or the test will fail.
  */
-#define pkcs11testEVENT_GROUP_TIMEOUT_MS    ( pdMS_TO_TICKS( 1000000UL ) )
+#define pkcs11testEVENT_GROUP_TIMEOUT_MS              ( pdMS_TO_TICKS( 1000000UL ) )
 
 /**
  * @brief The index of the slot that should be used to open sessions for PKCS #11 tests.
  */
-#define pkcs11testSLOT_NUMBER                 ( 0 )
+#define pkcs11testSLOT_NUMBER                         ( 0 )
 
 /*
  * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testRSA_KEY_SUPPORT             ( 1 )
+#define pkcs11testRSA_KEY_SUPPORT                     ( 1 )
 
 /*
  * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testEC_KEY_SUPPORT              ( 0 )
+#define pkcs11testEC_KEY_SUPPORT                      ( 0 )
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT       ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT          ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )
 
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT    ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 0 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.
@@ -88,7 +88,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
+#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS    pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for device public key.
@@ -97,7 +97,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for the device certificate.
@@ -106,7 +106,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS       pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS
+#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS    pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS
 
 /**
  * @brief The PKCS #11 label for the object to be used for code verification.
@@ -117,7 +117,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_CODE_VERIFICATION_KEY            pkcs11configLABEL_CODE_VERIFICATION_KEY
+#define pkcs11testLABEL_CODE_VERIFICATION_KEY         pkcs11configLABEL_CODE_VERIFICATION_KEY
 
 /**
  * @brief The PKCS #11 label for Just-In-Time-Provisioning.
@@ -130,12 +130,12 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_JITP_CERTIFICATE                 pkcs11configLABEL_JITP_CERTIFICATE
+#define pkcs11testLABEL_JITP_CERTIFICATE              pkcs11configLABEL_JITP_CERTIFICATE
 
 /**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
+#define pkcs11testLABEL_ROOT_CERTIFICATE              pkcs11configLABEL_ROOT_CERTIFICATE
 #endif /* _AWS_TEST_PKCS11_CONFIG_H_ */


### PR DESCRIPTION
Add test that private keys are not extract-able. Prevent overflow of Renesas RNG buffer.  Don't check for ECDSA support if it's disabled in static configuration.