### PR TITLE
Moved Log to multiple lines to prevent overflow. Abstracted configTOT…

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -322,11 +322,7 @@ void runDemoTask( void * pArgument )
 
     /* DO NOT EDIT - This demo start marker is used in the test framework to
      * determine the start of a demo. */
-    vTaskDelay( pdMS_TO_TICKS( 5000UL ) );
-    vTaskDelay( pdMS_TO_TICKS( 5000UL ) );
     IotLogInfo( "---------STARTING DEMO---------\n" );
-    IotLogInfo( "UUID: _uuid_a28dd41e8d5c4818818035b8a2cc8e70\n" );
-    IotLogInfo( "UUID: _uuid_d714daa01134460b8a6181960b66172c\n" );
 
     status = _initialize( pContext );
 
@@ -349,13 +345,13 @@ void runDemoTask( void * pArgument )
             /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
             xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-            IotLogInfo( "memory_metrics:heap:total:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
-            IotLogInfo( "memory_metrics:heap:before:%u", xBeforeDemoHeapSize );
-            IotLogInfo( "memory_metrics:heap:after:%u", xAfterDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:total:bytes:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
+            IotLogInfo( "memory_metrics:heap:before:bytes:%u", xBeforeDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:after:bytes:%u", xAfterDemoHeapSize );
             xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-            IotLogInfo( "memory_metrics:stack:total:%u", xDemoStackSize );
-            IotLogInfo( "memory_metrics:stack:before:%u", xBeforeDemoTaskWaterMark );
-            IotLogInfo( "memory_metrics:stack:after:%u", xAfterDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:total:stack_words:%u", xDemoStackSize );
+            IotLogInfo( "memory_metrics:stack:before:stack_words:%u", xBeforeDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:after:stack_words:%u", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
         /* Log the demo status. */

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -345,13 +345,13 @@ void runDemoTask( void * pArgument )
             /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
             xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-            IotLogInfo( "memory_metrics:heap:total:%u\n"
-                        "memory_metrics:heap:before:%u\n"
-                        "memory_metrics:heap:after:%u\r\n", configTOTAL_HEAP_SIZE, xBeforeDemoHeapSize, xAfterDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:total:%u\n", demoMEMORY_ANALYSIS_HEAP_SIZE );
+            IotLogInfo( "memory_metrics:heap:before:%u\n", xBeforeDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:after:%u\r\n", xAfterDemoHeapSize );
             xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-            IotLogInfo( "memory_metrics:stack:total:%u\n"
-                        "memory_metrics:stack:before:%u\n"
-                        "memory_metrics:stack:after:%u\r\n", xDemoStackSize, xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:total:%u\n", xDemoStackSize );
+            IotLogInfo( "memory_metrics:stack:before:%u\n", xBeforeDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:after:%u\r\n", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
         /* Log the demo status. */

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -459,4 +459,3 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
 }
 
 /*-----------------------------------------------------------*/
-

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -345,13 +345,13 @@ void runDemoTask( void * pArgument )
             /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
             xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-            IotLogInfo( "memory_metrics:heap:total:bytes:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
-            IotLogInfo( "memory_metrics:heap:before:bytes:%u", xBeforeDemoHeapSize );
-            IotLogInfo( "memory_metrics:heap:after:bytes:%u", xAfterDemoHeapSize );
+            IotLogInfo( "memory_metrics:freertos_heap:total:bytes:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
+            IotLogInfo( "memory_metrics:freertos_heap:before:bytes:%u", xBeforeDemoHeapSize );
+            IotLogInfo( "memory_metrics:freertos_heap:after:bytes:%u", xAfterDemoHeapSize );
             xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-            IotLogInfo( "memory_metrics:stack:total:stack_words:%u", xDemoStackSize );
-            IotLogInfo( "memory_metrics:stack:before:stack_words:%u", xBeforeDemoTaskWaterMark );
-            IotLogInfo( "memory_metrics:stack:after:stack_words:%u", xAfterDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:demo_task_stack:total:stack_words:%u", xDemoStackSize );
+            IotLogInfo( "memory_metrics:demo_task_stack:before:stack_words:%u", xBeforeDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:demo_task_stack:after:stack_words:%u", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
         /* Log the demo status. */
@@ -459,3 +459,4 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
 }
 
 /*-----------------------------------------------------------*/
+

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -322,7 +322,11 @@ void runDemoTask( void * pArgument )
 
     /* DO NOT EDIT - This demo start marker is used in the test framework to
      * determine the start of a demo. */
+    vTaskDelay( pdMS_TO_TICKS( 5000UL ) );
+    vTaskDelay( pdMS_TO_TICKS( 5000UL ) );
     IotLogInfo( "---------STARTING DEMO---------\n" );
+    IotLogInfo( "UUID: _uuid_a28dd41e8d5c4818818035b8a2cc8e70\n" );
+    IotLogInfo( "UUID: _uuid_d714daa01134460b8a6181960b66172c\n" );
 
     status = _initialize( pContext );
 
@@ -345,13 +349,13 @@ void runDemoTask( void * pArgument )
             /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
             xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-            IotLogInfo( "memory_metrics:heap:total:%u\n", demoMEMORY_ANALYSIS_HEAP_SIZE );
-            IotLogInfo( "memory_metrics:heap:before:%u\n", xBeforeDemoHeapSize );
-            IotLogInfo( "memory_metrics:heap:after:%u\r\n", xAfterDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:total:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
+            IotLogInfo( "memory_metrics:heap:before:%u", xBeforeDemoHeapSize );
+            IotLogInfo( "memory_metrics:heap:after:%u", xAfterDemoHeapSize );
             xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-            IotLogInfo( "memory_metrics:stack:total:%u\n", xDemoStackSize );
-            IotLogInfo( "memory_metrics:stack:before:%u\n", xBeforeDemoTaskWaterMark );
-            IotLogInfo( "memory_metrics:stack:after:%u\r\n", xAfterDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:total:%u", xDemoStackSize );
+            IotLogInfo( "memory_metrics:stack:before:%u", xBeforeDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:stack:after:%u", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
         /* Log the demo status. */

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -68,6 +68,7 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
     #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( )     xPortGetMinimumEverFreeHeapSize( )
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -70,7 +70,7 @@
 #ifdef democonfigMEMORY_ANALYSIS
     #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE( )     xPortGetMinimumEverFreeHeapSize( )
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
     #else

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
@@ -193,6 +193,6 @@ extern int iMainRand32( void );
 #define configTCP_ECHO_CLIENT_PORT    7
 
 /* The platform FreeRTOS is running on. */
-#define configPLATFORM_NAME    "STM32L475"
+#define configPLATFORM_NAME           "STM32L475"
 
 #endif /* FREERTOS_CONFIG_H */

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
@@ -91,6 +91,7 @@
 #define INCLUDE_vTaskSuspend                         1
 #define INCLUDE_vTaskDelayUntil                      1
 #define INCLUDE_vTaskDelay                           1
+#define INCLUDE_uxTaskGetStackHighWaterMark          1
 #define INCLUDE_xTaskGetSchedulerState               1
 
 /* Cortex-M specific definitions. */

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -72,6 +72,7 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
     #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
@@ -169,7 +169,7 @@ function. */
 #define INCLUDE_vTaskSuspend                        1
 #define INCLUDE_vTaskDelayUntil                     1
 #define INCLUDE_vTaskDelay                          1
-#define INCLUDE_uxTaskGetStackHighWaterMark         0
+#define INCLUDE_uxTaskGetStackHighWaterMark         1
 #define INCLUDE_xTaskGetSchedulerState              1
 #define INCLUDE_xTaskGetIdleTaskHandle              0
 #define INCLUDE_eTaskGetState                       1

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -76,13 +76,15 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
+    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
     #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()       xPortGetMinimumEverFreeHeapSize()
+    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
     #else
         #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
+
 
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -52,23 +52,23 @@
 
 #if defined( democonfigBLE_MQTT_ECHO_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES                    ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
+    #define democonfigNETWORK_TYPES                       ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
 #endif
 
-#define democonfigSHADOW_DEMO_NUM_TASKS                ( 1 )
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE          ( 1024 )
-#define democonfigSHADOW_DEMO_TASK_PRIORITY            ( tskIDLE_PRIORITY + 5 )
-#define shadowDemoUPDATE_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_NUM_TASKS                   ( 1 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE             ( 1024 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY               ( tskIDLE_PRIORITY + 5 )
+#define shadowDemoUPDATE_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 5 )
 
-#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT    pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY              ( tskIDLE_PRIORITY )
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT       pdMS_TO_TICKS( 12000 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */
-#define democonfigMQTT_TIMEOUT                         pdMS_TO_TICKS( 3000 )
+#define democonfigMQTT_TIMEOUT                            pdMS_TO_TICKS( 3000 )
 
 /* Send AWS IoT MQTT traffic encrypted. */
-#define democonfigMQTT_AGENT_CONNECT_FLAGS             ( mqttagentREQUIRE_TLS )
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                ( mqttagentREQUIRE_TLS )
 
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 14 )
 


### PR DESCRIPTION
…AL_HEAP_SIZE as it break ESP build. The error message is due to not finding "_heap_end", as on ESP configTOTAL_HEAP_SIZE is defined as &_heap_end - &heap_start.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.