### PR TITLE
Add exponential retry logic to all MQTT System tests.

### DIFF
--- a/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -224,9 +224,9 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
     #if ( IOT_TEST_MQTT_CONNECT_RETRY_ENABLED == 1 )
         int32_t retried = 0;
 
-        /* Often connections fail because the server throttles the tests. One second
-        * may be sufficient of a time to wait before trying again on the network. */
-        uint32_t periodMs = 1000;
+        /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+         * Wait until 1100 ms have elapsed since the last connection. */
+        uint32_t periodMs = 1100;
         int32_t retries = 3;
 
         for( ; retried <= retries; retried++ )

--- a/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -212,7 +212,7 @@ static bool _disconnectSerializerOverride = false;  /**< @brief Tracks if #_disc
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Establish an MQTT connection. Retry if retries are enabled.
+ * @brief Establish an MQTT connection. Retry if enabled.
  */
 static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
                                     const IotMqttConnectInfo_t * pConnectInfo,
@@ -221,19 +221,19 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
 
-    #if ( IOT_TEST_MQTT_CONNECT_RETRY_ENABLED == 1 )
+    #if defined( IOT_TEST_MQTT_CONNECT_RETRY_COUNT )
         int32_t retried = 0;
 
         /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
          * Wait until 1100 ms have elapsed since the last connection. */
         uint32_t periodMs = 1100;
-        int32_t retries = 3;
+        int32_t retries = IOT_TEST_MQTT_CONNECT_RETRY_COUNT;
 
         for( ; retried <= retries; retried++ )
         {
     #endif
     status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection );
-    #if ( IOT_TEST_MQTT_CONNECT_RETRY_ENABLED == 1 )
+    #if defined( IOT_TEST_MQTT_CONNECT_RETRY_COUNT )
         if( ( status == IOT_MQTT_NETWORK_ERROR ) || ( status == IOT_MQTT_TIMEOUT ) )
         {
             IotClock_SleepMs( periodMs );
@@ -245,7 +245,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
             break;
         }
 }
-    #endif /* if ( IOT_TEST_MQTT_CONNECT_RETRY_ENABLED == 1 ) */
+    #endif /* if defined( IOT_TEST_MQTT_CONNECT_RETRY_COUNT ) */
     return status;
 }
 

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -252,6 +252,10 @@ struct IotMqttSerializer;
 extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
 #define IOT_TEST_MQTT_SERIALIZER    IotTestNetwork_GetSerializer()
 
+/* Retry the MQTT Connections in the MQTT System unit tests for all hardware
+   platforms supported in Amazon FreeRTOS. */
+#define IOT_TEST_MQTT_CONNECT_RETRY_ENABLED  1
+
 /* Forward declarations of network types used in the tests. */
 typedef struct IotNetworkConnection    IotTestNetworkConnection_t;
 typedef struct IotNetworkServerInfo    IotTestNetworkServerInfo_t;

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -253,7 +253,7 @@ extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
 #define IOT_TEST_MQTT_SERIALIZER    IotTestNetwork_GetSerializer()
 
 /* Retry the MQTT Connections in the MQTT System unit tests for all hardware
-   platforms supported in Amazon FreeRTOS. */
+ * platforms supported in Amazon FreeRTOS. */
 #define IOT_TEST_MQTT_CONNECT_RETRY_ENABLED  1
 
 /* Forward declarations of network types used in the tests. */

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -250,11 +250,11 @@ extern const struct IotNetworkInterface * IotTestNetwork_GetNetworkInterface( vo
 /* Allow the network serializer to be chosen by at runtime. */
 struct IotMqttSerializer;
 extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
-#define IOT_TEST_MQTT_SERIALIZER    IotTestNetwork_GetSerializer()
+#define IOT_TEST_MQTT_SERIALIZER               IotTestNetwork_GetSerializer()
 
 /* Retry the MQTT Connections in the MQTT System unit tests for all hardware
  * platforms supported in Amazon FreeRTOS. */
-#define IOT_TEST_MQTT_CONNECT_RETRY_ENABLED  1
+#define IOT_TEST_MQTT_CONNECT_RETRY_ENABLED    1
 
 /* Forward declarations of network types used in the tests. */
 typedef struct IotNetworkConnection    IotTestNetworkConnection_t;

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -250,11 +250,13 @@ extern const struct IotNetworkInterface * IotTestNetwork_GetNetworkInterface( vo
 /* Allow the network serializer to be chosen by at runtime. */
 struct IotMqttSerializer;
 extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
-#define IOT_TEST_MQTT_SERIALIZER               IotTestNetwork_GetSerializer()
+#define IOT_TEST_MQTT_SERIALIZER             IotTestNetwork_GetSerializer()
 
 /* Retry the MQTT Connections in the MQTT System unit tests for all hardware
- * platforms supported in Amazon FreeRTOS. */
-#define IOT_TEST_MQTT_CONNECT_RETRY_ENABLED    1
+ * platforms supported in Amazon FreeRTOS.
+ * Set this to the number of connection attempts for the MQTT tests.
+ * If undefined, it should default to 1. */
+#define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    3
 
 /* Forward declarations of network types used in the tests. */
 typedef struct IotNetworkConnection    IotTestNetworkConnection_t;


### PR DESCRIPTION
Add exponential retry logic to all MQTT System tests.

Description
-----------
To reduce the probability of failures in MQTT connect because of transient network issues, we add exponential retries to all IotMqtt_Connect() calls in all MQTT_System tests.

This change once approved will be repeated in the CSDK. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.