### PR TITLE
Add CKA_VALUE with NULL retrieval function to private key template

### DIFF
--- a/vendors/microchip/secure_elements/lib/pkcs11/pkcs11_key.c
+++ b/vendors/microchip/secure_elements/lib/pkcs11/pkcs11_key.c
@@ -416,6 +416,8 @@ const pkcs11_attrib_model pkcs11_key_private_attributes[] = {
     { CKA_EC_PARAMS,           pkcs11_key_get_ec_params                                                              },
     /** DER - encoding of ANSI X9.62 ECPoint value Q */
     { CKA_EC_POINT,            pkcs11_key_get_ec_point                                                               },
+    /** The value of the private key should remain private.  A NULL function pointer is interpreted as a sensitive attribute. */
+    { CKA_VALUE,               NULL_PTR                                                                              },
 };
 
 const CK_ULONG pkcs11_key_private_attributes_count = PKCS11_UTIL_ARRAY_SIZE(pkcs11_key_private_attributes);


### PR DESCRIPTION
CKA_VALUE was missing from certificate template, causing GetAttributeValue
calls on private keys to return CKR_ATTRIBUTE_TYPE_INVALID instead of
CKR_ATTRIBUTE_SENSITIVE.  Adding this attribute to the template triggers
the CKR_ATTRIBUTE_SENSITIVE return value instead.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.