### PR TITLE
BUGFIX: Marvell MAC address was not properly initialized in TCP stack

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -148,22 +148,16 @@ void handle_data_packet(const t_u8 interface, const t_u8 *rcvdata,
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-    static BaseType_t xMACAdrInitialized = pdFALSE;
     uint8_t ret;
-
-    if (xInterfaceState == INTERFACE_UP) {
-	if (xMACAdrInitialized == pdFALSE) {
-	    mac_addr_t mac_addr;
-	    ret = wifi_get_device_mac_addr(&mac_addr);
-	    if (ret != WM_SUCCESS) {
+    mac_addr_t mac_addr;
+    
+	ret = wifi_get_device_mac_addr(&mac_addr);
+	if (ret != WM_SUCCESS) {
 		net_d("Failed to get mac address");
 		return pdFALSE;
-	    }
-	    FreeRTOS_UpdateMACAddress(mac_addr.mac);
-	    xMACAdrInitialized = pdTRUE;
-	 }
-	 return pdTRUE;
-    }
+	}
+	FreeRTOS_UpdateMACAddress(mac_addr.mac);
+
     return pdFALSE;
 }
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -150,15 +150,15 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
     uint8_t ret;
     mac_addr_t mac_addr;
-    
+
 	ret = wifi_get_device_mac_addr(&mac_addr);
 	if (ret != WM_SUCCESS) {
 		net_d("Failed to get mac address");
-		return pdFALSE;
 	}
+
 	FreeRTOS_UpdateMACAddress(mac_addr.mac);
 
-    return pdFALSE;
+    return ( xInterfaceState == INTERFACE_UP && ret == WM_SUCCESS ) ? pdTRUE : pdFALSE;
 }
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
@@ -159,11 +159,11 @@ to exclude the API function. */
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
 #define configMAC_ADDR0                      0x00
-#define configMAC_ADDR1                      0x50
-#define configMAC_ADDR2                      0x43
-#define configMAC_ADDR3                      0x21
-#define configMAC_ADDR4                      0xe5
-#define configMAC_ADDR5                      0xc7
+#define configMAC_ADDR1                      0x00
+#define configMAC_ADDR2                      0x00
+#define configMAC_ADDR3                      0x00
+#define configMAC_ADDR4                      0x00
+#define configMAC_ADDR5                      0x00
 
 /* Default IP address configuration.  Used in ipconfigUSE_DHCP is set to 0, or
  * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
@@ -162,11 +162,12 @@ to exclude the API function. */
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
 #define configMAC_ADDR0                      0x00
-#define configMAC_ADDR1                      0x50
-#define configMAC_ADDR2                      0x43
-#define configMAC_ADDR3                      0x21
-#define configMAC_ADDR4                      0xe5
-#define configMAC_ADDR5                      0xc7
+#define configMAC_ADDR1                      0x00
+#define configMAC_ADDR2                      0x00
+#define configMAC_ADDR3                      0x00
+#define configMAC_ADDR4                      0x00
+#define configMAC_ADDR5                      0x00
+
 
 /* Default IP address configuration.  Used in ipconfigUSE_DHCP is set to 0, or
  * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */


### PR DESCRIPTION
Description
-----------
```IP-task``` is created before ```wifi_driver``` and ```wlcmgr``` task. Right after entering IP task, network down event is sent to the queue in the same task to initialize local MAC address. Due to the condition ```if ( xInterfaceState == INTERFACE_UP )```, the code skips reading MAC address from NVM and fails updating IP stack local MAC address properly. 

The fix is proposed given reading MAC address does not need WiFi layer to be ready prior. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.