### PR TITLE
Use angle brackets for some include

### DIFF
--- a/demos/include/iot_config_common.h
+++ b/demos/include/iot_config_common.h
@@ -35,10 +35,10 @@
 #include "platform/iot_platform_types_freertos.h"
 
 /* Used to get the cloud broker endpoint for FreeRTOS. */
-#include "aws_clientcredential.h"
+#include <aws_clientcredential.h>
 
 /* Used to get the certificate used by the device. */
-#include "aws_clientcredential_keys.h"
+#include <aws_clientcredential_keys.h>
 
 /* SDK version. */
 #define IOT_SDK_VERSION    "4.0.0"

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -32,8 +32,8 @@
 #include "FreeRTOS.h"
 
 /* Credentials include. */
-#include "aws_clientcredential.h"
-#include "aws_clientcredential_keys.h"
+#include <aws_clientcredential.h>
+#include <aws_clientcredential_keys.h>
 
 /* Unity framework includes. */
 #include "unity.h"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
When using quotes, the compiler searches first in the same directory containing the current file. With this behavior, there's no way to specify another include path and tell compiler to search that first. One of the use cases is customer may want to set up our library as a submodule, and specify another include path for our config files that takes precedence over our default config directory. This commit fixes some immediate issues that are blocking this use case. Further discussions are needed for all other #include

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.