### PR TITLE
test: Changing thresholds for tsensor test

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_tsensor.c
+++ b/libraries/abstractions/common_io/test/test_iot_tsensor.c
@@ -39,10 +39,10 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
-#define testIotTSENSOR_ROOM_TEMP        ( 25000 )
-#define testIotTSENSOR_ROOM_TEMP_DELTA  ( 12000 )
+#define testIotTSENSOR_ROOM_TEMP        ( 30000 )
+#define testIotTSENSOR_ROOM_TEMP_DELTA  ( 15000 )
 #define testIotTSENSOR_TEMP_DELTA       ( 5000 )
-#define testIotTSENSOR_INVALID_INPUT ( 99 )
+#define testIotTSENSOR_INVALID_INPUT    ( 99 )
 #define TSENSOR_TEMP_ABSOLUTE_ZERO      ( -273150 )
 
 uint8_t uctestIotTsensorInstance = 0;


### PR DESCRIPTION
Changing the upper and lower limit for tsensor test

Why:  The tests were failing in pre-CI because the DUT is running
in a closed environment with no air circulation or a/c.  This is
causing it to run hotter than expected room temperature.

----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.