### PR TITLE
Fix an issue in nordic CMake file

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -504,6 +504,17 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
          "FLASH_PH_START=0x0$<SEMICOLON>FLASH_PH_SIZE=0x100000$<SEMICOLON>RAM_PH_START=0x20000000$<SEMICOLON>RAM_PH_SIZE=0x40000$<SEMICOLON>FLASH_START=0x27000$<SEMICOLON>FLASH_SIZE=0xda000$<SEMICOLON>RAM_START=0x200046F8$<SEMICOLON>RAM_SIZE=0x3B908"
     )
 
+    find_program(gcc_objectcopy objcopy HINTS "${AFR_COMPILER_DIR}")
+    find_program(gcc_size arm-none-eabi-size HINTS "${AFR_COMPILER_DIR}")
+
+    if(NOT gcc_objectcopy)
+        message(FATAL_ERROR "Cannot find objcopy.")
+    endif()
+
+    if(NOT gcc_size)
+        message(FATAL_ERROR "Cannot find arm-none-eabi-size.")
+    endif()
+
     function(nrf52840_build)
         set( build_target ${ARGV0} )
         set( build_mkld_flags ${${ARGV1}} )
@@ -512,13 +523,6 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
             PRE_LINK
             COMMAND VERBATIM "${AFR_COMPILER_DIR}/../../../bin/mkld" ${build_mkld_flags} "${CMAKE_BINARY_DIR}/${build_target}.ld"
         )
-
-        find_program(gcc_objectcopy objcopy)
-        find_program(gcc_size arm-none-eabi-size)
-
-        if(NOT gcc_objectcopy )
-            message(FATAL_ERROR "Cannot find objcopy.")
-        endif()
 
         set(output_file "$<TARGET_FILE_DIR:${build_target}>/${build_target}.hex")
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Throw an error if arm-none-eabi-size is not found
- Use the compiler location to search objcopy and arm-none-eabi-size

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.