### PR TITLE
AFR: NimBLE - Correct the HCI disconnect reason

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -392,7 +392,7 @@ BTStatus_t prvBTDisconnect( uint8_t ucAdapterIf,
 {
     BTStatus_t xStatus = eBTStatusSuccess;
 
-    if( ble_gap_terminate( usConnId, BLE_ERR_CONN_TERM_LOCAL ) != 0 )
+    if( ble_gap_terminate( usConnId, BLE_ERR_REM_USER_CONN_TERM ) != 0 )
     {
         xStatus = eBTStatusFail;
     }


### PR DESCRIPTION
NimBLE - Correct the HCI disconnect reason 


Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.