### PR TITLE
Replace the ipconfigRAND32 macro with a function

### DIFF
--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -632,8 +632,15 @@ static CK_RV prvSocketsGetCryptoSession( SemaphoreHandle_t * pxSessionLock,
 }
 /*-----------------------------------------------------------*/
 
-//uint32_t ulRand( void ) __attribute__ ((deprecated))
+/*uint32_t ulRand( void ) __attribute__ ((deprecated)) */
 #if 0
+
+/* Why is this function between #if 0? Because the function ulRand()
+ * is now reprecated. The function is still shown here for users who
+ * are looking for it.
+ * It is deprecated because a return value of 0 would mean that the
+ * RND module is broken. This was confusing because 0 is also a
+ * possible valid random number. */
     uint32_t ulRand( void )
     {
         uint32_t ulNumber = 0uL;
@@ -647,18 +654,19 @@ static CK_RV prvSocketsGetCryptoSession( SemaphoreHandle_t * pxSessionLock,
         {
             /* Function succeeded, a random number will be returned. */
         }
+
         return ulNumber;
     }
-#endif/* 0 */
+#endif /* 0 */
 
-BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
 {
     CK_RV xResult = 0;
     SemaphoreHandle_t xSessionLock = NULL;
     CK_SESSION_HANDLE xPkcs11Session = 0;
     CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
     uint32_t ulRandomValue = 0;
-    BaseType_t xReturn;	/* Return pdTRUE if successful */
+    BaseType_t xReturn; /* Return pdTRUE if successful */
 
     xResult = prvSocketsGetCryptoSession( &xSessionLock,
                                           &xPkcs11Session,

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -632,13 +632,33 @@ static CK_RV prvSocketsGetCryptoSession( SemaphoreHandle_t * pxSessionLock,
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulRand( void )
+//uint32_t ulRand( void ) __attribute__ ((deprecated))
+#if 0
+    uint32_t ulRand( void )
+    {
+        uint32_t ulNumber = 0uL;
+        BaseType_t xResult = xApplicationGetRandomNumber( &( ulNumber ) );
+
+        if( xResult == pdFALSE )
+        {
+            ulNumber = 0uL;
+        }
+        else
+        {
+            /* Function succeeded, a random number will be returned. */
+        }
+        return ulNumber;
+    }
+#endif/* 0 */
+
+BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
 {
     CK_RV xResult = 0;
     SemaphoreHandle_t xSessionLock = NULL;
     CK_SESSION_HANDLE xPkcs11Session = 0;
     CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
     uint32_t ulRandomValue = 0;
+    BaseType_t xReturn;	/* Return pdTRUE if successful */
 
     xResult = prvSocketsGetCryptoSession( &xSessionLock,
                                           &xPkcs11Session,
@@ -654,12 +674,18 @@ uint32_t ulRand( void )
     }
 
     /* Check if any of the API calls failed. */
-    if( 0 != xResult )
+    if( 0 == xResult )
     {
-        ulRandomValue = 0;
+        xReturn = pdTRUE;
+        *( pulNumber ) = ulRandomValue;
+    }
+    else
+    {
+        xReturn = pdFALSE;
+        *( pulNumber ) = 0uL;
     }
 
-    return ulRandomValue;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
@@ -275,6 +275,15 @@ void FreeRTOS_ClearARP( void );
 #endif /* ipconfigDHCP_REGISTER_HOSTNAME */
 
 
+/* This xApplicationGetRandomNumber() will set *pulNumber to a random number,
+and return pdTRUE. When the random number generator is broken, it shall return
+pdFALSE.
+The function is defined in 'iot_secure_sockets.c'.
+If that module is not included in the project, the application must provide an
+implementation of it.
+The macro's ipconfigRAND32() and configRAND32() are not in use anymore. */
+BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber );
+
 /* For backward compatibility define old structure names to the newer equivalent
 structure name. */
 #ifndef ipconfigENABLE_BACKWARD_COMPATIBILITY

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -471,6 +471,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 uint32_t ulIPAddress = 0uL;
 TickType_t uxReadTimeOut_ticks = ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS;
 TickType_t uxIdentifier = 0u;
+BaseType_t xHasRandom = pdFALSE;
 
 	if( pcHostName != NULL )
 	{
@@ -505,8 +506,11 @@ TickType_t uxIdentifier = 0u;
 		/* Generate a unique identifier. */
 		if( ulIPAddress == 0uL )
 		{
+		uint32_t ulNumber;
+
+			xHasRandom = xApplicationGetRandomNumber( &( ulNumber ) );
 			/* DNS identifiers are 16-bit. */
-			uxIdentifier = ( TickType_t ) ( ipconfigRAND32() & 0xffffu );
+			uxIdentifier = ( TickType_t ) ( ulNumber & 0xffffu );
 			/* ipconfigRAND32() may not return a non-zero value. */
 		}
 
@@ -517,10 +521,10 @@ TickType_t uxIdentifier = 0u;
 				if( ulIPAddress == 0uL )
 				{
 					/* The user has provided a callback function, so do not block on recvfrom() */
-					if( uxIdentifier != ( TickType_t ) 0u )
+					if( xHasRandom != pdFALSE )
 					{
 						uxReadTimeOut_ticks = 0u;
-						vDNSSetCallBack( pcHostName, pvSearchID, pCallback, uxTimeout, ( TickType_t ) uxIdentifier );
+						vDNSSetCallBack( pcHostName, pvSearchID, pCallback, uxTimeout, uxIdentifier );
 					}
 				}
 				else
@@ -532,7 +536,7 @@ TickType_t uxIdentifier = 0u;
 		}
 		#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
-		if( ( ulIPAddress == 0uL ) && ( uxIdentifier != ( TickType_t ) 0u ) )
+		if( ( ulIPAddress == 0uL ) && ( xHasRandom != pdFALSE ) )
 		{
 			ulIPAddress = prvGetHostByName( pcHostName, uxIdentifier, uxReadTimeOut_ticks );
 		}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
@@ -1654,7 +1654,6 @@ const uint16_t usEphemeralPortCount =
 uint16_t usIterations = usEphemeralPortCount;
 uint32_t ulRandomSeed = 0;
 uint16_t usResult = 0;
-BaseType_t xGotZeroOnce = pdFALSE;
 const List_t *pxList;
 
 #if ipconfigUSE_TCP == 1
@@ -1675,21 +1674,10 @@ const List_t *pxList;
 	point. */
 	do
 	{
-		/* Generate a random seed. */
-		ulRandomSeed = ipconfigRAND32( );
-
 		/* Only proceed if the random number generator succeeded. */
-		if( 0 == ulRandomSeed )
+		if( xApplicationGetRandomNumber( &( ulRandomSeed ) ) == pdFALSE )
 		{
-			if( pdFALSE == xGotZeroOnce )
-			{
-				xGotZeroOnce = pdTRUE;
-				continue;
-			}
-			else
-			{
-				break;
-			}
+			break;
 		}
 
 		/* Map the random to a candidate port. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/WinPCap/FaultInjection.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/WinPCap/FaultInjection.c
@@ -77,7 +77,8 @@ return pxNetworkBufferIn;
 
 	if( ulCallCount > ulNextFaultCallCount )
 	{
-		ulNextFaultCallCount = ipconfigRAND32() % xMAX_FAULT_INJECTION_RATE;
+		xApplicationGetRandomNumber( &( ulNextFaultCallCount ) );
+		ulNextFaultCallCount = ulNextFaultCallCount % xMAX_FAULT_INJECTION_RATE;
 		if( ulNextFaultCallCount < xMIN_FAULT_INJECTION_RATE )
 		{
 			ulNextFaultCallCount = xMIN_FAULT_INJECTION_RATE;
@@ -85,7 +86,8 @@ return pxNetworkBufferIn;
 
 		ulCallCount = 0;
 
-		ulFault = ipconfigRAND32() % xNUM_FAULT_TYPES;
+		xApplicationGetRandomNumber( &( ulFault ) );
+		ulFault = ulFault % xNUM_FAULT_TYPES;
 
 		if( ulFaultLogIndex < xFAULT_LOG_SIZE )
 		{

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/ports/secure_sockets/iot_secure_sockets.c
@@ -892,13 +892,33 @@ BaseType_t SOCKETS_Init( void )
 static CK_SESSION_HANDLE xPkcs11Session = 0;
 static CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
 
-uint32_t ulRand( void )
+//uint32_t ulRand( void ) __attribute__ ((deprecated))
+#if 0
+    uint32_t ulRand( void )
+    {
+        uint32_t ulNumber = 0uL;
+        BaseType_t xResult = xApplicationGetRandomNumber( &( ulNumber ) );
+
+        if( xResult == pdFALSE )
+        {
+            ulNumber = 0uL;
+        }
+        else
+        {
+            /* Function succeeded, a random number will be returned. */
+        }
+        return ulNumber;
+    }
+#endif/* 0 */
+
+BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
 {
     CK_RV xResult = 0;
     CK_C_GetFunctionList pxCkGetFunctionList = NULL;
     CK_ULONG ulCount = 1;
     uint32_t ulRandomValue = 0;
     CK_SLOT_ID xSlotId = 0;
+    BaseType_t xReturn;
 
     portENTER_CRITICAL();
 
@@ -951,11 +971,17 @@ uint32_t ulRand( void )
     portEXIT_CRITICAL();
 
     /* Check if any of the API calls failed. */
-    if( 0 != xResult )
+    if( 0 == xResult )
     {
-        ulRandomValue = 0;
+        xReturn = pdTRUE;
+        *( pulNumber ) = ulRandomValue;
+    }
+    else
+    {
+        xReturn = pdFALSE;
+        *( pulNumber ) = 0uL;
     }
 
-    return ulRandomValue;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/ports/secure_sockets/iot_secure_sockets.c
@@ -91,18 +91,18 @@
  */
 typedef struct SSocketContext_t
 {
-  esp_netconn_p xSocket;
-  uint32_t ulFlags;                   /**< Various properties of the socket (secured etc.). */
-  char * pcDestination;               /**< Destination URL. Set using SOCKETS_SO_SERVER_NAME_INDICATION option in SOCKETS_SetSockOpt function. */
-  void * pvTLSContext;                /**< The TLS Context. */
-  char * pcServerCertificate;         /**< Server certificate. Set using SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE option in SOCKETS_SetSockOpt function. */
-  uint32_t ulServerCertificateLength; /**< Length of the server certificate. */
-  char ** ppcAlpnProtocols;
-  uint32_t ulAlpnProtocolsCount;
-  uint8_t ucInUse;                    /**< Tracks whether the socket is in use or not. */
-  esp_pbuf_p pbuf;
-  BaseType_t available;
-  size_t offset;
+    esp_netconn_p xSocket;
+    uint32_t ulFlags;                   /**< Various properties of the socket (secured etc.). */
+    char * pcDestination;               /**< Destination URL. Set using SOCKETS_SO_SERVER_NAME_INDICATION option in SOCKETS_SetSockOpt function. */
+    void * pvTLSContext;                /**< The TLS Context. */
+    char * pcServerCertificate;         /**< Server certificate. Set using SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE option in SOCKETS_SetSockOpt function. */
+    uint32_t ulServerCertificateLength; /**< Length of the server certificate. */
+    char ** ppcAlpnProtocols;
+    uint32_t ulAlpnProtocolsCount;
+    uint8_t ucInUse;                  /**< Tracks whether the socket is in use or not. */
+    esp_pbuf_p pbuf;
+    BaseType_t available;
+    size_t offset;
 } SSocketContext_t, * SSocketContextPtr_t;
 
 /**
@@ -111,7 +111,7 @@ typedef struct SSocketContext_t
  * An index in this array is returned to the user from SOCKETS_Socket
  * function.
  */
-static SSocketContext_t xSockets[ESP_CFG_MAX_CONNS];
+static SSocketContext_t xSockets[ ESP_CFG_MAX_CONNS ];
 
 /**
  * @brief The global mutex to ensure that only one operation is accessing the
@@ -123,91 +123,91 @@ static const TickType_t xMaxSemaphoreBlockTime = pdMS_TO_TICKS( 60000UL );
 
 static uint32_t prvGetFreeSocket( void )
 {
-  uint32_t ulSocketNumber;
+    uint32_t ulSocketNumber;
 
-  /* Obtain the socketInUse mutex. */
-  if (xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime) == pdTRUE)
-  {
-    /* Iterate over xSockets array to see if any free socket
-     * is available. */
-    for (ulSocketNumber = 0 ; ulSocketNumber < ( uint32_t ) ESP_CFG_MAX_CONNS ; ulSocketNumber++)
+    /* Obtain the socketInUse mutex. */
+    if( xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime ) == pdTRUE )
     {
-      if (xSockets[ ulSocketNumber ].ucInUse == 0U)
-      {
-        /* Mark the socket as "in-use". */
-        xSockets[ ulSocketNumber ].ucInUse = 1;
+        /* Iterate over xSockets array to see if any free socket
+         * is available. */
+        for( ulSocketNumber = 0; ulSocketNumber < ( uint32_t ) ESP_CFG_MAX_CONNS; ulSocketNumber++ )
+        {
+            if( xSockets[ ulSocketNumber ].ucInUse == 0U )
+            {
+                /* Mark the socket as "in-use". */
+                xSockets[ ulSocketNumber ].ucInUse = 1;
 
-        /* We have found a free socket, so stop. */
-        break;
-      }
+                /* We have found a free socket, so stop. */
+                break;
+            }
+        }
+
+        /* Give back the socketInUse mutex. */
+        xSemaphoreGive( xUcInUse );
+    }
+    else
+    {
+        ulSocketNumber = ESP_CFG_MAX_CONNS;
     }
 
-    /* Give back the socketInUse mutex. */
-    xSemaphoreGive(xUcInUse);
-  }
-  else
-  {
-	ulSocketNumber = ESP_CFG_MAX_CONNS;
-  }
+    /* Did we find a free socket? */
+    if( ulSocketNumber == ( uint32_t ) ESP_CFG_MAX_CONNS )
+    {
+        /* Return SOCKETS_INVALID_SOCKET if we fail to
+         * find a free socket. */
+        ulSocketNumber = ( uint32_t ) SOCKETS_INVALID_SOCKET;
+    }
 
-  /* Did we find a free socket? */
-  if (ulSocketNumber == (uint32_t) ESP_CFG_MAX_CONNS)
-  {
-    /* Return SOCKETS_INVALID_SOCKET if we fail to
-     * find a free socket. */
-	ulSocketNumber = (uint32_t) SOCKETS_INVALID_SOCKET;
-  }
-
-  return ulSocketNumber;
+    return ulSocketNumber;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvReturnSocket( SSocketContextPtr_t pvContext )
 {
-  BaseType_t xResult = pdFAIL;
+    BaseType_t xResult = pdFAIL;
 
-  /* Since multiple tasks can be accessing this simultaneously,
-   * this has to be in critical section. */
-  /* Obtain the socketInUse mutex. */
-  if (xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime) == pdTRUE)
-  {
-    /* Mark the socket as free. */
-    pvContext->ucInUse = 0;
+    /* Since multiple tasks can be accessing this simultaneously,
+     * this has to be in critical section. */
+    /* Obtain the socketInUse mutex. */
+    if( xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime ) == pdTRUE )
+    {
+        /* Mark the socket as free. */
+        pvContext->ucInUse = 0;
 
-    xResult = pdTRUE;
+        xResult = pdTRUE;
 
-    /* Give back the socketInUse mutex. */
-    xSemaphoreGive(xUcInUse);
-  }
+        /* Give back the socketInUse mutex. */
+        xSemaphoreGive( xUcInUse );
+    }
 
-  return xResult;
+    return xResult;
 }
 
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvIsValidSocket( uint32_t ulSocketNumber )
 {
-  BaseType_t xValid = pdFALSE;
+    BaseType_t xValid = pdFALSE;
 
-  /* Check that the provided socket number is within the valid index range. */
-  if (ulSocketNumber < ( uint32_t ) ESP_CFG_MAX_CONNS )
-  {
-	/* Obtain the socketInUse mutex. */
-	if( xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime ) == pdTRUE )
-	{
-      /* Check that this socket is in use. */
-      if (xSockets[ ulSocketNumber ].ucInUse == 1U )
-      {
-        /* This is a valid socket number. */
-        xValid = pdTRUE;
-      }
+    /* Check that the provided socket number is within the valid index range. */
+    if( ulSocketNumber < ( uint32_t ) ESP_CFG_MAX_CONNS )
+    {
+        /* Obtain the socketInUse mutex. */
+        if( xSemaphoreTake( xUcInUse, xMaxSemaphoreBlockTime ) == pdTRUE )
+        {
+            /* Check that this socket is in use. */
+            if( xSockets[ ulSocketNumber ].ucInUse == 1U )
+            {
+                /* This is a valid socket number. */
+                xValid = pdTRUE;
+            }
 
-      /* Give back the socketInUse mutex. */
-      xSemaphoreGive(xUcInUse);
-	}
-  }
+            /* Give back the socketInUse mutex. */
+            xSemaphoreGive( xUcInUse );
+        }
+    }
 
-  return xValid;
+    return xValid;
 }
 /*-----------------------------------------------------------*/
 
@@ -215,24 +215,25 @@ static BaseType_t prvNetworkSend( void * pvContext,
                                   const unsigned char * pucData,
                                   size_t xDataLength )
 {
-  BaseType_t lRetVal = 0;
-  SSocketContextPtr_t pxContext = (SSocketContextPtr_t) pvContext;
+    BaseType_t lRetVal = 0;
+    SSocketContextPtr_t pxContext = ( SSocketContextPtr_t ) pvContext;
 
-  if ((pucData != NULL) && (pvContext != NULL))
-  {
-    espr_t res = esp_netconn_write(pxContext->xSocket, pucData, xDataLength);
-
-    if (res == espOK)
+    if( ( pucData != NULL ) && ( pvContext != NULL ) )
     {
-      res = esp_netconn_flush(pxContext->xSocket);    /* Flush data to output */
-      if (res == espOK)					            /* Were data sent? */
-      {
-        lRetVal = xDataLength;
-      }
-    }
-  }
+        espr_t res = esp_netconn_write( pxContext->xSocket, pucData, xDataLength );
 
-  return lRetVal;
+        if( res == espOK )
+        {
+            res = esp_netconn_flush( pxContext->xSocket ); /* Flush data to output */
+
+            if( res == espOK )                             /* Were data sent? */
+            {
+                lRetVal = xDataLength;
+            }
+        }
+    }
+
+    return lRetVal;
 }
 
 /*-----------------------------------------------------------*/
@@ -241,48 +242,49 @@ static BaseType_t prvNetworkRecv( void * pvContext,
                                   unsigned char * pucReceiveBuffer,
                                   size_t xReceiveLength )
 {
+    BaseType_t lRetVal = 0;
+    SSocketContextPtr_t pxContext = ( SSocketContextPtr_t ) pvContext;
 
-  BaseType_t lRetVal = 0;
-  SSocketContextPtr_t pxContext = (SSocketContextPtr_t) pvContext;
-
-  if ((pucReceiveBuffer != NULL) && (pvContext != NULL))
-  {
-  	if (pxContext->available == 0)
+    if( ( pucReceiveBuffer != NULL ) && ( pvContext != NULL ) )
     {
-      espr_t res = esp_netconn_receive(pxContext->xSocket, &(pxContext->pbuf));
-      if ((res == espCLOSED) || (res == espTIMEOUT))
-      {
-     	if (pxContext->pbuf != NULL)
-       	{
-          esp_pbuf_free(pxContext->pbuf);    /* Free the memory after usage */
-          pxContext->pbuf = NULL;
-      	}
-      }
-      else if ((res == espOK) && (pxContext->pbuf != NULL))
-      {
-    	pxContext->available = esp_pbuf_length(pxContext->pbuf, 1);
-    	pxContext->offset = 0;
-      }
-      else
-      {
-    	//
-      }
+        if( pxContext->available == 0 )
+        {
+            espr_t res = esp_netconn_receive( pxContext->xSocket, &( pxContext->pbuf ) );
+
+            if( ( res == espCLOSED ) || ( res == espTIMEOUT ) )
+            {
+                if( pxContext->pbuf != NULL )
+                {
+                    esp_pbuf_free( pxContext->pbuf ); /* Free the memory after usage */
+                    pxContext->pbuf = NULL;
+                }
+            }
+            else if( ( res == espOK ) && ( pxContext->pbuf != NULL ) )
+            {
+                pxContext->available = esp_pbuf_length( pxContext->pbuf, 1 );
+                pxContext->offset = 0;
+            }
+            else
+            {
+                /* */
+            }
+        }
+
+        if( pxContext->available > 0 )
+        {
+            lRetVal = esp_pbuf_copy( pxContext->pbuf, pucReceiveBuffer, xReceiveLength, pxContext->offset );
+            pxContext->offset += lRetVal;
+            pxContext->available -= lRetVal;
+
+            if( pxContext->available == 0 )
+            {
+                esp_pbuf_free( pxContext->pbuf ); /* Free the memory after usage */
+                pxContext->pbuf = NULL;
+            }
+        }
     }
 
-  	if (pxContext->available > 0)
-    {
-  	  lRetVal = esp_pbuf_copy(pxContext->pbuf, pucReceiveBuffer, xReceiveLength, pxContext->offset);
-  	  pxContext->offset += lRetVal;
-  	  pxContext->available -= lRetVal;
-      if (pxContext->available == 0)
-      {
-        esp_pbuf_free(pxContext->pbuf);    /* Free the memory after usage */
-        pxContext->pbuf = NULL;
-      }
-    }
-  }
-
-  return lRetVal;
+    return lRetVal;
 }
 /*-----------------------------------------------------------*/
 
@@ -290,45 +292,45 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
                          int32_t lType,
                          int32_t lProtocol )
 {
-  uint32_t ulSocketNumber;
+    uint32_t ulSocketNumber;
 
-  /* Ensure that only supported values are supplied. */
-  configASSERT( lDomain == SOCKETS_AF_INET );
-  configASSERT( lType == SOCKETS_SOCK_STREAM );
-  configASSERT( lProtocol == SOCKETS_IPPROTO_TCP );
+    /* Ensure that only supported values are supplied. */
+    configASSERT( lDomain == SOCKETS_AF_INET );
+    configASSERT( lType == SOCKETS_SOCK_STREAM );
+    configASSERT( lProtocol == SOCKETS_IPPROTO_TCP );
 
-  ulSocketNumber = prvGetFreeSocket();
+    ulSocketNumber = prvGetFreeSocket();
 
-  /* If we get a free socket, set its attributes. */
-  if(ulSocketNumber != (uint32_t)SOCKETS_INVALID_SOCKET)
-  {
-	SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
-
-	pxContext->ulFlags = 0;
-	pxContext->pcDestination = NULL;
-	pxContext->pvTLSContext = NULL;
-	pxContext->pcServerCertificate = NULL;
-	pxContext->ulServerCertificateLength = 0;
-	pxContext->ppcAlpnProtocols = NULL;
-	pxContext->ulAlpnProtocolsCount = 0;
-	pxContext->pbuf = NULL;
-	pxContext->available = 0;
-	pxContext->offset = 0;
-
-	pxContext->xSocket = esp_netconn_new(ESP_NETCONN_TYPE_TCP);
-
-	if (pxContext->xSocket != NULL)
+    /* If we get a free socket, set its attributes. */
+    if( ulSocketNumber != ( uint32_t ) SOCKETS_INVALID_SOCKET )
     {
-      esp_netconn_set_receive_timeout(pxContext->xSocket, 0);
-    }
-    else
-    {
-      return SOCKETS_INVALID_SOCKET;
-    }
-  }
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-  /* If we fail to get a free socket, we return SOCKETS_INVALID_SOCKET. */
-  return (Socket_t)ulSocketNumber;
+        pxContext->ulFlags = 0;
+        pxContext->pcDestination = NULL;
+        pxContext->pvTLSContext = NULL;
+        pxContext->pcServerCertificate = NULL;
+        pxContext->ulServerCertificateLength = 0;
+        pxContext->ppcAlpnProtocols = NULL;
+        pxContext->ulAlpnProtocolsCount = 0;
+        pxContext->pbuf = NULL;
+        pxContext->available = 0;
+        pxContext->offset = 0;
+
+        pxContext->xSocket = esp_netconn_new( ESP_NETCONN_TYPE_TCP );
+
+        if( pxContext->xSocket != NULL )
+        {
+            esp_netconn_set_receive_timeout( pxContext->xSocket, 0 );
+        }
+        else
+        {
+            return SOCKETS_INVALID_SOCKET;
+        }
+    }
+
+    /* If we fail to get a free socket, we return SOCKETS_INVALID_SOCKET. */
+    return ( Socket_t ) ulSocketNumber;
 }
 /*-----------------------------------------------------------*/
 
@@ -336,7 +338,7 @@ Socket_t SOCKETS_Accept( Socket_t xSocket,
                          SocketsSockaddr_t * pxAddress,
                          Socklen_t * pxAddressLength )
 {
-  return SOCKETS_INVALID_SOCKET;
+    return SOCKETS_INVALID_SOCKET;
 }
 /*-----------------------------------------------------------*/
 
@@ -344,82 +346,84 @@ int32_t SOCKETS_Connect( Socket_t xSocket,
                          SocketsSockaddr_t * pxAddress,
                          Socklen_t xAddressLength )
 {
-  uint32_t ulSocketNumber = ( uint32_t ) xSocket;
-  int32_t lRetVal = SOCKETS_SOCKET_ERROR;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
+    int32_t lRetVal = SOCKETS_SOCKET_ERROR;
 
-  (void)xAddressLength;
+    ( void ) xAddressLength;
 
-  if ((prvIsValidSocket( ulSocketNumber ) == pdTRUE) && (pxAddress != NULL) && (pxAddress->usPort != 0))
-  {
-    char host[20];
-	SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
-
-    /* Check that the socket is not already connected. */
-    if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0UL)
+    if( ( prvIsValidSocket( ulSocketNumber ) == pdTRUE ) && ( pxAddress != NULL ) && ( pxAddress->usPort != 0 ) )
     {
-      SOCKETS_inet_ntoa(pxAddress->ulAddress, host);
+        char host[ 20 ];
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-      if (esp_sta_has_ip())
-      {
-    	espr_t conn_status = esp_netconn_connect((esp_netconn_p)(pxContext->xSocket), host, SOCKETS_ntohs(pxAddress->usPort));
-        if (conn_status == espOK)
+        /* Check that the socket is not already connected. */
+        if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0UL )
         {
-          pxContext->ulFlags |= securesocketsSOCKET_IS_CONNECTED;
-          lRetVal = SOCKETS_ERROR_NONE;
-        }
-      }
+            SOCKETS_inet_ntoa( pxAddress->ulAddress, host );
 
-      /* Negotiate TLS if requested. */
-      if ((lRetVal == SOCKETS_ERROR_NONE) && ((pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG) != 0))
-      {
-        TLSParams_t xTLSParams = { 0 };
-        xTLSParams.ulSize = sizeof( xTLSParams );
-        xTLSParams.pcDestination = pxContext->pcDestination;
-        xTLSParams.pcServerCertificate = pxContext->pcServerCertificate;
-        xTLSParams.ulServerCertificateLength = pxContext->ulServerCertificateLength;
-        xTLSParams.ppcAlpnProtocols = ( const char ** ) pxContext->ppcAlpnProtocols;
-        xTLSParams.ulAlpnProtocolsCount = pxContext->ulAlpnProtocolsCount;
-        xTLSParams.pvCallerContext = pxContext;
-        xTLSParams.pxNetworkRecv = prvNetworkRecv;
-        xTLSParams.pxNetworkSend = prvNetworkSend;
-
-        /* Initialize TLS. */
-        if (TLS_Init(&(pxContext->pvTLSContext), &(xTLSParams)) == pdFREERTOS_ERRNO_NONE)
-        {
-          if (xSemaphoreTake(xTLSConnect, xMaxSemaphoreBlockTime) == pdTRUE)
-          {
-            /* Initiate TLS handshake. */
-            if (TLS_Connect(pxContext->pvTLSContext) != pdFREERTOS_ERRNO_NONE)
+            if( esp_sta_has_ip() )
             {
-              /* TLS handshake failed. */
-              esp_netconn_close(pxContext->xSocket);
-              pxContext->ulFlags &= ~securesocketsSOCKET_IS_CONNECTED;
-              TLS_Cleanup(pxContext->pvTLSContext);
-              pxContext->pvTLSContext = NULL;
-              lRetVal = SOCKETS_TLS_HANDSHAKE_ERROR;
+                espr_t conn_status = esp_netconn_connect( ( esp_netconn_p ) ( pxContext->xSocket ), host, SOCKETS_ntohs( pxAddress->usPort ) );
+
+                if( conn_status == espOK )
+                {
+                    pxContext->ulFlags |= securesocketsSOCKET_IS_CONNECTED;
+                    lRetVal = SOCKETS_ERROR_NONE;
+                }
             }
-            /* Release semaphore */
-            xSemaphoreGive(xTLSConnect);
-          }
+
+            /* Negotiate TLS if requested. */
+            if( ( lRetVal == SOCKETS_ERROR_NONE ) && ( ( pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG ) != 0 ) )
+            {
+                TLSParams_t xTLSParams = { 0 };
+                xTLSParams.ulSize = sizeof( xTLSParams );
+                xTLSParams.pcDestination = pxContext->pcDestination;
+                xTLSParams.pcServerCertificate = pxContext->pcServerCertificate;
+                xTLSParams.ulServerCertificateLength = pxContext->ulServerCertificateLength;
+                xTLSParams.ppcAlpnProtocols = ( const char ** ) pxContext->ppcAlpnProtocols;
+                xTLSParams.ulAlpnProtocolsCount = pxContext->ulAlpnProtocolsCount;
+                xTLSParams.pvCallerContext = pxContext;
+                xTLSParams.pxNetworkRecv = prvNetworkRecv;
+                xTLSParams.pxNetworkSend = prvNetworkSend;
+
+                /* Initialize TLS. */
+                if( TLS_Init( &( pxContext->pvTLSContext ), &( xTLSParams ) ) == pdFREERTOS_ERRNO_NONE )
+                {
+                    if( xSemaphoreTake( xTLSConnect, xMaxSemaphoreBlockTime ) == pdTRUE )
+                    {
+                        /* Initiate TLS handshake. */
+                        if( TLS_Connect( pxContext->pvTLSContext ) != pdFREERTOS_ERRNO_NONE )
+                        {
+                            /* TLS handshake failed. */
+                            esp_netconn_close( pxContext->xSocket );
+                            pxContext->ulFlags &= ~securesocketsSOCKET_IS_CONNECTED;
+                            TLS_Cleanup( pxContext->pvTLSContext );
+                            pxContext->pvTLSContext = NULL;
+                            lRetVal = SOCKETS_TLS_HANDSHAKE_ERROR;
+                        }
+
+                        /* Release semaphore */
+                        xSemaphoreGive( xTLSConnect );
+                    }
+                }
+                else
+                {
+                    /* TLS Initialization failed. */
+                    lRetVal = SOCKETS_TLS_INIT_ERROR;
+                }
+            }
         }
         else
         {
-          /* TLS Initialization failed. */
-          lRetVal = SOCKETS_TLS_INIT_ERROR;
+            lRetVal = SOCKETS_EISCONN;
         }
-      }
     }
     else
     {
-      lRetVal = SOCKETS_EISCONN;
+        lRetVal = SOCKETS_EINVAL;
     }
-  }
-  else
-  {
-    lRetVal = SOCKETS_EINVAL;
-  }
 
-  return lRetVal;
+    return lRetVal;
 }
 /*-----------------------------------------------------------*/
 
@@ -428,59 +432,59 @@ int32_t SOCKETS_Recv( Socket_t xSocket,
                       size_t xBufferLength,
                       uint32_t ulFlags )
 {
-  int32_t lReceivedBytes = 0;
-  uint32_t ulSocketNumber = (uint32_t)xSocket;
+    int32_t lReceivedBytes = 0;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
 
-  /* Remove warning about unused parameters. */
-  (void)ulFlags;
+    /* Remove warning about unused parameters. */
+    ( void ) ulFlags;
 
-  /* Ensure that a valid socket was passed and the
-   * passed buffer is not NULL. */
-  if ((prvIsValidSocket(ulSocketNumber) == pdTRUE) && (pvBuffer != NULL))
-  {
-	SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
+    /* Ensure that a valid socket was passed and the
+     * passed buffer is not NULL. */
+    if( ( prvIsValidSocket( ulSocketNumber ) == pdTRUE ) && ( pvBuffer != NULL ) )
+    {
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-	if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) != 0UL)
-	{
-      /* Check that receive is allowed on the socket. */
-      if ((pxContext->ulFlags & securesocketsSOCKET_READ_CLOSED_FLAG ) == 0UL)
-      {
-        if ((pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG) != 0UL)
+        if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) != 0UL )
         {
-          /* Receive through TLS pipe, if negotiated. */
-          lReceivedBytes = TLS_Recv(pxContext->pvTLSContext, pvBuffer, xBufferLength);
+            /* Check that receive is allowed on the socket. */
+            if( ( pxContext->ulFlags & securesocketsSOCKET_READ_CLOSED_FLAG ) == 0UL )
+            {
+                if( ( pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG ) != 0UL )
+                {
+                    /* Receive through TLS pipe, if negotiated. */
+                    lReceivedBytes = TLS_Recv( pxContext->pvTLSContext, pvBuffer, xBufferLength );
 
-          /* Convert the error code. */
-          if (lReceivedBytes < 0)
-          {
-            /* TLS_Recv failed. */
-            return SOCKETS_TLS_RECV_ERROR;
-          }
+                    /* Convert the error code. */
+                    if( lReceivedBytes < 0 )
+                    {
+                        /* TLS_Recv failed. */
+                        return SOCKETS_TLS_RECV_ERROR;
+                    }
+                }
+                else
+                {
+                    /* Receive un-encrypted. */
+                    lReceivedBytes = prvNetworkRecv( pxContext, pvBuffer, xBufferLength );
+                }
+            }
+            else
+            {
+                /* The socket has been closed for read. */
+                return SOCKETS_ECLOSED;
+            }
         }
         else
         {
-          /* Receive un-encrypted. */
-          lReceivedBytes = prvNetworkRecv(pxContext, pvBuffer, xBufferLength);
+            /* The socket has been closed for read. */
+            return SOCKETS_ECLOSED;
         }
-      }
-      else
-      {
-        /* The socket has been closed for read. */
-        return SOCKETS_ECLOSED;
-      }
-	}
+    }
     else
     {
-      /* The socket has been closed for read. */
-      return SOCKETS_ECLOSED;
+        return SOCKETS_EINVAL;
     }
-  }
-  else
-  {
-    return SOCKETS_EINVAL;
-  }
 
-  return lReceivedBytes;
+    return lReceivedBytes;
 }
 /*-----------------------------------------------------------*/
 
@@ -489,180 +493,180 @@ int32_t SOCKETS_Send( Socket_t xSocket,
                       size_t xDataLength,
                       uint32_t ulFlags )
 {
-  int32_t lSentBytes = 0;
-  uint32_t ulSocketNumber = (uint32_t)xSocket;
+    int32_t lSentBytes = 0;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
 
-  /* Remove warning about unused parameters. */
-  (void)ulFlags;
+    /* Remove warning about unused parameters. */
+    ( void ) ulFlags;
 
-  if ((prvIsValidSocket(ulSocketNumber) == pdTRUE) && (pvBuffer != NULL))
-  {
-	SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
+    if( ( prvIsValidSocket( ulSocketNumber ) == pdTRUE ) && ( pvBuffer != NULL ) )
+    {
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-	if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) != 0UL)
-	{
-      /* Check that send is allowed on the socket. */
-      if ((pxContext->ulFlags & securesocketsSOCKET_WRITE_CLOSED_FLAG ) == 0UL)
-      {
-        if ((pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG) != 0UL)
+        if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) != 0UL )
         {
-          /* Send through TLS pipe, if negotiated. */
-          lSentBytes = TLS_Send(pxContext->pvTLSContext, pvBuffer, xDataLength);
+            /* Check that send is allowed on the socket. */
+            if( ( pxContext->ulFlags & securesocketsSOCKET_WRITE_CLOSED_FLAG ) == 0UL )
+            {
+                if( ( pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG ) != 0UL )
+                {
+                    /* Send through TLS pipe, if negotiated. */
+                    lSentBytes = TLS_Send( pxContext->pvTLSContext, pvBuffer, xDataLength );
 
-          /* Convert the error code. */
-          if (lSentBytes < 0)
-          {
-            /* TLS_Recv failed. */
-            return SOCKETS_TLS_SEND_ERROR;
-          }
+                    /* Convert the error code. */
+                    if( lSentBytes < 0 )
+                    {
+                        /* TLS_Recv failed. */
+                        return SOCKETS_TLS_SEND_ERROR;
+                    }
+                }
+                else
+                {
+                    /* Send unencrypted. */
+                    lSentBytes = prvNetworkSend( pxContext, pvBuffer, xDataLength );
+                }
+            }
+            else
+            {
+                /* The socket has been closed for write. */
+                return SOCKETS_ECLOSED;
+            }
         }
         else
         {
-          /* Send unencrypted. */
-          lSentBytes = prvNetworkSend(pxContext, pvBuffer, xDataLength);
+            /* The supplied socket is closed. */
+            return SOCKETS_ECLOSED;
         }
-      }
-      else
-      {
-        /* The socket has been closed for write. */
-        return SOCKETS_ECLOSED;
-      }
-	}
+    }
     else
     {
-      /* The supplied socket is closed. */
-      return SOCKETS_ECLOSED;
+        return SOCKETS_EINVAL;
     }
-  }
-  else
-  {
-    return SOCKETS_EINVAL;
-  }
 
-  return lSentBytes;
+    return lSentBytes;
 }
 /*-----------------------------------------------------------*/
 
 int32_t SOCKETS_Shutdown( Socket_t xSocket,
                           uint32_t ulHow )
 {
-  uint32_t ulSocketNumber = ( uint32_t ) xSocket;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
 
-  /* Ensure that a valid socket was passed. */
-  if (prvIsValidSocket(ulSocketNumber) == pdTRUE)
-  {
-    SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
-
-    switch( ulHow )
+    /* Ensure that a valid socket was passed. */
+    if( prvIsValidSocket( ulSocketNumber ) == pdTRUE )
     {
-      case SOCKETS_SHUT_RD:
-        /* Further receive calls on this socket should return error. */
-    	pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG;
-        break;
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-      case SOCKETS_SHUT_WR:
-        /* Further send calls on this socket should return error. */
-    	pxContext->ulFlags |= securesocketsSOCKET_WRITE_CLOSED_FLAG;
-        break;
+        switch( ulHow )
+        {
+            case SOCKETS_SHUT_RD:
+                /* Further receive calls on this socket should return error. */
+                pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG;
+                break;
 
-      case SOCKETS_SHUT_RDWR:
-        /* Further send or receive calls on this socket should return error. */
-    	pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG | securesocketsSOCKET_WRITE_CLOSED_FLAG;
-        break;
+            case SOCKETS_SHUT_WR:
+                /* Further send calls on this socket should return error. */
+                pxContext->ulFlags |= securesocketsSOCKET_WRITE_CLOSED_FLAG;
+                break;
 
-      default:
-        /* An invalid value was passed for ulHow. */
-        return SOCKETS_EINVAL;
-        break;
+            case SOCKETS_SHUT_RDWR:
+                /* Further send or receive calls on this socket should return error. */
+                pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG | securesocketsSOCKET_WRITE_CLOSED_FLAG;
+                break;
+
+            default:
+                /* An invalid value was passed for ulHow. */
+                return SOCKETS_EINVAL;
+
+                break;
+        }
     }
-  }
-  else
-  {
-    return SOCKETS_EINVAL;
-  }
+    else
+    {
+        return SOCKETS_EINVAL;
+    }
 
-  return SOCKETS_ERROR_NONE;
+    return SOCKETS_ERROR_NONE;
 }
 /*-----------------------------------------------------------*/
 
 int32_t SOCKETS_Close( Socket_t xSocket )
 {
-  int32_t lRetVal = SOCKETS_SOCKET_ERROR;
-  uint32_t ulSocketNumber = (uint32_t)xSocket;
+    int32_t lRetVal = SOCKETS_SOCKET_ERROR;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
 
-  /* Ensure that a valid socket was passed. */
-  if (prvIsValidSocket(ulSocketNumber) == pdTRUE)
-  {
-	SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
-
-	pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG;
-	pxContext->ulFlags |= securesocketsSOCKET_WRITE_CLOSED_FLAG;
-
-    /* Clean-up destination string. */
-    if (pxContext->pcDestination != NULL)
+    /* Ensure that a valid socket was passed. */
+    if( prvIsValidSocket( ulSocketNumber ) == pdTRUE )
     {
-      vPortFree(pxContext->pcDestination);
-      pxContext->pcDestination = NULL;
-    }
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-    /* Clean-up server certificate. */
-    if (pxContext->pcServerCertificate != NULL)
-    {
-      vPortFree(pxContext->pcServerCertificate);
-      pxContext->pcServerCertificate = NULL;
-    }
+        pxContext->ulFlags |= securesocketsSOCKET_READ_CLOSED_FLAG;
+        pxContext->ulFlags |= securesocketsSOCKET_WRITE_CLOSED_FLAG;
 
-    /* Clean-up application protocol array. */
-    if (pxContext->ppcAlpnProtocols != NULL)
-    {
-      for (uint32_t ulProtocol = 0; ulProtocol < pxContext->ulAlpnProtocolsCount; ulProtocol++)
-      {
-        if (pxContext->ppcAlpnProtocols[ ulProtocol ] != NULL)
+        /* Clean-up destination string. */
+        if( pxContext->pcDestination != NULL )
         {
-          vPortFree( pxContext->ppcAlpnProtocols[ ulProtocol ] );
-          pxContext->ppcAlpnProtocols[ ulProtocol ] = NULL;
+            vPortFree( pxContext->pcDestination );
+            pxContext->pcDestination = NULL;
         }
-      }
 
-      vPortFree(pxContext->ppcAlpnProtocols);
-      pxContext->ppcAlpnProtocols = NULL;
+        /* Clean-up server certificate. */
+        if( pxContext->pcServerCertificate != NULL )
+        {
+            vPortFree( pxContext->pcServerCertificate );
+            pxContext->pcServerCertificate = NULL;
+        }
+
+        /* Clean-up application protocol array. */
+        if( pxContext->ppcAlpnProtocols != NULL )
+        {
+            for( uint32_t ulProtocol = 0; ulProtocol < pxContext->ulAlpnProtocolsCount; ulProtocol++ )
+            {
+                if( pxContext->ppcAlpnProtocols[ ulProtocol ] != NULL )
+                {
+                    vPortFree( pxContext->ppcAlpnProtocols[ ulProtocol ] );
+                    pxContext->ppcAlpnProtocols[ ulProtocol ] = NULL;
+                }
+            }
+
+            vPortFree( pxContext->ppcAlpnProtocols );
+            pxContext->ppcAlpnProtocols = NULL;
+        }
+
+        /* Clean-up TLS context. */
+        if( ( pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG ) != 0UL )
+        {
+            TLS_Cleanup( pxContext->pvTLSContext );
+            pxContext->pvTLSContext = NULL;
+        }
+
+        if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) != 0UL )
+        {
+            if( esp_netconn_close( pxContext->xSocket ) == espOK )
+            {
+                pxContext->ulFlags &= ~securesocketsSOCKET_IS_CONNECTED;
+                lRetVal = SOCKETS_ERROR_NONE;
+            }
+        }
+        else
+        {
+            lRetVal = SOCKETS_ERROR_NONE;
+        }
+
+        esp_netconn_delete( pxContext->xSocket );
+
+        /* Return the socket back to the free socket pool. */
+        if( prvReturnSocket( pxContext ) != pdTRUE )
+        {
+            lRetVal = SOCKETS_SOCKET_ERROR;
+        }
     }
-
-    /* Clean-up TLS context. */
-    if ((pxContext->ulFlags & securesocketsSOCKET_SECURE_FLAG) != 0UL)
+    else
     {
-      TLS_Cleanup(pxContext->pvTLSContext);
-      pxContext->pvTLSContext = NULL;
+        lRetVal = SOCKETS_EINVAL;
     }
 
- 	if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) != 0UL)
-	{
-      if (esp_netconn_close(pxContext->xSocket) == espOK)
-      {
-        pxContext->ulFlags &= ~securesocketsSOCKET_IS_CONNECTED;
-        lRetVal = SOCKETS_ERROR_NONE;
-      }
-    }
- 	else
- 	{
-      lRetVal = SOCKETS_ERROR_NONE;
- 	}
-
-    esp_netconn_delete(pxContext->xSocket);
-
-    /* Return the socket back to the free socket pool. */
-    if (prvReturnSocket(pxContext) != pdTRUE)
-    {
-      lRetVal = SOCKETS_SOCKET_ERROR;
-    }
-
-  }
-  else
-  {
-	lRetVal = SOCKETS_EINVAL;
-  }
-
-  return lRetVal;
+    return lRetVal;
 }
 /*-----------------------------------------------------------*/
 
@@ -672,227 +676,238 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
                             const void * pvOptionValue,
                             size_t xOptionLength )
 {
-  int32_t lRetCode = SOCKETS_ERROR_NONE;
-  uint32_t ulSocketNumber = ( uint32_t ) xSocket;
-  TickType_t xTimeout;
+    int32_t lRetCode = SOCKETS_ERROR_NONE;
+    uint32_t ulSocketNumber = ( uint32_t ) xSocket;
+    TickType_t xTimeout;
 
-  /* Remove compiler warnings about unused parameters. */
-  (void)lLevel;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) lLevel;
 
-  /* Ensure that a valid socket was passed. */
-  if (prvIsValidSocket(ulSocketNumber) == pdTRUE)
-  {
-	 SSocketContextPtr_t pxContext = &xSockets[ulSocketNumber];
+    /* Ensure that a valid socket was passed. */
+    if( prvIsValidSocket( ulSocketNumber ) == pdTRUE )
+    {
+        SSocketContextPtr_t pxContext = &xSockets[ ulSocketNumber ];
 
-	 switch( lOptionName )
-     {
-       case SOCKETS_SO_SERVER_NAME_INDICATION:
-         if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) == 0)
-         {
-           /* Non-NULL destination string indicates that SNI extension should
-            * be used during TLS negotiation. */
-           pxContext->pcDestination = ( char * ) pvPortMalloc( 1U + xOptionLength );
-
-           if (pxContext->pcDestination == NULL)
-           {
-        	 lRetCode = SOCKETS_ENOMEM;
-           }
-           else
-           {
-             if (pvOptionValue != NULL)
-             {
-               memcpy(pxContext->pcDestination, pvOptionValue, xOptionLength );
-               pxContext->pcDestination[ xOptionLength ] = '\0';
-             }
-             else
-             {
-               lRetCode = SOCKETS_EINVAL;
-             }
-           }
-         }
-         else
-         {
-           lRetCode = SOCKETS_EISCONN;
-         }
-
-         break;
-
-      case SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE:
-        if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) == 0)
+        switch( lOptionName )
         {
-          /* Non-NULL server certificate field indicates that the default trust
-           * list should not be used. */
-          pxContext->pcServerCertificate = ( char * ) pvPortMalloc( xOptionLength );
+            case SOCKETS_SO_SERVER_NAME_INDICATION:
 
-          if (pxContext->pcServerCertificate == NULL)
-          {
-        	lRetCode = SOCKETS_ENOMEM;
-          }
-          else
-          {
-            if (pvOptionValue != NULL)
-            {
-              memcpy( pxContext->pcServerCertificate, pvOptionValue, xOptionLength );
-              pxContext->ulServerCertificateLength = xOptionLength;
-            }
-            else
-            {
-              lRetCode = SOCKETS_EINVAL;
-            }
-          }
+                if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0 )
+                {
+                    /* Non-NULL destination string indicates that SNI extension should
+                     * be used during TLS negotiation. */
+                    pxContext->pcDestination = ( char * ) pvPortMalloc( 1U + xOptionLength );
+
+                    if( pxContext->pcDestination == NULL )
+                    {
+                        lRetCode = SOCKETS_ENOMEM;
+                    }
+                    else
+                    {
+                        if( pvOptionValue != NULL )
+                        {
+                            memcpy( pxContext->pcDestination, pvOptionValue, xOptionLength );
+                            pxContext->pcDestination[ xOptionLength ] = '\0';
+                        }
+                        else
+                        {
+                            lRetCode = SOCKETS_EINVAL;
+                        }
+                    }
+                }
+                else
+                {
+                    lRetCode = SOCKETS_EISCONN;
+                }
+
+                break;
+
+            case SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE:
+
+                if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0 )
+                {
+                    /* Non-NULL server certificate field indicates that the default trust
+                     * list should not be used. */
+                    pxContext->pcServerCertificate = ( char * ) pvPortMalloc( xOptionLength );
+
+                    if( pxContext->pcServerCertificate == NULL )
+                    {
+                        lRetCode = SOCKETS_ENOMEM;
+                    }
+                    else
+                    {
+                        if( pvOptionValue != NULL )
+                        {
+                            memcpy( pxContext->pcServerCertificate, pvOptionValue, xOptionLength );
+                            pxContext->ulServerCertificateLength = xOptionLength;
+                        }
+                        else
+                        {
+                            lRetCode = SOCKETS_EINVAL;
+                        }
+                    }
+                }
+                else
+                {
+                    lRetCode = SOCKETS_EISCONN;
+                }
+
+                break;
+
+            case SOCKETS_SO_REQUIRE_TLS:
+
+                if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0 )
+                {
+                    pxContext->ulFlags |= securesocketsSOCKET_SECURE_FLAG;
+                }
+                else
+                {
+                    /* Do not set the ALPN option if the socket is already connected. */
+                    lRetCode = SOCKETS_EISCONN;
+                }
+
+                break;
+
+            case SOCKETS_SO_ALPN_PROTOCOLS:
+
+                if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) == 0 )
+                {
+                    /* Allocate a sufficiently long array of pointers. */
+                    pxContext->ulAlpnProtocolsCount = 1 + xOptionLength;
+
+                    if( NULL == ( pxContext->ppcAlpnProtocols = ( char ** ) pvPortMalloc( pxContext->ulAlpnProtocolsCount * sizeof( char * ) ) ) )
+                    {
+                        lRetCode = SOCKETS_ENOMEM;
+                    }
+                    else
+                    {
+                        pxContext->ppcAlpnProtocols[ pxContext->ulAlpnProtocolsCount - 1 ] = NULL;
+                    }
+
+                    /* Copy each protocol string. */
+                    for( uint32_t ulProtocol = 0; ( ulProtocol < pxContext->ulAlpnProtocolsCount - 1 ) && ( lRetCode == pdFREERTOS_ERRNO_NONE ); ulProtocol++ )
+                    {
+                        char ** ppcAlpnIn = ( char ** ) pvOptionValue;
+                        size_t xLength = strlen( ppcAlpnIn[ ulProtocol ] );
+
+                        if( ( pxContext->ppcAlpnProtocols[ ulProtocol ] = ( char * ) pvPortMalloc( 1 + xLength ) ) == NULL )
+                        {
+                            lRetCode = SOCKETS_ENOMEM;
+                        }
+                        else
+                        {
+                            memcpy( pxContext->ppcAlpnProtocols[ ulProtocol ], ppcAlpnIn[ ulProtocol ], xLength );
+                            pxContext->ppcAlpnProtocols[ ulProtocol ][ xLength ] = '\0';
+                        }
+                    }
+                }
+                else
+                {
+                    /* Do not set the ALPN option if the socket is already connected. */
+                    lRetCode = SOCKETS_EISCONN;
+                }
+
+                break;
+
+            case SOCKETS_SO_SNDTIMEO:
+                break;
+
+            case SOCKETS_SO_RCVTIMEO:
+
+                if( pvOptionValue != NULL )
+                {
+                    xTimeout = *( ( const TickType_t * ) pvOptionValue ); /*lint !e9087 pvOptionValue passed should be of TickType_t. */
+                    esp_netconn_set_receive_timeout( pxContext->xSocket, xTimeout );
+                }
+                else
+                {
+                    lRetCode = SOCKETS_EINVAL;
+                }
+
+                break;
+
+            case SOCKETS_SO_NONBLOCK:
+
+                if( ( pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) != 0 )
+                {
+                    /* Set the timeouts to the smallest value possible.
+                     * This isn't true nonblocking, but as close as we can get. */
+                    esp_netconn_set_receive_timeout( pxContext->xSocket, 1 );
+                }
+                else
+                {
+                    lRetCode = SOCKETS_EISCONN;
+                }
+
+                break;
+
+            default:
+                lRetCode = SOCKETS_EINVAL;
         }
-        else
-        {
-          lRetCode = SOCKETS_EISCONN;
-        }
-
-        break;
-
-      case SOCKETS_SO_REQUIRE_TLS:
-        if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) == 0)
-        {
-          pxContext->ulFlags |= securesocketsSOCKET_SECURE_FLAG;
-        }
-        else
-        {
-          /* Do not set the ALPN option if the socket is already connected. */
-          lRetCode = SOCKETS_EISCONN;
-        }
-        break;
-
-      case SOCKETS_SO_ALPN_PROTOCOLS:
-        if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED) == 0)
-        {
-          /* Allocate a sufficiently long array of pointers. */
-          pxContext->ulAlpnProtocolsCount = 1 + xOptionLength;
-
-          if (NULL == (pxContext->ppcAlpnProtocols = (char **)pvPortMalloc(pxContext->ulAlpnProtocolsCount * sizeof(char *))))
-          {
-        	lRetCode = SOCKETS_ENOMEM;
-          }
-          else
-          {
-            pxContext->ppcAlpnProtocols[pxContext->ulAlpnProtocolsCount - 1 ] = NULL;
-          }
-
-          /* Copy each protocol string. */
-          for (uint32_t ulProtocol = 0; (ulProtocol < pxContext->ulAlpnProtocolsCount - 1) && (lRetCode == pdFREERTOS_ERRNO_NONE); ulProtocol++)
-          {
-        	char ** ppcAlpnIn = ( char ** ) pvOptionValue;
-        	size_t xLength = strlen(ppcAlpnIn[ ulProtocol ]);
-
-            if ((pxContext->ppcAlpnProtocols[ ulProtocol ] = (char *)pvPortMalloc(1 + xLength)) == NULL)
-            {
-              lRetCode = SOCKETS_ENOMEM;
-            }
-            else
-            {
-              memcpy( pxContext->ppcAlpnProtocols[ ulProtocol ], ppcAlpnIn[ ulProtocol ], xLength );
-              pxContext->ppcAlpnProtocols[ ulProtocol ][ xLength ] = '\0';
-            }
-          }
-        }
-        else
-        {
-          /* Do not set the ALPN option if the socket is already connected. */
-          lRetCode = SOCKETS_EISCONN;
-        }
-
-        break;
-
-      case SOCKETS_SO_SNDTIMEO:
-        break;
-
-      case SOCKETS_SO_RCVTIMEO:
-        if (pvOptionValue != NULL)
-        {
-          xTimeout = *( ( const TickType_t * ) pvOptionValue ); /*lint !e9087 pvOptionValue passed should be of TickType_t. */
-          esp_netconn_set_receive_timeout(pxContext->xSocket, xTimeout);
-        }
-        else
-        {
-          lRetCode = SOCKETS_EINVAL;
-        }
-
-        break;
-
-      case SOCKETS_SO_NONBLOCK:
-    	if ((pxContext->ulFlags & securesocketsSOCKET_IS_CONNECTED ) != 0)
-    	{
-    	  /* Set the timeouts to the smallest value possible.
-           * This isn't true nonblocking, but as close as we can get. */
-          esp_netconn_set_receive_timeout(pxContext->xSocket, 1);
-    	}
-    	else
-    	{
-          lRetCode = SOCKETS_EISCONN;
-    	}
-        break;
-
-      default:
-    	lRetCode = SOCKETS_EINVAL;
     }
-  }
-  else
-  {
-	lRetCode = SOCKETS_EINVAL;
-  }
+    else
+    {
+        lRetCode = SOCKETS_EINVAL;
+    }
 
-  return lRetCode;
+    return lRetCode;
 }
 /*-----------------------------------------------------------*/
 
-uint32_t SOCKETS_GetHostByName(const char * pcHostName)
+uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 {
-  if (pcHostName != NULL)
-  {
-    uint32_t ulIPAddres;
-    if (WIFI_GetHostIP((char * )pcHostName, ( uint8_t *)&(ulIPAddres)) == eWiFiSuccess)
+    if( pcHostName != NULL )
     {
-      return ulIPAddres;
-    }
-  }
+        uint32_t ulIPAddres;
 
-  return 0;
+        if( WIFI_GetHostIP( ( char * ) pcHostName, ( uint8_t * ) &( ulIPAddres ) ) == eWiFiSuccess )
+        {
+            return ulIPAddres;
+        }
+    }
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t SOCKETS_Init( void )
 {
-  uint32_t ulIndex;
+    uint32_t ulIndex;
 
-  /* Mark all the sockets as free */
-  for (ulIndex = 0 ; ulIndex < (uint32_t)ESP_CFG_MAX_CONNS ; ulIndex++)
-  {
-     xSockets[ ulIndex ].ucInUse = 0;
-  }
+    /* Mark all the sockets as free */
+    for( ulIndex = 0; ulIndex < ( uint32_t ) ESP_CFG_MAX_CONNS; ulIndex++ )
+    {
+        xSockets[ ulIndex ].ucInUse = 0;
+    }
 
-  /* Create the global mutex which is used to ensure
-   * that only one socket is accessing the ucInUse bits in
-   * the socket array. */
-  xUcInUse = xSemaphoreCreateMutex();
-  if (xUcInUse == NULL)
-  {
-	return pdFAIL;
-  }
+    /* Create the global mutex which is used to ensure
+     * that only one socket is accessing the ucInUse bits in
+     * the socket array. */
+    xUcInUse = xSemaphoreCreateMutex();
 
-  /* Create the global mutex which is used to ensure
-   * that only one socket is accessing the ucInUse bits in
-   * the socket array. */
-  xTLSConnect = xSemaphoreCreateMutex();
-  if (xTLSConnect == NULL)
-  {
-	return pdFAIL;
-  }
+    if( xUcInUse == NULL )
+    {
+        return pdFAIL;
+    }
 
-  return pdPASS;
+    /* Create the global mutex which is used to ensure
+     * that only one socket is accessing the ucInUse bits in
+     * the socket array. */
+    xTLSConnect = xSemaphoreCreateMutex();
+
+    if( xTLSConnect == NULL )
+    {
+        return pdFAIL;
+    }
+
+    return pdPASS;
 }
 /*-----------------------------------------------------------*/
 
 static CK_SESSION_HANDLE xPkcs11Session = 0;
 static CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
 
-//uint32_t ulRand( void ) __attribute__ ((deprecated))
+/*uint32_t ulRand( void ) __attribute__ ((deprecated)) */
 #if 0
     uint32_t ulRand( void )
     {
@@ -907,11 +922,12 @@ static CK_FUNCTION_LIST_PTR pxPkcs11FunctionList = NULL;
         {
             /* Function succeeded, a random number will be returned. */
         }
+
         return ulNumber;
     }
-#endif/* 0 */
+#endif /* 0 */
 
-BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
 {
     CK_RV xResult = 0;
     CK_C_GetFunctionList pxCkGetFunctionList = NULL;

--- a/vendors/vendor/boards/board/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/vendor/boards/board/ports/secure_sockets/iot_secure_sockets.c
@@ -133,8 +133,8 @@ uint32_t ulRand( void )
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
 {
-	*( pulNumber ) = 0uL;
-	return pdFALSE;
+    *( pulNumber ) = 0uL;
+    return pdFALSE;
 }

--- a/vendors/vendor/boards/board/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/vendor/boards/board/ports/secure_sockets/iot_secure_sockets.c
@@ -132,3 +132,9 @@ uint32_t ulRand( void )
     return 0;
 }
 /*-----------------------------------------------------------*/
+
+BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber )
+{
+	*( pulNumber ) = 0uL;
+	return pdFALSE;
+}


### PR DESCRIPTION
<!--- Title -->

Replace the ipconfigRAND32 macro with a function
-----------
<!--- Describe your changes in detail -->

Summary:

Any TCP/IP stack has a need for random numbers. Think of random port numbers and initial sequence numbers in a TCP connection. But also ID's when contacting a DNS server.

Until now, there was a macro `ipconfigRAND32()` that was usually defined as:

~~~c
extern uint32_t ulRand();
#define ipconfigRAND32()    ulRand()
~~~

When a random number is obtained from a peripheral, things may go wrong because of a hardware failure. We introduced the rule that a random value '0' stands for a failure.

However, the number 0 is a valid random number.

I propose a new function that delivers a random number, and that indicates if the operation was successful:

~~~c
/* xApplicationGetRandomNumber() will set *pulNumber to a random number,
and return pdTRUE. When the random number generator is broken, it shall return
pdFALSE.
The function is defined in 'iot_secure_sockets.c'.
If that module is not included in the project, the application must provide an
implementation of it.
The macro's ipconfigRAND32() and configRAND32() are not in use anymore. */
BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber );
~~~

Let the macro `ipconfigRAND32()` continue to exist for a while, also for backward compatibility.

Most importantly for now is that modules like FreeRTOS_DNS and FreeRTOS_TCP know if a random number of 0 means an error or a true random value.

The earlier ulRand() function can be implemented like this:

~~~c
#if 0
uint32_t ulRand( void )
{
	uint32_t ulNumber = 0uL;
	BaseType_t xResult = xApplicationGetRandomNumber( &( ulNumber ) );

	if( xResult == pdFALSE )
	{
		ulNumber = 0uL;
	}
	else
	{
		/* Function succeeded, a random number will be returned. */
	}
	return ulNumber;
}
#endif /* 0 */
~~~

 I put the function in an `#if 0` block to avoid compiling it. The compiler will point out where it has to be replaced with the new function `xApplicationGetRandomNumber()`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

The code has not been linted yet because the entire FreeRTOS+TCP library has not been linted yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.