### PR TITLE
Heap and Stack metrics for ESP32. Plus naming changes.

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -338,7 +338,7 @@ void runDemoTask( void * pArgument )
                                          pNetworkInterface );
 
         #ifdef democonfigMEMORY_ANALYSIS
-            /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
+            /* If memory analysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
             xAfterDemoHeapSize = democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
             IotLogInfo( "memory_metrics:freertos_heap:before:bytes:%u", xBeforeDemoHeapSize );

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -343,7 +343,7 @@ void runDemoTask( void * pArgument )
             xAfterDemoHeapSize = democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
             IotLogInfo( "memory_metrics:freertos_heap:before:bytes:%u", xBeforeDemoHeapSize );
             IotLogInfo( "memory_metrics:freertos_heap:after:bytes:%u", xAfterDemoHeapSize );
-    
+
             xAfterDemoTaskWaterMark = democonfigMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
             IotLogInfo( "memory_metrics:demo_task_stack:before:bytes:%u", xBeforeDemoTaskWaterMark );
             IotLogInfo( "memory_metrics:demo_task_stack:after:bytes:%u", xAfterDemoTaskWaterMark );

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -57,10 +57,6 @@ static IotSemaphore_t demoNetworkSemaphore;
 /* Variable used to indicate the connected network. */
 static uint32_t demoConnectedNetwork = AWSIOT_NETWORK_TYPE_NONE;
 
-#ifdef democonfigMEMORY_ANALYSIS
-    extern demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xDemoStackSize;
-#endif
-
 #if defined( MQTT_DEMO_TYPE_ENABLED )
     #if BLE_ENABLED
         extern const IotMqttSerializer_t IotBleMqttSerializer;
@@ -312,11 +308,11 @@ void runDemoTask( void * pArgument )
     #endif /* INSERT_DELAY_BEFORE_DEMO */
 
     #ifdef democonfigMEMORY_ANALYSIS
-        demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark = 0;
-        xBeforeDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
+        democonfigMEMORY_ANALYSIS_STACK_DEPTH_TYPE xBeforeDemoTaskWaterMark, xAfterDemoTaskWaterMark = 0;
+        xBeforeDemoTaskWaterMark = democonfigMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
 
         size_t xBeforeDemoHeapSize, xAfterDemoHeapSize = 0;
-        xBeforeDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
+        xBeforeDemoHeapSize = democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
     #endif /* democonfigMEMORY_ANALYSIS */
 
 
@@ -344,14 +340,13 @@ void runDemoTask( void * pArgument )
         #ifdef democonfigMEMORY_ANALYSIS
             /* If memory anaalysis is enabled metrics regarding the heap and stack usage of the demo will print. */
             /* This format is used for easier parsing and creates an avenue for future metrics to be added. */
-            xAfterDemoHeapSize = demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
-            IotLogInfo( "memory_metrics:freertos_heap:total:bytes:%u", demoMEMORY_ANALYSIS_HEAP_SIZE );
+            xAfterDemoHeapSize = democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE();
             IotLogInfo( "memory_metrics:freertos_heap:before:bytes:%u", xBeforeDemoHeapSize );
             IotLogInfo( "memory_metrics:freertos_heap:after:bytes:%u", xAfterDemoHeapSize );
-            xAfterDemoTaskWaterMark = demoMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
-            IotLogInfo( "memory_metrics:demo_task_stack:total:stack_words:%u", xDemoStackSize );
-            IotLogInfo( "memory_metrics:demo_task_stack:before:stack_words:%u", xBeforeDemoTaskWaterMark );
-            IotLogInfo( "memory_metrics:demo_task_stack:after:stack_words:%u", xAfterDemoTaskWaterMark );
+    
+            xAfterDemoTaskWaterMark = democonfigMEMORY_ANALYSIS_STACK_WATERMARK( NULL );
+            IotLogInfo( "memory_metrics:demo_task_stack:before:bytes:%u", xBeforeDemoTaskWaterMark );
+            IotLogInfo( "memory_metrics:demo_task_stack:after:bytes:%u", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
         /* Log the demo status. */

--- a/demos/demo_runner/iot_demo_runner.c
+++ b/demos/demo_runner/iot_demo_runner.c
@@ -70,10 +70,6 @@ int DEMO_entryFUNCTION( bool awsIotMqttMode,
     #define DEMO_networkDisconnectedCallback    ( NULL )
 #endif
 
-#ifdef democonfigMEMORY_ANALYSIS
-    demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE xDemoStackSize;
-#endif
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -82,10 +78,6 @@ int DEMO_entryFUNCTION( bool awsIotMqttMode,
 void DEMO_RUNNER_RunDemos( void )
 {
     /* These demos are shared with the C SDK and perform their own initialization and cleanup. */
-
-    #ifdef democonfigMEMORY_ANALYSIS
-        xDemoStackSize = democonfigDEMO_STACKSIZE;
-    #endif
 
     static demoContext_t mqttDemoContext =
     {

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -62,4 +62,18 @@
 
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 12 )
 
+#define democonfigMEMORY_ANALYSIS
+
+#ifdef democonfigMEMORY_ANALYSIS
+    #define democonfigMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
+    #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
+        /* Shift by left twice to convert from stack words to bytes */
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+    #else
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
+    #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
+#endif /* democonfigMEMORY_ANALYSIS */
+
+
 #endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_demo_config.h
@@ -68,13 +68,13 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
-    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
-    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
+    #define democonfigMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+        /* Shift by left twice to convert from stack words to bytes */
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x ) << 2
     #else
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
 

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -72,13 +72,13 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
-    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
-    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
+    #define democonfigMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+        /* Shift by left twice to convert from stack words to bytes */
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x ) << 2
     #else
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -76,13 +76,13 @@
 #define democonfigMEMORY_ANALYSIS
 
 #ifdef democonfigMEMORY_ANALYSIS
-    #define demoMEMORY_ANALYSIS_HEAP_SIZE           configTOTAL_HEAP_SIZE
-    #define demoMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
-    #define demoMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
+    #define democonfigMEMORY_ANALYSIS_STACK_DEPTH_TYPE    UBaseType_t
+    #define democonfigMEMORY_ANALYSIS_MIN_EVER_HEAP_SIZE()        xPortGetMinimumEverFreeHeapSize()
     #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x )
+        /* Shift by left twice to convert from stack words to bytes */
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    uxTaskGetStackHighWaterMark( x ) << 2
     #else
-        #define demoMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
+        #define democonfigMEMORY_ANALYSIS_STACK_WATERMARK( x )    NULL
     #endif /* if( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 #endif /* democonfigMEMORY_ANALYSIS */
 


### PR DESCRIPTION
Added stack and heap metrics logging to ESP32 demos. Abstracted data type of stack size as on ESP32 it is bytes, but FreeRTOS implementation is usually stack words. Changed variable prefixes from demo to democonfig as per convention.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.