### PR TITLE
AFR NimBLE: Misc fixes in prvBTSendResponse, prvValidGattRequest and application code (aws_demos & aws_tests)

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -185,11 +185,6 @@ static void prvMiscInitialization( void )
 
             xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
 
-            if( xRet == ESP_OK )
-            {
-                xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
-            }
-
             return xRet;
         }
 

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -333,11 +333,6 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
         xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
 
-        if( xRet == ESP_OK )
-        {
-            xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
-        }
-
         return xRet;
     }
 

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -416,8 +416,10 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                 if( xGattServerCb.pxRequestWriteCb != NULL )
                 {
                     ctxt.op = BLE_GATT_ACCESS_OP_WRITE_DSC;
+                    xSemLock = 1;
                     xGattServerCb.pxRequestWriteCb( event->subscribe.conn_handle, ( uint32_t ) &ctxt, ( BTBdaddr_t * ) desc.peer_id_addr.val, event->subscribe.attr_handle - gattOffset + 1, 0, sizeof( ccc_val ), 1, 0, ( uint8_t * ) &ccc_val );
                     prvGattGetSemaphore();
+                    xSemLock = 0;
                 }
             }
 

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -411,7 +411,7 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                 }
             }
 
-            if( event->subscribe.attr_handle > gattOffset )
+            if( ( event->subscribe.reason != BLE_GAP_SUBSCRIBE_REASON_TERM ) && ( event->subscribe.attr_handle > gattOffset ) )
             {
                 if( xGattServerCb.pxRequestWriteCb != NULL )
                 {

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -466,6 +466,7 @@ BTStatus_t prvBTGattServerInit( const BTGattServerCallbacks_t * pxCallbacks )
     BTStatus_t xStatus = eBTStatusSuccess;
 
     ble_hs_cfg.gatts_register_cb = prvGATTRegisterCb;
+    serviceCnt = 0;
 
     memset( espServices, 0, sizeof( struct ble_gatt_svc_def ) * ( MAX_SERVICES + 1 ) );
 

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_internals.h
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_internals.h
@@ -68,5 +68,6 @@ BTStatus_t prvSetIOs( BTIOtypes_t xPropertyIO );
 BTStatus_t prvToggleBondableFlag( bool bEnable );
 BTStatus_t prvToggleSecureConnectionOnlyMode( bool bEnable );
 void prvGattGetSemaphore();
+void prvGattGiveSemaphore();
 
 #endif /* ifndef _AWS_BLE_INTERNALS_H_ */

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_internals.h
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_internals.h
@@ -52,6 +52,7 @@ extern BTProperties_t xProperties;
 extern BTGattServerCallbacks_t xGattServerCb;
 extern uint16_t usGattConnHandle;
 extern uint16_t gattOffset;
+extern bool xSemLock;
 
 const void * prvBTGetGattServerInterface();
 const void * prvGetLeAdapter();


### PR DESCRIPTION
Helps in fixing the integration test:TEST( Full_BLE_Integration_Test_Connection, BLE_Send_Data_After_Disconected )​ getting stuck in middle.

<!--- Title -->

Description
-----------
- Fix return code in `prvBTSendResponse`.
- Changes `prvValidGattRequest` to handle valid/invalid gatt request properly.
- Introduce `prvGattGiveSemaphore` API inline with `prvGattGetSemaphore`.
- Remove redundant `esp_bt_controller_mem_release( ESP_BT_MODE_BTDM )` from **application_code** of **aws_tests** and **aws_demos** as `ESP_BT_MODE_CLASSIC_BT` memory is already released at the start. 


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.