### PR TITLE
feat: Add Get TX/RX Num bytes for I2S operations

### DIFF
--- a/libraries/abstractions/common_io/include/iot_i2s.h
+++ b/libraries/abstractions/common_io/include/iot_i2s.h
@@ -72,6 +72,8 @@ typedef enum
     eI2SSetConfig,      /*!< Set I2S configuration taking the struct IotI2SIoctlConfig_t */
     eI2SGetConfig,      /*!< Get I2S configuration returning the struct IotI2SIoctlConfig_t */
     eI2SGetBusState,    /*!< Get the State of the I2S Bus returning the struct IotI2SBusStatus_t */
+    eI2SGetTxNoOfbytes, /*!< Get the number of bytes sent in write operation. Returns uint32_t type. */
+    eI2SGetRxNoOfbytes, /*!< Get the number of bytes received in read operation. Returns uint32_t type. */
 } IotI2SIoctlRequest_t;
 
 /**
@@ -267,6 +269,19 @@ int32_t iot_i2s_close( IotI2SHandle_t const pxI2SPeripheral);
  * @param[in]   pxI2SPeripheral The I2S handle returned in open() call.
  * @param[in]   lRequest    Should be one of I2S_Ioctl_Request_t.
  * @param[in]   pvBuffer    The configuration values for the IOCTL request.
+ *
+ * @note eI2SGetTxNoOfbytes returns the number of written bytes in last operation.
+ * This is supposed to be called in the caller task or application callback, right after last operation completes.
+ * This request expects 4 bytes buffer (uint32_t).
+ *
+ * - If the last operation only did read, this returns 0.
+ *
+ * @note eI2SGetRxNoOfbytes returns the number of read bytes in last operation.
+ * This is supposed to be called in the caller task or application callback, right after last operation completes.
+ * This request expects 4 bytes buffer (uint32_t).
+ *
+ * - If the last operation was a read, this returns the actual number of read bytes which might be smaller than the requested number (partial read).
+ * - If the last operation was a write, this returns 0.
  *
  * @return
  *   - IOT_I2S_SUCCESS on success

--- a/libraries/abstractions/common_io/test/test_iot_i2s.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2s.c
@@ -157,6 +157,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadAsyncLoopback )
     uint8_t ucRxbuf[ testIotI2S_BUF_SIZE ] = {0};
     uint8_t ucTxbuf[ testIotI2S_BUF_SIZE ] = {0};
     int i;
+    uint32_t ulRxTxBytes;
 
     for(i=0; i<testIotI2S_BUF_SIZE; i++) {
        ucTxbuf[i] = i& 0xff;
@@ -185,6 +186,19 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadAsyncLoopback )
        lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
+       /* Get Tx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SSpkrHandle, eI2SGetTxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
+
+       /* Get Rx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SMicHandle, eI2SGetRxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
+
+
        /* Validate data was read correctly */
        for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
           TEST_ASSERT_EQUAL( (ucRxbuf[i]+1)&0xff, ucRxbuf[i+1] );
@@ -209,6 +223,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncReadAsyncLoopback )
     uint8_t ucRxbuf[ testIotI2S_BUF_SIZE ] = {0};
     uint8_t ucTxbuf[ testIotI2S_BUF_SIZE ] = {0};
     int i;
+    uint32_t ulRxTxBytes;
 
     for(i=0; i<testIotI2S_BUF_SIZE; i++) {
        ucTxbuf[i] = i& 0xff;
@@ -232,6 +247,12 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteSyncReadAsyncLoopback )
 
        lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Rx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SMicHandle, eI2SGetRxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
 
        /* Validate data was read correctly */
        for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
@@ -257,6 +278,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadSyncLoopback )
     uint8_t ucRxbuf[ testIotI2S_BUF_SIZE ] = {0};
     uint8_t ucTxbuf[ testIotI2S_BUF_SIZE ] = {0};
     int i;
+    uint32_t ulRxTxBytes;
 
     for(i=0; i<testIotI2S_BUF_SIZE; i++) {
        ucTxbuf[i] = i& 0xff;
@@ -274,6 +296,12 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsyncReadSyncLoopback )
 
        lRetVal = iot_i2s_read_sync( xI2SMicHandle, ucRxbuf, testIotI2S_BUF_SIZE );
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Tx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SMicHandle, eI2SGetTxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
 
        /* Validate data was read correctly */
        for(i=testIotI2S_LOOPBACK_OVERHEAD; i<testIotI2S_BUF_SIZE-testIotI2S_LOOPBACK_OVERHEAD; i++) {
@@ -397,6 +425,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsync )
     int32_t lRetVal;
     uint8_t ucRxbuf[ testIotI2S_BUF_SIZE ] = {0};
     int i;
+    uint32_t ulRxTxBytes;
 
     /* Open i2s to initialize hardware */
     xI2SMicHandle = iot_i2s_open( ltestIotI2sInputInstance );
@@ -410,6 +439,12 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SReadAsync )
 
        lRetVal = xSemaphoreTake(xtestIotI2SReadSemaphore, portMAX_DELAY);
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Rx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SMicHandle, eI2SGetTxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
 
        /* Validate data was read correctly */
        for(i=0; i<ltestIotI2SReadSize; i++) {
@@ -432,6 +467,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsync )
     int32_t lRetVal;
     uint8_t ucTxbuf[ testIotI2S_BUF_SIZE ] = {0};
     int i;
+    uint32_t ulRxTxBytes;
 
     for(i=0; i<testIotI2S_BUF_SIZE; i++) {
        ucTxbuf[i] = i& 0xff;
@@ -450,6 +486,12 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SWriteAsync )
 
        lRetVal = xSemaphoreTake(xtestIotI2SWriteSemaphore, portMAX_DELAY);
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Rx Num bytes */
+       ulRxTxBytes = 0;
+       lRetVal = iot_i2s_ioctl( xI2SSpkrHandle, eI2SGetTxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+       TEST_ASSERT_EQUAL( testIotI2S_BUF_SIZE, ulRxTxBytes );
     }
 
     /* Close instance */
@@ -469,6 +511,7 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SIoctl )
     IotI2SChannel_t xChannel;
     IotI2SClkPolarity_t xPolarity;
     uint32_t ulBusState;
+    uint32_t ulRxTxBytes;
 
     /* Open i2s to initialize hardware */
     xI2SHandle = iot_i2s_open( ltestIotI2sInputInstance );
@@ -561,6 +604,14 @@ TEST( TEST_IOT_I2S, AFQP_IotI2SIoctl )
 
        /* Get bus state */
        lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetBusState, &ulBusState );
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Tx Num bytes */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetTxNoOfbytes, &ulRxTxBytes);
+       TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
+
+       /* Get Rx Num bytes */
+       lRetVal = iot_i2s_ioctl( xI2SHandle, eI2SGetRxNoOfbytes, &ulRxTxBytes);
        TEST_ASSERT_EQUAL( IOT_I2S_SUCCESS, lRetVal );
 
     } else {


### PR DESCRIPTION
Adding ioctl for GetTxNoOfBytes/GetRxNoOfBytes

Why:  While reviewing tests for I2S, we discovered that we were
missing the ability to get the number of tx/rx bytes sent in the
previous calls to read/write.
So, we've added the ioctl, along with appropriate tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.