### PR TITLE
Make RPI BLE tests more robust

### DIFF
--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/runPI.sh
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/runPI.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-scp * root@10.60.172.116:
-ssh -t -t 10.60.172.116 -l root << 'ENDSSH'
+scp * root@192.168.1.3:
+ssh -t -t 192.168.1.3 -l root << 'ENDSSH'
 rm -rf "/var/lib/bluetooth/*"
 hciconfig hci0 reset
 python test1.py

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/runPI.sh
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/runPI.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-scp * root@192.168.1.3: 
-ssh -t -t 192.168.1.3 -l root << 'ENDSSH'
+scp * root@10.60.172.116:
+ssh -t -t 10.60.172.116 -l root << 'ENDSSH'
 rm -rf "/var/lib/bluetooth/*"
 hciconfig hci0 reset
 python test1.py

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/startTests_afqp.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/startTests_afqp.py
@@ -32,7 +32,6 @@ import time
 from testClass import runTest
 from bleAdapter import bleAdapter
 
-
 def main():
     scan_filter = dict()
 
@@ -144,9 +143,11 @@ def main():
     bleAdapter.stopDiscovery()
     runTest.reconnectWhileBonded()
 
+    #Test to wait for a disconnect from DUT.
+    runTest.waitForDisconnect()
+
     # reconnect while not bonded. Pairing should fail since Just works is not
     # accepted
-    bleAdapter.disconnect()
     bleAdapter.removeBondedDevices()
     time.sleep(2)  # wait for bonded devices to be deleted
     bleAdapter.setDiscoveryFilter(scan_filter)

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
@@ -219,7 +219,7 @@ class runTest:
 
     @staticmethod
     def waitForDisconnect():
-        isTestSuccessfull = bleAdapter.waitForDisconnect(timeout=runTest.GENERIC_TEST_TIMEOUT)
+        isTestSuccessfull = bleAdapter.isDisconnected(timeout=runTest.GENERIC_TEST_TIMEOUT)
         runTest.submitTestResult(isTestSuccessfull, runTest.waitForDisconnect)
 
     @staticmethod
@@ -229,7 +229,7 @@ class runTest:
             bleAdapter.writeCharacteristic(
                 runTest.DUT_ENCRYPT_CHAR_UUID,
                 runTest.DUT_ENCRYPT_CHAR_UUID)  # should trigger a pairing event
-            isTestSuccessFull = bleAdapter.isPaired()
+            isTestSuccessFull = bleAdapter.isPaired(timeout=runTest.GENERIC_TEST_TIMEOUT)
         else:
             isTestSuccessFull = False
         return isTestSuccessFull
@@ -408,7 +408,14 @@ class runTest:
 
     @staticmethod
     def discoverPrimaryServices():
-        return bleAdapter.getPropertie(runTest.testDevice, "ServicesResolved")
+        retries = 5
+        for x in range(retries):
+            status = bleAdapter.getPropertie(runTest.testDevice, "ServicesResolved")
+            if status == True:
+                return True
+            time.sleep(1)
+            print("Retrying....")
+        return False
 
     @staticmethod
     def checkProperties(gatt):

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
@@ -218,6 +218,11 @@ class runTest:
         runTest.submitTestResult(isTestSuccessFull, runTest.disconnect)
 
     @staticmethod
+    def waitForDisconnect():
+        isTestSuccessfull = bleAdapter.waitForDisconnect(timeout=runTest.GENERIC_TEST_TIMEOUT)
+        runTest.submitTestResult(isTestSuccessfull, runTest.waitForDisconnect)
+
+    @staticmethod
     def pairing():
         isTestSuccessFull = True
         if bleAdapter.isPaired() == False:
@@ -850,53 +855,23 @@ class runTest:
 
     @staticmethod
     def submitTestResult(isSuccessfull, testMethod):
-        switch = {
-            runTest.advertisement: "_advertisement",
-            runTest.discoverPrimaryServices: "_discoverPrimaryServices",
-            runTest.simpleConnection: "_simpleConnection",
-            runTest.reConnection: "_reConnection",
-            runTest.checkProperties: "_checkProperties",
-            runTest.checkUUIDs: "_checkUUIDs",
-            runTest.writereadLongCharacteristic: "_writereadLongCharacteristic",
-            runTest.readWriteSimpleConnection: "_readWriteSimpleConnection",
-            runTest.writeWithoutResponse: "_writeWithoutResponse",
-            runTest.notification: "_notification",
-            runTest.indication: "_indication",
-            runTest.removeNotification: "_removeNotification",
-            runTest.removeIndication: "_removeIndication",
-            runTest.readWriteProtectedAttributesWhileNotPaired: "_readWriteProtectedAttributesWhileNotPaired",
-            runTest.readWriteProtectedAttributesWhilePaired: "_readWriteProtectedAttributesWhilePaired",
-            runTest.pairing: "_pairing",
-            runTest.disconnect: "_disconnect",
-            runTest.reconnectWhileBonded: "_reconnectWhileBonded",
-            runTest.reconnectWhileNotBonded: "_reconnectWhileNotBonded",
-            runTest.stopAdvertisement: "_stopAdvertisement",
-            runTest.Advertise_Without_Properties: "_Advertise_Without_Properties",
-            runTest.Advertise_With_16bit_ServiceUUID: "_Advertise_With_16bit_ServiceUUID",
-            runTest.Advertise_With_Manufacture_Data: "_Advertise_With_Manufacture_Data",
-            runTest.Advertise_Interval_Consistent_After_BT_Reset: "_Advertise_Interval_Consistent_After_BT_Reset",
-            runTest.Send_Data_After_Disconnected: "_Send_Data_After_Disconnected",
-            runTest.Write_Notification_Size_Greater_Than_MTU_3: "_Write_Notification_Size_Greater_Than_MTU_3"
-        }
-
         runTest.numberOfTests += 1
 
-        if(isSuccessfull):
+        if isSuccessfull is True:
             successString = "PASS"
         else:
             successString = "FAIL"
             runTest.numberOfFailedTests += 1
 
-        print(
-            "TEST(" +
-            runTest.TEST_GROUP +
-            ", " +
-            runTest.TEST_NAME_PREFIX +
-            switch.get(
-                testMethod,
-                "methodNotFound") +
-            ") " +
-            successString)
+        print( "TEST("
+                + runTest.TEST_GROUP
+                + ", "
+                + runTest.TEST_NAME_PREFIX
+                + "_"
+                + testMethod.__name__
+                + ") "
+                + successString )
+
         sys.stdout.flush()
 
     @staticmethod

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
@@ -408,14 +408,7 @@ class runTest:
 
     @staticmethod
     def discoverPrimaryServices():
-        retries = 5
-        for x in range(retries):
-            status = bleAdapter.getPropertie(runTest.testDevice, "ServicesResolved")
-            if status == True:
-                return True
-            time.sleep(1)
-            print("Retrying....")
-        return False
+        return bleAdapter.isServicesResolved(timeout=runTest.GENERIC_TEST_TIMEOUT)
 
     @staticmethod
     def checkProperties(gatt):

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -134,7 +134,7 @@ TEST_GROUP_RUNNER( Full_BLE )
     RUN_TEST_CASE( Full_BLE, BLE_Connection_Mode1Level4_Property_WriteChar );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_BondedReconnectAndPair );
-    RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect );
+    RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect_From_DUT );
 
     RUN_TEST_CASE( Full_BLE, BLE_Connection_CheckBonding );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_RemoveBonding );
@@ -295,6 +295,14 @@ TEST( Full_BLE, BLE_Connection_BondedReconnectAndPair )
 TEST( Full_BLE, BLE_Connection_Disconnect )
 {
     IotTestBleHal_WaitConnection( false );
+}
+
+TEST( Full_BLE, BLE_Connection_Disconnect_From_DUT )
+{
+	BTStatus_t xStatus;
+	xStatus = _pxBTLeAdapterInterface->pxDisconnect( _ucBLEAdapterIf, &_xAddressConnectedDevice, _usBLEConnId );
+	TEST_ASSERT_EQUAL(eBTStatusSuccess, xStatus );
+
 }
 
 TEST( Full_BLE, BLE_Connection_Mode1Level4_Property_WriteDescr )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -299,18 +299,18 @@ TEST( Full_BLE, BLE_Connection_Disconnect )
 
 TEST( Full_BLE, BLE_Connection_Disconnect_From_Peripheral )
 {
-	BTStatus_t xStatus;
-	BLETESTConnectionCallback_t xConnectionEvent;
-	xStatus = _pxBTLeAdapterInterface->pxDisconnect( _ucBLEAdapterIf, &_xAddressConnectedDevice, _usBLEConnId );
-	TEST_ASSERT_EQUAL(eBTStatusSuccess, xStatus );
+    BTStatus_t xStatus;
+    BLETESTConnectionCallback_t xConnectionEvent;
 
-	xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventConnectionCb, NO_HANDLE, ( void * ) &xConnectionEvent, sizeof( BLETESTConnectionCallback_t ), BLE_TESTS_WAIT );
-	TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-	TEST_ASSERT_EQUAL( false, xConnectionEvent.bConnected );
-	TEST_ASSERT_EQUAL( _ucBLEServerIf, xConnectionEvent.ucServerIf );
-	TEST_ASSERT_EQUAL( 0, memcmp( &xConnectionEvent.pxBda, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-	TEST_ASSERT_EQUAL( eBTStatusSuccess, xConnectionEvent.xStatus );
+    xStatus = _pxBTLeAdapterInterface->pxDisconnect( _ucBLEAdapterIf, &_xAddressConnectedDevice, _usBLEConnId );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
+    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventConnectionCb, NO_HANDLE, ( void * ) &xConnectionEvent, sizeof( BLETESTConnectionCallback_t ), BLE_TESTS_WAIT );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    TEST_ASSERT_EQUAL( false, xConnectionEvent.bConnected );
+    TEST_ASSERT_EQUAL( _ucBLEServerIf, xConnectionEvent.ucServerIf );
+    TEST_ASSERT_EQUAL( 0, memcmp( &xConnectionEvent.pxBda, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, xConnectionEvent.xStatus );
 }
 
 TEST( Full_BLE, BLE_Connection_Mode1Level4_Property_WriteDescr )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -134,7 +134,7 @@ TEST_GROUP_RUNNER( Full_BLE )
     RUN_TEST_CASE( Full_BLE, BLE_Connection_Mode1Level4_Property_WriteChar );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_BondedReconnectAndPair );
-    RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect_From_DUT );
+    RUN_TEST_CASE( Full_BLE, BLE_Connection_Disconnect_From_Peripheral );
 
     RUN_TEST_CASE( Full_BLE, BLE_Connection_CheckBonding );
     RUN_TEST_CASE( Full_BLE, BLE_Connection_RemoveBonding );
@@ -297,11 +297,19 @@ TEST( Full_BLE, BLE_Connection_Disconnect )
     IotTestBleHal_WaitConnection( false );
 }
 
-TEST( Full_BLE, BLE_Connection_Disconnect_From_DUT )
+TEST( Full_BLE, BLE_Connection_Disconnect_From_Peripheral )
 {
 	BTStatus_t xStatus;
+	BLETESTConnectionCallback_t xConnectionEvent;
 	xStatus = _pxBTLeAdapterInterface->pxDisconnect( _ucBLEAdapterIf, &_xAddressConnectedDevice, _usBLEConnId );
 	TEST_ASSERT_EQUAL(eBTStatusSuccess, xStatus );
+
+	xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventConnectionCb, NO_HANDLE, ( void * ) &xConnectionEvent, sizeof( BLETESTConnectionCallback_t ), BLE_TESTS_WAIT );
+	TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+	TEST_ASSERT_EQUAL( false, xConnectionEvent.bConnected );
+	TEST_ASSERT_EQUAL( _ucBLEServerIf, xConnectionEvent.ucServerIf );
+	TEST_ASSERT_EQUAL( 0, memcmp( &xConnectionEvent.pxBda, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+	TEST_ASSERT_EQUAL( eBTStatusSuccess, xConnectionEvent.xStatus );
 
 }
 


### PR DESCRIPTION
Make RPI BLE tests more robust

Description
-----------

* Add wait with a timeout for disconnected, paired and service discovery events. This removes flakiness if there is a delay in receiving events.
* Add test for disconnect from peripheral


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.