### PR TITLE
Configuration of the stack depth for the lwip receive callback task.

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -221,7 +221,6 @@ static void vTaskRxSelect( void * param )
 
             /*vTaskDelete( rx_handle ); */
             vTaskDelete( NULL );
-            return;
         }
 
         if( FD_ISSET( s, &read_fds ) )
@@ -240,12 +239,13 @@ static void prvRxSelectSet( ss_ctx_t * ctx,
 {
     BaseType_t xReturned;
     TaskHandle_t xHandle = NULL;
+    configSTACK_DEPTH_TYPE xStackDepth = socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH;
 
     ctx->rx_callback = ( void ( * )( Socket_t ) )pvOptionValue;
 
     xReturned = xTaskCreate( vTaskRxSelect, /* pvTaskCode */
                              "rxs",         /* pcName */
-                             512,           /* usStackDepth */
+                             xStackDepth,   /* usStackDepth */
                              ctx,           /* pvParameters */
                              1,             /* uxPriority */
                              &xHandle );    /* pxCreatedTask */

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_secure_sockets_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_secure_sockets_config.h
@@ -54,6 +54,16 @@
 #define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     5
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_secure_sockets_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_secure_sockets_config.h
@@ -54,6 +54,16 @@
 #define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     5
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_secure_sockets_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_secure_sockets_config.h
@@ -54,6 +54,16 @@
 #define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     5
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_secure_sockets_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_secure_sockets_config.h
@@ -54,6 +54,16 @@
 #define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     5
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_secure_sockets_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/aws_secure_sockets_config.h
@@ -50,6 +50,16 @@
 #define socketsconfigDEFAULT_RECV_TIMEOUT    ( 20000 )
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_secure_sockets_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_secure_sockets_config.h
@@ -49,6 +49,16 @@
 #define socketsconfigDEFAULT_RECV_TIMEOUT    ( 20000 )
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Enable metrics of secure socket.
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_secure_sockets_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_secure_sockets_config.h
@@ -54,6 +54,16 @@
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )
 
 /**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
  * @brief Default max socket number support
  */
 #define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     6

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_secure_sockets_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_secure_sockets_config.h
@@ -53,4 +53,18 @@
  */
 #define AWS_IOT_SECURE_SOCKETS_METRICS_ENABLED    ( 1 )
 
+/**
+ * @brief Stack depth for the task that runs the receive callback function
+ *
+ * When SOCKETS_SetSockOpt() is called with SOCKETS_SO_WAKEUP_CALLBACK and
+ * a function pointer, a task is created to run the callback each time the
+ * socket becomes ready.  This is the number of words (not bytes!) to allocate
+ * for use as the task’s stack.
+ */
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      512u
+
+/**
+ * @brief Default max socket number support
+ */
+#define socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS     6
 #endif /* _AWS_SOCKETS_CONFIG_H_ */


### PR DESCRIPTION
This change makes the stack size for receive callbacks configurable.  Also a bad return after vTaskDelete() is removed.

TCP tests pass
* https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/cypress/job/cypress54-ide/99/
* https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/mediatek/job/mt7697hx-dev-kit-ide/130/

MQTT demo passes
* https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/cypress/job/cypress54-ide/100/
* https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/mediatek/job/mt7697hx-dev-kit-ide/131/