### PR TITLE
Change TooManySockets test to a concurrent count test

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -782,7 +782,7 @@ TEST_GROUP_RUNNER( Full_TCP )
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Close );
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Recv_ByteByByte );
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_SendRecv_VaryLength );
-    RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Socket_InvalidTooManySockets );
+    RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Socket_ConcurrentCount );
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Socket_InvalidInputParams );
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Send_Invalid );
     RUN_TEST_CASE( Full_TCP, AFQP_SOCKETS_Recv_Invalid );
@@ -1744,64 +1744,81 @@ TEST( Full_TCP, AFQP_SOCKETS_Socket_InvalidInputParams )
 
 /*-----------------------------------------------------------*/
 
-static void prvSOCKETS_Socket_InvalidTooManySockets( Server_t xConn )
+/*
+ * Verify the number of sockets that can be concurrently
+ * created up to a configured maximum.  Return pdFAIL if
+ * fewer than that number are created.  If more than the
+ * maximum can be created, a warning is printed, but this
+ * is not a failure condition.  Some ports are limited only
+ * by free memory. For these ports, check that a reasonable
+ * number of sockets can be created concurrently.
+ */
+static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
 {
-    #if !defined( WIN32 ) && !defined( PIC32MZ ) && !defined( ESP32 ) && !defined( ZYNQ7000 ) && !defined( __RX ) && !defined( MW320 ) /* Socket can be created as much as there is memory */
-        BaseType_t xResult;
-        Socket_t xCreatedSockets[ integrationtestportableMAX_NUM_UNSECURE_SOCKETS ];
-        BaseType_t xSocketsCreated;
-        Socket_t xSocket;
+    BaseType_t xResult = pdFAIL;
 
-        tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
+    #ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS
+        BaseType_t xMaxCount = integrationtestportableMAX_NUM_UNSECURE_SOCKETS;
+    #else
+        BaseType_t xMaxCount = 5u;
+    #endif
+    Socket_t xCreatedSockets[ xMaxCount ];
+    BaseType_t xSocketsCreated;
+    Socket_t xSocket;
 
-        xResult = pdPASS;
+    tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
-        for( xSocketsCreated = 0; xSocketsCreated < integrationtestportableMAX_NUM_UNSECURE_SOCKETS; xSocketsCreated++ )
+    xResult = pdPASS;
+
+    for( xSocketsCreated = 0; xSocketsCreated < xMaxCount; xSocketsCreated++ )
+    {
+        xSocket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
+
+        if( xSocket == SOCKETS_INVALID_SOCKET )
         {
-            xSocket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
-
-            if( xSocket == SOCKETS_INVALID_SOCKET )
-            {
-                xResult = pdFAIL;
-                tcptestPRINTF( ( "%s failed creating a socket number %d \r\n", __FUNCTION__, xSocketsCreated ) );
-                break;
-            }
-            else
-            {
-                xCreatedSockets[ xSocketsCreated ] = xSocket;
-            }
+            xResult = pdFAIL;
+            tcptestPRINTF( ( "%s failed creating a socket number %d \r\n", __FUNCTION__, xSocketsCreated ) );
+            break;
         }
+        else
+        {
+            xCreatedSockets[ xSocketsCreated ] = xSocket;
+        }
+    }
 
+    #ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS
         if( xResult == pdPASS )
         {
             xSocket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
 
             if( xSocket != SOCKETS_INVALID_SOCKET )
             {
-                xResult = pdFAIL;
                 SOCKETS_Close( xSocket );
+                tcptestPRINTF( ( "%s exceeded maximum number of sockets (%d > %d); is the value of " \
+                                 "integrationtestportableMAX_NUM_UNSECURE_SOCKETS correct?\r\n", __FUNCTION__,
+                                 ( xMaxCount + 1 ), xMaxCount ) );
             }
         }
+    #endif /* ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS */
 
-        /* Cleanup. */
-        while( xSocketsCreated > 0 )
-        {
-            --xSocketsCreated;
-            SOCKETS_Close( xCreatedSockets[ xSocketsCreated ] );
-        }
+    /* Cleanup. */
+    while( xSocketsCreated > 0 )
+    {
+        --xSocketsCreated;
+        SOCKETS_Close( xCreatedSockets[ xSocketsCreated ] );
+    }
 
-        TEST_ASSERT_EQUAL_UINT32_MESSAGE( pdPASS, xResult, "Max num sockets test failed" );
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE( pdPASS, xResult, "Concurrent num sockets test failed" );
 
-        /* Report Test Results. */
-        tcptestPRINTF( ( "%s passed\r\n", __FUNCTION__ ) );
-    #endif /*ifndef WIN32 */
+    /* Report Test Results. */
+    tcptestPRINTF( ( "%s passed\r\n", __FUNCTION__ ) );
 }
 
-TEST( Full_TCP, AFQP_SOCKETS_Socket_InvalidTooManySockets )
+TEST( Full_TCP, AFQP_SOCKETS_Socket_ConcurrentCount )
 {
     tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
-    prvSOCKETS_Socket_InvalidTooManySockets( eNonsecure );
+    prvSOCKETS_Socket_ConcurrentCount( eNonsecure );
 }
 
 TEST( Full_TCP, AFQP_SECURE_SOCKETS_Socket_InvalidTooManySockets )

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1754,7 +1754,7 @@ TEST( Full_TCP, AFQP_SOCKETS_Socket_InvalidInputParams )
  * number of sockets can be created concurrently.
  */
 #ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS
-    #define MAX_NUM_SOCKETS    integrationtestportableMAX_NUM_UNSECURE_SOCKETS;
+    #define MAX_NUM_SOCKETS    integrationtestportableMAX_NUM_UNSECURE_SOCKETS
 #else
     #define MAX_NUM_SOCKETS    5u
 #endif

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1753,16 +1753,15 @@ TEST( Full_TCP, AFQP_SOCKETS_Socket_InvalidInputParams )
  * by free memory. For these ports, check that a reasonable
  * number of sockets can be created concurrently.
  */
+#ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS
+    #define MAX_NUM_SOCKETS    integrationtestportableMAX_NUM_UNSECURE_SOCKETS;
+#else
+    #define MAX_NUM_SOCKETS    5u
+#endif
 static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
 {
     BaseType_t xResult = pdFAIL;
-
-    #ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS
-        BaseType_t xMaxCount = integrationtestportableMAX_NUM_UNSECURE_SOCKETS;
-    #else
-        BaseType_t xMaxCount = 5u;
-    #endif
-    Socket_t xCreatedSockets[ xMaxCount ];
+    Socket_t xCreatedSockets[ MAX_NUM_SOCKETS ];
     BaseType_t xSocketsCreated;
     Socket_t xSocket;
 
@@ -1770,7 +1769,7 @@ static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
 
     xResult = pdPASS;
 
-    for( xSocketsCreated = 0; xSocketsCreated < xMaxCount; xSocketsCreated++ )
+    for( xSocketsCreated = 0; xSocketsCreated < MAX_NUM_SOCKETS; xSocketsCreated++ )
     {
         xSocket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
 
@@ -1796,7 +1795,7 @@ static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
                 SOCKETS_Close( xSocket );
                 tcptestPRINTF( ( "%s exceeded maximum number of sockets (%d > %d); is the value of " \
                                  "integrationtestportableMAX_NUM_UNSECURE_SOCKETS correct?\r\n", __FUNCTION__,
-                                 ( xMaxCount + 1 ), xMaxCount ) );
+                                 ( MAX_NUM_SOCKETS + 1 ), MAX_NUM_SOCKETS ) );
             }
         }
     #endif /* ifdef integrationtestportableMAX_NUM_UNSECURE_SOCKETS */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,12 +31,6 @@
  * @brief Port-specific variables for TCP tests. */
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    1
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_tcp_config.h
@@ -29,12 +29,6 @@
 /**
  * @file aws_integration_test_tcp_portable.h
  * @brief Port-specific variables for TCP tests. */
-#define MW320
-/**
- * @brief The number of sockets that can be open at one time on a port.
- *
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    20
 
 /**
  * @brief Indicates how much longer than the specified timeout is acceptable for

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h
@@ -32,13 +32,6 @@
 
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- * This test is not run in WinSim as there are too many sockets that can be opened at one time.
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    0
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,13 +31,6 @@
 
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- * This test is not run in WinSim as there are too many sockets that can be opened at one time.
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    0
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,13 +31,6 @@
 
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- * This test is not run in WinSim as there are too many sockets that can be opened at one time.
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    0
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,12 +31,6 @@
  * @brief Port-specific variables for TCP tests. */
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    1
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,10 +31,12 @@
  * @brief Port-specific variables for TCP tests. */
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
+ * @brief Port-specific maximum number of concurrent sockets
+ * Do not define this if the number is limited only by free memory.
  */
+#if 0
 #define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    1    /* FIX ME. */
+#endif
 
 /**
  * @brief Indicates how much longer than the specified timeout is acceptable for

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_tcp_config.h
@@ -31,12 +31,6 @@
  * @brief Port-specific variables for TCP tests. */
 
 /**
- * @brief The number of sockets that can be open at one time on a port.
- *
- */
-#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    0
-
-/**
  * @brief Indicates how much longer than the specified timeout is acceptable for
  * RCVTIMEO tests.
  *


### PR DESCRIPTION
The old test returned pdPASS if integrationtestportableMAX_NUM_UNSECURE_SOCKETS sockets were created and pdFAIL for fewer or more sockets.  Some ports are limited only by free memory.  The test would return pdFAIL for those ports.  To work around this an exclusion list was added via preprocessor directive.

This PR removes the exclusion list, and returns pdFAIL only if fewer sockets were created.  The define directive is removed from ports without a hard limit. For those ports, the test looks for a reasonable number of sockets to be created.

https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom_ide/439/