### PR TITLE
FreeRTOS+TCP: Let xDataLength always mean "total number of bytes"

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c
@@ -605,11 +605,11 @@ void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffe
 {
 ARPPacket_t *pxARPPacket;
 
-        /* Buffer allocation ensures that buffers always have space
-	   for an ARP packet. See buffer allocation implementations 1
-	   and 2 under portable/BufferManagement. */
-        configASSERT( pxNetworkBuffer );
-        configASSERT( pxNetworkBuffer->xDataLength >= sizeof(ARPPacket_t) );
+	/* Buffer allocation ensures that buffers always have space
+	for an ARP packet. See buffer allocation implementations 1
+	and 2 under portable/BufferManagement. */
+	configASSERT( pxNetworkBuffer );
+	configASSERT( pxNetworkBuffer->xDataLength >= sizeof(ARPPacket_t) );
 
 	pxARPPacket = ( ARPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1172,7 +1172,7 @@ BaseType_t xDoStore = xExpected;
 
 					/* Set the size of the outgoing packet. */
 					pxNetworkBuffer->xDataLength = xDataLength;
-					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, xDataLength + 16 );
+					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, xDataLength + sizeof( LLMNRAnswer_t ) );
 
 					if( pxNewBuffer != NULL )
 					{
@@ -1329,7 +1329,7 @@ BaseType_t xDoStore = xExpected;
 
 					/* The field xDataLength was set to the total length of the UDP packet,
 					i.e. the payload size plus sizeof( UDPPacket_t ). */
-					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength + 16 );
+					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength + sizeof( NBNSAnswer_t ) );
 
 					if( pxNewBuffer != NULL )
 					{

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -1122,7 +1122,8 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t *pulIPAddress, const uint3
 				pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = FREERTOS_SO_UDPCKSUM_OUT;
 				pxNetworkBuffer->ulIPAddress = ulIPAddress;
 				pxNetworkBuffer->usPort = ipPACKET_CONTAINS_ICMP_DATA;
-				pxNetworkBuffer->xDataLength = xNumberOfBytesToSend + sizeof( ICMPHeader_t );
+				/* xDataLength is the size of the total packet, including the Ethernet header. */
+				pxNetworkBuffer->xDataLength = xNumberOfBytesToSend + sizeof( ICMPPacket_t );
 
 				/* Send to the stack. */
 				xStackTxEvent.pvData = pxNetworkBuffer;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -1615,14 +1615,14 @@ uint8_t ucProtocol;
 					if ( ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) ) && ( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) >= sizeof( UDPHeader_t ) ) )
 					{
 					size_t uxPayloadSize_1, uxPayloadSize_2;
-						/* Ensure that downstream UDP packet handling has the lesser
-						 * of: the actual network buffer Ethernet frame length, or
-						 * the sender's UDP packet header payload length, minus the
-						 * size of the UDP header.
-						 *
-						 * The size of the UDP packet structure in this implementation
-						 * includes the size of the Ethernet header, the size of
-						 * the IP header, and the size of the UDP header.
+						/* The UDP payload size can be calculated by subtracting the
+						 * header size from `xDataLength`.
+						 * However, the `xDataLength` may be longer that expected,
+						 * e.g. when a small packet is padded with zero's.
+						 * The UDP header contains a field `usLength` reflecting
+						 * the payload size plus the UDP header ( 8 bytes ).
+						 * Set `xDataLength` to the size of the headers,
+						 * plus the lower of the two calculated payload sizes.
 						 */
 
 						uxPayloadSize_1 = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -1612,8 +1612,9 @@ uint8_t ucProtocol;
 
 					/* Only proceed if the payload length indicated in the header
 					appears to be valid. */
-					if ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) )
+					if ( ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) ) && ( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) >= sizeof( UDPHeader_t ) ) )
 					{
+					size_t uxPayloadSize_1, uxPayloadSize_2;
 						/* Ensure that downstream UDP packet handling has the lesser
 						 * of: the actual network buffer Ethernet frame length, or
 						 * the sender's UDP packet header payload length, minus the
@@ -1624,11 +1625,11 @@ uint8_t ucProtocol;
 						 * the IP header, and the size of the UDP header.
 						 */
 
-						pxNetworkBuffer->xDataLength -= sizeof( UDPPacket_t );
-						if( ( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) - sizeof( UDPHeader_t ) ) <
-								pxNetworkBuffer->xDataLength )
+						uxPayloadSize_1 = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+						uxPayloadSize_2 = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) - sizeof( UDPHeader_t );
+						if( uxPayloadSize_1 > uxPayloadSize_2 )
 						{
-							pxNetworkBuffer->xDataLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) - sizeof( UDPHeader_t );
+							pxNetworkBuffer->xDataLength = uxPayloadSize_2 + sizeof( UDPPacket_t );
 						}
 
 						/* Fields in pxNetworkBuffer (usPort, ulIPAddress) are network order. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
@@ -704,7 +704,7 @@ EventBits_t xEventBits = ( EventBits_t ) 0;
 
 		/* The returned value is the data length, which may have been capped to
 		the receive buffer size. */
-		lReturn = ( int32_t ) pxNetworkBuffer->xDataLength;
+		lReturn = ( int32_t ) pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
 
 		if( pxSourceAddress != NULL )
 		{

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
@@ -833,7 +833,8 @@ FreeRTOS_Socket_t *pxSocket;
 
 			if( pxNetworkBuffer != NULL )
 			{
-				pxNetworkBuffer->xDataLength = xTotalDataLength;
+				/* xDataLength is the size of the total packet, including the Ethernet header. */
+				pxNetworkBuffer->xDataLength = xTotalDataLength + sizeof( UDPPacket_t );
 				pxNetworkBuffer->usPort = pxDestinationAddress->sin_port;
 				pxNetworkBuffer->usBoundPort = ( uint16_t ) socketGET_SOCKET_PORT( pxSocket );
 				pxNetworkBuffer->ulIPAddress = pxDestinationAddress->sin_addr;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
@@ -702,9 +702,11 @@ EventBits_t xEventBits = ( EventBits_t ) 0;
 		}
 		taskEXIT_CRITICAL();
 
-		/* The returned value is the data length, which may have been capped to
-		the receive buffer size. */
-		lReturn = ( int32_t ) pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+		/* The returned value is the length of the payload data, which is
+		calculated at the total packet size minus the headers.
+		The validity of `xDataLength` prvProcessIPPacket has been confirmed
+		in 'prvProcessIPPacket()'. */
+		lReturn = ( int32_t ) ( pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t ) );
 
 		if( pxSourceAddress != NULL )
 		{

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c
@@ -78,9 +78,21 @@ UDPPacket_t *pxUDPPacket;
 IPHeader_t *pxIPHeader;
 eARPLookupResult_t eReturned;
 uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
+size_t uxPayloadSize;
 
 	/* Map the UDP packet onto the start of the frame. */
 	pxUDPPacket = ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
+
+#if ipconfigSUPPORT_OUTGOING_PINGS == 1
+	if( pxNetworkBuffer->usPort == ipPACKET_CONTAINS_ICMP_DATA )
+	{
+		uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
+	}
+	else
+#endif
+	{
+		uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+	}
 
 	/* Determine the ARP cache status for the requested IP address. */
 	eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ) );
@@ -109,7 +121,7 @@ uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
 
 				pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
 				pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
-				pxUDPHeader->usLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength + sizeof( UDPHeader_t ) );
+				pxUDPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( UDPHeader_t ) );
 				pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
 				pxUDPHeader->usChecksum = 0u;
 			}
@@ -143,16 +155,14 @@ uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
 			if( pxNetworkBuffer->usPort == ipPACKET_CONTAINS_ICMP_DATA )
 			{
 				pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
-				pxIPHeader->usLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength + sizeof( IPHeader_t ) );
+				pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
 			}
 			else
 		#endif /* ipconfigSUPPORT_OUTGOING_PINGS */
 			{
-				pxIPHeader->usLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
+				pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
 			}
 
-			/* The total transmit size adds on the Ethernet header. */
-			pxNetworkBuffer->xDataLength = pxIPHeader->usLength + sizeof( EthernetHeader_t );
 			pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
 			/* HT:endian: changed back to network endian */
 			pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;


### PR DESCRIPTION
Description
-----------
A network buffer (`NetworkBufferDescriptor_t`) has a field `xDataLength`. This is the total length of the buffer. It includes the 14-byte Ethernet header and everything after that.

Just recently, @aggarg  wanted to add a length check in the function `vARPGenerateRequestPacket()`, something like:

~~~c
	configASSERT( pxNetworkBuffer->xDataLength >= sizeof(ARPPacket_t) )
~~~

This function failed because there are two cases in which `xDataLength` has a different meaning.

- In an outgoing ICMP/ping packet, it means the number of bytes to send plus the size of an ICMP header.
- In an outgoing UDP packet, it is the payload size ( without the UDP header ).

In order to avoid confusion, I'd like to correct that: `xDataLength` will always contain the total number of bytes.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.