### PR TITLE
AFR NimBLE: Wait for eBLEHALEventIndicateCb event in BLE_Write_Notification_Size_Greater_Than_MTU_3

### DIFF
--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -403,6 +403,7 @@ TEST( Full_BLE_Integration_Test_Advertisement, BLE_Advertise_Interval_Consistent
 TEST( Full_BLE_Integration_Test_Connection, BLE_Write_Notification_Size_Greater_Than_MTU_3 )
 {
     BTStatus_t xStatus, xfStatus;
+    BLETESTindicateCallback_t xIndicateEvent;
 
     IotTestBleHal_checkNotificationIndication( bletestATTR_SRVCB_CCCD_E, true );
 
@@ -415,6 +416,8 @@ TEST( Full_BLE_Integration_Test_Connection, BLE_Write_Notification_Size_Greater_
                                                         ucLargeBuffer,
                                                         false );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+
+    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventIndicateCb, NO_HANDLE, ( void * ) &xIndicateEvent, sizeof( BLETESTindicateCallback_t ), BLE_TESTS_WAIT );
 
     IotTestBleHal_checkNotificationIndication( bletestATTR_SRVCB_CCCD_E, false );
 }


### PR DESCRIPTION
In `BLE_Write_Notification_Size_Greater_Than_MTU_3` (integration tests), test should wait for `eBLEHALEventIndicateCb` event after sending notification.   

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
After sending notification, stack sends GAP event `BLE_GAP_EVENT_NOTIFY_TX` to tell the application that notification transmission was attempted. This is followed by calling callback `prvIndicationSentCb`, where event  `eBLEHALEventIndicateCb` is pushed to queue. Since test does not wait for event to become available in current implementation, it gives invalid results e.g. if followed with `BLE_Send_Data_After_Disconnected` test, where after disconnection sending notification should be unsuccessful but results in success. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.