### PR TITLE
Fix compilation issues with ARM and IAR compilers

### DIFF
--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -87,7 +87,6 @@ if(EXISTS "${AFR_3RDPARTY_DIR}/lwip" AND NOT "${AFR_BOARD}" STREQUAL "pc.windows
         afr_3rdparty_lwip
         PUBLIC
             "${AFR_3RDPARTY_DIR}/lwip/src/include"
-            "${AFR_3RDPARTY_DIR}/lwip/src/include/lwip"
             "${AFR_MODULES_ABSTRACTIONS_DIR}/lwip_osal/include"
     )
     target_link_libraries(

--- a/libraries/3rdparty/tracealyzer_recorder/streamports/TCPIP/trcStreamingPort.c
+++ b/libraries/3rdparty/tracealyzer_recorder/streamports/TCPIP/trcStreamingPort.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Trace Recorder Library for Tracealyzer v3.1.2
+ * Trace Recorder Library for Tracealyzer v4.3.5.1
  * Percepio AB, www.percepio.com
  *
  * trcStreamingPort.c
@@ -53,8 +53,7 @@
 /* TCP/IP includes */
 #include "lwip/tcpip.h"
 #include "lwip/sockets.h"
-
-int errno;
+#include "lwip/errno.h"
 
 #define TRC_TCPIP_PORT 12000
 

--- a/libraries/abstractions/lwip_osal/include/arch/cc.h
+++ b/libraries/abstractions/lwip_osal/include/arch/cc.h
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <stdlib.h> /* abort */
 /*#include <errno.h> */
-#if ( !defined( __CC_ARM ) ) && ( !defined( __ICCARM__ ) )
+#if ( !defined( __CC_ARM ) ) && ( !defined( __ICCARM__ ) ) && ( !defined( __ARMCC_VERSION ) )
     #include <sys/time.h>
 #endif
 
@@ -59,7 +59,9 @@
     #pragma warning (disable: 4103) /* structure packing changed by including file */
 #endif
 
-#define LWIP_PROVIDE_ERRNO
+#if !defined( LWIP_PROVIDE_ERRNO ) && !defined( LWIP_ERRNO_INCLUDE ) && !defined( LWIP_ERRNO_STDINCLUDE )
+    #define LWIP_PROVIDE_ERRNO
+#endif
 
 /* Define generic types used in lwIP */
 #define LWIP_NO_STDINT_H    1
@@ -85,6 +87,7 @@ typedef u32_t            sys_prot_t;
 
 /* Compiler hints for packing structures */
 #if defined( __ICCARM__ )
+    #define PACK_STRUCT_BEGIN     __packed
     #define PACK_STRUCT_STRUCT    __packed
 #else
     #define PACK_STRUCT_STRUCT    __attribute__( ( packed ) )

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -36,8 +36,8 @@
 #include "iot_secure_sockets.h"
 
 
-#include "sockets.h"
-#include "netdb.h"
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
 
 #include "iot_wifi.h"
 

--- a/tools/cmake/toolchains/arm-armclang.cmake
+++ b/tools/cmake/toolchains/arm-armclang.cmake
@@ -1,0 +1,31 @@
+include("${CMAKE_CURRENT_LIST_DIR}/find_compiler.cmake")
+
+set(CMAKE_SYSTEM_NAME Generic)
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+  set(CMAKE_SYSTEM_PROCESSOR cortex-m4)
+endif()
+
+# Find Keil for ARM.
+afr_find_compiler(AFR_COMPILER_CC armclang)
+afr_find_compiler(AFR_COMPILER_CXX armclang)
+afr_find_compiler(AFR_COMPILER_ASM armasm)
+
+# Specify the cross compiler.
+set(CMAKE_C_COMPILER ${AFR_COMPILER_CC} CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER ${AFR_COMPILER_CXX} CACHE FILEPATH "C++ compiler")
+set(CMAKE_ASM_COMPILER ${AFR_COMPILER_ASM} CACHE FILEPATH "ASM compiler")
+
+# Disable compiler checks.
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+# Add target system root to cmake find path.
+get_filename_component(AFR_COMPILER_DIR "${AFR_COMPILER_CC}" DIRECTORY)
+get_filename_component(CMAKE_FIND_ROOT_PATH "${AFR_COMPILER_DIR}" DIRECTORY)
+
+# Don't look for executable in target system prefix.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# Look for includes and libraries only in the target system prefix.
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
<!--- Title -->
Fix compilation issues with ARM and IAR compilers

Description
-----------
- Add CMake toolchain file for ARM Compiler 6
  - arm-armclang.cmake is based on arm-keil.cmake
  - CMake 3.15 or newer is required to detect ARMClang
  - CMake requires the CMAKE_SYSTEM_PROCESSOR variable to be configured
    in order to detect ARMClang
- LwIP: ARM Compiler does not provide sys/time.h
- LwIP: Allow overriding LwIP's errno declaration
  - cc.h no longer defines LWIP_PROVIDE_ERRNO when
    LWIP_ERRNO_STDINCLUDE or LWIP_ERRNO_INCLUDE is defined
  - Remove libraries/3rdparty/lwip/src/include/lwip from the include
    path because LwIP's errno.h conflicts with the standard library's
    errno.h
  - Update source files that contained unqualified paths to LwIP 
    header files
- LwIP: Fix incorrect struct packing with IAR EWARM
  - When __packed appears before the struct keyword, it affects the
    alignment of each member of the structure. When __packed appears
    after the struct keyword, it affects the alignment of the struct
    type itself.

errno Notes
-----------
There are several possible definitions of `errno`:
- C/C++ standard library. The C specification only requires EDOM, EILSEQ, and ERANGE.
- LwIP (lwip/errno.h). LwIP uses some custom and/or POSIX-defined errno values which it can optionally define if the system headers do not.
- FreeRTOS+POSIX: Also provides some POSIX-defined errno values.

However, there are some issues with using alternate errno implementations:
1. When you use `errno`, it's hard to tell which one you are referring to.
2. In the C specification, errno is a macro. Attempting to define it as a variable could cause a confusing compiler error message due to macro substitution.
3. The C library is free to assign any values to the ERRNO constants. These may or may not be equivalent to LwIP's or FreeRTOS+POSIX's values which could cause macro redefinition errors and/or confusion about the meaning of the numeric values.
4. Implementing errno as a (non-thread-local) variable is not thread-safe. FreeRTOS+POSIX and most multithread-aware C libraries have a thread-local implementation of errno but LwIP does not.

The Cypress projects are using the C library's errno with a custom header (via LWIP_ERRNO_INCLUDE) to define the additional values expected by LwIP.

Compatibility Notes
------------------
After this change, directives that refer to LwIP headers must use the directory name (e.g. lwip/socket.h). This change only affects CMake builds. I have searched for common LwIP header names in the in-tree targets but I have not verified whether all targets still compile.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

As far as I can tell none of the in-tree projects use cmake with armclang or IAR so I have only been able to compile with unpublished Cypress-specific targets. The Cypress targets seem to boot with these changes but I have not run a full test suite yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.