### PR TITLE
Clean up PKCS #11 FindObject if error occurs

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2615,6 +2615,16 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
         }
     }
 
+    /* Clean up memory if there was an error finding the object. */
+    if( xResult != CKR_OK )
+    {
+        if( pxSession->pxFindObjectLabel != NULL )
+        {
+            vPortFree( pxSession->pxFindObjectLabel );
+            pxSession->pxFindObjectLabel = NULL;
+        }
+    }
+
     return xResult;
 }
 

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -363,16 +363,24 @@ static CK_RV prvDestroyTestCredentials( void )
     CK_BYTE * pxPkcsLabels[] =
     {
         ( CK_BYTE * ) pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS,
-        ( CK_BYTE * ) pkcs11testLABEL_CODE_VERIFICATION_KEY,
         ( CK_BYTE * ) pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-        ( CK_BYTE * ) pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
+        ( CK_BYTE * ) pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
+        #if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED == 1 )
+            ( CK_BYTE * ) pkcs11testLABEL_CODE_VERIFICATION_KEY,
+            ( CK_BYTE * ) pkcs11testLABEL_JITP_CERTIFICATE,
+            ( CK_BYTE * ) pkcs11testLABEL_ROOT_CERTIFICATE
+        #endif
     };
     CK_OBJECT_CLASS xClass[] =
     {
         CKO_CERTIFICATE,
-        CKO_PUBLIC_KEY,
         CKO_PRIVATE_KEY,
-        CKO_PUBLIC_KEY
+        CKO_PUBLIC_KEY,
+        #if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED == 1 )
+            CKO_PUBLIC_KEY,
+            CKO_CERTIFICATE,
+            CKO_CERTIFICATE
+        #endif
     };
 
     xResult = xDestroyProvidedObjects( xGlobalSession,

--- a/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
+++ b/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
@@ -330,7 +330,7 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
         xResult = pxFunctionList->C_FindObjectsFinal( xSession );
     }
 
-    if( ( CKR_OK == xResult ) && ( ulCount == 0 ) )
+    if( ( CKR_ARGUMENTS_BAD != xResult ) && ( ulCount == 0 ) )
     {
         *pxHandle = CK_INVALID_HANDLE;
     }

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
                               sizeof( pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
         {
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
-            *pHandle = eInvalidHandle; /* OTA & Code Signing Keys are not supported on this platform. */
+            *pHandle = eAwsCodeSigningKey;
         }
         else
         {
@@ -180,6 +180,12 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
     return xHandle;
 }
 
+
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+    uint8_t ** ppucData,
+    uint32_t * pulDataSize,
+    CK_BBOOL * pIsPrivate );
+    
 /**
 * @brief Translates a PKCS #11 label into an object handle.
 *
@@ -198,9 +204,24 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
+    uint8_t * pucData = NULL;
+    uint32_t xDataSize = 0;
+    CK_BBOOL xIsPrivate = CK_FALSE;
+    CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
     prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+
+    if (xHandle != CK_INVALID_HANDLE)
+    {
+        /* Attempt to read the object to see if something valid is there. */
+        xResult = PKCS11_PAL_GetObjectValue(xHandle, &pucData, &xDataSize, &xIsPrivate );
+
+        if (xResult != CK_INVALID_HANDLE)
+        {
+            xHandle = 0;
+        }
+    }
 
     return xHandle;
 }

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
                               sizeof( pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
         {
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
-            *pHandle = eAwsCodeSigningKey;
+            *pHandle = eInvalidHandle; /* OTA & Code Signing Keys are not supported on this platform. */
         }
         else
         {

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
                               sizeof( pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
         {
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
-            *pHandle = eInvalidHandle; /* OTA & Code Signing Keys are not supported on this platform. */
+            *pHandle = eAwsCodeSigningKey;
         }
         else
         {
@@ -180,6 +180,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
     return xHandle;
 }
 
+
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+    uint8_t ** ppucData,
+    uint32_t * pulDataSize,
+    CK_BBOOL * pIsPrivate );
 /**
 * @brief Translates a PKCS #11 label into an object handle.
 *
@@ -198,9 +203,24 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
+    uint8_t * pucData = NULL;
+    uint32_t xDataSize = 0;
+    CK_BBOOL xIsPrivate = CK_FALSE;
+    CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
     prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+
+    if (xHandle != CK_INVALID_HANDLE)
+    {
+        /* Attempt to read the object to see if something valid is there. */
+        xResult = PKCS11_PAL_GetObjectValue(xHandle, &pucData, &xDataSize, &xIsPrivate );
+
+        if (xResult != CK_INVALID_HANDLE)
+        {
+            xHandle = 0;
+        }
+    }
 
     return xHandle;
 }

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,7 +98,7 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
                               sizeof( pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
         {
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
-            *pHandle = eAwsCodeSigningKey;
+            *pHandle = eInvalidHandle; /* OTA & Code Signing Keys are not supported on this platform. */
         }
         else
         {

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -176,12 +176,17 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
+    uint8_t * pFile = NULL;
+    size_t xFileLength = 0;
 
     /* Translate from the PKCS#11 label to local storage file name. */
     prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
 
-    /*TODO: check if file actually there.
-     * Note: g_cert_files only seems to check if the entry in the array is present */
+    /* Check if the file exists. */
+    if( pdFALSE == mflash_read_file( pcFileName, &pFile, &xFileLength ) )
+    {
+        xHandle = eInvalidHandle;
+    }
 
     return xHandle;
 }
@@ -293,7 +298,7 @@ extern CK_RV prvMbedTLS_Initialize( void );
 #endif
 
 CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
-{   /*lint !e9072 It's OK to have different parameter name. */
+{ /*lint !e9072 It's OK to have different parameter name. */
     ( void ) ( pvInitArgs );
 
     CK_RV xResult = CKR_OK;


### PR DESCRIPTION
In #1498 https://github.com/aws/amazon-freertos/commit/6d86aab2383e730c08a81d66acb8d533eada9d2b
a bug was fixed in xFindObjectWithLabelAndClass.

xFindObjectWithLabelAndClass calls a sequence of operations, C_FindObjectInit, C_FindObject, C_FindObjectFinal.   Previously, the error code from C_FindObject was overwritten by the error code in C_FindObjectFinal.  After the fix, the error from C_FindObject is propagated properly, exposing an issue in several PAL layers where PKCS11_PAL_FindObject returned a valid object handle when non exists.

This fix cleans up some logic in the use of FindObject and corrects these PALs.

Description --> Fixes regression in NXP and Cypress PKCS #11 tests.
-----------
Cypress: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/cypress/job/cypress54-ide/136/console
NXP: https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/nxp/job/lpc54018iotmodule-ide/149/console
PC:
https://amazon-freertos-ci.corp.amazon.com/job/master/job/custom/job/pc/job/windows-ide/115/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.