### PR TITLE
Fix for prvConnectHelperWithRetry function in iot_test_tcp.c

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -448,6 +448,8 @@ static BaseType_t prvConnectHelperWithRetry( volatile Socket_t * pxSocket,
         if( SOCKETS_INVALID_SOCKET == *pxSocket )
         {
             xResult = SOCKETS_SOCKET_ERROR;
+            tcptestFAILUREPRINTF( ( "Failed to allocate Socket Descriptor \r\n" ) );
+            break;
         }
 
         /* Set the appropriate socket options for the destination. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
The function ```prvTcpSocketHelper``` called by ```prvConnectHelperWithRetry``` returns error code, if Socket cannot be allocated and the error code is stored in variable ```xResult```.

Previously this variable was never addressed after an error is received. Thus, the code runs in an infinite loop(which is not expected). This is the reason for failure of ```AFQP_SOCKETS_Threadsafe_DifferentSocketsDifferentTasks``` test-case.

The expected behaviour is; the function should retry obtaining a socket repetitively after a specific delay.

In prvConnectHelperWithRetry, check is added to retry until valid socket is received.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.