### PR TITLE
FreeRTOS+TCP: Revisiting the network interface for Renesas RX65N

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -16,18 +16,20 @@
 *
 * Copyright (C) 2018 Renesas Electronics Corporation. All rights reserved.
 ***********************************************************************************************************************/
+
 /***********************************************************************************************************************
 * File Name    : NetworkInterface.c
 * Device(s)    : RX
 * Description  : Interfaces FreeRTOS TCP/IP stack to RX Ethernet driver.
 ***********************************************************************************************************************/
+
 /***********************************************************************************************************************
 * History : DD.MM.YYYY Version  Description
 *         : 07.03.2018 0.1     Development
 ***********************************************************************************************************************/
 
 /***********************************************************************************************************************
-Includes   <System Includes> , "Project Includes"
+*  Includes   <System Includes> , "Project Includes"
 ***********************************************************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
@@ -39,7 +41,7 @@ Includes   <System Includes> , "Project Includes"
 #include "task.h"
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
-//#include "FreeRTOS_DNS.h"
+/*#include "FreeRTOS_DNS.h" */
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
 
@@ -47,28 +49,29 @@ Includes   <System Includes> , "Project Includes"
 #include "r_pinset.h"
 
 /***********************************************************************************************************************
- Macro definitions
+ * Macro definitions
  **********************************************************************************************************************/
-#define ETHER_BUFSIZE_MIN 60
+#define ETHER_BUFSIZE_MIN    60
 
-#if defined(BSP_MCU_RX65N) || defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX71M)
-#if ETHER_CFG_MODE_SEL == 0
-#define R_ETHER_PinSet_CHANNEL_0()  R_ETHER_PinSet_ETHERC0_MII()
-#elif ETHER_CFG_MODE_SEL == 1
-#define R_ETHER_PinSet_CHANNEL_0()  R_ETHER_PinSet_ETHERC0_RMII()
-#endif
-#elif defined(BSP_MCU_RX63N)
-#if ETHER_CFG_MODE_SEL == 0
-#define R_ETHER_PinSet_CHANNEL_0()  R_ETHER_PinSet_ETHERC_MII()
-#elif ETHER_CFG_MODE_SEL == 1
-#define R_ETHER_PinSet_CHANNEL_0()  R_ETHER_PinSet_ETHERC_RMII()
-#endif
-#endif
+#if defined( BSP_MCU_RX65N ) || defined( BSP_MCU_RX64M ) || defined( BSP_MCU_RX71M )
+    #if ETHER_CFG_MODE_SEL == 0
+        #define R_ETHER_PinSet_CHANNEL_0()    R_ETHER_PinSet_ETHERC0_MII()
+    #elif ETHER_CFG_MODE_SEL == 1
+        #define R_ETHER_PinSet_CHANNEL_0()    R_ETHER_PinSet_ETHERC0_RMII()
+    #endif
+#elif defined( BSP_MCU_RX63N )
+    #if ETHER_CFG_MODE_SEL == 0
+        #define R_ETHER_PinSet_CHANNEL_0()    R_ETHER_PinSet_ETHERC_MII()
+    #elif ETHER_CFG_MODE_SEL == 1
+        #define R_ETHER_PinSet_CHANNEL_0()    R_ETHER_PinSet_ETHERC_RMII()
+    #endif
+#endif /* if defined( BSP_MCU_RX65N ) || defined( BSP_MCU_RX64M ) || defined( BSP_MCU_RX71M ) */
 
 #ifndef PHY_LS_HIGH_CHECK_TIME_MS
-    /* Check if the LinkSStatus in the PHY is still high after 2 seconds of not
-    receiving packets. */
-    #define PHY_LS_HIGH_CHECK_TIME_MS   2000
+
+/* Check if the LinkSStatus in the PHY is still high after 2 seconds of not
+ * receiving packets. */
+    #define PHY_LS_HIGH_CHECK_TIME_MS    2000
 #endif
 
 #ifndef PHY_LS_LOW_CHECK_TIME_MS
@@ -77,13 +80,13 @@ Includes   <System Includes> , "Project Includes"
 #endif
 
 /***********************************************************************************************************************
- Private global variables and functions
+ * Private global variables and functions
  **********************************************************************************************************************/
 typedef enum
 {
-    eMACInit,                               /* Must initialise MAC. */
-    eMACPass,                               /* Initialisation was successful. */
-    eMACFailed,                             /* Initialisation failed. */
+    eMACInit,   /* Must initialise MAC. */
+    eMACPass,   /* Initialisation was successful. */
+    eMACFailed, /* Initialisation failed. */
 } eMAC_INIT_STATUS_TYPE;
 
 static TaskHandle_t ether_receive_check_task_handle = 0;
@@ -93,17 +96,19 @@ static BaseType_t xPHYLinkStatus;
 static BaseType_t xReportedStatus;
 static eMAC_INIT_STATUS_TYPE xMacInitStatus = eMACInit;
 
-static int16_t SendData( uint8_t *pucBuffer, size_t length );
-static int InitializeNetwork(void);
-static void prvEMACDeferredInterruptHandlerTask( void *pvParameters );
-static void clear_all_ether_rx_discriptors(uint32_t event);
+static int16_t SendData( uint8_t * pucBuffer,
+                         size_t length );
+static int InitializeNetwork( void );
+static void prvEMACDeferredInterruptHandlerTask( void * pvParameters );
+static void clear_all_ether_rx_discriptors( uint32_t event );
 
-int32_t callback_ether_regist(void);
-void EINT_Trig_isr(void *);
-void get_random_number(uint8_t *data, uint32_t len);
+int32_t callback_ether_regist( void );
+void EINT_Trig_isr( void * );
+void get_random_number( uint8_t * data,
+                        uint32_t len );
 
 void prvLinkStatusChange( BaseType_t xStatus );
-static void prvMonitorResources(void);
+static void prvMonitorResources( void );
 
 /***********************************************************************************************************************
  * Function Name: xNetworkInterfaceInitialise ()
@@ -132,6 +137,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
             /* Indicate that the MAC initialisation succeeded. */
             xMacInitStatus = eMACPass;
         }
+
         configPRINTF( ( "InitializeNetwork returns %s\n", ( xMacInitStatus == eMACPass ) ? "OK" : " Fail" ) );
     }
 
@@ -156,21 +162,22 @@ BaseType_t xNetworkInterfaceInitialise( void )
  * Arguments    : pxDescriptor, xReleaseAfterSend
  * Return Value : pdTRUE, pdFALSE
  **********************************************************************************************************************/
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t xReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor,
+                                    BaseType_t xReleaseAfterSend )
 {
     BaseType_t xReturn = pdFALSE;
 
     /* Simple network interfaces (as opposed to more efficient zero copy network
-    interfaces) just use Ethernet peripheral driver library functions to copy
-    data from the FreeRTOS+TCP buffer into the peripheral driver's own buffer.
-    This example assumes SendData() is a peripheral driver library function that
-    takes a pointer to the start of the data to be sent and the length of the
-    data to be sent as two separate parameters.  The start of the data is located
-    by pxDescriptor->pucEthernetBuffer.  The length of the data is located
-    by pxDescriptor->xDataLength. */
+     * interfaces) just use Ethernet peripheral driver library functions to copy
+     * data from the FreeRTOS+TCP buffer into the peripheral driver's own buffer.
+     * This example assumes SendData() is a peripheral driver library function that
+     * takes a pointer to the start of the data to be sent and the length of the
+     * data to be sent as two separate parameters.  The start of the data is located
+     * by pxDescriptor->pucEthernetBuffer.  The length of the data is located
+     * by pxDescriptor->xDataLength. */
     if( xPHYLinkStatus != 0 )
     {
-        if(SendData( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength ) >= 0)
+        if( SendData( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength ) >= 0 )
         {
             xReturn = pdTRUE;
             /* Call the standard trace macro to log the send event. */
@@ -185,8 +192,8 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescript
     if( xReleaseAfterSend != pdFALSE )
     {
         /* It is assumed SendData() copies the data out of the FreeRTOS+TCP Ethernet
-        buffer.  The Ethernet buffer is therefore no longer needed, and must be
-        freed for re-use. */
+         * buffer.  The Ethernet buffer is therefore no longer needed, and must be
+         * freed for re-use. */
         vReleaseNetworkBufferAndDescriptor( pxDescriptor );
     }
 
@@ -204,19 +211,19 @@ static void prvMonitorResources()
     size_t uxCurSize;
 
     uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
+
     if( uxLastMinBufferCount != uxCurrentBufferCount )
     {
         /* The logging produced below may be helpful
-        while tuning +TCP: see how many buffers are in use. */
+         * while tuning +TCP: see how many buffers are in use. */
         uxLastMinBufferCount = uxCurrentBufferCount;
         FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-            uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
+                           uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
     }
 
     uxMinSize = xPortGetMinimumEverFreeHeapSize();
     uxCurSize = xPortGetFreeHeapSize();
 
-//      if( ( uxCurLastSize != uxCurSize ) || ( uxMinLastSize != uxMinSize ) )
     if( uxMinLastSize != uxMinSize )
     {
         uxCurLastSize = uxCurSize;
@@ -224,20 +231,21 @@ static void prvMonitorResources()
         FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", uxCurSize, uxMinSize ) );
     }
 
-    #if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-    {
-    static UBaseType_t uxLastMinQueueSpace = 0;
-    UBaseType_t uxCurrentCount = 0u;
-
-        uxCurrentCount = uxGetMinimumIPQueueSpace();
-        if( uxLastMinQueueSpace != uxCurrentCount )
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
         {
-            /* The logging produced below may be helpful
-            while tuning +TCP: see how many buffers are in use. */
-            uxLastMinQueueSpace = uxCurrentCount;
-            FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+            static UBaseType_t uxLastMinQueueSpace = 0;
+            UBaseType_t uxCurrentCount = 0u;
+
+            uxCurrentCount = uxGetMinimumIPQueueSpace();
+
+            if( uxLastMinQueueSpace != uxCurrentCount )
+            {
+                /* The logging produced below may be helpful
+                 * while tuning +TCP: see how many buffers are in use. */
+                uxLastMinQueueSpace = uxCurrentCount;
+                FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+            }
         }
-    }
     #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 }
 
@@ -247,19 +255,19 @@ static void prvMonitorResources()
  * Arguments    : pvParameters
  * Return Value : none
  **********************************************************************************************************************/
-static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
+static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
 {
-    NetworkBufferDescriptor_t *pxBufferDescriptor;
+    NetworkBufferDescriptor_t * pxBufferDescriptor;
     int32_t xBytesReceived = 0;
 
     /* Avoid compiler warning about unreferenced parameter. */
     ( void ) pvParameters;
 
     /* Used to indicate that xSendEventStructToIPTask() is being called because
-    of an Ethernet receive event. */
+     * of an Ethernet receive event. */
     IPStackEvent_t xRxEvent;
 
-    uint8_t *buffer_pointer;
+    uint8_t * buffer_pointer;
 
     /* Some variables related to monitoring the PHY. */
     TimeOut_t xPhyTime;
@@ -272,19 +280,19 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
     configPRINTF( ( "Deferred Interrupt Handler Task started\n" ) );
     xTaskToNotify = ether_receive_check_task_handle;
 
-    for( ;; )
+    for( ; ; )
     {
         prvMonitorResources();
 
         /* Wait for the Ethernet MAC interrupt to indicate that another packet
-        has been received.  */
+         * has been received.  */
         if( xBytesReceived <= 0 )
         {
             ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
         }
 
         /* See how much data was received.  */
-        xBytesReceived = R_ETHER_Read_ZC2(ETHER_CHANNEL_0, (void **)&buffer_pointer);
+        xBytesReceived = R_ETHER_Read_ZC2( ETHER_CHANNEL_0, ( void ** ) &buffer_pointer );
 
         if( xBytesReceived < 0 )
         {
@@ -294,40 +302,40 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
         else if( xBytesReceived > 0 )
         {
             /* Allocate a network buffer descriptor that points to a buffer
-            large enough to hold the received frame.  As this is the simple
-            rather than efficient example the received data will just be copied
-            into this buffer. */
-            pxBufferDescriptor = pxGetNetworkBufferWithDescriptor( (size_t)xBytesReceived, 0 );
+             * large enough to hold the received frame.  As this is the simple
+             * rather than efficient example the received data will just be copied
+             * into this buffer. */
+            pxBufferDescriptor = pxGetNetworkBufferWithDescriptor( ( size_t ) xBytesReceived, 0 );
 
             if( pxBufferDescriptor != NULL )
             {
                 /* pxBufferDescriptor->pucEthernetBuffer now points to an Ethernet
-                buffer large enough to hold the received data.  Copy the
-                received data into pcNetworkBuffer->pucEthernetBuffer.  Here it
-                is assumed ReceiveData() is a peripheral driver function that
-                copies the received data into a buffer passed in as the function's
-                parameter.  Remember! While is is a simple robust technique -
-                it is not efficient.  An example that uses a zero copy technique
-                is provided further down this page. */
-                memcpy(pxBufferDescriptor->pucEthernetBuffer, buffer_pointer, (size_t)xBytesReceived);
-                //ReceiveData( pxBufferDescriptor->pucEthernetBuffer );
+                 * buffer large enough to hold the received data.  Copy the
+                 * received data into pcNetworkBuffer->pucEthernetBuffer.  Here it
+                 * is assumed ReceiveData() is a peripheral driver function that
+                 * copies the received data into a buffer passed in as the function's
+                 * parameter.  Remember! While is is a simple robust technique -
+                 * it is not efficient.  An example that uses a zero copy technique
+                 * is provided further down this page. */
+                memcpy( pxBufferDescriptor->pucEthernetBuffer, buffer_pointer, ( size_t ) xBytesReceived );
+                /*ReceiveData( pxBufferDescriptor->pucEthernetBuffer ); */
 
                 /* Set the actual packet length, in case a larger buffer was returned. */
-                pxBufferDescriptor->xDataLength = (size_t)xBytesReceived;
+                pxBufferDescriptor->xDataLength = ( size_t ) xBytesReceived;
 
-                R_ETHER_Read_ZC2_BufRelease(ETHER_CHANNEL_0);
+                R_ETHER_Read_ZC2_BufRelease( ETHER_CHANNEL_0 );
 
                 /* See if the data contained in the received Ethernet frame needs
-                to be processed.  NOTE! It is preferable to do this in
-                the interrupt service routine itself, which would remove the need
-                to unblock this task for packets that don't need processing. */
+                 * to be processed.  NOTE! It is preferable to do this in
+                 * the interrupt service routine itself, which would remove the need
+                 * to unblock this task for packets that don't need processing. */
                 if( eConsiderFrameForProcessing( pxBufferDescriptor->pucEthernetBuffer ) == eProcessBuffer )
                 {
                     /* The event about to be sent to the TCP/IP is an Rx event. */
                     xRxEvent.eEventType = eNetworkRxEvent;
 
                     /* pvData is used to point to the network buffer descriptor that
-                    now references the received data. */
+                     * now references the received data. */
                     xRxEvent.pvData = ( void * ) pxBufferDescriptor;
 
                     /* Send the data to the TCP/IP stack. */
@@ -338,12 +346,12 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
 
                         /* Make a call to the standard trace macro to log the occurrence. */
                         iptraceETHERNET_RX_EVENT_LOST();
-                        clear_all_ether_rx_discriptors(0);
+                        clear_all_ether_rx_discriptors( 0 );
                     }
                     else
                     {
                         /* The message was successfully sent to the TCP/IP stack.
-                        Call the standard trace macro to log the occurrence. */
+                         * Call the standard trace macro to log the occurrence. */
                         iptraceNETWORK_INTERFACE_RECEIVE();
                         R_NOP();
                     }
@@ -357,9 +365,9 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
             else
             {
                 /* The event was lost because a network buffer was not available.
-                Call the standard trace macro to log the occurrence. */
+                 * Call the standard trace macro to log the occurrence. */
                 iptraceETHERNET_RX_EVENT_LOST();
-                clear_all_ether_rx_discriptors(1);
+                clear_all_ether_rx_discriptors( 1 );
                 configPRINTF( ( "R_ETHER_Read_ZC2: Cleared descriptors\n" ) );
             }
         }
@@ -367,11 +375,12 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
         if( xBytesReceived > 0 )
         {
             /* A packet was received. No need to check for the PHY status now,
-            but set a timer to check it later on. */
+             * but set a timer to check it later on. */
             vTaskSetTimeOutState( &xPhyTime );
             xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+
             /* Indicate that the Link Status is high, so that
-            xNetworkInterfaceOutput() can send packets. */
+             * xNetworkInterfaceOutput() can send packets. */
             if( xPHYLinkStatus == 0 )
             {
                 xPHYLinkStatus = 1;
@@ -380,7 +389,7 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
         }
         else if( ( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE ) || ( FreeRTOS_IsNetworkUp() == pdFALSE ) )
         {
-            R_ETHER_LinkProcess(0);
+            R_ETHER_LinkProcess( 0 );
 
             if( xPHYLinkStatus != xReportedStatus )
             {
@@ -389,6 +398,7 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
             }
 
             vTaskSetTimeOutState( &xPhyTime );
+
             if( xPHYLinkStatus != 0 )
             {
                 xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
@@ -403,18 +413,6 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
 
 
 /***********************************************************************************************************************
- * Function Name: xApplicationDNSQueryHook ()
- * Description  :
- * Arguments    : pcName string pointer
- * Return Value :
- **********************************************************************************************************************/
-//BaseType_t xApplicationDNSQueryHook(const char *pcName )
-//{
-//    return strcmp( pcName, "RenesasRX" ); //TODO complete stub function
-//} /* End of function xApplicationDNSQueryHook() */
-
-
-/***********************************************************************************************************************
  * Function Name: vNetworkInterfaceAllocateRAMToBuffers ()
  * Description  : .
  * Arguments    : pxNetworkBuffers
@@ -423,16 +421,17 @@ static void prvEMACDeferredInterruptHandlerTask( void *pvParameters )
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint32_t ul;
-    uint8_t *buffer_address;
-    R_EXTERN_SEC(B_ETHERNET_BUFFERS_1)
+    uint8_t * buffer_address;
 
-    buffer_address = R_SECTOP(B_ETHERNET_BUFFERS_1);
+    R_EXTERN_SEC( B_ETHERNET_BUFFERS_1 )
+
+    buffer_address = R_SECTOP( B_ETHERNET_BUFFERS_1 );
 
     for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
     {
-        pxNetworkBuffers[ul].pucEthernetBuffer = (buffer_address + (ETHER_CFG_BUFSIZE * ul));
+        pxNetworkBuffers[ ul ].pucEthernetBuffer = ( buffer_address + ( ETHER_CFG_BUFSIZE * ul ) );
     }
-}  /* End of function vNetworkInterfaceAllocateRAMToBuffers() */
+} /* End of function vNetworkInterfaceAllocateRAMToBuffers() */
 
 
 /***********************************************************************************************************************
@@ -456,12 +455,12 @@ void prvLinkStatusChange( BaseType_t xStatus )
  * Arguments    : none
  * Return Value : pdTRUE, pdFALSE
  **********************************************************************************************************************/
-static int InitializeNetwork(void)
+static int InitializeNetwork( void )
 {
     ether_return_t eth_ret;
     BaseType_t return_code = pdFALSE;
-    ether_param_t   param;
-    uint8_t myethaddr[6] =
+    ether_param_t param;
+    uint8_t myethaddr[ 6 ] =
     {
         configMAC_ADDR0,
         configMAC_ADDR1,
@@ -469,35 +468,35 @@ static int InitializeNetwork(void)
         configMAC_ADDR3,
         configMAC_ADDR4,
         configMAC_ADDR5
-    }; //XXX Fix me
+    }; /*XXX Fix me */
 
     R_ETHER_PinSet_CHANNEL_0();
     R_ETHER_Initial();
     callback_ether_regist();
 
     param.channel = ETHER_CHANNEL_0;
-    eth_ret = R_ETHER_Control(CONTROL_POWER_ON, param);        // PHY mode settings, module stop cancellation
+    eth_ret = R_ETHER_Control( CONTROL_POWER_ON, param ); /* PHY mode settings, module stop cancellation */
 
-    if (ETHER_SUCCESS != eth_ret)
+    if( ETHER_SUCCESS != eth_ret )
     {
         return pdFALSE;
     }
 
-    eth_ret = R_ETHER_Open_ZC2(ETHER_CHANNEL_0, myethaddr, ETHER_FLAG_OFF);
+    eth_ret = R_ETHER_Open_ZC2( ETHER_CHANNEL_0, myethaddr, ETHER_FLAG_OFF );
 
-    if (ETHER_SUCCESS != eth_ret)
+    if( ETHER_SUCCESS != eth_ret )
     {
         return pdFALSE;
     }
 
-    return_code = xTaskCreate(prvEMACDeferredInterruptHandlerTask,
-                              "ETHER_RECEIVE_CHECK_TASK",
-                              512u,
-                              0,
-                              configMAX_PRIORITIES - 1,
-                              &ether_receive_check_task_handle);
+    return_code = xTaskCreate( prvEMACDeferredInterruptHandlerTask,
+                               "ETHER_RECEIVE_CHECK_TASK",
+                               512u,
+                               0,
+                               configMAX_PRIORITIES - 1,
+                               &ether_receive_check_task_handle );
 
-    if (pdFALSE == return_code)
+    if( pdFALSE == return_code )
     {
         return pdFALSE;
     }
@@ -512,33 +511,36 @@ static int InitializeNetwork(void)
  * Arguments    : pucBuffer, length
  * Return Value : 0 success, negative fail
  **********************************************************************************************************************/
-static int16_t SendData( uint8_t *pucBuffer, size_t length )//TODO complete stub function
+static int16_t SendData( uint8_t * pucBuffer,
+                         size_t length )                    /*TODO complete stub function */
 {
     ether_return_t ret;
     uint8_t * pwrite_buffer;
     uint16_t write_buf_size;
 
     /* (1) Retrieve the transmit buffer location controlled by the  descriptor. */
-    ret = R_ETHER_Write_ZC2_GetBuf(ETHER_CHANNEL_0, (void **) &pwrite_buffer, &write_buf_size);
+    ret = R_ETHER_Write_ZC2_GetBuf( ETHER_CHANNEL_0, ( void ** ) &pwrite_buffer, &write_buf_size );
 
-    if (ETHER_SUCCESS == ret)
+    if( ETHER_SUCCESS == ret )
     {
-        if (write_buf_size >= length)
+        if( write_buf_size >= length )
         {
-            memcpy(pwrite_buffer, pucBuffer, length);
+            memcpy( pwrite_buffer, pucBuffer, length );
         }
-        if (length < ETHER_BUFSIZE_MIN)                                         /*under minimum*/
+
+        if( length < ETHER_BUFSIZE_MIN )                                             /*under minimum*/
         {
-            memset((pwrite_buffer + length), 0, (ETHER_BUFSIZE_MIN - length));  /*padding*/
-            length = ETHER_BUFSIZE_MIN;                                         /*resize*/
+            memset( ( pwrite_buffer + length ), 0, ( ETHER_BUFSIZE_MIN - length ) ); /*padding*/
+            length = ETHER_BUFSIZE_MIN;                                              /*resize*/
         }
-        ret = R_ETHER_Write_ZC2_SetBuf(ETHER_CHANNEL_0, (uint16_t)length);
-        ret = R_ETHER_CheckWrite(ETHER_CHANNEL_0);
+
+        ret = R_ETHER_Write_ZC2_SetBuf( ETHER_CHANNEL_0, ( uint16_t ) length );
+        ret = R_ETHER_CheckWrite( ETHER_CHANNEL_0 );
     }
 
-    if (ETHER_SUCCESS != ret)
+    if( ETHER_SUCCESS != ret )
     {
-        return -5; // XXX return meaningful value
+        return -5; /* XXX return meaningful value */
     }
     else
     {
@@ -554,48 +556,50 @@ static int16_t SendData( uint8_t *pucBuffer, size_t length )//TODO complete stub
 * Return Value : None
 * Note         : This callback function is executed when EINT0 interrupt occurred.
 ***********************************************************************************************************************/
-void EINT_Trig_isr(void *ectrl)
+void EINT_Trig_isr( void * ectrl )
 {
-    ether_cb_arg_t *pdecode;
+    ether_cb_arg_t * pdecode;
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-    pdecode = (ether_cb_arg_t*)ectrl;
+    pdecode = ( ether_cb_arg_t * ) ectrl;
 
-    if (pdecode->status_eesr & 0x00040000)// EDMAC FR (Frame Receive Event) interrupt
+    if( pdecode->status_eesr & 0x00040000 ) /* EDMAC FR (Frame Receive Event) interrupt */
     {
-        if(xTaskToNotify != NULL)
+        if( xTaskToNotify != NULL )
         {
-            vTaskNotifyGiveFromISR(ether_receive_check_task_handle, &xHigherPriorityTaskWoken);
+            vTaskNotifyGiveFromISR( ether_receive_check_task_handle, &xHigherPriorityTaskWoken );
         }
+
         /* If xHigherPriorityTaskWoken is now set to pdTRUE then a context switch
-        should be performed to ensure the interrupt returns directly to the highest
-        priority task.  The macro used for this purpose is dependent on the port in
-        use and may be called portEND_SWITCHING_ISR(). */
+         * should be performed to ensure the interrupt returns directly to the highest
+         * priority task.  The macro used for this purpose is dependent on the port in
+         * use and may be called portEND_SWITCHING_ISR(). */
         portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-        //TODO complete interrupt handler for other events.
+        /*TODO complete interrupt handler for other events. */
     }
 } /* End of function EINT_Trig_isr() */
 
 
-static void clear_all_ether_rx_discriptors(uint32_t event)
+static void clear_all_ether_rx_discriptors( uint32_t event )
 {
     int32_t xBytesReceived;
-    uint8_t *buffer_pointer;
+    uint8_t * buffer_pointer;
 
     /* Avoid compiler warning about unreferenced parameter. */
-    (void)event;
+    ( void ) event;
 
-    while(1)
+    while( 1 )
     {
         /* See how much data was received.  */
-        xBytesReceived = R_ETHER_Read_ZC2(ETHER_CHANNEL_0, (void **)&buffer_pointer);
-        if(0 > xBytesReceived)
+        xBytesReceived = R_ETHER_Read_ZC2( ETHER_CHANNEL_0, ( void ** ) &buffer_pointer );
+
+        if( 0 > xBytesReceived )
         {
             /* This is an error. Ignored. */
         }
-        else if(0 < xBytesReceived)
+        else if( 0 < xBytesReceived )
         {
-            R_ETHER_Read_ZC2_BufRelease(ETHER_CHANNEL_0);
+            R_ETHER_Read_ZC2_BufRelease( ETHER_CHANNEL_0 );
             iptraceETHERNET_RX_EVENT_LOST();
         }
         else
@@ -606,5 +610,5 @@ static void clear_all_ether_rx_discriptors(uint32_t event)
 }
 
 /***********************************************************************************************************************
- End of file "NetworkInterface.c"
+ * End of file "NetworkInterface.c"
  **********************************************************************************************************************/

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -138,7 +138,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
             xMacInitStatus = eMACPass;
         }
 
-        configPRINTF( ( "InitializeNetwork returns %s\n", ( xMacInitStatus == eMACPass ) ? "OK" : " Fail" ) );
+        FreeRTOS_printf( ( "InitializeNetwork returns %s\n", ( xMacInitStatus == eMACPass ) ? "OK" : " Fail" ) );
     }
 
     if( xMacInitStatus == eMACPass )
@@ -150,7 +150,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
         xReturn = pdFAIL;
     }
 
-    configPRINTF( ( "xNetworkInterfaceInitialise returns %d\n", xReturn ) );
+    FreeRTOS_printf( ( "xNetworkInterfaceInitialise returns %d\n", xReturn ) );
 
     return xReturn;
 } /* End of function xNetworkInterfaceInitialise() */
@@ -277,7 +277,7 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
     vTaskSetTimeOutState( &xPhyTime );
     xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-    configPRINTF( ( "Deferred Interrupt Handler Task started\n" ) );
+    FreeRTOS_printf( ( "Deferred Interrupt Handler Task started\n" ) );
     xTaskToNotify = ether_receive_check_task_handle;
 
     for( ; ; )
@@ -297,7 +297,7 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
         if( xBytesReceived < 0 )
         {
             /* This is an error. Logged. */
-            configPRINTF( ( "R_ETHER_Read_ZC2: rc = %d\n", xBytesReceived ) );
+            FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d\n", xBytesReceived ) );
         }
         else if( xBytesReceived > 0 )
         {
@@ -368,7 +368,7 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
                  * Call the standard trace macro to log the occurrence. */
                 iptraceETHERNET_RX_EVENT_LOST();
                 clear_all_ether_rx_discriptors( 1 );
-                configPRINTF( ( "R_ETHER_Read_ZC2: Cleared descriptors\n" ) );
+                FreeRTOS_printf( ( "R_ETHER_Read_ZC2: Cleared descriptors\n" ) );
             }
         }
 
@@ -444,7 +444,7 @@ void prvLinkStatusChange( BaseType_t xStatus )
 {
     if( xReportedStatus != xStatus )
     {
-        configPRINTF( ( "prvLinkStatusChange( %d )\n", xStatus ) );
+        FreeRTOS_printf( ( "prvLinkStatusChange( %d )\n", xStatus ) );
         xReportedStatus = xStatus;
     }
 }

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/ether_callback.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/ether_callback.c
@@ -46,6 +46,11 @@ volatile uint8_t  link_detect[ETHER_CHANNEL_MAX];
 
 void EINT_Trig_isr(void *);
 
+/*
+ * When that Link Status changes, the following function will be called:
+ */
+void prvLinkStatusChange( BaseType_t xStatus );
+
 /***********************************************************************************************************************
 * Function Name: callback_ether
 * Description  : Regist of callback function
@@ -147,6 +152,7 @@ static void callback_link_on(uint32_t channel)
         link_detect[channel] = ETHER_FLAG_ON_LINK_ON;
 
         /* Please add necessary processing when becoming Link up. */
+		prvLinkStatusChange( 1 );
     }
 } /* End of function callback_link_on() */
 
@@ -164,6 +170,7 @@ static void callback_link_off(uint32_t channel)
         link_detect[channel] = ETHER_FLAG_ON_LINK_OFF;
 
         /* Please add necessary processing when becoming Link down. */
+		prvLinkStatusChange( 0 );
     }
 } /* End of function ether_cb_link_off() */
 

--- a/vendors/renesas/FIT/RDP_v1.15_modified/r_ether_rx/src/r_ether_rx.c
+++ b/vendors/renesas/FIT/RDP_v1.15_modified/r_ether_rx/src/r_ether_rx.c
@@ -1016,12 +1016,13 @@ void R_ETHER_LinkProcess (uint32_t channel)
                     cb_arg.event_id = ETHER_CB_EVENT_ID_LINK_ON;
                     (*cb_func.pcb_func)((void *) &cb_arg);
                 }
+                lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
             }
             else
             {
                 /* When PHY auto-negotiation is not completed */
                 transfer_enable_flag[channel] = ETHER_FLAG_OFF;
-                lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
+                lchng_flag[channel] = ETHER_FLAG_ON_LINK_OFF;
             }
         }
         else
@@ -1059,12 +1060,13 @@ void R_ETHER_LinkProcess (uint32_t channel)
                 cb_arg.event_id = ETHER_CB_EVENT_ID_LINK_ON;
                 (*cb_func.pcb_func)((void *) &cb_arg);
             }
+            lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
         }
         else
         {
             /* When PHY auto-negotiation is not completed */
             transfer_enable_flag[channel] = ETHER_FLAG_OFF;
-            lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
+            lchng_flag[channel] = ETHER_FLAG_ON_LINK_OFF;
         }
 #endif
     }

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/application_code/main.c
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/application_code/main.c
@@ -153,7 +153,7 @@ void vApplicationDaemonTaskStartupHook( void )
         {
             vTaskDelay(300);
         }
-		configPRINTF( ( "The network is up and running\n" ) );
+		FreeRTOS_printf( ( "The network is up and running\n" ) );
 
         /* Provision the device with AWS certificate and private key. */
         vDevModeKeyProvisioning();

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/application_code/main.c
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/application_code/main.c
@@ -151,8 +151,9 @@ void vApplicationDaemonTaskStartupHook( void )
         /* We should wait for the network to be up before we run any demos. */
         while( FreeRTOS_IsNetworkUp() == pdFALSE )
         {
-            vTaskDelay(3000);
+            vTaskDelay(300);
         }
+		configPRINTF( ( "The network is up and running\n" ) );
 
         /* Provision the device with AWS certificate and private key. */
         vDevModeKeyProvisioning();

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSConfig.h
@@ -55,7 +55,7 @@
 #define configMAX_PRIORITIES                       ( 7 )
 #define configTICK_RATE_HZ                         ( 1000 )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 512 )
-#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 128U * 1024U ) )
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 256U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 12 )
 #define configUSE_TRACE_FACILITY                   1
 #define configUSE_16_BIT_TICKS                     0

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -189,7 +189,7 @@ uint32_t ulRand(void);
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    ETHER_CFG_EMAC_TX_DESCRIPTORS
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    8
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
@@ -220,7 +220,7 @@ uint32_t ulRand(void);
 #define ipconfigUSE_TCP                                ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                            ( 0 )
+#define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
@@ -278,10 +278,10 @@ uint32_t ulRand(void);
 
 /* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
  * maximum size.  Define the size of Rx buffer for TCP sockets. */
-#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 3000 )
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 1460 * 3 )
 
 /* Define the size of Tx buffer for TCP sockets. */
-#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 3000 )
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 1460 * 3 )
 
 /* When using call-back handlers, the driver may check if the handler points to
  * real program memory (RAM or flash) or just has a random non-zero value. */
@@ -316,5 +316,8 @@ uint32_t ulRand(void);
 void vApplicationMQTTGetKeys( const char ** ppcRootCA,
                               const char ** ppcClientCert,
                               const char ** ppcClientPrivateKey );
+
+/* Let NetworkInterface check the free space in the working queue for the IP-task. */
+#define ipconfigCHECK_IP_QUEUE_SPACE			1
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/src/smc_gen/r_config/r_ether_rx_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/src/smc_gen/r_config/r_ether_rx_config.h
@@ -54,10 +54,10 @@
     #define ETHER_CFG_CH1_PHY_ADDRESS                   (1)     /* Please define the PHY-LSI address in the range of 0-31. */
 
 /* The number of Rx descriptors. */
-    #define ETHER_CFG_EMAC_RX_DESCRIPTORS               (1)
+    #define ETHER_CFG_EMAC_RX_DESCRIPTORS               (6)
 
 /* The number of Tx descriptors. */
-    #define ETHER_CFG_EMAC_TX_DESCRIPTORS               (1)
+    #define ETHER_CFG_EMAC_TX_DESCRIPTORS               (3)
 
 /* Please define the size of the sending and receiving buffer in the value where one frame can surely be stored 
  because the driver is single-frame/single-buffer processing.  */

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/application_code/main.c
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/application_code/main.c
@@ -154,7 +154,7 @@ void vApplicationDaemonTaskStartupHook( void )
         {
             vTaskDelay(300);
         }
-        configPRINTF( ( "The network is up and running\n" ) );
+        FreeRTOS_printf( ( "The network is up and running\n" ) );
 
         /* Provision the device with AWS certificate and private key. */
         vDevModeKeyProvisioning();

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/application_code/main.c
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/application_code/main.c
@@ -152,8 +152,9 @@ void vApplicationDaemonTaskStartupHook( void )
         /* We should wait for the network to be up before we run any tests. */
         while( FreeRTOS_IsNetworkUp() == pdFALSE )
         {
-            vTaskDelay(3000);
+            vTaskDelay(300);
         }
+        configPRINTF( ( "The network is up and running\n" ) );
 
         /* Provision the device with AWS certificate and private key. */
         vDevModeKeyProvisioning();

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -35,18 +35,11 @@
 #ifndef FREERTOS_IP_CONFIG_H
 #define FREERTOS_IP_CONFIG_H
 
-/* Prototype for the function used to print out.  In this case it prints to the
- * console before the network is connected then a UDP port after the network has
- * connected. */
-//extern void vLoggingPrintf( const char * pcFormatString,
-//                            ... );
-
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
 #define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    //#define FreeRTOS_debug_printf( X )    vLoggingPrintf( X )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif
 
@@ -196,7 +189,7 @@ uint32_t ulRand(void);
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    ETHER_CFG_EMAC_TX_DESCRIPTORS
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    8
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
@@ -323,5 +316,8 @@ uint32_t ulRand(void);
 void vApplicationMQTTGetKeys( const char ** ppcRootCA,
                               const char ** ppcClientCert,
                               const char ** ppcClientPrivateKey );
+
+/* Let NetworkInterface check the free space in the working queue for the IP-task. */
+#define ipconfigCHECK_IP_QUEUE_SPACE			1
 
 #endif /* FREERTOS_IP_CONFIG_H */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The NetworkInterface driver for Renesas' RX65N works fine to do a demo and some tests.
In order to make it ready for a real-life application, I would like to propose some changes:

- The detection of the PHY Link Status should be repaired, the code contains a few typo's.
~~~c
     if (ETHER_SUCCESS == ret)
     {
         if ((NULL != cb_func.pcb_func) && (FIT_NO_FUNC != cb_func.pcb_func))
         {
             cb_arg.channel = channel;
             cb_arg.event_id = ETHER_CB_EVENT_ID_LINK_ON;
             (*cb_func.pcb_func)((void *) &cb_arg);
         }
+        lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
     }
     else
     {
         /* When PHY auto-negotiation is not completed */
         transfer_enable_flag[channel] = ETHER_FLAG_OFF;
-        lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
+        lchng_flag[channel] = ETHER_FLAG_ON_LINK_OFF;
     }
~~~

This code occurs two times.

- The PHY Link Status can be used for two purposes:
  1. No packets should be sent as long as the status is low 
     `xNetworkInterfaceOutput()` will now check `xPHYLinkStatus`.
  2. Inform the user that the apparatus is unplugged from the LAN

- The PHY is now polled from a separate task called `check_ether_link()`.
  I would propose to make this a sub-task of `prvEMACDeferredInterruptHandlerTask()`.

- The PHY was checked every second, which is disturbing for the communication. I found a decrease in performance of almost 50%.
In other FreeRTOS+TCP drivers, the following approach is used:
  1. As long as packets are received, **assume** that the Link Status is high.
  2. Only when no packets come in for N seconds, poll the PHY Link Status.
  3. Once the Link Status is low, polling can be done frequently.
The above method is controlled by two macros:
~~~c
    /* Check if the LinkSStatus in the PHY is still high after 2 seconds of not
    receiving packets. */
    #define PHY_LS_HIGH_CHECK_TIME_MS   2000

    /* Check if the LinkSStatus in the PHY is still low every second. */
    #define PHY_LS_LOW_CHECK_TIME_MS    1000
~~~

- `xNetworkInterfaceInitialise()` is supposed to return `pdPASS` when both the peripheral has been initialised successfully, and when the PHY Link Status is up.
The current code blocks for ever until the Link Status is up. Therefore, the IP-task will also block for ever, and any +TCP API will block as well.
Let `prvEMACDeferredInterruptHandlerTask()` poll the PHY, and let `xNetworkInterfaceInitialise()` return `pdPASS` as soon as a link is detected (just like has been done in other NetworkInterfaces ).

- In `RX\ether_callback.c`, there is a callback mechanism for PHY changes. This has been prepared but not finished. I added a call to a new function `prvLinkStatusChange()` to let the NetworkInterface know that the PHY Link Status has changed.

- When developing and testing a +TCP application, it is important to keep an eye on a few resources:
  1. The number of available Network Buffers
  2. The free space in the working queue of the IP-task.
  3. The free HEAP space.
Many existing drivers check this and issue logging about it.

- Two tasks were started with a priority of `configMAX_PRIORITIES`. That should have been `configMAX_PRIORITIES-1` of course.  The priority of the IP-task was correctly set at:
~~~c
    #define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
~~~
Beside that, the tasks were given 100 words of stack space, which would soon lead to a stack overflow after a few additions of code.

- The maximum number of Network Buffers is important. It is defined as:
~~~c
    #define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    ETHER_CFG_EMAC_TX_DESCRIPTORS
~~~
  Which evaluates to 1. Any application with this setting will drop incoming packets. Chances are also big that tasks will wait for an available Network buffer, thus losing time.
I would rather propose a fair assesment, like e.g. :
~~~c
#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    8
~~~

- Also the number of DMA RX-descriptors was very low :
~~~c
#define ETHER_CFG_EMAC_RX_DESCRIPTORS               (1)
~~~
I tested with a value of 8 and sliding TCP windows ( `ipconfigUSE_TCP_WIN = 1` ).

Before and after all changes, I tested both the demo and the test application and also added a IPERF3 server to measure performance. The IPERF3 code is not part of this PR.

Also tested: unplug and plug the LAN during a TCP connection. The connection resumed without a problem.

Uncrustify: I will apply it in a separate commit.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.