### PR TITLE
ACE-12177: Enable Pre-CI LL-HAL tests for Beignet iot vendor dev [MTK…

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_main.c
+++ b/libraries/abstractions/common_io/test/test_iot_main.c
@@ -493,6 +493,7 @@ static void RUN_TEST_IOT_ALL_GROUP(void){
       RUN_TEST_IOT_UART();
     */
     RUN_IOT_TEST_EFUSE();
+    RUN_IOT_TEST_SPI(0);
     /* ACE-9604 */
     //RUN_TEST_IOT_FLASH();
     RUN_TEST_IOT_RTC();
@@ -521,7 +522,6 @@ static void RUN_TEST_IOT_ALL_GROUP(void){
     RUN_TEST_CASE( TEST_IOT_POWER, AFQP_IotPower_IoctlFuzzing );
     RUN_TEST_CASE( TEST_IOT_POWER, AFQP_IotPower_GetModeFuzzing );
     RUN_TEST_CASE( TEST_IOT_POWER, AFQP_IotPower_CloseFuzzing );
-    RUN_IOT_TEST_SPI(0);
 }
 
 void RunIotTests(int testIndex, int testCaseIndex)


### PR DESCRIPTION
…7697] [1/1]

[Problem]
SPI test logs on the console is interfering with the PreCI test logs, resulting in false failure.

[Solution]
Re-ordring the PreCI test sequence to prevent false failures.

iot_tests test 0

TEST(TEST_IOT_EFUSE, AFQP_IotEfuseOpenClose) PASS
TEST(TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead32BitWord) PASS
TEST(TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead16BitWord) PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcOpenClose) PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcOpenCloseFailure)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetGetDateTime)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetGetAlarm)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcCancelAlarm)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetGetWakeup)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcCancelWakeup)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcGetStatus)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetWakeupInvalid)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetAlarmInvalid)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcSetDateTimeFuzzing)reduce RTC power

 PASS
TEST(TEST_IOT_RTC, AFQP_IotRtcGetDateTimeFuzzing)reduce RTC power

 PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenClose) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenOpenClose) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenCloseClose) PASS
TEST(TEST_IOT_GPIO, AF[1970-49 E  01-01 00:03: 8 00000000]49.849 E  hal:hal_eiGpioMode)00]hal:hal_eint_apply_c:225:hal_eint_init: debounce disable.

TEST(TEST_IOT_GPIO, AFQP_IotGpioMode)

 PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioPull) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioSpeed) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOperation)
GPIO[0] read value = 0x0
 PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioOpenCloseFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioReadWriteSyncFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioIoctlFuzz) PASS
TEST(TEST_IOT_GPIO, AFQP_IotGpioInterrupt[1970-al:hal_TEST(EST_IOT_TITEST_IOT_TIMMER, AFWP_IoER, AFWP_ItTimer_OpenCotTimer_Openlose) PASS
Close) PASt_apply_c:22S
5:hal_eint_init: debounce disable.

TEST(T PASS
EST_IOT_TIMER, AFWP_IotTimer_Stop)ng)

TEST(TEST_IOT_TIMER, AFWP_IotTi Pmer_Stop)[ASS
TEST(TEST_IOT_TckIMER, AFWP_I) PASS
1 00otTimer_Call:03:50.359 Eback) PASS   8 0000000
TEST(TEST_0]hal:hal_eiIOT_TIMER,nt_apply_c:2 AFWP_IotTim25:hal_eint_er_NoCallbinit: debounack) PASS
Tce disable.
EST(TEST_IOT

[1970-01-01 00:0:03:50.360 E 03:50.360 E   8 000000  8 0000000000]hal:hal_e]hal:hal_einint_apply_tTEST(TEST_IOTc:225:hal__TIMER, AFWPeint_init:_IotTimer_Ca debounce dincel)lRetValsable.

[1970-01in-01 00:03:50t_a.361 E   8 00000000]hal:hal_eint_apply_c:225:hal_eint_init: debounce disable.

[1970-01-01 00:03:50.361 E   8 00000000]hal:hal_eint_apply_c:225:hal_eint_init: debounce disable.

 PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_OpenFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_CloseFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_StartFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_GetFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_StopFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_CallbackFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_CancelFuzzing) PASS
TEST(TEST_IOT_TIMER, AFWP_IotTimer_DelayFuzzing) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogOpenClose) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogValidateBarkTimer) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogValidateBiteInterrupt) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogStartNoTimerSet) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogRestartNoStart) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogSetBarkGreaterThanBiteSetWatchdogBarkFirst) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogSetBarkGreaterThanBiteSetWatchdogBiteFirst) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogOpenOpenClose) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_Fuzz_IotWatchdogClose) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_Fuzz_IotWatchdogStartStop) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_Fuzz_IotWatchdog_ioctl) PASS
TEST(TEST_IOT_WATCHDOG, AFQP_IotWatchdogOpenCloseClose) PASS
TEST(TEST_IOT_PERFCOUNTER, AFQP_IotPerfCounterGetValue) PASS
TEST(TEST_IOT_PERFCOUNTER, AFQP_IotPerfCounterGetValueWithDelay) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_OpenClose) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_SetGetConfig) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_Start) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_Stop) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_NoConfig) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_OpenFuzzing) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_CloseFuzzing) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_SetConfigFuzzing) PASS
TEST(TEST_IOT_PWM, AFQP_IotPwm_GetConfigFuzzing) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorOpenCloseSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorOpenCloseFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorMultipleOpenFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorMultipleCloseFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorEnableDisableSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorEnableDisableFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorGetTempSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorGetTempKTimesSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorGetTempInvalidHandleInputFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorGetTempDisabledFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorSetGetThresholdSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorSetGetThresholdInvalidHandleFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorSetGetThresholdNullInputFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorCalibrationSuccess) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorCalibrationInvalidHandleFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorCalibrationNullInputFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorCalibrationInvalidInputFuzz) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorTriggerMinThreshold) PASS
TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorTriggerMaxThreshold) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_OpenClose) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_SetModeHigh) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_SetModeNormal) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_SetModeLow) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_EnterIdle) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_EnterIdleCancel) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_IoctlEnum) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_SetModeFuzzing) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_ResetModeFuzzing) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_IoctlFuzzing) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_GetModeFuzzing) PASS
TEST(TEST_IOT_POWER, AFQP_IotPower_CloseFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_OpenClose) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_Init) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_CancelFail) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_CancelSuccess)[1970-01-01 00:00:00.000 I   8 00000000]hal:hal_spi_master_m:111:[SPIM]: g_spi_master_cs_n: 7.

[1970-01-01 00:00:00.000 I   8 00000000]hal:hal_spi_master_m:111:[SPIM]: g_spi_master_cs_n: 7.

[1970-01-01 00:00:00.000 I   8 00000000]hal:hal_spi_master_m:111:[SPIM]: g_spi_master_cs_n: 7.

[1970-01-01 00:00:00.000 I   8 00000000]hal:hal_spi_master_m:111:[SPIM]: g_spi_master_cs_n: 7.

[1970-01-01 00:00:00.000 I   6 10050b57]aceusagestat.wifi:Wifi not available

[1970-01-01 00:00:00.000 I   6 10050b57]aceusagestat.scheduler: Starting Timer (1)

 PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_OpenFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_CloseFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_IoctlFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_ReadSyncFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_Wri[1970-0100000]hal:hal_spi_maTEST(TEST_T_IOT_SPI, AFQP_IotSPI_WriteAsyncFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_TransferSyncFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncFuzzing) PASS
TEST(TEST_IOT_SPI, AFQP_IotSPI_CancelFuzzing) PASS

-----------------------
110 Tests 0 Failures 0 Ignored
OK
cli duration 4294744209ms

Change-Id: I3bbfa290afd26bd5d26acb84521c81a6a7a29ad4

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.