### PR TITLE
Fix BLE porting layer get bonded devices property

### DIFF
--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -171,16 +171,16 @@ TEST( Full_BLE, BLE_Free )
 
 size_t prvGetNumberOfBonds()
 {
-	 BTProperty_t xProperty;
-	 size_t xNumElements;
+    BTProperty_t xProperty;
+    size_t xNumElements;
 
-	 xProperty.xType = eBTpropertyAdapterBondedDevices;
+    xProperty.xType = eBTpropertyAdapterBondedDevices;
 
-	 /* Get bonded devices list */
-	 IotTestBleHal_SetGetProperty( &xProperty, false );
-	 xNumElements = ( xProperty.xLen ) / ( sizeof( BTBdaddr_t ) );
+    /* Get bonded devices list */
+    IotTestBleHal_SetGetProperty( &xProperty, false );
+    xNumElements = ( xProperty.xLen ) / ( sizeof( BTBdaddr_t ) );
 
-	 return xNumElements;
+    return xNumElements;
 }
 
 

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -171,24 +171,27 @@ TEST( Full_BLE, BLE_Free )
 
 TEST( Full_BLE, BLE_Connection_RemoveAllBonds )
 {
-    BTProperty_t pxProperty;
-    uint16_t usIndex;
+    BTProperty_t xProperty;
+    size_t xIndex, xNumElements;
 
     /* Set the name */
-    pxProperty.xType = eBTpropertyAdapterBondedDevices;
+    xProperty.xType = eBTpropertyAdapterBondedDevices;
 
     /* Get bonded devices */
-    IotTestBleHal_SetGetProperty( &pxProperty, false );
+    IotTestBleHal_SetGetProperty( &xProperty, false );
 
-    for( usIndex = 0; usIndex < pxProperty.xLen; usIndex++ )
+    xNumElements = ( xProperty.xLen ) / ( sizeof( BTBdaddr_t ) );
+
+    for( xIndex = 0; xIndex < xNumElements; xIndex++ )
     {
-        prvRemoveBond( &( ( BTBdaddr_t * ) pxProperty.pvVal )[ usIndex ] );
+        prvRemoveBond( &( ( BTBdaddr_t * ) xProperty.pvVal )[ xIndex ] );
     }
 
     /* Get bonded devices. */
-    IotTestBleHal_SetGetProperty( &pxProperty, false );
+    IotTestBleHal_SetGetProperty( &xProperty, false );
+
     /* Check none are left. */
-    TEST_ASSERT_EQUAL( 0, pxProperty.xLen );
+    TEST_ASSERT_EQUAL( 0, xProperty.xLen );
 }
 
 bool prvGetCheckDeviceBonded( BTBdaddr_t * pxDeviceAddress )

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
@@ -659,7 +659,7 @@ BTStatus_t prvGetBondableDeviceList( void )
                 memcpy( &( ( BTBdaddr_t * ) xBondedDevices.pvVal )[ usIndex ], &pxESPDevlist[ usIndex ].bd_addr, sizeof( BTBdaddr_t ) );
             }
 
-            xBondedDevices.xLen = usNbDevices;
+            xBondedDevices.xLen = usNbDevices * sizeof( BTBdaddr_t );
             xBondedDevices.xType = eBTpropertyAdapterBondedDevices;
 
             xBTCallbacks.pxAdapterPropertiesCb( eBTStatusSuccess, 1, &xBondedDevices );

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -683,7 +683,7 @@ BTStatus_t prvGetBondableDeviceList( void )
         xStatus = eBTStatusFail;
     }
 
-    xBondedDevices.xLen = usNbDevices;
+    xBondedDevices.xLen = usNbDevices * sizeof( BTBdaddr_t );
     xBondedDevices.xType = eBTpropertyAdapterBondedDevices;
 
     if( xBTCallbacks.pxAdapterPropertiesCb != NULL )

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -243,8 +243,10 @@ int prvGAPeventHandler( struct ble_gap_event * event,
                 {
                     xStatus = eBTStatusFail;
                 }
+
                 xBTBleAdapterCallbacks.pxAdvStatusCb( xStatus, ulGattServerIFhandle, false );
             }
+
             return 0;
 
         case BLE_GAP_EVENT_PAIRING_REQUEST:

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
@@ -891,7 +891,7 @@ BTStatus_t prvBTGetDeviceProperty( BTPropertyType_t xType )
                    }
 
                    xReturnedProperty.pvVal = pucBondedAddresses;
-                   xReturnedProperty.xLen = peer_count;
+                   xReturnedProperty.xLen = peer_count * btADDRESS_LEN;
                    xBTCallbacks.pxAdapterPropertiesCb( eBTStatusSuccess, 1, &xReturnedProperty );
                }
 


### PR DESCRIPTION
Fix BLE porting layer get bonded devices property

Description
-----------
The API was returning the number of elements in the array of bonded devices, instead of length of the array (as per the API definition). Changed to use length and have number of elements derived from it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.