### PR TITLE
Set connection interval range only for scan response

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
@@ -97,8 +97,8 @@ typedef struct
     BTGattAdvName_t ucName;
     bool bSetScanRsp;
     uint32_t ulAppearance;
-    uint32_t ulMinInterval; /**< Minimum Connection Interval. If set to 0, HAL implementation shall use vendor specific default values. */
-    uint32_t ulMaxInterval; /**< Maximum Connection Interval. If set to 0, HAL implementation shall use vendor specific default values. */
+    uint32_t ulMinInterval; /**< Minimum Connection Interval. If set to 0, minimum connection interval is not included in advertisement/scan response data. */
+    uint32_t ulMaxInterval; /**< Maximum Connection Interval. If set to 0, maximum connection interval is not included in advertisement/scan response data. */
     uint8_t ucChannelMap;
     uint8_t ucTxPower;
     uint8_t ucTimeout;

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -103,7 +103,7 @@ static IotBleAdvertisementParams_t _scanRespParams =
 /**
  * @brief Contains parameters to be set in the advertisement data.
  *
- * Note that total available data size in scan response
+ * Note that total available data size in advertisement
  * is 31 bytes. Parameters are chosen below such that overall size
  * does not exceed 31 bytes.
  */

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -55,7 +55,7 @@
 
 #if ( IOT_BLE_ADVERTISING_UUID_SIZE == 2 )
     #define BT_ADV_UUID_TYPE    eBTuuidType16
-#elif( IOT_BLE_ADVERTISING_UUID_SIZE == 4 )
+#elif ( IOT_BLE_ADVERTISING_UUID_SIZE == 4 )
     #define BT_ADV_UUID_TYPE    eBTuuidType32
 #else
     #define BT_ADV_UUID_TYPE    eBTuuidType128
@@ -106,13 +106,12 @@ static IotBleAdvertisementParams_t _scanRespParams =
  * Note that total available data size in scan response
  * is 31 bytes. Parameters are chosen below such that overall size
  * does not exceed 31 bytes.
- * .
  */
 
 static IotBleAdvertisementParams_t _advParams =
 {
     .includeTxPower    = true,
-    .name              = { BTGattAdvNameShort,                 IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE},
+    .name              = { BTGattAdvNameShort,          IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE},
     .setScanRsp        = false,
     .appearance        = IOT_BLE_ADVERTISING_APPEARANCE,
     .minInterval       = 0,
@@ -694,7 +693,6 @@ BTStatus_t IotBle_Init( void )
 
         status = _setAdvData( &_advParams );
         IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
-
 
         if( status == eBTStatusSuccess )
         {

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -55,6 +55,8 @@
 
 #if ( IOT_BLE_ADVERTISING_UUID_SIZE == 2 )
     #define BT_ADV_UUID_TYPE    eBTuuidType16
+#elif( IOT_BLE_ADVERTISING_UUID_SIZE == 4 )
+    #define BT_ADV_UUID_TYPE    eBTuuidType32
 #else
     #define BT_ADV_UUID_TYPE    eBTuuidType128
 #endif
@@ -69,6 +71,15 @@ static const BTUuid_t _serverUUID =
     .ucType   = eBTuuidType128,
     .uu.uu128 = IOT_BLE_SERVER_UUID
 };
+
+
+/**
+ * @brief Contains parameters to be set in the scan response data.
+ *
+ * Note that total available data size in scan response
+ * is 31 bytes. Parameters are chosen below such that overall size
+ * does not exceed 31 bytes.
+ */
 static IotBleAdvertisementParams_t _scanRespParams =
 {
     .includeTxPower    = true,
@@ -89,14 +100,23 @@ static IotBleAdvertisementParams_t _scanRespParams =
     .pUUID2            = NULL
 };
 
+/**
+ * @brief Contains parameters to be set in the advertisement data.
+ *
+ * Note that total available data size in scan response
+ * is 31 bytes. Parameters are chosen below such that overall size
+ * does not exceed 31 bytes.
+ * .
+ */
+
 static IotBleAdvertisementParams_t _advParams =
 {
     .includeTxPower    = true,
     .name              = { BTGattAdvNameShort,                 IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE},
     .setScanRsp        = false,
     .appearance        = IOT_BLE_ADVERTISING_APPEARANCE,
-    .minInterval       = IOT_BLE_ADVERTISING_CONN_INTERVAL_MIN,
-    .maxInterval       = IOT_BLE_ADVERTISING_CONN_INTERVAL_MAX,
+    .minInterval       = 0,
+    .maxInterval       = 0,
     .serviceDataLen    = 0,
     .pServiceData      = NULL,
     .manufacturerLen   = 0,
@@ -674,6 +694,7 @@ BTStatus_t IotBle_Init( void )
 
         status = _setAdvData( &_advParams );
         IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+
 
         if( status == eBTStatusSuccess )
         {


### PR DESCRIPTION
Set connection interval range only for scan response

Description
-----------
Advertisement payload allows only 31 bytes of data. With connection interval included in advertisement it exceeds by 3 bytes.

Skipping connection interval in advertisement and instead setting in scan response data.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.