### PR TITLE
fix UART non-assisted tests

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -416,7 +416,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
     {
         cpBufferLarge[i] = 0xAA;
     }
-    cpBufferLarge[testIotUART_BUFFER_LENGTH_LARGE] = '\n';
+    cpBufferLarge[testIotUART_BUFFER_LENGTH_LARGE - 1] = '\n';
 
     xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -410,7 +410,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
     IotUARTHandle_t xUartHandle;
     int32_t lIoctl, lWrite, lClose, lTransferAmount_1, lTransferAmount_2;
     uint8_t i;
-    uint8_t cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE + 1 ] = { 0 };
+    uint8_t cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE ] = { 0 };
 
     for (i = 0; i < testIotUART_BUFFER_LENGTH_LARGE; i++)
     {
@@ -423,7 +423,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
 
     if( TEST_PROTECT() )
     {
-        lWrite = iot_uart_write_async( xUartHandle, cpBufferLarge, testIotUART_BUFFER_LENGTH_LARGE + 1 );
+        lWrite = iot_uart_write_async( xUartHandle, cpBufferLarge, testIotUART_BUFFER_LENGTH_LARGE );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
         lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount_1 );

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -416,6 +416,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
     {
         cpBufferLarge[i] = 0xAA;
     }
+    cpBufferLarge[testIotUART_BUFFER_LENGTH_LARGE] = '\n';
 
     xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -423,7 +423,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
 
     if( TEST_PROTECT() )
     {
-        lWrite = iot_uart_write_async( xUartHandle, cpBufferLarge, testIotUART_BUFFER_LENGTH_LARGE );
+        lWrite = iot_uart_write_async( xUartHandle, cpBufferLarge, testIotUART_BUFFER_LENGTH_LARGE + 1 );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
         lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount_1 );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
1. Remove test case: AFQP_IotUARTWriteSyncReadAsyncLoopbackTest
This test works with a loopback wiring setup. When it does a sync write, all the bytes will go to Rx register and cause an overrun error. This test only works if there is a hardware FIFO buffer on the UART. 
2. AFQP_IotUARTWriteReadAsyncWithCallback is fixed for similar reason above.
3. Removed some local unused variable.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.