### PR TITLE
BLE AFR: Make 16 bit Service UUID as default while advertising with Service Data (Bluedroid & NimBLE port)

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
@@ -751,7 +751,7 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
 
     if( ( pcServiceData != NULL ) && ( xStatus == eBTStatusSuccess ) )
     {
-        xStatus = prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_128SERVICE_DATA, ( uint8_t * ) pcServiceData, usServiceDataLen );
+        xStatus = prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_SERVICE_DATA, ( uint8_t * ) pcServiceData, usServiceDataLen );
     }
 
     if( ( xNbServices != 0 ) && ( xStatus == eBTStatusSuccess ) )

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -620,8 +620,8 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
 
     if( usServiceDataLen && pcServiceData )
     {
-        fields.svc_data_uuid128 = ( uint8_t * ) pcServiceData;
-        fields.svc_data_uuid128_len = usServiceDataLen;
+        fields.svc_data_uuid16 = ( uint8_t * ) pcServiceData;
+        fields.svc_data_uuid16_len = usServiceDataLen;
     }
 
     if( pxServiceUuid != NULL )


### PR DESCRIPTION
Modify the default 128 bit Service UUID to 16 bit Service UUID in Service Data.

<!--- Title -->

Description
-----------
In `iot_ble_hal_gap.c`, use 16 bit Service UUID inside the Service Data as a default while setting advertisement data with `prvSetAdvData`. 

<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.