### PR TITLE
ESP32 PKCS11 PAL: make NVS partition and namespace configurable

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/iot_pkcs11_config.h
@@ -38,12 +38,12 @@
 /**
  * @brief ESP32 NVS Partition where PKCS #11 data is stored
  */
-#define configPKCS11_STORAGE_PARTITION  "storage"
+#define pkcs11configSTORAGE_PARTITION  "storage"
 
 /**
  * @brief ESP32 NVS namespace for PKCS #11 data
  */
-#define configPKCS11_STORAGE_NS         "creds"
+#define pkcs11configSTORAGE_NS         "creds"
 
 /**
  * @brief PKCS #11 default user PIN.

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/iot_pkcs11_config.h
@@ -36,6 +36,16 @@
 /* #define pkcs11configC_INITIALIZE_ALT */
 
 /**
+ * @brief ESP32 NVS Partition where PKCS #11 data is stored
+ */
+#define configPKCS11_STORAGE_PARTITION  "storage"
+
+/**
+ * @brief ESP32 NVS namespace for PKCS #11 data
+ */
+#define configPKCS11_STORAGE_NS         "creds"
+
+/**
  * @brief PKCS #11 default user PIN.
  *
  * The PKCS #11 standard specifies the presence of a user PIN. That feature is

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/iot_pkcs11_config.h
@@ -37,6 +37,16 @@
 /* #define pkcs11configC_INITIALIZE_ALT */
 
 /**
+ * @brief ESP32 NVS Partition where PKCS #11 data is stored
+ */
+#define pkcs11configSTORAGE_PARTITION  "storage"
+
+/**
+ * @brief ESP32 NVS namespace for PKCS #11 data
+ */
+#define pkcs11configSTORAGE_NS         "creds"
+
+/**
  * @brief PKCS #11 default user PIN.
  *
  * The PKCS #11 standard specifies the presence of a user PIN. That feature is

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -36,11 +36,10 @@
 #include "esp_flash_encrypt.h"
 #include "nvs_flash.h"
 
-#define NVS_PART_NAME "storage"
-#define NAMESPACE "creds"
+#define NVS_PART_NAME                             configPKCS11_STORAGE_PARTITION
+#define NAMESPACE                                 configPKCS11_STORAGE_NS
 static const char *TAG = "PKCS11";
 
-#define pkcsFLASH_PARTITION                      "storage"
 #define pkcs11palFILE_NAME_CLIENT_CERTIFICATE    "P11_Cert"
 #define pkcs11palFILE_NAME_KEY                   "P11_Key"
 #define pkcs11palFILE_CODE_SIGN_PUBLIC_KEY       "P11_CSK"

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -36,8 +36,8 @@
 #include "esp_flash_encrypt.h"
 #include "nvs_flash.h"
 
-#define NVS_PART_NAME                             configPKCS11_STORAGE_PARTITION
-#define NAMESPACE                                 configPKCS11_STORAGE_NS
+#define NVS_PART_NAME                             pkcs11configSTORAGE_PARTITION
+#define NAMESPACE                                 pkcs11configSTORAGE_NS
 static const char *TAG = "PKCS11";
 
 #define pkcs11palFILE_NAME_CLIENT_CERTIFICATE    "P11_Cert"


### PR DESCRIPTION
ESP32 PKCS11 PAL: make NVS partition and namespace configurable

Description
-----------
This allows the common manufacturing pattern where per-device credentials are flashed as a separate read-only partition. This pattern allows the per-device credentials to be decoupled from user data, and simplifies the implementation of "factory reset" functionality (the user partition can just be reinitialised, leaving credentials intact)

Currently this requires patching AFR manually.

This PR addresses #1566 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.