### PR TITLE
PKCS#11 Multithread stack fix

### DIFF
--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -344,7 +344,7 @@ static MultithreadTaskParams_t xGlobalTaskParams[ pkcs11testMULTI_THREAD_TASK_CO
 /*-----------------------------------------------------------*/
 /* Stack size of each task. This can be configured in iot_test_pkcs11_config.h. */
 #ifndef pkcs11testMULTI_TASK_STACK_SIZE
-    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 8 )
 #endif
 
 /* Priority of each task. This can be configured in iot_test_pkcs11_config.h. */


### PR DESCRIPTION
Increased mulithreaded task stack sizes for the pkcs#11 tests as the current config led to stack overflows on ESP.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.