### PR TITLE
Fix bad pointer de-reference in HTTPS Client demo

### DIFF
--- a/demos/https/iot_demo_https_common.c
+++ b/demos/https/iot_demo_https_common.c
@@ -86,7 +86,7 @@ int _IotHttpsDemo_GetS3ObjectFileSize( uint32_t * pFileSize,
      * IotHttpsClient_InitializeRequest(). */
     IotHttpsRequestHandle_t fileSizeReqHandle = NULL;
 
-    /* Handle identifying the HTTP response. This is valid after the reponse has been received with
+    /* Handle identifying the HTTP response. This is valid after the response has been received with
      * IotHttpsClient_SendSync(). */
     IotHttpsResponseHandle_t fileSizeRespHandle = NULL;
 

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -418,9 +418,9 @@ static void _freeRequestIndex( int i )
  * This function is used during reconnection to free any possible requests that
  * might still have been scheduled to the HTTPS Client library to run but have
  * not been sent yet. Reconnection happens during the _readReadyCallback().
- * The response's memory cannot be used until the _responseCompleteCallback() return,
- * so during reconnection, we need to indicate that all memory except the current
- * response is to be marked as free.
+ * The response's memory cannot be used until the _responseCompleteCallback() 
+ * returns, so during reconnection we need to indicate that all memory except 
+ * the current response is to be marked as free.
  *
  * @param[in] exception Request index to not free. This is -1 for no exceptions.
  */
@@ -542,7 +542,7 @@ static bool _getNextIncompleteRange( uint32_t * currentRange )
     do
     {
         /* Check if the current range in the file is already downloaded or is has already been scheduled. The
-         * bitmaps contains as many bits are there are blocks of byte ranges. The lines below help to index
+         * bitmaps contain as many bits as there are blocks of byte ranges. The lines below help to index
          * into the bitmaps and check if the bit representing that byte range is set. */
         bitMask = BITMASK( *currentRange );
         byteOffset = BYTE_OFFSET( *currentRange );

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -222,7 +222,7 @@ typedef struct _fileDownloadInfo
 {
     uint32_t fileSize;          /**< @brief The total size of the file to be downloaded. */
     uint32_t totalRanges;       /**< @brief the total number of ranges in the file size. */
-    uint8_t * downloadedBitmap; /**< @brief Bitmap to keep track of chunks downlaoded. */
+    uint8_t * downloadedBitmap; /**< @brief Bitmap to keep track of chunks downloaded. */
     uint8_t * scheduledBitmap;  /**< @brief Bitmap of ranges scheduled, but not completed. */
     uint32_t rangesRemaining;   /**< @brief The total number of ranges remaining to download. */
 } _fileDownloadInfo_t;
@@ -523,7 +523,7 @@ static bool _getNextIncompleteRange( uint32_t * currentRange )
     bool found = false;
     /* An intermediate bitMask calculation for checking if the currentRange is already downloaded or not. */
     uint32_t bitMask = 0;
-    /* An intermediate byteOffset into the downlaodedBitmap to check if the currentRange is already downloaded or not. */
+    /* An intermediate byteOffset into the downloadedBitmap to check if the currentRange is already downloaded or not. */
     uint32_t byteOffset = 0;
 
     /* A count from 0 to check if the total ranges is reached because, in the logic below, currentRange will wrap
@@ -667,7 +667,7 @@ static void _readReadyCallback( void * pPrivData,
             return;
         }
 
-        IotLogDebug("Reading the content length for reponse %d.", respHandle);
+        IotLogDebug("Reading the content length for response %d.", respHandle);
         returnStatus = IotHttpsClient_ReadContentLength( respHandle, &contentLength );
 
         if( ( returnStatus != IOT_HTTPS_OK ) || ( contentLength == 0 ) )
@@ -783,13 +783,13 @@ static void _readReadyCallback( void * pPrivData,
                 IotLogInfo( "Successfully reconnected to the S3 server." );
                 /* For all requests from the pool that have been scheduled. We want to free them so they will get
                  * rescheduled by the main application. When a request from the pool is set to unused its associated
-                 * response is also set to unused. This current response is not set to unused so that it's reponse
+                 * response is also set to unused. This current response is not set to unused so that it's response
                  * handle memory is not overwritten. The response cannot be reused until the responseCompleteCallback
                  * is finished. */
                 _freeAllScheduledRequests( pRequestContext->reqNum );
 
                 /* For each of the scheduled ranges mark them as unscheduled so that the main application will assign
-                 * them to a free request. This current requests's range will not be rescheduled because earlier in this
+                 * them to a free request. This current request's range will not be rescheduled because earlier in this
                  * function the downloadedBitmap was marked before this routine. */
                 _clearAllScheduledRanges();
             }
@@ -1049,7 +1049,7 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Asynchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
-    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This function returns the length of the path
      * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL, strlen( IOT_DEMO_HTTPS_PRESIGNED_GET_URL ), &pPath, &pathLen );
 

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -667,7 +667,7 @@ static void _readReadyCallback( void * pPrivData,
             return;
         }
 
-        IotLogDebug("Reading the content length for response %d.", respHandle);
+        IotLogDebug( "Reading the content length for response %d.", respHandle );
         returnStatus = IotHttpsClient_ReadContentLength( respHandle, &contentLength );
 
         if( ( returnStatus != IOT_HTTPS_OK ) || ( contentLength == 0 ) )
@@ -746,7 +746,7 @@ static void _readReadyCallback( void * pPrivData,
          * at the same time a request is being sent, a reconnection needs to be made before the next request sends and
          * gets a network error ending the demo. Please see the design flow for more information:
          * https://docs.aws.amazon.com/freertos/latest/lib-ref/https/https_design.html#Asynchronous_Design */
-        IotLogDebug("Looking for the \"Connection\" header in response %d.", respHandle);
+        IotLogDebug( "Looking for the \"Connection\" header in response %d.", respHandle );
         returnStatus = IotHttpsClient_ReadHeader( respHandle,
                                                   CONNECTION_HEADER_FIELD,
                                                   CONNECTION_HEADER_FILED_LENGTH,
@@ -781,6 +781,7 @@ static void _readReadyCallback( void * pPrivData,
             else
             {
                 IotLogInfo( "Successfully reconnected to the S3 server." );
+
                 /* For all requests from the pool that have been scheduled. We want to free them so they will get
                  * rescheduled by the main application. When a request from the pool is set to unused its associated
                  * response is also set to unused. This current response is not set to unused so that it's response

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -667,6 +667,7 @@ static void _readReadyCallback( void * pPrivData,
             return;
         }
 
+        IotLogDebug("Reading the content length for reponse %d.", respHandle);
         returnStatus = IotHttpsClient_ReadContentLength( respHandle, &contentLength );
 
         if( ( returnStatus != IOT_HTTPS_OK ) || ( contentLength == 0 ) )
@@ -745,6 +746,7 @@ static void _readReadyCallback( void * pPrivData,
          * at the same time a request is being sent, a reconnection needs to be made before the next request sends and
          * gets a network error ending the demo. Please see the design flow for more information:
          * https://docs.aws.amazon.com/freertos/latest/lib-ref/https/https_design.html#Asynchronous_Design */
+        IotLogDebug("Looking for the \"Connection\" header in response %d.", respHandle);
         returnStatus = IotHttpsClient_ReadHeader( respHandle,
                                                   CONNECTION_HEADER_FIELD,
                                                   CONNECTION_HEADER_FILED_LENGTH,
@@ -778,6 +780,7 @@ static void _readReadyCallback( void * pPrivData,
             }
             else
             {
+                IotLogInfo( "Successfully reconnected to the S3 server." );
                 /* For all requests from the pool that have been scheduled. We want to free them so they will get
                  * rescheduled by the main application. When a request from the pool is set to unused its associated
                  * response is also set to unused. This current response is not set to unused so that it's reponse
@@ -898,7 +901,7 @@ static void _errorCallback( void * pPrivData,
     ( void ) respHandle;
 
     char * pRangeValueStr = ( ( _requestContext_t * ) ( pPrivData ) )->pRangeValueStr;
-    IotLogError( "An error occurred during asynchronous operation with code: %d", pRangeValueStr, rc );
+    IotLogError( "An error occurred during range %s with code: %d", pRangeValueStr, rc );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -418,8 +418,8 @@ static void _freeRequestIndex( int i )
  * This function is used during reconnection to free any possible requests that
  * might still have been scheduled to the HTTPS Client library to run but have
  * not been sent yet. Reconnection happens during the _readReadyCallback().
- * The response's memory cannot be used until the _responseCompleteCallback() 
- * returns, so during reconnection we need to indicate that all memory except 
+ * The response's memory cannot be used until the _responseCompleteCallback()
+ * returns, so during reconnection we need to indicate that all memory except
  * the current response is to be marked as free.
  *
  * @param[in] exception Request index to not free. This is -1 for no exceptions.

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -414,7 +414,7 @@ static void _freeRequestIndex( int i )
 /**
  * @brief Free all requests in the pool that have been marked as scheduled, except
  * for the exception index.
- * 
+ *
  * @param[in] exception Request index to not free. This is -1 for no exceptions.
  */
 static void _freeAllScheduledRequests( int exception )
@@ -426,8 +426,8 @@ static void _freeAllScheduledRequests( int exception )
 
     for( i = 0; i < IOT_HTTPS_DEMO_MAX_ASYNC_REQUESTS; i++ )
     {
-        if( ( i != exception ) && 
-            (_requestPool.pRequestDatas[ i ].scheduled == true ) )
+        if( ( i != exception ) &&
+            ( _requestPool.pRequestDatas[ i ].scheduled == true ) )
         {
             _pInUseRequests[ i ] = false;
             _clearRequestData( i );
@@ -895,7 +895,7 @@ static void _errorCallback( void * pPrivData,
                             IotHttpsReturnCode_t rc )
 {
     ( void ) reqHandle;
-    ( void )respHandle;
+    ( void ) respHandle;
 
     char * pRangeValueStr = ( ( _requestData_t * ) ( pPrivData ) )->pRangeValueStr;
     IotLogError( "An error occurred during asynchronous operation with code: %d", pRangeValueStr, rc );
@@ -974,7 +974,7 @@ static int _scheduleAsyncRequest( int reqIndex,
 
     /* Send the request and receive the response asynchronously. This will schedule the async request. This function
      * will return immediately after scheduling. */
-    IotLogDebug( "Sending asynchronously %s, req num: %d", _requestPool.pRequestDatas[reqIndex].pRangeValueStr, _requestPool.pReqHandles[reqIndex] );
+    IotLogDebug( "Sending asynchronously %s, req num: %d", _requestPool.pRequestDatas[ reqIndex ].pRangeValueStr, _requestPool.pReqHandles[ reqIndex ] );
     httpsClientStatus = IotHttpsClient_SendAsync( _connHandle,
                                                   _requestPool.pReqHandles[ reqIndex ],
                                                   &( _requestPool.pRespHandles[ reqIndex ] ),

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -374,7 +374,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
 
     if( httpsClientStatus != IOT_HTTPS_OK )
     {
-        IotLogError( "Failed to connect to the S3 server. Error code: %d.", httpsClientStatus );
+        IotLogError( "Failed to connect to the server. Error code: %d.", httpsClientStatus );
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 
@@ -552,7 +552,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
 
             if( httpsClientStatus != IOT_HTTPS_OK )
             {
-                IotLogError( "Failed to reconnect to the S3 server. Error code: %d.", httpsClientStatus );
+                IotLogError( "Failed to reconnect to the server. Error code: %d.", httpsClientStatus );
                 IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
             }
         }

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -49,7 +49,7 @@
 #include "platform/iot_clock.h"
 
 /**
- * This demonstates downloading a file from S3 using a pre-signed URL using the Amazon FreeRTOS HTTP Client library.
+ * This demonstrates downloading a file from S3 using a pre-signed URL using the Amazon FreeRTOS HTTP Client library.
  * The HTTPS Client library is a generic HTTP/1.1 client library that be used to download files from other webservers as
  * well.
  *
@@ -114,14 +114,14 @@
 #endif
 
 /* Size in bytes of the user buffer used to store the internal request context and HTTP request header lines.
- * The size presented here accounts for the storeage of the internal context, the first request line in the HTTP
+ * The size presented here accounts for the storage of the internal context, the first request line in the HTTP
  * formatted header and extra headers. The minimum size can be found in extern const uint32_t requestUserBufferMinimumSize. */
 #ifndef IOT_DEMO_HTTPS_REQ_USER_BUFFER_SIZE
     #define IOT_DEMO_HTTPS_REQ_USER_BUFFER_SIZE    ( ( int ) 512 )
 #endif
 
 /* Size in bytes of the user buffer used to store the internal response context and the HTTP response header lines.
- * The size presented here accounts for the storeage of the internal context, the first request line in the HTTP
+ * The size presented here accounts for the storage of the internal context, the first request line in the HTTP
  * formatted header and extra headers. The minimum can be found in responseUserBufferMinimumSize.
  * Keep in mind that if the headers from the response do not all fit into this buffer, then the rest of the headers
  * will be discarded. The minimum size can be found in extern const uint32_t responseUserBufferMinimumSize. */
@@ -231,7 +231,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
      * IotHttpsClient_InitializeRequest(). */
     IotHttpsRequestHandle_t reqHandle = IOT_HTTPS_REQUEST_HANDLE_INITIALIZER;
 
-    /* Handle identifying the HTTP response. This is valid after the reponse has been received with
+    /* Handle identifying the HTTP response. This is valid after the response has been received with
      * IotHttpsClient_SendSync(). */
     IotHttpsResponseHandle_t respHandle = IOT_HTTPS_RESPONSE_HANDLE_INITIALIZER;
     /* Synchronous request specific configurations. */
@@ -270,7 +270,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Synchronous S3 download demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_GET_URL );
 
-    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This function returns the length of the path
      * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_GET_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_GET_URL ),
@@ -517,7 +517,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
         IotLogInfo( "Downloaded %d/%d", curByte, fileSize );
 
         /* If amount of file remaining to request is less than the current amount of bytes to request next time, then
-         * udpdate the amount of bytes to request, on the next iteration, to be the amount remaining. */
+         * update the amount of bytes to request, on the next iteration, to be the amount remaining. */
         if( curByte > fileSize )
         {
             IotLogError( "Received more data than the size of the file specified." );

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -319,7 +319,7 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Asynchronous S3 upload demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_PUT_URL );
 
-    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This function returns the length of the path
      * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL ),

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -236,7 +236,7 @@ static void _responseCompleteCallback( void * pPrivData,
                                        IotHttpsReturnCode_t rc,
                                        uint16_t status )
 {
-    ( void )rc;
+    ( void ) rc;
 
     bool * pUploadSuccess = ( bool * ) pPrivData;
 

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -236,6 +236,8 @@ static void _responseCompleteCallback( void * pPrivData,
                                        IotHttpsReturnCode_t rc,
                                        uint16_t status )
 {
+    ( void )rc;
+
     bool * pUploadSuccess = ( bool * ) pPrivData;
 
     /* When the remote server response with 200 OK, the file was successfully uploaded. */

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -437,7 +437,7 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
 
     if( httpsClientStatus != IOT_HTTPS_OK )
     {
-        IotLogError( "Failed to connect to the S3 server. Error code: %d.", httpsClientStatus );
+        IotLogError( "Failed to connect to the server. Error code: %d.", httpsClientStatus );
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 

--- a/demos/https/iot_demo_https_s3_upload_sync.c
+++ b/demos/https/iot_demo_https_s3_upload_sync.c
@@ -368,7 +368,7 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
 
     if( httpsClientStatus != IOT_HTTPS_OK )
     {
-        IotLogError( "Failed to connect to the S3 server. Error code: %d.", httpsClientStatus );
+        IotLogError( "Failed to connect to the server. Error code: %d.", httpsClientStatus );
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 

--- a/demos/https/iot_demo_https_s3_upload_sync.c
+++ b/demos/https/iot_demo_https_s3_upload_sync.c
@@ -227,7 +227,7 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
      * IotHttpsClient_InitializeRequest(). */
     IotHttpsRequestHandle_t reqHandle = IOT_HTTPS_REQUEST_HANDLE_INITIALIZER;
 
-    /* Handle identifying the HTTP response. This is valid after the reponse has been received with
+    /* Handle identifying the HTTP response. This is valid after the response has been received with
      * IotHttpsClient_SendSync(). */
     IotHttpsResponseHandle_t respHandle = IOT_HTTPS_RESPONSE_HANDLE_INITIALIZER;
     /* Synchronous request specific configurations. */
@@ -250,7 +250,7 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
 
     IotLogInfo( "HTTPS Client Synchronous S3 upload demo using pre-signed URL: %s", IOT_DEMO_HTTPS_PRESIGNED_PUT_URL );
 
-    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This fuction returns the length of the path
+    /* Retrieve the path location from IOT_DEMO_HTTPS_PRESIGNED_GET_URL. This function returns the length of the path
      * without the query into pathLen. */
     httpsClientStatus = IotHttpsClient_GetUrlPath( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL,
                                                    strlen( IOT_DEMO_HTTPS_PRESIGNED_PUT_URL ),

--- a/doc/generate_doc.sh
+++ b/doc/generate_doc.sh
@@ -38,7 +38,7 @@ i=0; while [ $i -le 1 ]; do
         else
             echo "Generating documentation for $file..."
 
-            # Redirect errors to file when running under Travis CI.
+            # Redirect errors to a file.
             doxygen $file 2>>doxygen_warnings.txt
         fi
     done

--- a/libraries/c_sdk/standard/https/include/iot_https_client.h
+++ b/libraries/c_sdk/standard/https/include/iot_https_client.h
@@ -184,7 +184,7 @@ void IotHttpsClient_Cleanup( void );
  * @ref https_client_function_sendasync.
  *
  * Keep in mind that many HTTP servers will close a connection, if it does not receive any requests, after a certain
- * amount of time. Many webservers may close the connection after 30-60 seconds. The state of pConnHandle will still be
+ * amount of time. Many web servers may close the connection after 30-60 seconds. The state of pConnHandle will still be
  * in a connected state if this happens. If the server closed the connection, then the next request on the connection
  * will fail to send with a network error and the connection will move to a closed state.
  *
@@ -518,7 +518,7 @@ IotHttpsReturnCode_t IotHttpsClient_WriteRequestBody( IotHttpsRequestHandle_t re
  * #IOT_HTTPS_MESSAGE_TOO_LARGE. To avoid this issue, the application needs to determine beforehand how large the file
  * to download is. This can be done with a HEAD request first, then extracting the "Content-Length" with
  * @ref https_client_function_readcontentlength. This could also be done with a GET request with the header
- * "Range: bytes=0-0", then extracing the "Content-Range" with @ref https_client_function_readheader. Keep in mind that
+ * "Range: bytes=0-0", then extracting the "Content-Range" with @ref https_client_function_readheader. Keep in mind that
  * not all HTTP servers support Partial Content responses.
  *
  * Once a the file size is known, the application can initialize the request with a large
@@ -595,7 +595,7 @@ IotHttpsReturnCode_t IotHttpsClient_SendSync( IotHttpsConnectionHandle_t connHan
  * - #IOT_HTTPS_CONNECTION_ERROR if the connection failed.
  * - #IOT_HTTPS_FATAL if there was a grave error with the last async job finishing.
  * - #IOT_HTTPS_ASYNC_SCHEDULING_ERROR if there was an error scheduling the asynchronous request.
- * - #IOT_HTTPS_INTERNAL_ERROR if there was an internal error with starting an asyncrhonous request servicing task.
+ * - #IOT_HTTPS_INTERNAL_ERROR if there was an internal error with starting an asynchronous request servicing task.
  * - #IOT_HTTPS_INVALID_PARAMETER if there were NULL parameters or the request passed in was a synchronous type.
  *
  */
@@ -620,7 +620,7 @@ IotHttpsReturnCode_t IotHttpsClient_SendAsync( IotHttpsConnectionHandle_t connHa
  * application wants to stop the rest of the request processing.
  *
  * If the asynchronous request stops processing, the buffers in #IotHttpsRequestInfo_t.userBuffer can be safely freed,
- * modified, or resused, only once #IotHttpsClientCallbacks_t.readReadyCallback is invoked.
+ * modified, or reused, only once #IotHttpsClientCallbacks_t.readReadyCallback is invoked.
  *
  * <b> Example Asynchronous Code </b>
  * @code{c}

--- a/libraries/c_sdk/standard/https/include/types/iot_https_types.h
+++ b/libraries/c_sdk/standard/https/include/types/iot_https_types.h
@@ -49,7 +49,7 @@
  * @brief Variables calculating the size of #IotHttpsUserBuffer_t.bufferLen needed for the request, response, and
  * connection.
  *
- * @note These user buffer minumum values may change at any time in future versions, but their names will remain the
+ * @note These user buffer minimum values may change at any time in future versions, but their names will remain the
  * same.
  * - @ref requestUserBufferMinimumSize <br>
  *   @copybrief requestUserBufferMinimumSize
@@ -61,7 +61,7 @@
  * @section https_connection_flags HTTPS Client Connection Flags
  * @brief Flags that modify the behavior of the HTTPS Connection.
  *
- * Flags should be bitwised-ORed with each other to change the behavior of @ref https_client_function_sendasync and
+ * Flags should be bitwise-ORed with each other to change the behavior of @ref https_client_function_sendasync and
  * @ref https_client_function_sendsync. These flags are set in #IotHttpsConnectionInfo_t.flags.
  *
  * @note The values of flags may change at any time in future versions, but their names will remain the same.
@@ -149,7 +149,7 @@ extern const uint32_t requestUserBufferMinimumSize;
 extern const uint32_t responseUserBufferMinimumSize;
 
 /**
- * @brief The minimum user buffer size for the HTTP connection conext and headers.
+ * @brief The minimum user buffer size for the HTTP connection context and headers.
  *
  * This helps to calculate the size of the buffer needed for #IotHttpsConnectionInfo_t.userBuffer.
  *
@@ -236,7 +236,7 @@ extern const uint32_t connectionUserBufferMinimumSize;
  * returns, the connection handle should no longer be used. The application must call @ref https_client_function_connect
  * again to retrieve a new handle and a new connection.
  *
- * Typical webservers disconnect the client in around 30-60 seconds. The application needs to be aware of this, when
+ * Typical web servers disconnect the client in around 30-60 seconds. The application needs to be aware of this, when
  * taking time between requests in a persistent connection.
  *
  * A connection handle is not thread safe. Multiple threads cannot connect and disconnect with the same handle at the
@@ -533,7 +533,7 @@ typedef struct IotHttpsClientCallbacks
      * If this is set to NULL, then it will not be invoked.
      * See @ref https_client_function_addheader for more information on adding a header in this callback.
      *
-     * Appending the header when request is in progress is good for things like time limitted authentication tokens.
+     * Appending the header when request is in progress is good for things like time limited authentication tokens.
      *
      * @param[in] pPrivData - User context configured in #IotHttpsAsyncInfo_t.pPrivData
      * @param[in] reqHandle - The handle for the current HTTP request in progress.
@@ -800,7 +800,7 @@ typedef struct IotHttpsRequestInfo
      * The absolute path includes the path to the file AND the optional query.
      * An example URI path: "/v20160207/directives?query".
      *
-     * If this is NULL, a "/" will be added to the Request-Line automaticaly.
+     * If this is NULL, a "/" will be added to the Request-Line automatically.
      *
      * This is used to generate the Request-Line in the HTTP request message, see
      * @ref https_client_function_initializerequest for more information.
@@ -821,7 +821,7 @@ typedef struct IotHttpsRequestInfo
      *
      * This is the same as the address in #IotHttpsConnectionInfo_t.pAddress. This is here in the request structure to
      * automatically generate the "Host" header field in the header buffer space configured in
-     * #IotHttpsRequestInfo_t.userBuffer. See @ref https_client_function_initializerequest for more informaiton.
+     * #IotHttpsRequestInfo_t.userBuffer. See @ref https_client_function_initializerequest for more information.
      */
     const char * pHost;
     uint32_t hostLen; /**< @brief Host address length. */
@@ -885,7 +885,7 @@ typedef struct IotHttpsResponseInfo
     /**
      * The application owned buffer for storing the response headers and internal response context.
      *
-     * For an asychronous request, if the application owns the memory for this buffer, then it must not be modified,
+     * For an asynchronous request, if the application owns the memory for this buffer, then it must not be modified,
      * freed, or reused until the the #IotHttpsClientCallbacks_t.responseCompleteCallback is invoked.
      *
      * Please see #IotHttpsUserBuffer_t for more information.

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -69,7 +69,7 @@
  *
  * This is used for writing headers automatically during the sending of the HTTP request.
  * "Connection: keep-alive\r\n" is written automatically for a persistent connection.
- * "Connection: close\r\n" is written automatically for a non-presistent connection.
+ * "Connection: close\r\n" is written automatically for a non-persistent connection.
  */
 #define HTTPS_CONNECTION_KEEP_ALIVE_HEADER_LINE           HTTPS_CONNECTION_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_CONNECTION_KEEP_ALIVE_HEADER_VALUE HTTPS_END_OF_HEADER_LINES_INDICATOR /**< @brief String literal for "Connection: keep-alive\r\n". */
 #define HTTPS_CONNECTION_CLOSE_HEADER_LINE                HTTPS_CONNECTION_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_CONNECTION_CLOSE_HEADER_VALUE HTTPS_END_OF_HEADER_LINES_INDICATOR      /**< @brief String literal for "Connection: close\r\n". */
@@ -197,7 +197,7 @@ static int _httpParserOnHeaderValueCallback( http_parser * pHttpParser,
                                              size_t length );
 
 /**
- * @brief Callback from http-parser to indicate it reached the end of the headers in the HTTP response messsage.
+ * @brief Callback from http-parser to indicate it reached the end of the headers in the HTTP response message.
  *
  * The end of the headers is signalled in a HTTP response message by another "\r\n" after the final header line.
  *
@@ -232,10 +232,10 @@ static int _httpParserOnBodyCallback( http_parser * pHttpParser,
                                       size_t length );
 
 /**
- * @brief Callback from http-parser to indicate it reached the end of the HTTP response messsage.
+ * @brief Callback from http-parser to indicate it reached the end of the HTTP response message.
  *
  * The end of the message is signalled in a HTTP response message by another "\r\n" after the final header line, with no
- * entity body; or it is singalled by "\r\n" at the end of the entity body.
+ * entity body; or it is singaled by "\r\n" at the end of the entity body.
  *
  * For a Transfer-Encoding: chunked type of response message, the end of the message is signalled by a terminating
  * chunk header with length zero.
@@ -272,7 +272,7 @@ static int _httpParserOnMessageCompleteCallback( http_parser * pHttpParser );
     static int _httpParserOnChunkHeaderCallback( http_parser * pHttpParser );
 
 /**
- * @brief Callback from http-parser to indicate it reached the end of an HTTP response messsage "chunk".
+ * @brief Callback from http-parser to indicate it reached the end of an HTTP response message "chunk".
  *
  * A chunk is complete when the chunk header size is read fully in the body.
  *
@@ -610,7 +610,7 @@ static IotHttpsReturnCode_t _initializeResponse( IotHttpsResponseHandle_t * pRes
 /**
  * @brief Increment the pointer stored in pBufCur depending on the character found in there.
  *
- * This function increments the pHeadersCur pointer further if the message ended with a header line delimitter.
+ * This function increments the pHeadersCur pointer further if the message ended with a header line delimiter.
  *
  * @param[in] pBufCur - Pointer to the next location to write data into the buffer pBuf. This is a double pointer to update the response context buffer pointers.
  * @param[in] pBufEnd - Pointer to the end of the buffer to receive the HTTP response into.
@@ -773,7 +773,7 @@ static int _httpParserOnHeadersCompleteCallback( http_parser * pHttpParser )
     /* This if-case is not incrementing any pHeaderCur pointers, so this case is safe to call when flushing the
      * network buffer. Flushing the network buffer needs the logic below to reach PARSER_STATE_BODY_COMPLETE if the
      * response is for a HEAD request. Before flushing the network buffer the bufferProcessingState is set to
-     * PROCESSING_STATE_FINISHED so that other callback fuctions don't update header or body current pointers in the
+     * PROCESSING_STATE_FINISHED so that other callback functions don't update header or body current pointers in the
      * response context. We don't want those pointers incremented because flushing the network uses a different buffer
      * to receive the rest of the response. */
     if( pHttpsResponse->bufferProcessingState <= PROCESSING_STATE_FINISHED )
@@ -792,7 +792,7 @@ static int _httpParserOnHeadersCompleteCallback( http_parser * pHttpParser )
          * response, then the body buffer will be filled with the zeros from rest of the header buffer. http-parser
          * will invoke the on_body callback and consider the zeros following the headers as body. */
 
-        /* If there is not body configured for a synchronous reponse, we do not stop the parser from continueing. */
+        /* If there is not body configured for a synchronous response, we do not stop the parser from continueing. */
 
         /* Skipping the body will cause the parser to invoke the _httpParserOnMessageComplete() callback. This is
          * not desired when there is actually HTTP response body sent by the server because this will set the parser
@@ -1110,7 +1110,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
         {
             /* Given the function signature of IotNetworkInterface_t.receive, we can only receive 0 to the number of bytes
              * requested. Receiving less than the number of bytes requests is OK since we do not how much data is expected, so
-             * we ask for the full size of the receive buffer. Thereofore, the only error that can be returned from receiving
+             * we ask for the full size of the receive buffer. Therefore, the only error that can be returned from receiving
              * the headers or body is a timeout. We always disconnect from the network when there is a timeout because the
              * server may be slow to respond. If the server happens to send the response later at the same time another response
              * is waiting in the queue, then the workflow is corrupted. Pipelining is not current supported in this library. */
@@ -1167,7 +1167,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
         }
         else if( status == IOT_HTTPS_NETWORK_ERROR )
         {
-            /* We walways disconnect for a network error because failure to receive the HTTPS body will result in a
+            /* We always disconnect for a network error because failure to receive the HTTPS body will result in a
              * corruption of the workflow. */
             IotLogError( "Network error receiving the HTTPS body for response %d. Error code: %d",
                          pCurrentHttpsResponse,
@@ -1322,7 +1322,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
     }
     else if( pCurrentHttpsResponse->pCallbacks->responseCompleteCallback )
     {
-        /* Signal to a synchronous reponse that the response is complete. */
+        /* Signal to a synchronous response that the response is complete. */
         pCurrentHttpsResponse->pCallbacks->responseCompleteCallback( pCurrentHttpsResponse->pUserPrivData, pCurrentHttpsResponse, status, pCurrentHttpsResponse->status );
     }
 }
@@ -1693,7 +1693,7 @@ static IotHttpsReturnCode_t _sendHttpsHeaders( _httpsConnection_t * pHttpsConnec
      * both the connection type strings will fit in the buffer. */
     char finalHeaders[ HTTPS_MAX_CONTENT_LENGTH_LINE_LENGTH + HTTPS_CONNECTION_KEEP_ALIVE_HEADER_LINE_LENGTH + HTTPS_END_OF_HEADER_LINES_INDICATOR_LENGTH ] = { 0 };
 
-    /* Send the headers passed into this function first. These headers are not termined with a second set of "\r\n". */
+    /* Send the headers passed into this function first. These headers are not terminated with a second set of "\r\n". */
     status = _networkSend( pHttpsConnection, pHeadersBuf, headersLength );
 
     if( HTTPS_FAILED( status ) )
@@ -1810,13 +1810,13 @@ static void _incrementNextLocationToWriteBeyondParsed( uint8_t ** pBufCur,
                                                        uint8_t ** pBufEnd )
 {
     /* There is an edge case where the final one or two character received in the header buffer is part of
-     * the header field separator ": " or part of the header line end "\r\n" delimitters. When this
+     * the header field separator ": " or part of the header line end "\r\n" delimiters. When this
      * happens, pHeadersCur in the response will point not the end of the buffer, but to a character in
      * the delimiter. For example:
      * Let's say this is our current header buffer after receiving and parsing:
      * ["HTTP/1.1 200 OK\r\n\header0: value0\r\nheader1: value1\r\n"]
      * pHeadersCur will point to \r because the http-parser does not invoke a callback on the
-     * delimitters. Since no callback is invoked, pHeadersCur is not incremented. pHeadersEnd points to
+     * delimiters. Since no callback is invoked, pHeadersCur is not incremented. pHeadersEnd points to
      * the end of the header buffer which is the unwritable memory location right after the final '\n'.
      * Because pHeadersCur is less than pHeaderEnd we loop again and receive on the network causing the
      * buffer to look like this:
@@ -1924,7 +1924,7 @@ static IotHttpsReturnCode_t _receiveHttpsMessage( _httpsConnection_t * pHttpsCon
             _incrementNextLocationToWriteBeyondParsed( pBufCur, pBufEnd );
         }
 
-        /* The _httResponse->pHeadersCur pointer is updated in the http_parser callbacks. */
+        /* The _httpsResponse->pHeadersCur pointer is updated in the http_parser callbacks. */
         IotLogDebug( "There is %d of space left in the buffer.", *pBufEnd - *pBufCur );
     }
 
@@ -2900,14 +2900,14 @@ IotHttpsReturnCode_t IotHttpsClient_AddHeader( IotHttpsRequestHandle_t reqHandle
                                          HTTPS_CONNECTION_HEADER );
 
     /* Check for auto-generated header "Host". This header is created and placed into the header buffer space
-     * in IotHttpClient_InitializeRequest(). */
+     * in IotHttpsClient_InitializeRequest(). */
     HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP( strncmp( pName, HTTPS_HOST_HEADER, FAST_MACRO_STRLEN( HTTPS_HOST_HEADER ) ) != 0,
                                          IOT_HTTPS_INVALID_PARAMETER,
                                          "Attempting to add auto-generated header %s. This is not allowed.",
                                          HTTPS_HOST_HEADER );
 
     /* Check for auto-generated header "User-Agent". This header is created and placed into the header buffer space
-     * in IotHttpClient_InitializeRequest(). */
+     * in IotHttpsClient_InitializeRequest(). */
     HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP( strncmp( pName, HTTPS_USER_AGENT_HEADER, FAST_MACRO_STRLEN( HTTPS_USER_AGENT_HEADER ) ) != 0,
                                          IOT_HTTPS_INVALID_PARAMETER,
                                          "Attempting to add auto-generated header %s. This is not allowed.",
@@ -3106,7 +3106,7 @@ IotHttpsReturnCode_t IotHttpsClient_ReadResponseBody( IotHttpsResponseHandle_t r
     respHandle->pBodyEnd = respHandle->pBodyCur + *pLen;
 
     /* When there is part of the body in the header pBuffer. We need to move that data to this body pBuffer
-     *  provided in this fuction. */
+     * provided in this function. */
     bodyLengthInHeaderBuf = respHandle->pBodyCurInHeaderBuf - respHandle->pBodyInHeaderBuf;
 
     if( bodyLengthInHeaderBuf > 0 )
@@ -3268,10 +3268,10 @@ IotHttpsReturnCode_t IotHttpsClient_ReadHeader( IotHttpsResponseHandle_t respHan
     savedParserState = respHandle->parserState;
 
     /* The header search parameters in the response handle are used as context in the http-parser callbacks. During
-     * the callback, pReadHeaderField is checked against the currently parsed header name. foundHeaderFiled is set to
+     * the callback, pReadHeaderField is checked against the currently parsed header name. foundHeaderField is set to
      * true when the pReadHeaderField is found in a header field callback. The bufferProcessingState tells the callback
      * to skip the logic pertaining to when the response is being parsed for the first time. pReadHeaderValue will store
-     * the header value found. readHeaderValueLength will store the the header value found's length from within the
+     * the header value found. readHeaderValueLength will store the length of the header value found from within the
      * response headers. */
     respHandle->pReadHeaderField = pName;
     respHandle->readHeaderFieldLength = nameLen;

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -958,7 +958,8 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
                  * the parser state and the networks status. */
                 break;
             }
-            IotLogDebug( "Invoking the readReadyCallback again.");
+
+            IotLogDebug( "Invoking the readReadyCallback again." );
         } while( ( pHttpsResponse->parserState < PARSER_STATE_BODY_COMPLETE ) && ( pHttpsResponse->bodyRxStatus == IOT_HTTPS_OK ) );
 
         if( HTTPS_FAILED( pHttpsResponse->bodyRxStatus ) )
@@ -1572,7 +1573,7 @@ static IotHttpsReturnCode_t _addHeader( _httpsRequest_t * pHttpsRequest,
      * (name:value\r\n). We need to add a "\r\n" at the end of headers. The use of
      * possibleLastHeaderAdditionalLength is to make sure that there is always
      * space for the last "\r\n". */
-    if( ( additionalLength + possibleLastHeaderAdditionalLength ) > ( (uint32_t)( pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur ) ) )
+    if( ( additionalLength + possibleLastHeaderAdditionalLength ) > ( ( uint32_t ) ( pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur ) ) )
     {
         IotLogError( "There is %d space left in the header buffer, but we want to add %d more of header.",
                      pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur,

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -943,7 +943,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
         /* If there is still more body that has not been passed back to the user, then this callback is invoked again. */
         do
         {
-            IotLogDebug( "Invoking the readReadyCallback." );
+            IotLogDebug( "Invoking the readReadyCallback for response %d.", pHttpsResponse );
             pHttpsResponse->pCallbacks->readReadyCallback( pHttpsResponse->pUserPrivData,
                                                            pHttpsResponse,
                                                            pHttpsResponse->bodyRxStatus,
@@ -958,6 +958,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
                  * the parser state and the networks status. */
                 break;
             }
+            IotLogDebug( "Invoking the readReadyCallback again.");
         } while( ( pHttpsResponse->parserState < PARSER_STATE_BODY_COMPLETE ) && ( pHttpsResponse->bodyRxStatus == IOT_HTTPS_OK ) );
 
         if( HTTPS_FAILED( pHttpsResponse->bodyRxStatus ) )
@@ -1571,7 +1572,7 @@ static IotHttpsReturnCode_t _addHeader( _httpsRequest_t * pHttpsRequest,
      * (name:value\r\n). We need to add a "\r\n" at the end of headers. The use of
      * possibleLastHeaderAdditionalLength is to make sure that there is always
      * space for the last "\r\n". */
-    if( ( additionalLength + possibleLastHeaderAdditionalLength ) > ( pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur ) )
+    if( ( additionalLength + possibleLastHeaderAdditionalLength ) > ( (uint32_t)( pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur ) ) )
     {
         IotLogError( "There is %d space left in the header buffer, but we want to add %d more of header.",
                      pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur,
@@ -2668,6 +2669,9 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect( IotHttpsConnectionHandle_t connH
             IotDeQueue_EnqueueHead( &( connHandle->respQ ), pRespItem );
         }
     }
+
+    /* Debug code */
+    IotLogDebug( "There were %d requests in the queue while disconnecting. ", IotDeQueue_Count( &( connHandle->reqQ ) ) );
 
     /* Remove all pending requests. If this routine is called from the application context and there is a
      * network receive callback in process, this routine will wait in _networkDestroy until that routine returns.

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -958,8 +958,6 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
                  * the parser state and the networks status. */
                 break;
             }
-
-            IotLogDebug( "Invoking the readReadyCallback again." );
         } while( ( pHttpsResponse->parserState < PARSER_STATE_BODY_COMPLETE ) && ( pHttpsResponse->bodyRxStatus == IOT_HTTPS_OK ) );
 
         if( HTTPS_FAILED( pHttpsResponse->bodyRxStatus ) )
@@ -2081,6 +2079,7 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
         IotLogError( "Error sending the HTTPS headers with error code: %d", status );
         HTTPS_GOTO_CLEANUP();
     }
+    IotLogDebug("Sent HTTPS headers for request %d.", pHttpsRequest);
 
     if( ( pHttpsRequest->pBody != NULL ) && ( pHttpsRequest->bodyLength > 0 ) )
     {
@@ -2091,6 +2090,7 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
             IotLogError( "Error sending final HTTPS body. Return code: %d", status );
             HTTPS_GOTO_CLEANUP();
         }
+        IotLogDebug("Sent HTTPS body for request %d.", pHttpsRequest);
     }
 
     HTTPS_FUNCTION_EXIT_NO_CLEANUP();
@@ -2378,6 +2378,7 @@ IotHttpsReturnCode_t _addRequestToConnectionReqQ( _httpsRequest_t * pHttpsReques
     if( ( IotDeQueue_IsEmpty( &( pHttpsConnection->reqQ ) ) ) &&
         ( IotDeQueue_IsEmpty( &( pHttpsConnection->respQ ) ) ) )
     {
+        IotLogDebug("Both the request and response queue are empty, so schedule the request to run in the taskpool.");
         scheduleRequest = true;
     }
 
@@ -2638,6 +2639,7 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect( IotHttpsConnectionHandle_t connH
     if( pRespItem != NULL )
     {
         pHttpsResponse = IotLink_Container( _httpsResponse_t, pRespItem, link );
+        IotLogDebug( "Response %d found in the queue during disconnect.", pHttpsResponse );
 
         if( pHttpsResponse->reqFinishedSending == false )
         {

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -235,7 +235,7 @@ static int _httpParserOnBodyCallback( http_parser * pHttpParser,
  * @brief Callback from http-parser to indicate it reached the end of the HTTP response message.
  *
  * The end of the message is signalled in a HTTP response message by another "\r\n" after the final header line, with no
- * entity body; or it is singaled by "\r\n" at the end of the entity body.
+ * entity body; or it is signaled by "\r\n" at the end of the entity body.
  *
  * For a Transfer-Encoding: chunked type of response message, the end of the message is signalled by a terminating
  * chunk header with length zero.

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2079,7 +2079,8 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
         IotLogError( "Error sending the HTTPS headers with error code: %d", status );
         HTTPS_GOTO_CLEANUP();
     }
-    IotLogDebug("Sent HTTPS headers for request %d.", pHttpsRequest);
+
+    IotLogDebug( "Sent HTTPS headers for request %d.", pHttpsRequest );
 
     if( ( pHttpsRequest->pBody != NULL ) && ( pHttpsRequest->bodyLength > 0 ) )
     {
@@ -2090,7 +2091,8 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
             IotLogError( "Error sending final HTTPS body. Return code: %d", status );
             HTTPS_GOTO_CLEANUP();
         }
-        IotLogDebug("Sent HTTPS body for request %d.", pHttpsRequest);
+
+        IotLogDebug( "Sent HTTPS body for request %d.", pHttpsRequest );
     }
 
     HTTPS_FUNCTION_EXIT_NO_CLEANUP();
@@ -2378,7 +2380,7 @@ IotHttpsReturnCode_t _addRequestToConnectionReqQ( _httpsRequest_t * pHttpsReques
     if( ( IotDeQueue_IsEmpty( &( pHttpsConnection->reqQ ) ) ) &&
         ( IotDeQueue_IsEmpty( &( pHttpsConnection->respQ ) ) ) )
     {
-        IotLogDebug("Both the request and response queue are empty, so schedule the request to run in the taskpool.");
+        IotLogDebug( "Both the request and response queue are empty, so schedule the request to run in the taskpool." );
         scheduleRequest = true;
     }
 

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -62,12 +62,12 @@
 /* Convenience macros for handling errors in a standard way. */
 
 /**
- * @brief Every public API return an enumeration value with an undelying value of 0 in case of success.
+ * @brief Every public API return an enumeration value with an underlying value of 0 in case of success.
  */
 #define HTTPS_SUCCEEDED( x )                         ( ( x ) == IOT_HTTPS_OK )
 
 /**
- * @brief Every public API returns an enumeration value with an undelying value different than 0 in case of success.
+ * @brief Every public API returns an enumeration value with an underlying value different than 0 in case of success.
  */
 #define HTTPS_FAILED( x )                            ( ( x ) != IOT_HTTPS_OK )
 
@@ -284,7 +284,7 @@
  *
  * PARSER_STATE_IN_HEADERS is assigned at the start of the HTTP Response message. This occurs in the
  * _httpParserOnMessageBeginCallback(). HTTP headers are always first and there is always the response status line
- * and some headers in a response message acccording to RFC 2616.
+ * and some headers in a response message according to RFC 2616.
  *
  * PARSER_STATE_HEADERS_COMPLETE is assigned when all of the headers are finished being parsed in the HTTP response
  * message. This occurs in the _httpParserOnHeadersCompleteCallback(). The state can end here if the response has no
@@ -327,7 +327,7 @@ typedef enum IotHttpsResponseParserState
  * This state is then used in the parser callbacks _httpParserOnStatusCallback(), _httpParserOnHeaderFieldCallback(),
  * _httpParserOnHeaderValueCallback(), and _httpParserOnHeadersCompleteCallback() to move the
  * #_httpsResponse_t.headersCur pointer along in the header buffer.
- * Since the server sends the HTTP response as a single continuous message, somtimes during receiving of the HTTP
+ * Since the server sends the HTTP response as a single continuous message, sometimes during receiving of the HTTP
  * headers we may receive part or all of the HTTP response body:
  * ((example header buffer))[headers headers headers headers body body body]
  * When parsing this header buffer the parser will execute _httpParserOnBodyCallback() in the
@@ -436,7 +436,7 @@ typedef struct _httpsResponse
                                                           *          On the following parser callback _httpParserOnHeaderValueCallback() we will store the value in pReadHeaderValue and then exit the parsing. */
     struct _httpsConnection * pHttpsConnection;          /**< @brief Connection associated with response. This is set during IotHttpsClient_SendAsync(). This is needed during the asynchronous workflow to receive data given the respHandle only in the callback. */
     bool isAsync;                                        /**< @brief This is set to true if this response is to be retrieved asynchronously. Set to false otherwise. */
-    uint8_t * pBodyInHeaderBuf;                          /**< @brief Pointer to the start of body inside the header buffer for copying to a body buffer provided later by the asyncrhonous response process. */
+    uint8_t * pBodyInHeaderBuf;                          /**< @brief Pointer to the start of body inside the header buffer for copying to a body buffer provided later by the asynchronous response process. */
     uint8_t * pBodyCurInHeaderBuf;                       /**< @brief Pointer to the next location to write body data during processing of the header buffer. This is necessary in case there is a chunk encoded HTTP response. */
     IotHttpsReturnCode_t bodyRxStatus;                   /**< @brief The status of network receiving the HTTPS body to be returned during the #IotHttpsClientCallbacks_t.readReadyCallback. */
     bool cancelled;                                      /**< @brief This is set to true to stop the request/response processing in the asynchronous request workflow. */


### PR DESCRIPTION
Description
-----------
* Fix `_requestPool.pRequestDatas->scheduled = true;` to `_requestPool.pRequestContexts[ reqIndex ].scheduled = true;` as found by third-party static analysis tool.
* Changed all "requestDatas" to "requestContexts" this is because the "datas" is weird as data is already plural. "Context" postfixed to a variable name is vague to use, but better than postfixing "Data". These variables have a collection of information that get updated during the callbacks, so they are essentially "callbackContexts". 
* Fix spellings of words in all HTTPS Client library and demo files.
* Add more debug logging to the HTTPS Client library code and the async download demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.