### PR TITLE
Fix AFR_METADATA_MODE on espressif

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 # -------------------------------------------------------------------------------------------------
 # Compiler settings
 # -------------------------------------------------------------------------------------------------
+if(AFR_METADATA_MODE)
+    set(PYTHON_DEPS_CHECKED 1)
+endif()
 
 set(esp_idf_dir "${AFR_VENDORS_DIR}/espressif/esp-idf")
 # Provides idf_import_components and idf_link_components

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 # -------------------------------------------------------------------------------------------------
 # Compiler settings
 # -------------------------------------------------------------------------------------------------
+# Mark the python dependencies as checked so that esp-idf does not check them since this is not
+# needed when we are only generating metadata and not building the project.
 if(AFR_METADATA_MODE)
     set(PYTHON_DEPS_CHECKED 1)
 endif()


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- esp-idf CMakefile checks for python dependencies before
 configuring, which breaks metadata upload step in OCW
- This commit marks python dependencies as checked if
 AFR_METADATA_MODE is enabled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.