### PR TITLE
Fixes to Optiga Trust X PKCS #11 implementation

### DIFF
--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -1999,6 +1999,7 @@ CK_DEFINE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
                         }
                         else if( pxTemplate[ iAttrib ].ulValueLen < ulLength )
                         {
+                            pxTemplate[ iAttrib ].ulValueLen = ulLength;
                             xResult = CKR_BUFFER_TOO_SMALL;
                         }
                         else
@@ -2272,9 +2273,9 @@ CK_DEFINE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
         }
         else
         {
-            /*xIsObjectWithNoNvmStorage(pxSession->pxFindObjectLabel, strlen(pxSession->pxFindObjectLabel), ) */
-            PKCS11_PRINT( ( "ERROR: Object with label '%s' not found. \r\n", ( char * ) pxSession->pxFindObjectLabel ) );
-            xResult = CKR_FUNCTION_FAILED;
+            /* If FindObject doesn't see an object, return CKR_OK with an invalid handle and an object count of 0. */
+            PKCS11_WARNING_PRINT( ( "ERROR: Object with label '%s' not found. \r\n", ( char * ) pxSession->pxFindObjectLabel ) );
+            *pxObject = CK_INVALID_HANDLE;
         }
     }
 


### PR DESCRIPTION
- In FindObject, return CKR_OK & count=0 when object not found
- In GetAttributeValue when buffer provided is too small,
supply required buffer size.

<!--- Title -->

Description
-----------
https://amazon-freertos-ci.corp.amazon.com/job/im_master/job/tests_ide/job/infineon/job/xmc4800_plus_optiga_trust_x-ide/12/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.