### PR TITLE
fix for ESP32 Nimble: prvBTSetAdvData assumes exactly 1 UUID to be ad…

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -634,27 +634,54 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
       {
         if( pxServiceUuid[i].ucType == eBTuuidType16 )
         {
-          uuid16[fields.num_uuids16].u.type = BLE_UUID_TYPE_16;
-          uuid16[fields.num_uuids16].value = pxServiceUuid->uu.uu16;
-          fields.uuids16 = uuid16;
-          fields.num_uuids16++;
-          fields.uuids16_is_complete = 1;
+          if(fields.num_uuids16==0)
+          {
+            uuid16[fields.num_uuids16].u.type = BLE_UUID_TYPE_16;
+            uuid16[fields.num_uuids16].value = pxServiceUuid->uu.uu16;
+            fields.uuids16 = uuid16;
+            fields.num_uuids16++;
+            fields.uuids16_is_complete = 1;
+          }
+          else
+          {
+            /// there are more than 1 service of this type, but as per bluetooth core specification supplement v8,
+            /// page 10, only one service UUID per type is allowed. Mark this as incomplete.
+            fields.uuids16_is_complete = 0;
+          }
         }
         else if( pxServiceUuid[i].ucType == eBTuuidType32 )
         {
-          uuid32[fields.num_uuids32].u.type = BLE_UUID_TYPE_32;
-          uuid32[fields.num_uuids32].value = pxServiceUuid->uu.uu32;
-          fields.uuids32 = uuid32;
-          fields.num_uuids32++;
-          fields.uuids32_is_complete = 1;
+          if(fields.num_uuids32==0)
+          {
+            uuid32[fields.num_uuids32].u.type = BLE_UUID_TYPE_32;
+            uuid32[fields.num_uuids32].value = pxServiceUuid->uu.uu32;
+            fields.uuids32 = uuid32;
+            fields.num_uuids32++;
+            fields.uuids32_is_complete = 1;
+          }
+          else
+          {
+            /// there are more than 1 service of this type, but as per bluetooth core specification supplement v8,
+            /// page 10, only one service UUID per type is allowed. Mark this as incomplete.
+            fields.uuids32_is_complete = 0;
+          }
         }
         else if( pxServiceUuid[i].ucType == eBTuuidType128 )
         {
-          uuid128[fields.num_uuids128].u.type = BLE_UUID_TYPE_128;
-          memcpy( uuid128[fields.num_uuids128].value, pxServiceUuid->uu.uu128, sizeof( pxServiceUuid->uu.uu128 ) );
-          fields.uuids128 = uuid128;
-          fields.num_uuids128++;
-          fields.uuids128_is_complete = 1;
+          if(fields.num_uuids128==0)
+          {
+            uuid128[fields.num_uuids128].u.type = BLE_UUID_TYPE_128;
+            memcpy( uuid128[fields.num_uuids128].value, pxServiceUuid->uu.uu128, sizeof( pxServiceUuid->uu.uu128 ) );
+            fields.uuids128 = uuid128;
+            fields.num_uuids128++;
+            fields.uuids128_is_complete = 1;
+          }
+          else
+          {
+            /// there are more than 1 service of this type, but as per bluetooth core specification supplement v8,
+            /// page 10, only one service UUID per type is allowed. Mark this as incomplete.
+            fields.uuids128_is_complete = 0;
+          }
         }
       }
     }

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -627,9 +627,9 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
     fields.num_uuids16=0;
     fields.num_uuids32=0;
     fields.num_uuids128=0;
-    for (size_t i = 0; i < xNbServices; i++)
+    if( pxServiceUuid != NULL )
     {
-      if( &(pxServiceUuid[i]) != NULL )
+      for (size_t i = 0; i < xNbServices; i++)
       {
         if( pxServiceUuid[i].ucType == eBTuuidType16 )
         {

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -535,13 +535,12 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
                             BTUuid_t * pxServiceUuid,
                             size_t xNbServices )
 {
-    const size_t c_max_uuid_per_adv_message = 2;
     struct ble_hs_adv_fields fields;
     const char * name;
     int xESPStatus;
-    ble_uuid16_t uuid16[c_max_uuid_per_adv_message];
-    ble_uuid32_t uuid32[c_max_uuid_per_adv_message];
-    ble_uuid128_t uuid128[c_max_uuid_per_adv_message];
+    ble_uuid16_t uuid16;
+    ble_uuid32_t uuid32;
+    ble_uuid128_t uuid128;
 
     BTStatus_t xStatus = eBTStatusSuccess;
 
@@ -636,9 +635,9 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
         {
           if(fields.num_uuids16==0)
           {
-            uuid16[fields.num_uuids16].u.type = BLE_UUID_TYPE_16;
-            uuid16[fields.num_uuids16].value = pxServiceUuid->uu.uu16;
-            fields.uuids16 = uuid16;
+            uuid16.u.type = BLE_UUID_TYPE_16;
+            uuid16.value = pxServiceUuid->uu.uu16;
+            fields.uuids16 = &uuid16;
             fields.num_uuids16++;
             fields.uuids16_is_complete = 1;
           }
@@ -653,9 +652,9 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
         {
           if(fields.num_uuids32==0)
           {
-            uuid32[fields.num_uuids32].u.type = BLE_UUID_TYPE_32;
-            uuid32[fields.num_uuids32].value = pxServiceUuid->uu.uu32;
-            fields.uuids32 = uuid32;
+            uuid32.u.type = BLE_UUID_TYPE_32;
+            uuid32.value = pxServiceUuid->uu.uu32;
+            fields.uuids32 = &uuid32;
             fields.num_uuids32++;
             fields.uuids32_is_complete = 1;
           }
@@ -670,9 +669,9 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
         {
           if(fields.num_uuids128==0)
           {
-            uuid128[fields.num_uuids128].u.type = BLE_UUID_TYPE_128;
-            memcpy( uuid128[fields.num_uuids128].value, pxServiceUuid->uu.uu128, sizeof( pxServiceUuid->uu.uu128 ) );
-            fields.uuids128 = uuid128;
+            uuid128.u.type = BLE_UUID_TYPE_128;
+            memcpy( uuid128.value, pxServiceUuid->uu.uu128, sizeof( pxServiceUuid->uu.uu128 ) );
+            fields.uuids128 = &uuid128;
             fields.num_uuids128++;
             fields.uuids128_is_complete = 1;
           }


### PR DESCRIPTION
fix for ESP32 Nimble: prvBTSetAdvData assumes exactly 1 UUID to be advertised

Description
-----------
fixes #1569 :
In iot_ble_hal_gap.c, function prvBTSetAdvData() never uses the xNbServices parameter and assumes there is exactly 1 UUID to be advertised if pxServiceUuid is not NULL.
At the same time, _setAdvData always gives a value to pxServiceUuid and sets xNbServices as 0 if there are no UUIDs to advertise.
This means that trying to advertise 0 UUIDs (e.g. to save advertisement space) does not work. Trying to advertise 2 UUIDs would also not work.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.