### PR TITLE
Web server support for ESP32

### DIFF
--- a/vendors/espressif/boards/esp32/components/freertos_tcpip/esp_http_server/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/components/freertos_tcpip/esp_http_server/CMakeLists.txt
@@ -1,0 +1,1 @@
+# Nothing to do, esp_http_server component can not be supported with FreeRTOS TCP stack

--- a/vendors/espressif/boards/esp32/components/freertos_tcpip/esp_http_server/component.mk
+++ b/vendors/espressif/boards/esp32/components/freertos_tcpip/esp_http_server/component.mk
@@ -1,0 +1,2 @@
+# Nothing to do, esp_http_server component can not be supported with FreeRTOS TCP stack
+COMPONENT_CONFIG_ONLY := 1

--- a/vendors/espressif/esp-idf/components/driver/uart.c
+++ b/vendors/espressif/esp-idf/components/driver/uart.c
@@ -53,7 +53,7 @@ static const char* UART_TAG = "uart";
 #define UART_ENTER_CRITICAL_ISR(mux)    portENTER_CRITICAL_ISR(mux)
 #define UART_EXIT_CRITICAL_ISR(mux)     portEXIT_CRITICAL_ISR(mux)
 #define UART_ENTER_CRITICAL(mux)        portENTER_CRITICAL_SAFE(mux)
-#define UART_EXIT_CRITICAL(mux)         portEXIT_CRITICAL_ISR(mux)
+#define UART_EXIT_CRITICAL(mux)         portEXIT_CRITICAL_SAFE(mux)
 
 // Check actual UART mode set
 #define UART_IS_MODE_SET(uart_number, mode) ((p_uart_obj[uart_number]->uart_mode == mode))

--- a/vendors/espressif/esp-idf/components/esp_http_server/CMakeLists.txt
+++ b/vendors/espressif/esp-idf/components/esp_http_server/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(COMPONENT_ADD_INCLUDEDIRS include)
+set(COMPONENT_PRIV_INCLUDEDIRS src/port/esp32 src/util)
+set(COMPONENT_SRCS "src/httpd_main.c"
+                   "src/httpd_parse.c"
+                   "src/httpd_sess.c"
+                   "src/httpd_txrx.c"
+                   "src/httpd_uri.c"
+                   "src/util/ctrl_sock.c")
+
+set(COMPONENT_REQUIRES nghttp)  # for http_parser.h
+set(COMPONENT_PRIV_REQUIRES lwip)
+
+register_component()

--- a/vendors/espressif/esp-idf/components/esp_http_server/Kconfig
+++ b/vendors/espressif/esp-idf/components/esp_http_server/Kconfig
@@ -1,0 +1,42 @@
+menu "HTTP Server"
+
+    config HTTPD_MAX_REQ_HDR_LEN
+        int "Max HTTP Request Header Length"
+        default 512
+        help
+            This sets the maximum supported size of headers section in HTTP request packet to be processed by the
+            server
+
+    config HTTPD_MAX_URI_LEN
+        int "Max HTTP URI Length"
+        default 512
+        help
+            This sets the maximum supported size of HTTP request URI to be processed by the server
+
+    config HTTPD_ERR_RESP_NO_DELAY
+        bool "Use TCP_NODELAY socket option when sending HTTP error responses"
+        default y
+        help
+            Using TCP_NODEALY socket option ensures that HTTP error response reaches the client before the
+            underlying socket is closed. Please note that turning this off may cause multiple test failures
+
+    config HTTPD_PURGE_BUF_LEN
+        int "Length of temporary buffer for purging data"
+        default 32
+        help
+            This sets the size of the temporary buffer used to receive and discard any remaining data that is
+            received from the HTTP client in the request, but not processed as part of the server HTTP request
+            handler.
+
+            If the remaining data is larger than the available buffer size, the buffer will be filled in multiple
+            iterations. The buffer should be small enough to fit on the stack, but large enough to avoid excessive
+            iterations.
+
+    config HTTPD_LOG_PURGE_DATA
+        bool "Log purged content data at Debug level"
+        default n
+        help
+            Enabling this will log discarded binary HTTP request data at Debug level.
+            For large content data this may not be desirable as it will clutter the log.
+
+endmenu

--- a/vendors/espressif/esp-idf/components/esp_http_server/component.mk
+++ b/vendors/espressif/esp-idf/components/esp_http_server/component.mk
@@ -1,0 +1,4 @@
+
+COMPONENT_SRCDIRS := src src/util
+COMPONENT_ADD_INCLUDEDIRS := include
+COMPONENT_PRIV_INCLUDEDIRS := src/port/esp32 src/util

--- a/vendors/espressif/esp-idf/components/esp_http_server/include/esp_http_server.h
+++ b/vendors/espressif/esp-idf/components/esp_http_server/include/esp_http_server.h
@@ -1,0 +1,1457 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _ESP_HTTP_SERVER_H_
+#define _ESP_HTTP_SERVER_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <http_parser.h>
+#include <sdkconfig.h>
+#include <esp_err.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+note: esp_https_server.h includes a customized copy of this
+initializer that should be kept in sync
+*/
+#define HTTPD_DEFAULT_CONFIG() {                        \
+        .task_priority      = tskIDLE_PRIORITY+5,       \
+        .stack_size         = 4096,                     \
+        .server_port        = 80,                       \
+        .ctrl_port          = 32768,                    \
+        .max_open_sockets   = 7,                        \
+        .max_uri_handlers   = 8,                        \
+        .max_resp_headers   = 8,                        \
+        .backlog_conn       = 5,                        \
+        .lru_purge_enable   = false,                    \
+        .recv_wait_timeout  = 5,                        \
+        .send_wait_timeout  = 5,                        \
+        .global_user_ctx = NULL,                        \
+        .global_user_ctx_free_fn = NULL,                \
+        .global_transport_ctx = NULL,                   \
+        .global_transport_ctx_free_fn = NULL,           \
+        .open_fn = NULL,                                \
+        .close_fn = NULL,                               \
+        .uri_match_fn = NULL                            \
+}
+
+#define ESP_ERR_HTTPD_BASE              (0x8000)                    /*!< Starting number of HTTPD error codes */
+#define ESP_ERR_HTTPD_HANDLERS_FULL     (ESP_ERR_HTTPD_BASE +  1)   /*!< All slots for registering URI handlers have been consumed */
+#define ESP_ERR_HTTPD_HANDLER_EXISTS    (ESP_ERR_HTTPD_BASE +  2)   /*!< URI handler with same method and target URI already registered */
+#define ESP_ERR_HTTPD_INVALID_REQ       (ESP_ERR_HTTPD_BASE +  3)   /*!< Invalid request pointer */
+#define ESP_ERR_HTTPD_RESULT_TRUNC      (ESP_ERR_HTTPD_BASE +  4)   /*!< Result string truncated */
+#define ESP_ERR_HTTPD_RESP_HDR          (ESP_ERR_HTTPD_BASE +  5)   /*!< Response header field larger than supported */
+#define ESP_ERR_HTTPD_RESP_SEND         (ESP_ERR_HTTPD_BASE +  6)   /*!< Error occured while sending response packet */
+#define ESP_ERR_HTTPD_ALLOC_MEM         (ESP_ERR_HTTPD_BASE +  7)   /*!< Failed to dynamically allocate memory for resource */
+#define ESP_ERR_HTTPD_TASK              (ESP_ERR_HTTPD_BASE +  8)   /*!< Failed to launch server task/thread */
+
+/* Symbol to be used as length parameter in httpd_resp_send APIs
+ * for setting buffer length to string length */
+#define HTTPD_RESP_USE_STRLEN -1
+
+/* ************** Group: Initialization ************** */
+/** @name Initialization
+ * APIs related to the Initialization of the web server
+ * @{
+ */
+
+/**
+ * @brief   HTTP Server Instance Handle
+ *
+ * Every instance of the server will have a unique handle.
+ */
+typedef void* httpd_handle_t;
+
+/**
+ * @brief   HTTP Method Type wrapper over "enum http_method"
+ *          available in "http_parser" library
+ */
+typedef enum http_method httpd_method_t;
+
+/**
+ * @brief  Prototype for freeing context data (if any)
+ * @param[in] ctx   object to free
+ */
+typedef void (*httpd_free_ctx_fn_t)(void *ctx);
+
+/**
+ * @brief  Function prototype for opening a session.
+ *
+ * Called immediately after the socket was opened to set up the send/recv functions and
+ * other parameters of the socket.
+ *
+ * @param[in] hd       server instance
+ * @param[in] sockfd   session socket file descriptor
+ * @return
+ *  - ESP_OK   : On success
+ *  - Any value other than ESP_OK will signal the server to close the socket immediately
+ */
+typedef esp_err_t (*httpd_open_func_t)(httpd_handle_t hd, int sockfd);
+
+/**
+ * @brief  Function prototype for closing a session.
+ *
+ * @note   It's possible that the socket descriptor is invalid at this point, the function
+ *         is called for all terminated sessions. Ensure proper handling of return codes.
+ *
+ * @param[in] hd   server instance
+ * @param[in] sockfd   session socket file descriptor
+ */
+typedef void (*httpd_close_func_t)(httpd_handle_t hd, int sockfd);
+
+/**
+ * @brief  Function prototype for URI matching.
+ *
+ * @param[in] reference_uri   URI/template with respect to which the other URI is matched
+ * @param[in] uri_to_match    URI/template being matched to the reference URI/template
+ * @param[in] match_upto      For specifying the actual length of `uri_to_match` up to
+ *                            which the matching algorithm is to be applied (The maximum
+ *                            value is `strlen(uri_to_match)`, independent of the length
+ *                            of `reference_uri`)
+ * @return true on match
+ */
+typedef bool (*httpd_uri_match_func_t)(const char *reference_uri,
+                                       const char *uri_to_match,
+                                       size_t match_upto);
+
+/**
+ * @brief   HTTP Server Configuration Structure
+ *
+ * @note    Use HTTPD_DEFAULT_CONFIG() to initialize the configuration
+ *          to a default value and then modify only those fields that are
+ *          specifically determined by the use case.
+ */
+typedef struct httpd_config {
+    unsigned    task_priority;      /*!< Priority of FreeRTOS task which runs the server */
+    size_t      stack_size;         /*!< The maximum stack size allowed for the server task */
+
+    /**
+     * TCP Port number for receiving and transmitting HTTP traffic
+     */
+    uint16_t    server_port;
+
+    /**
+     * UDP Port number for asynchronously exchanging control signals
+     * between various components of the server
+     */
+    uint16_t    ctrl_port;
+
+    uint16_t    max_open_sockets;   /*!< Max number of sockets/clients connected at any time*/
+    uint16_t    max_uri_handlers;   /*!< Maximum allowed uri handlers */
+    uint16_t    max_resp_headers;   /*!< Maximum allowed additional headers in HTTP response */
+    uint16_t    backlog_conn;       /*!< Number of backlog connections */
+    bool        lru_purge_enable;   /*!< Purge "Least Recently Used" connection */
+    uint16_t    recv_wait_timeout;  /*!< Timeout for recv function (in seconds)*/
+    uint16_t    send_wait_timeout;  /*!< Timeout for send function (in seconds)*/
+
+    /**
+     * Global user context.
+     *
+     * This field can be used to store arbitrary user data within the server context.
+     * The value can be retrieved using the server handle, available e.g. in the httpd_req_t struct.
+     *
+     * When shutting down, the server frees up the user context by
+     * calling free() on the global_user_ctx field. If you wish to use a custom
+     * function for freeing the global user context, please specify that here.
+     */
+    void * global_user_ctx;
+
+    /**
+     * Free function for global user context
+     */
+    httpd_free_ctx_fn_t global_user_ctx_free_fn;
+
+    /**
+     * Global transport context.
+     *
+     * Similar to global_user_ctx, but used for session encoding or encryption (e.g. to hold the SSL context).
+     * It will be freed using free(), unless global_transport_ctx_free_fn is specified.
+     */
+    void * global_transport_ctx;
+
+    /**
+     * Free function for global transport context
+     */
+    httpd_free_ctx_fn_t global_transport_ctx_free_fn;
+
+    /**
+     * Custom session opening callback.
+     *
+     * Called on a new session socket just after accept(), but before reading any data.
+     *
+     * This is an opportunity to set up e.g. SSL encryption using global_transport_ctx
+     * and the send/recv/pending session overrides.
+     *
+     * If a context needs to be maintained between these functions, store it in the session using
+     * httpd_sess_set_transport_ctx() and retrieve it later with httpd_sess_get_transport_ctx()
+     *
+     * Returning a value other than ESP_OK will immediately close the new socket.
+     */
+    httpd_open_func_t open_fn;
+
+    /**
+     * Custom session closing callback.
+     *
+     * Called when a session is deleted, before freeing user and transport contexts and before
+     * closing the socket. This is a place for custom de-init code common to all sockets.
+     *
+     * Set the user or transport context to NULL if it was freed here, so the server does not
+     * try to free it again.
+     *
+     * This function is run for all terminated sessions, including sessions where the socket
+     * was closed by the network stack - that is, the file descriptor may not be valid anymore.
+     */
+    httpd_close_func_t close_fn;
+
+    /**
+     * URI matcher function.
+     *
+     * Called when searching for a matching URI:
+     *     1) whose request handler is to be executed right
+     *        after an HTTP request is successfully parsed
+     *     2) in order to prevent duplication while registering
+     *        a new URI handler using `httpd_register_uri_handler()`
+     *
+     * Available options are:
+     *     1) NULL : Internally do basic matching using `strncmp()`
+     *     2) `httpd_uri_match_wildcard()` : URI wildcard matcher
+     *
+     * Users can implement their own matching functions (See description
+     * of the `httpd_uri_match_func_t` function prototype)
+     */
+    httpd_uri_match_func_t uri_match_fn;
+} httpd_config_t;
+
+/**
+ * @brief Starts the web server
+ *
+ * Create an instance of HTTP server and allocate memory/resources for it
+ * depending upon the specified configuration.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * //Function for starting the webserver
+ * httpd_handle_t start_webserver(void)
+ * {
+ *      // Generate default configuration
+ *      httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+ *
+ *      // Empty handle to http_server
+ *      httpd_handle_t server = NULL;
+ *
+ *      // Start the httpd server
+ *      if (httpd_start(&server, &config) == ESP_OK) {
+ *          // Register URI handlers
+ *          httpd_register_uri_handler(server, &uri_get);
+ *          httpd_register_uri_handler(server, &uri_post);
+ *      }
+ *      // If server failed to start, handle will be NULL
+ *      return server;
+ * }
+ *
+ * @endcode
+ *
+ * @param[in]  config   Configuration for new instance of the server
+ * @param[out] handle   Handle to newly created instance of the server. NULL on error
+ * @return
+ *  - ESP_OK    : Instance created successfully
+ *  - ESP_ERR_INVALID_ARG      : Null argument(s)
+ *  - ESP_ERR_HTTPD_ALLOC_MEM  : Failed to allocate memory for instance
+ *  - ESP_ERR_HTTPD_TASK       : Failed to launch server task
+ */
+esp_err_t  httpd_start(httpd_handle_t *handle, const httpd_config_t *config);
+
+/**
+ * @brief Stops the web server
+ *
+ * Deallocates memory/resources used by an HTTP server instance and
+ * deletes it. Once deleted the handle can no longer be used for accessing
+ * the instance.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * // Function for stopping the webserver
+ * void stop_webserver(httpd_handle_t server)
+ * {
+ *      // Ensure handle is non NULL
+ *      if (server != NULL) {
+ *          // Stop the httpd server
+ *          httpd_stop(server);
+ *      }
+ * }
+ *
+ * @endcode
+ *
+ * @param[in] handle Handle to server returned by httpd_start
+ * @return
+ *  - ESP_OK : Server stopped successfully
+ *  - ESP_ERR_INVALID_ARG : Handle argument is Null
+ */
+esp_err_t httpd_stop(httpd_handle_t handle);
+
+/** End of Group Initialization
+ * @}
+ */
+
+/* ************** Group: URI Handlers ************** */
+/** @name URI Handlers
+ * APIs related to the URI handlers
+ * @{
+ */
+
+/* Max supported HTTP request header length */
+#define HTTPD_MAX_REQ_HDR_LEN CONFIG_HTTPD_MAX_REQ_HDR_LEN
+
+/* Max supported HTTP request URI length */
+#define HTTPD_MAX_URI_LEN CONFIG_HTTPD_MAX_URI_LEN
+
+/**
+ * @brief HTTP Request Data Structure
+ */
+typedef struct httpd_req {
+    httpd_handle_t  handle;                     /*!< Handle to server instance */
+    int             method;                     /*!< The type of HTTP request, -1 if unsupported method */
+    const char      uri[HTTPD_MAX_URI_LEN + 1]; /*!< The URI of this request (1 byte extra for null termination) */
+    size_t          content_len;                /*!< Length of the request body */
+    void           *aux;                        /*!< Internally used members */
+
+    /**
+     * User context pointer passed during URI registration.
+     */
+    void *user_ctx;
+
+    /**
+     * Session Context Pointer
+     *
+     * A session context. Contexts are maintained across 'sessions' for a
+     * given open TCP connection. One session could have multiple request
+     * responses. The web server will ensure that the context persists
+     * across all these request and responses.
+     *
+     * By default, this is NULL. URI Handlers can set this to any meaningful
+     * value.
+     *
+     * If the underlying socket gets closed, and this pointer is non-NULL,
+     * the web server will free up the context by calling free(), unless
+     * free_ctx function is set.
+     */
+    void *sess_ctx;
+
+    /**
+     * Pointer to free context hook
+     *
+     * Function to free session context
+     *
+     * If the web server's socket closes, it frees up the session context by
+     * calling free() on the sess_ctx member. If you wish to use a custom
+     * function for freeing the session context, please specify that here.
+     */
+    httpd_free_ctx_fn_t free_ctx;
+
+    /**
+     * Flag indicating if Session Context changes should be ignored
+     *
+     * By default, if you change the sess_ctx in some URI handler, the http server
+     * will internally free the earlier context (if non NULL), after the URI handler
+     * returns. If you want to manage the allocation/reallocation/freeing of
+     * sess_ctx yourself, set this flag to true, so that the server will not
+     * perform any checks on it. The context will be cleared by the server
+     * (by calling free_ctx or free()) only if the socket gets closed.
+     */
+    bool ignore_sess_ctx_changes;
+} httpd_req_t;
+
+/**
+ * @brief Structure for URI handler
+ */
+typedef struct httpd_uri {
+    const char       *uri;    /*!< The URI to handle */
+    httpd_method_t    method; /*!< Method supported by the URI */
+
+    /**
+     * Handler to call for supported request method. This must
+     * return ESP_OK, or else the underlying socket will be closed.
+     */
+    esp_err_t (*handler)(httpd_req_t *r);
+
+    /**
+     * Pointer to user context data which will be available to handler
+     */
+    void *user_ctx;
+} httpd_uri_t;
+
+/**
+ * @brief   Registers a URI handler
+ *
+ * @note    URI handlers can be registered in real time as long as the
+ *          server handle is valid.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * esp_err_t my_uri_handler(httpd_req_t* req)
+ * {
+ *     // Recv , Process and Send
+ *     ....
+ *     ....
+ *     ....
+ *
+ *     // Fail condition
+ *     if (....) {
+ *         // Return fail to close session //
+ *         return ESP_FAIL;
+ *     }
+ *
+ *     // On success
+ *     return ESP_OK;
+ * }
+ *
+ * // URI handler structure
+ * httpd_uri_t my_uri {
+ *     .uri      = "/my_uri/path/xyz",
+ *     .method   = HTTPD_GET,
+ *     .handler  = my_uri_handler,
+ *     .user_ctx = NULL
+ * };
+ *
+ * // Register handler
+ * if (httpd_register_uri_handler(server_handle, &my_uri) != ESP_OK) {
+ *    // If failed to register handler
+ *    ....
+ * }
+ *
+ * @endcode
+ *
+ * @param[in] handle      handle to HTTPD server instance
+ * @param[in] uri_handler pointer to handler that needs to be registered
+ *
+ * @return
+ *  - ESP_OK : On successfully registering the handler
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_HANDLERS_FULL  : If no slots left for new handler
+ *  - ESP_ERR_HTTPD_HANDLER_EXISTS : If handler with same URI and
+ *                                   method is already registered
+ */
+esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
+                                     const httpd_uri_t *uri_handler);
+
+/**
+ * @brief   Unregister a URI handler
+ *
+ * @param[in] handle    handle to HTTPD server instance
+ * @param[in] uri       URI string
+ * @param[in] method    HTTP method
+ *
+ * @return
+ *  - ESP_OK : On successfully deregistering the handler
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_NOT_FOUND   : Handler with specified URI and method not found
+ */
+esp_err_t httpd_unregister_uri_handler(httpd_handle_t handle,
+                                       const char *uri, httpd_method_t method);
+
+/**
+ * @brief   Unregister all URI handlers with the specified uri string
+ *
+ * @param[in] handle   handle to HTTPD server instance
+ * @param[in] uri      uri string specifying all handlers that need
+ *                     to be deregisterd
+ *
+ * @return
+ *  - ESP_OK : On successfully deregistering all such handlers
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_NOT_FOUND   : No handler registered with specified uri string
+ */
+esp_err_t httpd_unregister_uri(httpd_handle_t handle, const char* uri);
+
+/** End of URI Handlers
+ * @}
+ */
+
+/* ************** Group: HTTP Error ************** */
+/** @name HTTP Error
+ * Prototype for HTTP errors and error handling functions
+ * @{
+ */
+
+/**
+ * @brief Error codes sent as HTTP response in case of errors
+ *        encountered during processing of an HTTP request
+ */
+typedef enum {
+    /* For any unexpected errors during parsing, like unexpected
+     * state transitions, or unhandled errors.
+     */
+    HTTPD_500_INTERNAL_SERVER_ERROR = 0,
+
+    /* For methods not supported by http_parser. Presently
+     * http_parser halts parsing when such methods are
+     * encountered and so the server responds with 400 Bad
+     * Request error instead.
+     */
+    HTTPD_501_METHOD_NOT_IMPLEMENTED,
+
+    /* When HTTP version is not 1.1 */
+    HTTPD_505_VERSION_NOT_SUPPORTED,
+
+    /* Returned when http_parser halts parsing due to incorrect
+     * syntax of request, unsupported method in request URI or
+     * due to chunked encoding / upgrade field present in headers
+     */
+    HTTPD_400_BAD_REQUEST,
+
+    /* When requested URI is not found */
+    HTTPD_404_NOT_FOUND,
+
+    /* When URI found, but method has no handler registered */
+    HTTPD_405_METHOD_NOT_ALLOWED,
+
+    /* Intended for recv timeout. Presently it's being sent
+     * for other recv errors as well. Client should expect the
+     * server to immediately close the connection after
+     * responding with this.
+     */
+    HTTPD_408_REQ_TIMEOUT,
+
+    /* Intended for responding to chunked encoding, which is
+     * not supported currently. Though unhandled http_parser
+     * callback for chunked request returns "400 Bad Request"
+     */
+    HTTPD_411_LENGTH_REQUIRED,
+
+    /* URI length greater than CONFIG_HTTPD_MAX_URI_LEN */
+    HTTPD_414_URI_TOO_LONG,
+
+    /* Headers section larger than CONFIG_HTTPD_MAX_REQ_HDR_LEN */
+    HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE,
+
+    /* Used internally for retrieving the total count of errors */
+    HTTPD_ERR_CODE_MAX
+} httpd_err_code_t;
+
+/**
+ * @brief  Function prototype for HTTP error handling.
+ *
+ * This function is executed upon HTTP errors generated during
+ * internal processing of an HTTP request. This is used to override
+ * the default behavior on error, which is to send HTTP error response
+ * and close the underlying socket.
+ *
+ * @note
+ *  - If implemented, the server will not automatically send out HTTP
+ *    error response codes, therefore, httpd_resp_send_err() must be
+ *    invoked inside this function if user wishes to generate HTTP
+ *    error responses.
+ *  - When invoked, the validity of `uri`, `method`, `content_len`
+ *    and `user_ctx` fields of the httpd_req_t parameter is not
+ *    guaranteed as the HTTP request may be partially received/parsed.
+ *  - The function must return ESP_OK if underlying socket needs to
+ *    be kept open. Any other value will ensure that the socket is
+ *    closed. The return value is ignored when error is of type
+ *    `HTTPD_500_INTERNAL_SERVER_ERROR` and the socket closed anyway.
+ *
+ * @param[in] req    HTTP request for which the error needs to be handled
+ * @param[in] error  Error type
+ *
+ * @return
+ *  - ESP_OK   : error handled successful
+ *  - ESP_FAIL : failure indicates that the underlying socket needs to be closed
+ */
+typedef esp_err_t (*httpd_err_handler_func_t)(httpd_req_t *req,
+                                              httpd_err_code_t error);
+
+/**
+ * @brief  Function for registering HTTP error handlers
+ *
+ * This function maps a handler function to any supported error code
+ * given by `httpd_err_code_t`. See prototype `httpd_err_handler_func_t`
+ * above for details.
+ *
+ * @param[in] handle     HTTP server handle
+ * @param[in] error      Error type
+ * @param[in] handler_fn User implemented handler function
+ *                       (Pass NULL to unset any previously set handler)
+ *
+ * @return
+ *  - ESP_OK : handler registered successfully
+ *  - ESP_ERR_INVALID_ARG : invalid error code or server handle
+ */
+esp_err_t httpd_register_err_handler(httpd_handle_t handle,
+                                     httpd_err_code_t error,
+                                     httpd_err_handler_func_t handler_fn);
+
+/** End of HTTP Error
+ * @}
+ */
+
+/* ************** Group: TX/RX ************** */
+/** @name TX / RX
+ * Prototype for HTTPDs low-level send/recv functions
+ * @{
+ */
+
+#define HTTPD_SOCK_ERR_FAIL      -1
+#define HTTPD_SOCK_ERR_INVALID   -2
+#define HTTPD_SOCK_ERR_TIMEOUT   -3
+
+/**
+ * @brief  Prototype for HTTPDs low-level send function
+ *
+ * @note   User specified send function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will eventually be conveyed as
+ *         return value of httpd_send() function
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes sent successfully
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket send()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket send()
+ */
+typedef int (*httpd_send_func_t)(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief  Prototype for HTTPDs low-level recv function
+ *
+ * @note   User specified recv function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will eventually be conveyed as
+ *         return value of httpd_req_recv() function
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes received successfully
+ *  - 0     : Buffer length parameter is zero / connection closed by peer
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket recv()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket recv()
+ */
+typedef int (*httpd_recv_func_t)(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief  Prototype for HTTPDs low-level "get pending bytes" function
+ *
+ * @note   User specified pending function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will be handled accordingly in
+ *         the server task.
+ *
+ * @param[in] hd       server instance
+ * @param[in] sockfd   session socket file descriptor
+ * @return
+ *  - Bytes : The number of bytes waiting to be received
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket pending()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket pending()
+ */
+typedef int (*httpd_pending_func_t)(httpd_handle_t hd, int sockfd);
+
+/** End of TX / RX
+ * @}
+ */
+
+/* ************** Group: Request/Response ************** */
+/** @name Request / Response
+ * APIs related to the data send/receive by URI handlers.
+ * These APIs are supposed to be called only from the context of
+ * a URI handler where httpd_req_t* request pointer is valid.
+ * @{
+ */
+
+/**
+ * @brief   Override web server's receive function (by session FD)
+ *
+ * This function overrides the web server's receive function. This same function is
+ * used to read HTTP request packets.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd        HTTPD instance handle
+ * @param[in] sockfd    Session socket FD
+ * @param[in] recv_func The receive function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_recv_override(httpd_handle_t hd, int sockfd, httpd_recv_func_t recv_func);
+
+/**
+ * @brief   Override web server's send function (by session FD)
+ *
+ * This function overrides the web server's send function. This same function is
+ * used to send out any response to any HTTP request.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd        HTTPD instance handle
+ * @param[in] sockfd    Session socket FD
+ * @param[in] send_func The send function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_send_override(httpd_handle_t hd, int sockfd, httpd_send_func_t send_func);
+
+/**
+ * @brief   Override web server's pending function (by session FD)
+ *
+ * This function overrides the web server's pending function. This function is
+ * used to test for pending bytes in a socket.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd           HTTPD instance handle
+ * @param[in] sockfd       Session socket FD
+ * @param[in] pending_func The receive function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_pending_override(httpd_handle_t hd, int sockfd, httpd_pending_func_t pending_func);
+
+/**
+ * @brief   Get the Socket Descriptor from the HTTP request
+ *
+ * This API will return the socket descriptor of the session for
+ * which URI handler was executed on reception of HTTP request.
+ * This is useful when user wants to call functions that require
+ * session socket fd, from within a URI handler, ie. :
+ *      httpd_sess_get_ctx(),
+ *      httpd_sess_trigger_close(),
+ *      httpd_sess_update_lru_counter().
+ *
+ * @note    This API is supposed to be called only from the context of
+ *          a URI handler where httpd_req_t* request pointer is valid.
+ *
+ * @param[in] r The request whose socket descriptor should be found
+ *
+ * @return
+ *  - Socket descriptor : The socket descriptor for this request
+ *  - -1 : Invalid/NULL request pointer
+ */
+int httpd_req_to_sockfd(httpd_req_t *r);
+
+/**
+ * @brief   API to read content data from the HTTP request
+ *
+ * This API will read HTTP content data from the HTTP request into
+ * provided buffer. Use content_len provided in httpd_req_t structure
+ * to know the length of data to be fetched. If content_len is too
+ * large for the buffer then user may have to make multiple calls to
+ * this function, each time fetching 'buf_len' number of bytes,
+ * while the pointer to content data is incremented internally by
+ * the same number.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - If an error is returned, the URI handler must further return an error.
+ *    This will ensure that the erroneous socket is closed and cleaned up by
+ *    the web server.
+ *  - Presently Chunked Encoding is not supported
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Pointer to a buffer that the data will be read into
+ * @param[in] buf_len   Length of the buffer
+ *
+ * @return
+ *  - Bytes : Number of bytes read into the buffer successfully
+ *  - 0     : Buffer length parameter is zero / connection closed by peer
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket recv()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket recv()
+ */
+int httpd_req_recv(httpd_req_t *r, char *buf, size_t buf_len);
+
+/**
+ * @brief   Search for a field in request headers and
+ *          return the string length of it's value
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once httpd_resp_send() API is called all request headers
+ *    are purged, so request headers need be copied into separate
+ *    buffers if they are required later.
+ *
+ * @param[in]  r        The request being responded to
+ * @param[in]  field    The header field to be searched in the request
+ *
+ * @return
+ *  - Length    : If field is found in the request URL
+ *  - Zero      : Field not found / Invalid request / Null arguments
+ */
+size_t httpd_req_get_hdr_value_len(httpd_req_t *r, const char *field);
+
+/**
+ * @brief   Get the value string of a field from the request headers
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once httpd_resp_send() API is called all request headers
+ *    are purged, so request headers need be copied into separate
+ *    buffers if they are required later.
+ *  - If output size is greater than input, then the value is truncated,
+ *    accompanied by truncation error as return value.
+ *  - Use httpd_req_get_hdr_value_len() to know the right buffer length
+ *
+ * @param[in]  r        The request being responded to
+ * @param[in]  field    The field to be searched in the header
+ * @param[out] val      Pointer to the buffer into which the value will be copied if the field is found
+ * @param[in]  val_size Size of the user buffer "val"
+ *
+ * @return
+ *  - ESP_OK : Field found in the request header and value string copied
+ *  - ESP_ERR_NOT_FOUND          : Key not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ  : Invalid HTTP request pointer
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+ */
+esp_err_t httpd_req_get_hdr_value_str(httpd_req_t *r, const char *field, char *val, size_t val_size);
+
+/**
+ * @brief   Get Query string length from the request URL
+ *
+ * @note    This API is supposed to be called only from the context of
+ *          a URI handler where httpd_req_t* request pointer is valid
+ *
+ * @param[in]  r    The request being responded to
+ *
+ * @return
+ *  - Length    : Query is found in the request URL
+ *  - Zero      : Query not found / Null arguments / Invalid request
+ */
+size_t httpd_req_get_url_query_len(httpd_req_t *r);
+
+/**
+ * @brief   Get Query string from the request URL
+ *
+ * @note
+ *  - Presently, the user can fetch the full URL query string, but decoding
+ *    will have to be performed by the user. Request headers can be read using
+ *    httpd_req_get_hdr_value_str() to know the 'Content-Type' (eg. Content-Type:
+ *    application/x-www-form-urlencoded) and then the appropriate decoding
+ *    algorithm needs to be applied.
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid
+ *  - If output size is greater than input, then the value is truncated,
+ *    accompanied by truncation error as return value
+ *  - Prior to calling this function, one can use httpd_req_get_url_query_len()
+ *    to know the query string length beforehand and hence allocate the buffer
+ *    of right size (usually query string length + 1 for null termination)
+ *    for storing the query string
+ *
+ * @param[in]  r         The request being responded to
+ * @param[out] buf       Pointer to the buffer into which the query string will be copied (if found)
+ * @param[in]  buf_len   Length of output buffer
+ *
+ * @return
+ *  - ESP_OK : Query is found in the request URL and copied to buffer
+ *  - ESP_ERR_NOT_FOUND          : Query not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ  : Invalid HTTP request pointer
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Query string truncated
+ */
+esp_err_t httpd_req_get_url_query_str(httpd_req_t *r, char *buf, size_t buf_len);
+
+/**
+ * @brief   Helper function to get a URL query tag from a query
+ *          string of the type param1=val1&param2=val2
+ *
+ * @note
+ *  - The components of URL query string (keys and values) are not URLdecoded.
+ *    The user must check for 'Content-Type' field in the request headers and
+ *    then depending upon the specified encoding (URLencoded or otherwise) apply
+ *    the appropriate decoding algorithm.
+ *  - If actual value size is greater than val_size, then the value is truncated,
+ *    accompanied by truncation error as return value.
+ *
+ * @param[in]  qry       Pointer to query string
+ * @param[in]  key       The key to be searched in the query string
+ * @param[out] val       Pointer to the buffer into which the value will be copied if the key is found
+ * @param[in]  val_size  Size of the user buffer "val"
+ *
+ * @return
+ *  - ESP_OK : Key is found in the URL query string and copied to buffer
+ *  - ESP_ERR_NOT_FOUND          : Key not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+ */
+esp_err_t httpd_query_key_value(const char *qry, const char *key, char *val, size_t val_size);
+
+/**
+ * @brief Test if a URI matches the given wildcard template.
+ *
+ * Template may end with "?" to make the previous character optional (typically a slash),
+ * "*" for a wildcard match, and "?*" to make the previous character optional, and if present,
+ * allow anything to follow.
+ *
+ * Example:
+ *   - * matches everything
+ *   - /foo/? matches /foo and /foo/
+ *   - /foo/\* (sans the backslash) matches /foo/ and /foo/bar, but not /foo or /fo
+ *   - /foo/?* or /foo/\*?  (sans the backslash) matches /foo/, /foo/bar, and also /foo, but not /foox or /fo
+ *
+ * The special characters "?" and "*" anywhere else in the template will be taken literally.
+ *
+ * @param[in] uri_template   URI template (pattern)
+ * @param[in] uri_to_match   URI to be matched
+ * @param[in] match_upto     how many characters of the URI buffer to test
+ *                          (there may be trailing query string etc.)
+ *
+ * @return true if a match was found
+ */
+bool httpd_uri_match_wildcard(const char *uri_template, const char *uri_to_match, size_t match_upto);
+
+/**
+ * @brief   API to send a complete HTTP response.
+ *
+ * This API will send the data as an HTTP response to the request.
+ * This assumes that you have the entire response ready in a single
+ * buffer. If you wish to send response in incremental chunks use
+ * httpd_resp_send_chunk() instead.
+ *
+ * If no status code and content-type were set, by default this
+ * will send 200 OK status code and content type as text/html.
+ * You may call the following functions before this API to configure
+ * the response headers :
+ *      httpd_resp_set_status() - for setting the HTTP status string,
+ *      httpd_resp_set_type()   - for setting the Content Type,
+ *      httpd_resp_set_hdr()    - for appending any additional field
+ *                                value entries in the response header
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, the request has been responded to.
+ *  - No additional data can then be sent for the request.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Buffer from where the content is to be fetched
+ * @param[in] buf_len   Length of the buffer, HTTPD_RESP_USE_STRLEN to use strlen()
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+esp_err_t httpd_resp_send(httpd_req_t *r, const char *buf, ssize_t buf_len);
+
+/**
+ * @brief   API to send one HTTP chunk
+ *
+ * This API will send the data as an HTTP response to the
+ * request. This API will use chunked-encoding and send the response
+ * in the form of chunks. If you have the entire response contained in
+ * a single buffer, please use httpd_resp_send() instead.
+ *
+ * If no status code and content-type were set, by default this will
+ * send 200 OK status code and content type as text/html. You may
+ * call the following functions before this API to configure the
+ * response headers
+ *      httpd_resp_set_status() - for setting the HTTP status string,
+ *      httpd_resp_set_type()   - for setting the Content Type,
+ *      httpd_resp_set_hdr()    - for appending any additional field
+ *                                value entries in the response header
+ *
+ * @note
+ * - This API is supposed to be called only from the context of
+ *   a URI handler where httpd_req_t* request pointer is valid.
+ * - When you are finished sending all your chunks, you must call
+ *   this function with buf_len as 0.
+ * - Once this API is called, all request headers are purged, so
+ *   request headers need be copied into separate buffers if they
+ *   are required later.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Pointer to a buffer that stores the data
+ * @param[in] buf_len   Length of the buffer, HTTPD_RESP_USE_STRLEN to use strlen()
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet chunk
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len);
+
+/**
+ * @brief   API to send a complete string as HTTP response.
+ *
+ * This API simply calls http_resp_send with buffer length
+ * set to string length assuming the buffer contains a null
+ * terminated string
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] str       String to be sent as response body
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+static inline esp_err_t httpd_resp_sendstr(httpd_req_t *r, const char *str) {
+    return httpd_resp_send(r, str, (str == NULL) ? 0 : strlen(str));
+}
+
+/**
+ * @brief   API to send a string as an HTTP response chunk.
+ *
+ * This API simply calls http_resp_send_chunk with buffer length
+ * set to string length assuming the buffer contains a null
+ * terminated string
+ *
+ * @param[in] r    The request being responded to
+ * @param[in] str  String to be sent as response body (NULL to finish response packet)
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+static inline esp_err_t httpd_resp_sendstr_chunk(httpd_req_t *r, const char *str) {
+    return httpd_resp_send_chunk(r, str, (str == NULL) ? 0 : strlen(str));
+}
+
+/* Some commonly used status codes */
+#define HTTPD_200      "200 OK"                     /*!< HTTP Response 200 */
+#define HTTPD_204      "204 No Content"             /*!< HTTP Response 204 */
+#define HTTPD_207      "207 Multi-Status"           /*!< HTTP Response 207 */
+#define HTTPD_400      "400 Bad Request"            /*!< HTTP Response 400 */
+#define HTTPD_404      "404 Not Found"              /*!< HTTP Response 404 */
+#define HTTPD_408      "408 Request Timeout"        /*!< HTTP Response 408 */
+#define HTTPD_500      "500 Internal Server Error"  /*!< HTTP Response 500 */
+
+/**
+ * @brief   API to set the HTTP status code
+ *
+ * This API sets the status of the HTTP response to the value specified.
+ * By default, the '200 OK' response is sent as the response.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - This API only sets the status to this value. The status isn't
+ *    sent out until any of the send APIs is executed.
+ *  - Make sure that the lifetime of the status string is valid till
+ *    send function is called.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] status    The HTTP status code of this response
+ *
+ * @return
+ *  - ESP_OK : On success
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_status(httpd_req_t *r, const char *status);
+
+/* Some commonly used content types */
+#define HTTPD_TYPE_JSON   "application/json"            /*!< HTTP Content type JSON */
+#define HTTPD_TYPE_TEXT   "text/html"                   /*!< HTTP Content type text/HTML */
+#define HTTPD_TYPE_OCTET  "application/octet-stream"    /*!< HTTP Content type octext-stream */
+
+/**
+ * @brief   API to set the HTTP content type
+ *
+ * This API sets the 'Content Type' field of the response.
+ * The default content type is 'text/html'.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - This API only sets the content type to this value. The type
+ *    isn't sent out until any of the send APIs is executed.
+ *  - Make sure that the lifetime of the type string is valid till
+ *    send function is called.
+ *
+ * @param[in] r     The request being responded to
+ * @param[in] type  The Content Type of the response
+ *
+ * @return
+ *  - ESP_OK   : On success
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_type(httpd_req_t *r, const char *type);
+
+/**
+ * @brief   API to append any additional headers
+ *
+ * This API sets any additional header fields that need to be sent in the response.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - The header isn't sent out until any of the send APIs is executed.
+ *  - The maximum allowed number of additional headers is limited to
+ *    value of max_resp_headers in config structure.
+ *  - Make sure that the lifetime of the field value strings are valid till
+ *    send function is called.
+ *
+ * @param[in] r     The request being responded to
+ * @param[in] field The field name of the HTTP header
+ * @param[in] value The value of this HTTP header
+ *
+ * @return
+ *  - ESP_OK : On successfully appending new header
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Total additional headers exceed max allowed
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_hdr(httpd_req_t *r, const char *field, const char *value);
+
+/**
+ * @brief   For sending out error code in response to HTTP request.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *  - If you wish to send additional data in the body of the
+ *    response, please use the lower-level functions directly.
+ *
+ * @param[in] req     Pointer to the HTTP request for which the response needs to be sent
+ * @param[in] error   Error type to send
+ * @param[in] msg     Error message string (pass NULL for default message)
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const char *msg);
+
+/**
+ * @brief   Helper function for HTTP 404
+ *
+ * Send HTTP 404 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_404(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_404_NOT_FOUND, NULL);
+}
+
+/**
+ * @brief   Helper function for HTTP 408
+ *
+ * Send HTTP 408 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_408(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_408_REQ_TIMEOUT, NULL);
+}
+
+/**
+ * @brief   Helper function for HTTP 500
+ *
+ * Send HTTP 500 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_500(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_500_INTERNAL_SERVER_ERROR, NULL);
+}
+
+/**
+ * @brief   Raw HTTP send
+ *
+ * Call this API if you wish to construct your custom response packet.
+ * When using this, all essential header, eg. HTTP version, Status Code,
+ * Content Type and Length, Encoding, etc. will have to be constructed
+ * manually, and HTTP delimeters (CRLF) will need to be placed correctly
+ * for separating sub-sections of the HTTP response packet.
+ *
+ * If the send override function is set, this API will end up
+ * calling that function eventually to send data out.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Unless the response has the correct HTTP structure (which the
+ *    user must now ensure) it is not guaranteed that it will be
+ *    recognized by the client. For most cases, you wouldn't have
+ *    to call this API, but you would rather use either of :
+ *          httpd_resp_send(),
+ *          httpd_resp_send_chunk()
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Buffer from where the fully constructed packet is to be read
+ * @param[in] buf_len   Length of the buffer
+ *
+ * @return
+ *  - Bytes : Number of bytes that were sent successfully
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket send()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket send()
+ */
+int httpd_send(httpd_req_t *r, const char *buf, size_t buf_len);
+
+/** End of Request / Response
+ * @}
+ */
+
+/* ************** Group: Session ************** */
+/** @name Session
+ * Functions for controlling sessions and accessing context data
+ * @{
+ */
+
+/**
+ * @brief   Get session context from socket descriptor
+ *
+ * Typically if a session context is created, it is available to URI handlers
+ * through the httpd_req_t structure. But, there are cases where the web
+ * server's send/receive functions may require the context (for example, for
+ * accessing keying information etc). Since the send/receive function only have
+ * the socket descriptor at their disposal, this API provides them with a way to
+ * retrieve the session context.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ *
+ * @return
+ *  - void* : Pointer to the context associated with this session
+ *  - NULL  : Empty context / Invalid handle / Invalid socket fd
+ */
+void *httpd_sess_get_ctx(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Set session context by socket descriptor
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @param[in] ctx       Context object to assign to the session
+ * @param[in] free_fn   Function that should be called to free the context
+ */
+void httpd_sess_set_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Get session 'transport' context by socket descriptor
+ * @see     httpd_sess_get_ctx()
+ *
+ * This context is used by the send/receive functions, for example to manage SSL context.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @return
+ *  - void* : Pointer to the transport context associated with this session
+ *  - NULL  : Empty context / Invalid handle / Invalid socket fd
+ */
+void *httpd_sess_get_transport_ctx(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Set session 'transport' context by socket descriptor
+ * @see     httpd_sess_set_ctx()
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @param[in] ctx       Transport context object to assign to the session
+ * @param[in] free_fn   Function that should be called to free the transport context
+ */
+void httpd_sess_set_transport_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Get HTTPD global user context (it was set in the server config struct)
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @return global user context
+ */
+void *httpd_get_global_user_ctx(httpd_handle_t handle);
+
+/**
+ * @brief   Get HTTPD global transport context (it was set in the server config struct)
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @return global transport context
+ */
+void *httpd_get_global_transport_ctx(httpd_handle_t handle);
+
+/**
+ * @brief   Trigger an httpd session close externally
+ *
+ * @note    Calling this API is only required in special circumstances wherein
+ *          some application requires to close an httpd client session asynchronously.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor of the session to be closed
+ *
+ * @return
+ *  - ESP_OK    : On successfully initiating closure
+ *  - ESP_FAIL  : Failure to queue work
+ *  - ESP_ERR_NOT_FOUND   : Socket fd not found
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_trigger_close(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Update LRU counter for a given socket
+ *
+ * LRU Counters are internally associated with each session to monitor
+ * how recently a session exchanged traffic. When LRU purge is enabled,
+ * if a client is requesting for connection but maximum number of
+ * sockets/sessions is reached, then the session having the earliest
+ * LRU counter is closed automatically.
+ *
+ * Updating the LRU counter manually prevents the socket from being purged
+ * due to the Least Recently Used (LRU) logic, even though it might not
+ * have received traffic for some time. This is useful when all open
+ * sockets/session are frequently exchanging traffic but the user specifically
+ * wants one of the sessions to be kept open, irrespective of when it last
+ * exchanged a packet.
+ *
+ * @note    Calling this API is only necessary if the LRU Purge Enable option
+ *          is enabled.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor of the session for which LRU counter
+ *                      is to be updated
+ *
+ * @return
+ *  - ESP_OK : Socket found and LRU counter updated
+ *  - ESP_ERR_NOT_FOUND   : Socket not found
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_update_lru_counter(httpd_handle_t handle, int sockfd);
+
+/** End of Session
+ * @}
+ */
+
+/* ************** Group: Work Queue ************** */
+/** @name Work Queue
+ * APIs related to the HTTPD Work Queue
+ * @{
+ */
+
+/**
+ * @brief   Prototype of the HTTPD work function
+ *          Please refer to httpd_queue_work() for more details.
+ * @param[in] arg   The arguments for this work function
+ */
+typedef void (*httpd_work_fn_t)(void *arg);
+
+/**
+ * @brief   Queue execution of a function in HTTPD's context
+ *
+ * This API queues a work function for asynchronous execution
+ *
+ * @note    Some protocols require that the web server generate some asynchronous data
+ *          and send it to the persistently opened connection. This facility is for use
+ *          by such protocols.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] work      Pointer to the function to be executed in the HTTPD's context
+ * @param[in] arg       Pointer to the arguments that should be passed to this function
+ *
+ * @return
+ *  - ESP_OK   : On successfully queueing the work
+ *  - ESP_FAIL : Failure in ctrl socket
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_queue_work(httpd_handle_t handle, httpd_work_fn_t work, void *arg);
+
+/** End of Group Work Queue
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _ESP_HTTP_SERVER_H_ */

--- a/vendors/espressif/esp-idf/components/esp_http_server/include/http_server.h
+++ b/vendors/espressif/esp-idf/components/esp_http_server/include/http_server.h
@@ -1,0 +1,2 @@
+#warning http_server.h has been renamed to esp_http_server.h, please update include directives
+#include "esp_http_server.h"

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/esp_httpd_priv.h
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/esp_httpd_priv.h
@@ -1,0 +1,478 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef _HTTPD_PRIV_H_
+#define _HTTPD_PRIV_H_
+
+#include <stdbool.h>
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <netinet/in.h>
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_http_server.h>
+#include "osal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Size of request data block/chunk (not to be confused with chunked encoded data)
+ * that is received and parsed in one turn of the parsing process. This should not
+ * exceed the scratch buffer size and should at least be 8 bytes */
+#define PARSER_BLOCK_SIZE  128
+
+/* Calculate the maximum size needed for the scratch buffer */
+#define HTTPD_SCRATCH_BUF  MAX(HTTPD_MAX_REQ_HDR_LEN, HTTPD_MAX_URI_LEN)
+
+/* Formats a log string to prepend context function name */
+#define LOG_FMT(x)      "%s: " x, __func__
+
+/**
+ * @brief Thread related data for internal use
+ */
+struct thread_data {
+    othread_t handle;   /*!< Handle to thread/task */
+    enum {
+        THREAD_IDLE = 0,
+        THREAD_RUNNING,
+        THREAD_STOPPING,
+        THREAD_STOPPED,
+    } status;           /*!< State of the thread */
+};
+
+/**
+ * @brief A database of all the open sockets in the system.
+ */
+struct sock_db {
+    int fd;                                 /*!< The file descriptor for this socket */
+    void *ctx;                              /*!< A custom context for this socket */
+    bool ignore_sess_ctx_changes;           /*!< Flag indicating if session context changes should be ignored */
+    void *transport_ctx;                    /*!< A custom 'transport' context for this socket, to be used by send/recv/pending */
+    httpd_handle_t handle;                  /*!< Server handle */
+    httpd_free_ctx_fn_t free_ctx;      /*!< Function for freeing the context */
+    httpd_free_ctx_fn_t free_transport_ctx; /*!< Function for freeing the 'transport' context */
+    httpd_send_func_t send_fn;              /*!< Send function for this socket */
+    httpd_recv_func_t recv_fn;              /*!< Receive function for this socket */
+    httpd_pending_func_t pending_fn;        /*!< Pending function for this socket */
+    uint64_t lru_counter;                   /*!< LRU Counter indicating when the socket was last used */
+    char pending_data[PARSER_BLOCK_SIZE];   /*!< Buffer for pending data to be received */
+    size_t pending_len;                     /*!< Length of pending data to be received */
+};
+
+/**
+ * @brief   Auxiliary data structure for use during reception and processing
+ *          of requests and temporarily keeping responses
+ */
+struct httpd_req_aux {
+    struct sock_db *sd;                             /*!< Pointer to socket database */
+    char            scratch[HTTPD_SCRATCH_BUF + 1]; /*!< Temporary buffer for our operations (1 byte extra for null termination) */
+    size_t          remaining_len;                  /*!< Amount of data remaining to be fetched */
+    char           *status;                         /*!< HTTP response's status code */
+    char           *content_type;                   /*!< HTTP response's content type */
+    bool            first_chunk_sent;               /*!< Used to indicate if first chunk sent */
+    unsigned        req_hdrs_count;                 /*!< Count of total headers in request packet */
+    unsigned        resp_hdrs_count;                /*!< Count of additional headers in response packet */
+    struct resp_hdr {
+        const char *field;
+        const char *value;
+    } *resp_hdrs;                                   /*!< Additional headers in response packet */
+    struct http_parser_url url_parse_res;           /*!< URL parsing result, used for retrieving URL elements */
+};
+
+/**
+ * @brief   Server data for each instance. This is exposed publicly as
+ *          httpd_handle_t but internal structure/members are kept private.
+ */
+struct httpd_data {
+    httpd_config_t config;                  /*!< HTTPD server configuration */
+    int listen_fd;                          /*!< Server listener FD */
+    int ctrl_fd;                            /*!< Ctrl message receiver FD */
+    int msg_fd;                             /*!< Ctrl message sender FD */
+    struct thread_data hd_td;               /*!< Information for the HTTPD thread */
+    struct sock_db *hd_sd;                  /*!< The socket database */
+    httpd_uri_t **hd_calls;                 /*!< Registered URI handlers */
+    struct httpd_req hd_req;                /*!< The current HTTPD request */
+    struct httpd_req_aux hd_req_aux;        /*!< Additional data about the HTTPD request kept unexposed */
+
+    /* Array of registered error handler functions */
+    httpd_err_handler_func_t *err_handler_fns;
+};
+
+/******************* Group : Session Management ********************/
+/** @name Session Management
+ * Functions related to HTTP session management
+ * @{
+ */
+
+/**
+ * @brief Retrieve a session by its descriptor
+ *
+ * @param[in] hd     Server instance data
+ * @param[in] sockfd Socket FD
+ * @return pointer into the socket DB, or NULL if not found
+ */
+struct sock_db *httpd_sess_get(struct httpd_data *hd, int sockfd);
+
+/**
+ * @brief Delete sessions whose FDs have became invalid.
+ *        This is a recovery strategy e.g. after select() fails.
+ *
+ * @param[in] hd    Server instance data
+ */
+void httpd_sess_delete_invalid(struct httpd_data *hd);
+
+/**
+ * @brief   Initializes an http session by resetting the sockets database.
+ *
+ * @param[in] hd    Server instance data
+ */
+void httpd_sess_init(struct httpd_data *hd);
+
+/**
+ * @brief   Starts a new session for client requesting connection and adds
+ *          it's descriptor to the socket database.
+ *
+ * @param[in] hd    Server instance data
+ * @param[in] newfd Descriptor of the new client to be added to the session.
+ *
+ * @return
+ *  - ESP_OK   : on successfully queuing the work
+ *  - ESP_FAIL : in case of control socket error while sending
+ */
+esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd);
+
+/**
+ * @brief   Processes incoming HTTP requests
+ *
+ * @param[in] hd    Server instance data
+ * @param[in] clifd Descriptor of the client from which data is to be received
+ *
+ * @return
+ *  - ESP_OK    : on successfully receiving, parsing and responding to a request
+ *  - ESP_FAIL  : in case of failure in any of the stages of processing
+ */
+esp_err_t httpd_sess_process(struct httpd_data *hd, int clifd);
+
+/**
+ * @brief   Remove client descriptor from the session / socket database
+ *          and close the connection for this client.
+ *
+ * @note    The returned descriptor should be used by httpd_sess_iterate()
+ *          to continue the iteration correctly. This ensures that the
+ *          iteration is not restarted abruptly which may cause reading from
+ *          a socket which has been already processed and thus blocking
+ *          the server loop until data appears on that socket.
+ *
+ * @param[in] hd    Server instance data
+ * @param[in] clifd Descriptor of the client to be removed from the session.
+ *
+ * @return
+ *  - +VE : Client descriptor preceding the one being deleted
+ *  - -1  : No descriptor preceding the one being deleted
+ */
+int httpd_sess_delete(struct httpd_data *hd, int clifd);
+
+/**
+ * @brief   Free session context
+ *
+ * @param[in] ctx     Pointer to session context
+ * @param[in] free_fn Free function to call on session context
+ */
+void httpd_sess_free_ctx(void *ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Add descriptors present in the socket database to an fdset and
+ *          update the value of maxfd which are needed by the select function
+ *          for looking through all available sockets for incoming data.
+ *
+ * @param[in]  hd    Server instance data
+ * @param[out] fdset File descriptor set to be updated.
+ * @param[out] maxfd Maximum value among all file descriptors.
+ */
+void httpd_sess_set_descriptors(struct httpd_data *hd, fd_set *fdset, int *maxfd);
+
+/**
+ * @brief   Iterates through the list of client fds in the session /socket database.
+ *          Passing the value of a client fd returns the fd for the next client
+ *          in the database. In order to iterate from the beginning pass -1 as fd.
+ *
+ * @param[in] hd    Server instance data
+ * @param[in] fd    Last accessed client descriptor.
+ *                  -1 to reset iterator to start of database.
+ *
+ * @return
+ *  - +VE : Client descriptor next in the database
+ *  - -1  : End of iteration
+ */
+int httpd_sess_iterate(struct httpd_data *hd, int fd);
+
+/**
+ * @brief   Checks if session can accept another connection from new client.
+ *          If sockets database is full then this returns false.
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return True if session can accept new clients
+ */
+bool httpd_is_sess_available(struct httpd_data *hd);
+
+/**
+ * @brief   Checks if session has any pending data/packets
+ *          for processing
+ *
+ * This is needed as httpd_unrecv may un-receive next
+ * packet in the stream. If only partial packet was
+ * received then select() would mark the fd for processing
+ * as remaining part of the packet would still be in socket
+ * recv queue. But if a complete packet got unreceived
+ * then it would not be processed until further data is
+ * received on the socket. This is when this function
+ * comes in use, as it checks the socket's pending data
+ * buffer.
+ *
+ * @param[in] hd  Server instance data
+ * @param[in] fd  Client descriptor
+ *
+ * @return True if there is any pending data
+ */
+bool httpd_sess_pending(struct httpd_data *hd, int fd);
+
+/**
+ * @brief   Removes the least recently used client from the session
+ *
+ * This may be useful if new clients are requesting for connection but
+ * max number of connections is reached, in which case the client which
+ * is inactive for the longest will be removed from the session.
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return
+ *  - ESP_OK    : if session closure initiated successfully
+ *  - ESP_FAIL  : if failed
+ */
+esp_err_t httpd_sess_close_lru(struct httpd_data *hd);
+
+/** End of Group : Session Management
+ * @}
+ */
+
+/****************** Group : URI Handling ********************/
+/** @name URI Handling
+ * Methods for accessing URI handlers
+ * @{
+ */
+
+/**
+ * @brief   For an HTTP request, searches through all the registered URI handlers
+ *          and invokes the appropriate one if found
+ *
+ * @param[in] hd  Server instance data for which handler needs to be invoked
+ *
+ * @return
+ *  - ESP_OK    : if handler found and executed successfully
+ *  - ESP_FAIL  : otherwise
+ */
+esp_err_t httpd_uri(struct httpd_data *hd);
+
+/**
+ * @brief   Unregister all URI handlers
+ *
+ * @param[in] hd  Server instance data
+ */
+void httpd_unregister_all_uri_handlers(struct httpd_data *hd);
+
+/**
+ * @brief   Validates the request to prevent users from calling APIs, that are to
+ *          be called only inside a URI handler, outside the handler context
+ *
+ * @param[in] req Pointer to HTTP request that needs to be validated
+ *
+ * @return
+ *  - true  : if valid request
+ *  - false : otherwise
+ */
+bool httpd_validate_req_ptr(httpd_req_t *r);
+
+/* httpd_validate_req_ptr() adds some overhead to frequently used APIs,
+ * and is useful mostly for debugging, so it's preferable to disable
+ * the check by default and enable it only if necessary */
+#ifdef CONFIG_HTTPD_VALIDATE_REQ
+#define httpd_valid_req(r)  httpd_validate_req_ptr(r)
+#else
+#define httpd_valid_req(r)  true
+#endif
+
+/** End of Group : URI Handling
+ * @}
+ */
+
+/****************** Group : Processing ********************/
+/** @name Processing
+ * Methods for processing HTTP requests
+ * @{
+ */
+
+/**
+ * @brief   Initiates the processing of HTTP request
+ *
+ * Receives incoming TCP packet on a socket, then parses the packet as
+ * HTTP request and fills httpd_req_t data structure with the extracted
+ * URI, headers are ready to be fetched from scratch buffer and calling
+ * http_recv() after this reads the body of the request.
+ *
+ * @param[in] hd  Server instance data
+ * @param[in] sd  Pointer to socket which is needed for receiving TCP packets.
+ *
+ * @return
+ *  - ESP_OK    : if request packet is valid
+ *  - ESP_FAIL  : otherwise
+ */
+esp_err_t httpd_req_new(struct httpd_data *hd, struct sock_db *sd);
+
+/**
+ * @brief   For an HTTP request, resets the resources allocated for it and
+ *          purges any data left to be received
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return
+ *  - ESP_OK    : if request packet deleted and resources cleaned.
+ *  - ESP_FAIL  : otherwise.
+ */
+esp_err_t httpd_req_delete(struct httpd_data *hd);
+
+/**
+ * @brief   For handling HTTP errors by invoking registered
+ *          error handler function
+ *
+ * @param[in] req     Pointer to the HTTP request for which error occurred
+ * @param[in] error   Error type
+ *
+ * @return
+ *  - ESP_OK    : error handled successful
+ *  - ESP_FAIL  : failure indicates that the underlying socket needs to be closed
+ */
+esp_err_t httpd_req_handle_err(httpd_req_t *req, httpd_err_code_t error);
+
+/** End of Group : Parsing
+ * @}
+ */
+
+/****************** Group : Send/Receive ********************/
+/** @name Send and Receive
+ * Methods for transmitting and receiving HTTP requests and responses
+ * @{
+ */
+
+/**
+ * @brief   For sending out data in response to an HTTP request.
+ *
+ * @param[in] req     Pointer to the HTTP request for which the response needs to be sent
+ * @param[in] buf     Pointer to the buffer from where the body of the response is taken
+ * @param[in] buf_len Length of the buffer
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - ESP_FAIL       : if failed
+ */
+int httpd_send(httpd_req_t *req, const char *buf, size_t buf_len);
+
+/**
+ * @brief   For receiving HTTP request data
+ *
+ * @note    The exposed API httpd_recv() is simply this function with last parameter
+ *          set as false. This function is used internally during reception and
+ *          processing of a new request. The option to halt after receiving pending
+ *          data prevents the server from requesting more data than is needed for
+ *          completing a packet in case when all the remaining part of the packet is
+ *          in the pending buffer.
+ *
+ * @param[in]  req    Pointer to new HTTP request which only has the socket descriptor
+ * @param[out] buf    Pointer to the buffer which will be filled with the received data
+ * @param[in] buf_len Length of the buffer
+ * @param[in] halt_after_pending When set true, halts immediately after receiving from
+ *                               pending buffer
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - ESP_FAIL       : if failed
+ */
+int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, bool halt_after_pending);
+
+/**
+ * @brief   For un-receiving HTTP request data
+ *
+ * This function copies data into internal buffer pending_data so that
+ * when httpd_recv is called, it first fetches this pending data and
+ * then only starts receiving from the socket
+ *
+ * @note    If data is too large for the internal buffer then only
+ *          part of the data is unreceived, reflected in the returned
+ *          length. Make sure that such truncation is checked for and
+ *          handled properly.
+ *
+ * @param[in] req     Pointer to new HTTP request which only has the socket descriptor
+ * @param[in] buf     Pointer to the buffer from where data needs to be un-received
+ * @param[in] buf_len Length of the buffer
+ *
+ * @return  Length of data copied into pending buffer
+ */
+size_t httpd_unrecv(struct httpd_req *r, const char *buf, size_t buf_len);
+
+/**
+ * @brief   This is the low level default send function of the HTTPD. This should
+ *          NEVER be called directly. The semantics of this is exactly similar to
+ *          send() of the BSD socket API.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] sockfd  Socket descriptor for sending data
+ * @param[in] buf     Pointer to the buffer from where the body of the response is taken
+ * @param[in] buf_len Length of the buffer
+ * @param[in] flags   Flags for mode selection
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - -1             : if failed (appropriate errno is set)
+ */
+int httpd_default_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief   This is the low level default recv function of the HTTPD. This should
+ *          NEVER be called directly. The semantics of this is exactly similar to
+ *          recv() of the BSD socket API.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] sockfd  Socket descriptor for sending data
+ * @param[out] buf    Pointer to the buffer which will be filled with the received data
+ * @param[in] buf_len Length of the buffer
+ * @param[in] flags   Flags for mode selection
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - -1             : if failed (appropriate errno is set)
+ */
+int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+/** End of Group : Send and Receive
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _HTTPD_PRIV_H_ */

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_main.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_main.c
@@ -1,0 +1,447 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <assert.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include "ctrl_sock.h"
+
+static const char *TAG = "httpd";
+
+static esp_err_t httpd_accept_conn(struct httpd_data *hd, int listen_fd)
+{
+    /* If no space is available for new session, close the least recently used one */
+    if (hd->config.lru_purge_enable == true) {
+        if (!httpd_is_sess_available(hd)) {
+            /* Queue asynchronous closure of the least recently used session */
+            return httpd_sess_close_lru(hd);
+            /* Returning from this allowes the main server thread to process
+             * the queued asynchronous control message for closing LRU session.
+             * Since connection request hasn't been addressed yet using accept()
+             * therefore httpd_accept_conn() will be called again, but this time
+             * with space available for one session
+             */
+       }
+    }
+
+    struct sockaddr_in addr_from;
+    socklen_t addr_from_len = sizeof(addr_from);
+    int new_fd = accept(listen_fd, (struct sockaddr *)&addr_from, &addr_from_len);
+    if (new_fd < 0) {
+        ESP_LOGW(TAG, LOG_FMT("error in accept (%d)"), errno);
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("newfd = %d"), new_fd);
+
+    struct timeval tv;
+    /* Set recv timeout of this fd as per config */
+    tv.tv_sec = hd->config.recv_wait_timeout;
+    tv.tv_usec = 0;
+    setsockopt(new_fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+
+    /* Set send timeout of this fd as per config */
+    tv.tv_sec = hd->config.send_wait_timeout;
+    tv.tv_usec = 0;
+    setsockopt(new_fd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&tv, sizeof(tv));
+
+    if (ESP_OK != httpd_sess_new(hd, new_fd)) {
+        ESP_LOGW(TAG, LOG_FMT("session creation failed"));
+        close(new_fd);
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("complete"));
+    return ESP_OK;
+}
+
+struct httpd_ctrl_data {
+    enum httpd_ctrl_msg {
+        HTTPD_CTRL_SHUTDOWN,
+        HTTPD_CTRL_WORK,
+    } hc_msg;
+    httpd_work_fn_t hc_work;
+    void *hc_work_arg;
+};
+
+esp_err_t httpd_queue_work(httpd_handle_t handle, httpd_work_fn_t work, void *arg)
+{
+    if (handle == NULL || work == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    struct httpd_ctrl_data msg = {
+        .hc_msg = HTTPD_CTRL_WORK,
+        .hc_work = work,
+        .hc_work_arg = arg,
+    };
+
+    int ret = cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg));
+    if (ret < 0) {
+        ESP_LOGW(TAG, LOG_FMT("failed to queue work"));
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+void *httpd_get_global_user_ctx(httpd_handle_t handle)
+{
+    return ((struct httpd_data *)handle)->config.global_user_ctx;
+}
+
+void *httpd_get_global_transport_ctx(httpd_handle_t handle)
+{
+    return ((struct httpd_data *)handle)->config.global_transport_ctx;
+}
+
+static void httpd_close_all_sessions(struct httpd_data *hd)
+{
+    int fd = -1;
+    while ((fd = httpd_sess_iterate(hd, fd)) != -1) {
+        ESP_LOGD(TAG, LOG_FMT("cleaning up socket %d"), fd);
+        httpd_sess_delete(hd, fd);
+        close(fd);
+    }
+}
+
+static void httpd_process_ctrl_msg(struct httpd_data *hd)
+{
+    struct httpd_ctrl_data msg;
+    int ret = recv(hd->ctrl_fd, &msg, sizeof(msg), 0);
+    if (ret <= 0) {
+        ESP_LOGW(TAG, LOG_FMT("error in recv (%d)"), errno);
+        return;
+    }
+    if (ret != sizeof(msg)) {
+        ESP_LOGW(TAG, LOG_FMT("incomplete msg"));
+        return;
+    }
+
+    switch (msg.hc_msg) {
+    case HTTPD_CTRL_WORK:
+        if (msg.hc_work) {
+            ESP_LOGD(TAG, LOG_FMT("work"));
+            (*msg.hc_work)(msg.hc_work_arg);
+        }
+        break;
+    case HTTPD_CTRL_SHUTDOWN:
+        ESP_LOGD(TAG, LOG_FMT("shutdown"));
+        hd->hd_td.status = THREAD_STOPPING;
+        break;
+    default:
+        break;
+    }
+}
+
+/* Manage in-coming connection or data requests */
+static esp_err_t httpd_server(struct httpd_data *hd)
+{
+    fd_set read_set;
+    FD_ZERO(&read_set);
+    if (hd->config.lru_purge_enable || httpd_is_sess_available(hd)) {
+        /* Only listen for new connections if server has capacity to
+         * handle more (or when LRU purge is enabled, in which case
+         * older connections will be closed) */
+        FD_SET(hd->listen_fd, &read_set);
+    }
+    FD_SET(hd->ctrl_fd, &read_set);
+
+    int tmp_max_fd;
+    httpd_sess_set_descriptors(hd, &read_set, &tmp_max_fd);
+    int maxfd = MAX(hd->listen_fd, tmp_max_fd);
+    tmp_max_fd = maxfd;
+    maxfd = MAX(hd->ctrl_fd, tmp_max_fd);
+
+    ESP_LOGD(TAG, LOG_FMT("doing select maxfd+1 = %d"), maxfd + 1);
+    int active_cnt = select(maxfd + 1, &read_set, NULL, NULL, NULL);
+    if (active_cnt < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in select (%d)"), errno);
+        httpd_sess_delete_invalid(hd);
+        return ESP_OK;
+    }
+
+    /* Case0: Do we have a control message? */
+    if (FD_ISSET(hd->ctrl_fd, &read_set)) {
+        ESP_LOGD(TAG, LOG_FMT("processing ctrl message"));
+        httpd_process_ctrl_msg(hd);
+        if (hd->hd_td.status == THREAD_STOPPING) {
+            ESP_LOGD(TAG, LOG_FMT("stopping thread"));
+            return ESP_FAIL;
+        }
+    }
+
+    /* Case1: Do we have any activity on the current data
+     * sessions? */
+    int fd = -1;
+    while ((fd = httpd_sess_iterate(hd, fd)) != -1) {
+        if (FD_ISSET(fd, &read_set) || (httpd_sess_pending(hd, fd))) {
+            ESP_LOGD(TAG, LOG_FMT("processing socket %d"), fd);
+            if (httpd_sess_process(hd, fd) != ESP_OK) {
+                ESP_LOGD(TAG, LOG_FMT("closing socket %d"), fd);
+                close(fd);
+                /* Delete session and update fd to that
+                 * preceding the one being deleted */
+                fd = httpd_sess_delete(hd, fd);
+            }
+        }
+    }
+
+    /* Case2: Do we have any incoming connection requests to
+     * process? */
+    if (FD_ISSET(hd->listen_fd, &read_set)) {
+        ESP_LOGD(TAG, LOG_FMT("processing listen socket %d"), hd->listen_fd);
+        if (httpd_accept_conn(hd, hd->listen_fd) != ESP_OK) {
+            ESP_LOGW(TAG, LOG_FMT("error accepting new connection"));
+        }
+    }
+    return ESP_OK;
+}
+
+/* The main HTTPD thread */
+static void httpd_thread(void *arg)
+{
+    int ret;
+    struct httpd_data *hd = (struct httpd_data *) arg;
+    hd->hd_td.status = THREAD_RUNNING;
+
+    ESP_LOGD(TAG, LOG_FMT("web server started"));
+    while (1) {
+        ret = httpd_server(hd);
+        if (ret != ESP_OK) {
+            break;
+        }
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("web server exiting"));
+    close(hd->msg_fd);
+    cs_free_ctrl_sock(hd->ctrl_fd);
+    httpd_close_all_sessions(hd);
+    close(hd->listen_fd);
+    hd->hd_td.status = THREAD_STOPPED;
+    httpd_os_thread_delete();
+}
+
+static esp_err_t httpd_server_init(struct httpd_data *hd)
+{
+    int fd = socket(PF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in socket (%d)"), errno);
+        return ESP_FAIL;
+    }
+
+    struct in6_addr inaddr_any = IN6ADDR_ANY_INIT;
+    struct sockaddr_in6 serv_addr = {
+        .sin6_family  = PF_INET6,
+        .sin6_addr    = inaddr_any,
+        .sin6_port    = htons(hd->config.server_port)
+    };
+
+    /* Enable SO_REUSEADDR to allow binding to the same
+     * address and port when restarting the server */
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        /* This will fail if CONFIG_LWIP_SO_REUSE is not enabled. But
+         * it does not affect the normal working of the HTTP Server */
+        ESP_LOGW(TAG, LOG_FMT("error enabling SO_REUSEADDR (%d)"), errno);
+    }
+
+    int ret = bind(fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+    if (ret < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in bind (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    ret = listen(fd, hd->config.backlog_conn);
+    if (ret < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in listen (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    int ctrl_fd = cs_create_ctrl_sock(hd->config.ctrl_port);
+    if (ctrl_fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in creating ctrl socket (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    int msg_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (msg_fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in creating msg socket (%d)"), errno);
+        close(fd);
+        close(ctrl_fd);
+        return ESP_FAIL;
+    }
+
+    hd->listen_fd = fd;
+    hd->ctrl_fd = ctrl_fd;
+    hd->msg_fd  = msg_fd;
+    return ESP_OK;
+}
+
+static struct httpd_data *httpd_create(const httpd_config_t *config)
+{
+    /* Allocate memory for httpd instance data */
+    struct httpd_data *hd = calloc(1, sizeof(struct httpd_data));
+    if (!hd) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP server instance"));
+        return NULL;
+    }
+    hd->hd_calls = calloc(config->max_uri_handlers, sizeof(httpd_uri_t *));
+    if (!hd->hd_calls) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP URI handlers"));
+        free(hd);
+        return NULL;
+    }
+    hd->hd_sd = calloc(config->max_open_sockets, sizeof(struct sock_db));
+    if (!hd->hd_sd) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP session data"));
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    struct httpd_req_aux *ra = &hd->hd_req_aux;
+    ra->resp_hdrs = calloc(config->max_resp_headers, sizeof(struct resp_hdr));
+    if (!ra->resp_hdrs) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP response headers"));
+        free(hd->hd_sd);
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    hd->err_handler_fns = calloc(HTTPD_ERR_CODE_MAX, sizeof(httpd_err_handler_func_t));
+    if (!hd->err_handler_fns) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP error handlers"));
+        free(ra->resp_hdrs);
+        free(hd->hd_sd);
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    /* Save the configuration for this instance */
+    hd->config = *config;
+    return hd;
+}
+
+static void httpd_delete(struct httpd_data *hd)
+{
+    struct httpd_req_aux *ra = &hd->hd_req_aux;
+    /* Free memory of httpd instance data */
+    free(hd->err_handler_fns);
+    free(ra->resp_hdrs);
+    free(hd->hd_sd);
+
+    /* Free registered URI handlers */
+    httpd_unregister_all_uri_handlers(hd);
+    free(hd->hd_calls);
+    free(hd);
+}
+
+esp_err_t httpd_start(httpd_handle_t *handle, const httpd_config_t *config)
+{
+    if (handle == NULL || config == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Sanity check about whether LWIP is configured for providing the
+     * maximum number of open sockets sufficient for the server. Though,
+     * this check doesn't guarantee that many sockets will actually be
+     * available at runtime as other processes may use up some sockets.
+     * Note that server also uses 3 sockets for its internal use :
+     *     1) listening for new TCP connections
+     *     2) for sending control messages over UDP
+     *     3) for receiving control messages over UDP
+     * So the total number of required sockets is max_open_sockets + 3
+     */
+    if (CONFIG_LWIP_MAX_SOCKETS < config->max_open_sockets + 3) {
+        ESP_LOGE(TAG, "Configuration option max_open_sockets is too large (max allowed %d)\n\t"
+                      "Either decrease this or configure LWIP_MAX_SOCKETS to a larger value",
+                      CONFIG_LWIP_MAX_SOCKETS - 3);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = httpd_create(config);
+    if (hd == NULL) {
+        /* Failed to allocate memory */
+        return ESP_ERR_HTTPD_ALLOC_MEM;
+    }
+
+    if (httpd_server_init(hd) != ESP_OK) {
+        httpd_delete(hd);
+        return ESP_FAIL;
+    }
+
+    httpd_sess_init(hd);
+    if (httpd_os_thread_create(&hd->hd_td.handle, "httpd",
+                               hd->config.stack_size,
+                               hd->config.task_priority,
+                               httpd_thread, hd) != ESP_OK) {
+        /* Failed to launch task */
+        httpd_delete(hd);
+        return ESP_ERR_HTTPD_TASK;
+    }
+
+    *handle = (httpd_handle_t *)hd;
+    return ESP_OK;
+}
+
+esp_err_t httpd_stop(httpd_handle_t handle)
+{
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_ctrl_data msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.hc_msg = HTTPD_CTRL_SHUTDOWN;
+    cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg));
+
+    ESP_LOGD(TAG, LOG_FMT("sent control msg to stop server"));
+    while (hd->hd_td.status != THREAD_STOPPED) {
+        httpd_os_thread_sleep(100);
+    }
+
+    /* Release global user context, if not NULL */
+    if (hd->config.global_user_ctx) {
+        if (hd->config.global_user_ctx_free_fn) {
+            hd->config.global_user_ctx_free_fn(hd->config.global_user_ctx);
+        } else {
+            free(hd->config.global_user_ctx);
+        }
+        hd->config.global_user_ctx = NULL;
+    }
+
+    /* Release global transport context, if not NULL */
+    if (hd->config.global_transport_ctx) {
+        if (hd->config.global_transport_ctx_free_fn) {
+            hd->config.global_transport_ctx_free_fn(hd->config.global_transport_ctx);
+        } else {
+            free(hd->config.global_transport_ctx);
+        }
+        hd->config.global_transport_ctx = NULL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("server stopped"));
+    httpd_delete(hd);
+    return ESP_OK;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_parse.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_parse.c
@@ -1,0 +1,1002 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <stdlib.h>
+#include <sys/param.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <http_parser.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include "osal.h"
+
+static const char *TAG = "httpd_parse";
+
+typedef struct {
+    /* Parser settings for http_parser_execute() */
+    http_parser_settings settings;
+
+    /* Request being parsed */
+    struct httpd_req *req;
+
+    /* Status of the parser describes the part of the
+     * HTTP request packet being processed at any moment.
+     */
+    enum {
+        PARSING_IDLE = 0,
+        PARSING_URL,
+        PARSING_HDR_FIELD,
+        PARSING_HDR_VALUE,
+        PARSING_BODY,
+        PARSING_COMPLETE,
+        PARSING_FAILED
+    } status;
+
+    /* Response error code in case of PARSING_FAILED */
+    httpd_err_code_t error;
+
+    /* For storing last callback parameters */
+    struct {
+        const char *at;
+        size_t      length;
+    } last;
+
+    /* State variables */
+    bool   paused;          /*!< Parser is paused */
+    size_t pre_parsed;      /*!< Length of data to be skipped while parsing */
+    size_t raw_datalen;     /*!< Full length of the raw data in scratch buffer */
+} parser_data_t;
+
+static esp_err_t verify_url (http_parser *parser)
+{
+    parser_data_t *parser_data  = (parser_data_t *) parser->data;
+    struct httpd_req *r         = parser_data->req;
+    struct httpd_req_aux *ra    = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Get previous values of the parser callback arguments */
+    const char *at = parser_data->last.at;
+    size_t  length = parser_data->last.length;
+
+    if ((r->method = parser->method) < 0) {
+        ESP_LOGW(TAG, LOG_FMT("HTTP Operation not supported"));
+        parser_data->error = HTTPD_501_METHOD_NOT_IMPLEMENTED;
+        return ESP_FAIL;
+    }
+
+    if (sizeof(r->uri) < (length + 1)) {
+        ESP_LOGW(TAG, LOG_FMT("URI length (%d) greater than supported (%d)"),
+                 length, sizeof(r->uri));
+        parser_data->error = HTTPD_414_URI_TOO_LONG;
+        return ESP_FAIL;
+    }
+
+    /* Keep URI with terminating null character. Note URI string pointed
+     * by 'at' is not NULL terminated, therefore use length provided by
+     * parser while copying the URI to buffer */
+    strlcpy((char *)r->uri, at, (length + 1));
+    ESP_LOGD(TAG, LOG_FMT("received URI = %s"), r->uri);
+
+    /* Make sure version is HTTP/1.1 */
+    if ((parser->http_major != 1) && (parser->http_minor != 1)) {
+        ESP_LOGW(TAG, LOG_FMT("unsupported HTTP version = %d.%d"),
+                 parser->http_major, parser->http_minor);
+        parser_data->error = HTTPD_505_VERSION_NOT_SUPPORTED;
+        return ESP_FAIL;
+    }
+
+    /* Parse URL and keep result for later */
+    http_parser_url_init(res);
+    if (http_parser_parse_url(r->uri, strlen(r->uri),
+                              r->method == HTTP_CONNECT, res)) {
+        ESP_LOGW(TAG, LOG_FMT("http_parser_parse_url failed with errno = %d"),
+                              parser->http_errno);
+        parser_data->error = HTTPD_400_BAD_REQUEST;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+/* http_parser callback on finding url in HTTP request
+ * Will be invoked ATLEAST once every packet
+ */
+static esp_err_t cb_url(http_parser *parser,
+                        const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    if (parser_data->status == PARSING_IDLE) {
+        ESP_LOGD(TAG, LOG_FMT("message begin"));
+
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_URL;
+    } else if (parser_data->status != PARSING_URL) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing url = %.*s"), length, at);
+
+    /* Update length of URL string */
+    if ((parser_data->last.length += length) > HTTPD_MAX_URI_LEN) {
+        ESP_LOGW(TAG, LOG_FMT("URI length (%d) greater than supported (%d)"),
+                 parser_data->last.length, HTTPD_MAX_URI_LEN);
+        parser_data->error = HTTPD_414_URI_TOO_LONG;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t pause_parsing(http_parser *parser, const char* at)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* The length of data that was not parsed due to interruption
+     * and hence needs to be read again later for parsing */
+    ssize_t unparsed = parser_data->raw_datalen - (at - ra->scratch);
+    if (unparsed < 0) {
+        ESP_LOGE(TAG, LOG_FMT("parsing beyond valid data = %d"), -unparsed);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Push back the un-parsed data into pending buffer for
+     * receiving again with httpd_recv_with_opt() later when
+     * read_block() executes */
+    if (unparsed && (unparsed != httpd_unrecv(r, at, unparsed))) {
+        ESP_LOGE(TAG, LOG_FMT("data too large for un-recv = %d"), unparsed);
+        return ESP_FAIL;
+    }
+
+    /* Signal http_parser to pause execution and save the maximum
+     * possible length, of the yet un-parsed data, that may get
+     * parsed before http_parser_execute() returns. This pre_parsed
+     * length will be updated then to reflect the actual length
+     * that got parsed, and must be skipped when parsing resumes */
+    parser_data->pre_parsed = unparsed;
+    http_parser_pause(parser, 1);
+    parser_data->paused = true;
+    ESP_LOGD(TAG, LOG_FMT("paused"));
+    return ESP_OK;
+}
+
+static size_t continue_parsing(http_parser *parser, size_t length)
+{
+    parser_data_t *data = (parser_data_t *) parser->data;
+
+    /* Part of the received data may have been parsed earlier
+     * so we must skip that before parsing resumes */
+    length = MIN(length, data->pre_parsed);
+    data->pre_parsed -= length;
+    ESP_LOGD(TAG, LOG_FMT("skip pre-parsed data of size = %d"), length);
+
+    http_parser_pause(parser, 0);
+    data->paused = false;
+    ESP_LOGD(TAG, LOG_FMT("un-paused"));
+    return length;
+}
+
+/* http_parser callback on header field in HTTP request
+ * May be invoked ATLEAST once every header field
+ */
+static esp_err_t cb_header_field(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        ESP_LOGD(TAG, LOG_FMT("headers begin"));
+        /* Last at is set to start of scratch where headers
+         * will be received next */
+        parser_data->last.at     = ra->scratch;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_FIELD;
+
+        /* Stop parsing for now and give control to process */
+        if (pause_parsing(parser, at) != ESP_OK) {
+            parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status == PARSING_HDR_VALUE) {
+        /* Overwrite terminator (CRLFs) following last header
+         * (key: value) pair with null characters */
+        char *term_start = (char *)parser_data->last.at + parser_data->last.length;
+        memset(term_start, '\0', at - term_start);
+
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_FIELD;
+
+        /* Increment header count */
+        ra->req_hdrs_count++;
+    } else if (parser_data->status != PARSING_HDR_FIELD) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing field = %.*s"), length, at);
+
+    /* Update length of header string */
+    parser_data->last.length += length;
+    return ESP_OK;
+}
+
+/* http_parser callback on header value in HTTP request.
+ * May be invoked ATLEAST once every header value
+ */
+static esp_err_t cb_header_value(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_HDR_FIELD) {
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_VALUE;
+
+        if (length == 0) {
+            /* As per behavior of http_parser, when length > 0,
+             * `at` points to the start of CRLF. But, in the
+             * case when header value is empty (zero length),
+             * then `at` points to the position right after
+             * the CRLF. Since for our purpose we need `last.at`
+             * to point to exactly where the CRLF starts, it
+             * needs to be adjusted by the right offset */
+            char *at_adj = (char *)parser_data->last.at;
+            /* Find the end of header field string */
+            while (*(--at_adj) != ':');
+            /* Now skip leading spaces' */
+            while (*(++at_adj) == ' ');
+            /* Now we are at the right position */
+            parser_data->last.at = at_adj;
+        }
+    } else if (parser_data->status != PARSING_HDR_VALUE) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing value = %.*s"), length, at);
+
+    /* Update length of header string */
+    parser_data->last.length += length;
+    return ESP_OK;
+}
+
+/* http_parser callback on completing headers in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_headers_complete(http_parser *parser)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        ESP_LOGD(TAG, LOG_FMT("no headers"));
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status == PARSING_HDR_VALUE) {
+        /* Locate end of last header */
+        char *at = (char *)parser_data->last.at + parser_data->last.length;
+
+        /* Check if there is data left to parse. This value should
+         * at least be equal to the number of line terminators, i.e. 2 */
+        ssize_t remaining_length = parser_data->raw_datalen - (at - ra->scratch);
+        if (remaining_length < 2) {
+            ESP_LOGE(TAG, LOG_FMT("invalid length of data remaining to be parsed"));
+            parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* Locate end of headers section by skipping the remaining
+         * two line terminators. No assumption is made here about the
+         * termination sequence used apart from the necessity that it
+         * must end with an LF, because:
+         *      1) some clients may send non standard LFs instead of
+         *         CRLFs for indicating termination.
+         *      2) it is the responsibility of http_parser to check
+         *         that the termination is either CRLF or LF and
+         *         not any other sequence */
+        unsigned short remaining_terminators = 2;
+        while (remaining_length-- && remaining_terminators) {
+            if (*at == '\n') {
+                remaining_terminators--;
+            }
+            /* Overwrite termination characters with null */
+            *(at++) = '\0';
+        }
+        if (remaining_terminators) {
+            ESP_LOGE(TAG, LOG_FMT("incomplete termination of headers"));
+            parser_data->error = HTTPD_400_BAD_REQUEST;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* Place the parser ptr right after the end of headers section */
+        parser_data->last.at = at;
+
+        /* Increment header count */
+        ra->req_hdrs_count++;
+    } else {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* In absence of body/chunked encoding, http_parser sets content_len to -1 */
+    r->content_len = ((int)parser->content_length != -1 ?
+                      parser->content_length : 0);
+
+    ESP_LOGD(TAG, LOG_FMT("bytes read     = %d"),  parser->nread);
+    ESP_LOGD(TAG, LOG_FMT("content length = %zu"), r->content_len);
+
+    if (parser->upgrade) {
+        ESP_LOGW(TAG, LOG_FMT("upgrade from HTTP not supported"));
+        /* There is no specific HTTP error code to notify the client that
+         * upgrade is not supported, thus sending 400 Bad Request */
+        parser_data->error = HTTPD_400_BAD_REQUEST;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    parser_data->status = PARSING_BODY;
+    ra->remaining_len = r->content_len;
+    return ESP_OK;
+}
+
+/* Last http_parser callback if body present in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_on_body(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status != PARSING_BODY) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* Pause parsing so that if part of another packet
+     * is in queue then it doesn't get parsed, which
+     * may reset the parser state and cause current
+     * request packet to be lost */
+    if (pause_parsing(parser, at) != ESP_OK) {
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    parser_data->last.at     = 0;
+    parser_data->last.length = 0;
+    parser_data->status      = PARSING_COMPLETE;
+    ESP_LOGD(TAG, LOG_FMT("body begins"));
+    return ESP_OK;
+}
+
+/* Last http_parser callback if body absent in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_no_body(http_parser *parser)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        ESP_LOGD(TAG, LOG_FMT("no headers"));
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status != PARSING_BODY) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* Pause parsing so that if part of another packet
+     * is in queue then it doesn't get parsed, which
+     * may reset the parser state and cause current
+     * request packet to be lost */
+    if (pause_parsing(parser, parser_data->last.at) != ESP_OK) {
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    parser_data->last.at     = 0;
+    parser_data->last.length = 0;
+    parser_data->status      = PARSING_COMPLETE;
+    ESP_LOGD(TAG, LOG_FMT("message complete"));
+    return ESP_OK;
+}
+
+static int read_block(httpd_req_t *req, size_t offset, size_t length)
+{
+    struct httpd_req_aux *raux  = req->aux;
+
+    /* Limits the read to scratch buffer size */
+    ssize_t buf_len = MIN(length, (sizeof(raux->scratch) - offset));
+    if (buf_len <= 0) {
+        return 0;
+    }
+
+    /* Receive data into buffer. If data is pending (from unrecv) then return
+     * immediately after receiving pending data, as pending data may just complete
+     * this request packet. */
+    int nbytes = httpd_recv_with_opt(req, raux->scratch + offset, buf_len, true);
+    if (nbytes < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in httpd_recv"));
+        /* If timeout occurred allow the
+         * situation to be handled */
+        if (nbytes == HTTPD_SOCK_ERR_TIMEOUT) {
+            /* Invoke error handler which may return ESP_OK
+             * to signal for retrying call to recv(), else it may
+             * return ESP_FAIL to signal for closure of socket */
+            return (httpd_req_handle_err(req, HTTPD_408_REQ_TIMEOUT) == ESP_OK) ?
+                    HTTPD_SOCK_ERR_TIMEOUT : HTTPD_SOCK_ERR_FAIL;
+        }
+        /* Some socket error occurred. Return failure
+         * to force closure of underlying socket.
+         * Error message is not sent as socket may not
+         * be valid anymore */
+        return HTTPD_SOCK_ERR_FAIL;
+    } else if (nbytes == 0) {
+        ESP_LOGD(TAG, LOG_FMT("connection closed"));
+        /* Connection closed by client so no
+         * need to send error response */
+        return HTTPD_SOCK_ERR_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("received HTTP request block size = %d"), nbytes);
+    return nbytes;
+}
+
+static int parse_block(http_parser *parser, size_t offset, size_t length)
+{
+    parser_data_t        *data  = (parser_data_t *)(parser->data);
+    httpd_req_t          *req   = data->req;
+    struct httpd_req_aux *raux  = req->aux;
+    size_t nparsed = 0;
+
+    if (!length) {
+        /* Parsing is still happening but nothing to
+         * parse means no more space left on buffer,
+         * therefore it can be inferred that the
+         * request URI/header must be too long */
+        ESP_LOGW(TAG, LOG_FMT("request URI/header too long"));
+        switch (data->status) {
+            case PARSING_URL:
+                data->error = HTTPD_414_URI_TOO_LONG;
+                break;
+            case PARSING_HDR_FIELD:
+            case PARSING_HDR_VALUE:
+                data->error = HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE;
+                break;
+            default:
+                ESP_LOGE(TAG, LOG_FMT("unexpected state"));
+                data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+                break;
+        }
+        data->status = PARSING_FAILED;
+        return -1;
+    }
+
+    /* Un-pause the parsing if paused */
+    if (data->paused) {
+        nparsed = continue_parsing(parser, length);
+        length -= nparsed;
+        offset += nparsed;
+        if (!length) {
+            return nparsed;
+        }
+    }
+
+    /* Execute http_parser */
+    nparsed = http_parser_execute(parser, &data->settings,
+                                  raux->scratch + offset, length);
+
+    /* Check state */
+    if (data->status == PARSING_FAILED) {
+        /* It is expected that the error field of
+         * parser data should have been set by now */
+        ESP_LOGW(TAG, LOG_FMT("parsing failed"));
+        return -1;
+    } else if (data->paused) {
+        /* Update the value of pre_parsed which was set when
+         * pause_parsing() was called. (length - nparsed) is
+         * the length of the data that will need to be parsed
+         * again later and hence must be deducted from the
+         * pre_parsed length */
+        data->pre_parsed -= (length - nparsed);
+        return 0;
+    } else if (nparsed != length) {
+        /* http_parser error */
+        data->error  = HTTPD_400_BAD_REQUEST;
+        data->status = PARSING_FAILED;
+        ESP_LOGW(TAG, LOG_FMT("incomplete (%d/%d) with parser error = %d"),
+                 nparsed, length, parser->http_errno);
+        return -1;
+    }
+
+    /* Return with the total length of the request packet
+     * that has been parsed till now */
+    ESP_LOGD(TAG, LOG_FMT("parsed block size = %d"), offset + nparsed);
+    return offset + nparsed;
+}
+
+static void parse_init(httpd_req_t *r, http_parser *parser, parser_data_t *data)
+{
+    /* Initialize parser data */
+    memset(data, 0, sizeof(parser_data_t));
+    data->req = r;
+
+    /* Initialize parser */
+    http_parser_init(parser, HTTP_REQUEST);
+    parser->data = (void *)data;
+
+    /* Initialize parser settings */
+    http_parser_settings_init(&data->settings);
+
+    /* Set parser callbacks */
+    data->settings.on_url              = cb_url;
+    data->settings.on_header_field     = cb_header_field;
+    data->settings.on_header_value     = cb_header_value;
+    data->settings.on_headers_complete = cb_headers_complete;
+    data->settings.on_body             = cb_on_body;
+    data->settings.on_message_complete = cb_no_body;
+}
+
+/* Function that receives TCP data and runs parser on it
+ */
+static esp_err_t httpd_parse_req(struct httpd_data *hd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    int blk_len,  offset;
+    http_parser   parser;
+    parser_data_t parser_data;
+
+    /* Initialize parser */
+    parse_init(r, &parser, &parser_data);
+
+    /* Set offset to start of scratch buffer */
+    offset = 0;
+    do {
+        /* Read block into scratch buffer */
+        if ((blk_len = read_block(r, offset, PARSER_BLOCK_SIZE)) < 0) {
+            if (blk_len == HTTPD_SOCK_ERR_TIMEOUT) {
+                /* Retry read in case of non-fatal timeout error.
+                 * read_block() ensures that the timeout error is
+                 * handled properly so that this doesn't get stuck
+                 * in an infinite loop */
+                continue;
+            }
+            /* If not HTTPD_SOCK_ERR_TIMEOUT, returned error must
+             * be HTTPD_SOCK_ERR_FAIL which means we need to return
+             * failure and thereby close the underlying socket */
+            return ESP_FAIL;
+        }
+
+        /* This is used by the callbacks to track
+         * data usage of the buffer */
+        parser_data.raw_datalen = blk_len + offset;
+
+        /* Parse data block from buffer */
+        if ((offset = parse_block(&parser, offset, blk_len)) < 0) {
+            /* HTTP error occurred.
+             * Send error code as response status and
+             * invoke error handler */
+            return httpd_req_handle_err(r, parser_data.error);
+        }
+    } while (parser_data.status != PARSING_COMPLETE);
+
+    ESP_LOGD(TAG, LOG_FMT("parsing complete"));
+    return httpd_uri(hd);
+}
+
+static void init_req(httpd_req_t *r, httpd_config_t *config)
+{
+    r->handle = 0;
+    r->method = 0;
+    memset((char*)r->uri, 0, sizeof(r->uri));
+    r->content_len = 0;
+    r->aux = 0;
+    r->user_ctx = 0;
+    r->sess_ctx = 0;
+    r->free_ctx = 0;
+    r->ignore_sess_ctx_changes = 0;
+}
+
+static void init_req_aux(struct httpd_req_aux *ra, httpd_config_t *config)
+{
+    ra->sd = 0;
+    memset(ra->scratch, 0, sizeof(ra->scratch));
+    ra->remaining_len = 0;
+    ra->status = 0;
+    ra->content_type = 0;
+    ra->first_chunk_sent = 0;
+    ra->req_hdrs_count = 0;
+    ra->resp_hdrs_count = 0;
+    memset(ra->resp_hdrs, 0, config->max_resp_headers * sizeof(struct resp_hdr));
+}
+
+static void httpd_req_cleanup(httpd_req_t *r)
+{
+    struct httpd_req_aux *ra = r->aux;
+
+    /* Check if the context has changed and needs to be cleared */
+    if ((r->ignore_sess_ctx_changes == false) && (ra->sd->ctx != r->sess_ctx)) {
+        httpd_sess_free_ctx(ra->sd->ctx, ra->sd->free_ctx);
+    }
+    /* Retrieve session info from the request into the socket database. */
+    ra->sd->ctx = r->sess_ctx;
+    ra->sd->free_ctx = r->free_ctx;
+    ra->sd->ignore_sess_ctx_changes = r->ignore_sess_ctx_changes;
+
+    /* Clear out the request and request_aux structures */
+    ra->sd = NULL;
+    r->handle = NULL;
+    r->aux = NULL;
+}
+
+/* Function that processes incoming TCP data and
+ * updates the http request data httpd_req_t
+ */
+esp_err_t httpd_req_new(struct httpd_data *hd, struct sock_db *sd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    init_req(r, &hd->config);
+    init_req_aux(&hd->hd_req_aux, &hd->config);
+    r->handle = hd;
+    r->aux = &hd->hd_req_aux;
+    /* Associate the request to the socket */
+    struct httpd_req_aux *ra = r->aux;
+    ra->sd = sd;
+    /* Set defaults */
+    ra->status = (char *)HTTPD_200;
+    ra->content_type = (char *)HTTPD_TYPE_TEXT;
+    ra->first_chunk_sent = false;
+    /* Copy session info to the request */
+    r->sess_ctx = sd->ctx;
+    r->free_ctx = sd->free_ctx;
+    r->ignore_sess_ctx_changes = sd->ignore_sess_ctx_changes;
+    /* Parse request */
+    esp_err_t err = httpd_parse_req(hd);
+    if (err != ESP_OK) {
+        httpd_req_cleanup(r);
+    }
+    return err;
+}
+
+/* Function that resets the http request data
+ */
+esp_err_t httpd_req_delete(struct httpd_data *hd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    struct httpd_req_aux *ra = r->aux;
+
+    /* Finish off reading any pending/leftover data */
+    while (ra->remaining_len) {
+        /* Any length small enough not to overload the stack, but large
+         * enough to finish off the buffers fast */
+        char dummy[CONFIG_HTTPD_PURGE_BUF_LEN];
+        int recv_len = MIN(sizeof(dummy), ra->remaining_len);
+        recv_len = httpd_req_recv(r, dummy, recv_len);
+        if (recv_len < 0) {
+            httpd_req_cleanup(r);
+            return ESP_FAIL;
+        }
+
+        ESP_LOGD(TAG, LOG_FMT("purging data size : %d bytes"), recv_len);
+
+#ifdef CONFIG_HTTPD_LOG_PURGE_DATA
+        /* Enabling this will log discarded binary HTTP content data at
+         * Debug level. For large content data this may not be desirable
+         * as it will clutter the log */
+        ESP_LOGD(TAG, "================= PURGED DATA =================");
+        ESP_LOG_BUFFER_HEX_LEVEL(TAG, dummy, recv_len, ESP_LOG_DEBUG);
+        ESP_LOGD(TAG, "===============================================");
+#endif
+    }
+
+    httpd_req_cleanup(r);
+    return ESP_OK;
+}
+
+/* Validates the request to prevent users from calling APIs, that are to
+ * be called only inside URI handler, outside the handler context
+ */
+bool httpd_validate_req_ptr(httpd_req_t *r)
+{
+    if (r) {
+        struct httpd_data *hd = (struct httpd_data *) r->handle;
+        if (hd) {
+            /* Check if this function is running in the context of
+             * the correct httpd server thread */
+            if (httpd_os_thread_handle() == hd->hd_td.handle) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* Helper function to get a URL query tag from a query string of the type param1=val1&param2=val2 */
+esp_err_t httpd_query_key_value(const char *qry_str, const char *key, char *val, size_t val_size)
+{
+    if (qry_str == NULL || key == NULL || val == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char   *qry_ptr = qry_str;
+    const size_t  buf_len = val_size;
+
+    while (strlen(qry_ptr)) {
+        /* Search for the '=' character. Else, it would mean
+         * that the parameter is invalid */
+        const char *val_ptr = strchr(qry_ptr, '=');
+        if (!val_ptr) {
+            break;
+        }
+        size_t offset = val_ptr - qry_ptr;
+
+        /* If the key, does not match, continue searching.
+         * Compare lengths first as key from url is not
+         * null terminated (has '=' in the end) */
+        if ((offset != strlen(key)) ||
+            (strncasecmp(qry_ptr, key, offset))) {
+            /* Get the name=val string. Multiple name=value pairs
+             * are separated by '&' */
+            qry_ptr = strchr(val_ptr, '&');
+            if (!qry_ptr) {
+                break;
+            }
+            qry_ptr++;
+            continue;
+        }
+
+        /* Locate start of next query */
+        qry_ptr = strchr(++val_ptr, '&');
+        /* Or this could be the last query, in which
+         * case get to the end of query string */
+        if (!qry_ptr) {
+            qry_ptr = val_ptr + strlen(val_ptr);
+        }
+
+        /* Update value length, including one byte for null */
+        val_size = qry_ptr - val_ptr + 1;
+
+        /* Copy value to the caller's buffer. */
+        strlcpy(val, val_ptr, MIN(val_size, buf_len));
+
+        /* If buffer length is smaller than needed, return truncation error */
+        if (buf_len < val_size) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        return ESP_OK;
+    }
+    ESP_LOGD(TAG, LOG_FMT("key %s not found"), key);
+    return ESP_ERR_NOT_FOUND;
+}
+
+size_t httpd_req_get_url_query_len(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return 0;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return 0;
+    }
+
+    struct httpd_req_aux   *ra  = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Check if query field is present in the URL */
+    if (res->field_set & (1 << UF_QUERY)) {
+        return res->field_data[UF_QUERY].len;
+    }
+    return 0;
+}
+
+esp_err_t httpd_req_get_url_query_str(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux   *ra  = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Check if query field is present in the URL */
+    if (res->field_set & (1 << UF_QUERY)) {
+        const char *qry = r->uri + res->field_data[UF_QUERY].off;
+
+        /* Minimum required buffer len for keeping
+         * null terminated query string */
+        size_t min_buf_len = res->field_data[UF_QUERY].len + 1;
+
+        strlcpy(buf, qry, MIN(buf_len, min_buf_len));
+        if (buf_len < min_buf_len) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+/* Get the length of the value string of a header request field */
+size_t httpd_req_get_hdr_value_len(httpd_req_t *r, const char *field)
+{
+    if (r == NULL || field == NULL) {
+        return 0;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return 0;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char   *hdr_ptr = ra->scratch;         /*!< Request headers are kept in scratch buffer */
+    unsigned      count   = ra->req_hdrs_count;  /*!< Count set during parsing  */
+
+    while (count--) {
+        /* Search for the ':' character. Else, it would mean
+         * that the field is invalid
+         */
+        const char *val_ptr = strchr(hdr_ptr, ':');
+        if (!val_ptr) {
+            break;
+        }
+
+        /* If the field, does not match, continue searching.
+         * Compare lengths first as field from header is not
+         * null terminated (has ':' in the end).
+         */
+        if ((val_ptr - hdr_ptr != strlen(field)) ||
+            (strncasecmp(hdr_ptr, field, strlen(field)))) {
+            if (count) {
+                /* Jump to end of header field-value string */
+                hdr_ptr = 1 + strchr(hdr_ptr, '\0');
+
+                /* Skip all null characters (with which the line
+                 * terminators had been overwritten) */
+                while (*hdr_ptr == '\0') {
+                    hdr_ptr++;
+                }
+            }
+            continue;
+        }
+
+        /* Skip ':' */
+        val_ptr++;
+
+        /* Skip preceding space */
+        while ((*val_ptr != '\0') && (*val_ptr == ' ')) {
+            val_ptr++;
+        }
+        return strlen(val_ptr);
+    }
+    return 0;
+}
+
+/* Get the value of a field from the request headers */
+esp_err_t httpd_req_get_hdr_value_str(httpd_req_t *r, const char *field, char *val, size_t val_size)
+{
+    if (r == NULL || field == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char   *hdr_ptr = ra->scratch;         /*!< Request headers are kept in scratch buffer */
+    unsigned     count    = ra->req_hdrs_count;  /*!< Count set during parsing  */
+    const size_t buf_len  = val_size;
+
+    while (count--) {
+        /* Search for the ':' character. Else, it would mean
+         * that the field is invalid
+         */
+        const char *val_ptr = strchr(hdr_ptr, ':');
+        if (!val_ptr) {
+            break;
+        }
+
+        /* If the field, does not match, continue searching.
+         * Compare lengths first as field from header is not
+         * null terminated (has ':' in the end).
+         */
+        if ((val_ptr - hdr_ptr != strlen(field)) ||
+            (strncasecmp(hdr_ptr, field, strlen(field)))) {
+            if (count) {
+                /* Jump to end of header field-value string */
+                hdr_ptr = 1 + strchr(hdr_ptr, '\0');
+
+                /* Skip all null characters (with which the line
+                 * terminators had been overwritten) */
+                while (*hdr_ptr == '\0') {
+                    hdr_ptr++;
+                }
+            }
+            continue;
+        }
+
+        /* Skip ':' */
+        val_ptr++;
+
+        /* Skip preceding space */
+        while ((*val_ptr != '\0') && (*val_ptr == ' ')) {
+            val_ptr++;
+        }
+
+        /* Get the NULL terminated value and copy it to the caller's buffer. */
+        strlcpy(val, val_ptr, buf_len);
+
+        /* Update value length, including one byte for null */
+        val_size = strlen(val_ptr) + 1;
+
+        /* If buffer length is smaller than needed, return truncation error */
+        if (buf_len < val_size) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_sess.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_sess.c
@@ -1,0 +1,400 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <stdlib.h>
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+
+static const char *TAG = "httpd_sess";
+
+bool httpd_is_sess_available(struct httpd_data *hd)
+{
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd == -1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct sock_db *httpd_sess_get(struct httpd_data *hd, int sockfd)
+{
+    if (hd == NULL) {
+        return NULL;
+    }
+
+    /* Check if called inside a request handler, and the
+     * session sockfd in use is same as the parameter */
+    if ((hd->hd_req_aux.sd) && (hd->hd_req_aux.sd->fd == sockfd)) {
+        /* Just return the pointer to the sock_db
+         * corresponding to the request */
+        return hd->hd_req_aux.sd;
+    }
+
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd == sockfd) {
+            return &hd->hd_sd[i];
+        }
+    }
+    return NULL;
+}
+
+esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd)
+{
+    ESP_LOGD(TAG, LOG_FMT("fd = %d"), newfd);
+
+    if (httpd_sess_get(hd, newfd)) {
+        ESP_LOGE(TAG, LOG_FMT("session already exists with fd = %d"), newfd);
+        return ESP_FAIL;
+    }
+
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd == -1) {
+            memset(&hd->hd_sd[i], 0, sizeof(hd->hd_sd[i]));
+            hd->hd_sd[i].fd = newfd;
+            hd->hd_sd[i].handle = (httpd_handle_t) hd;
+            hd->hd_sd[i].send_fn = httpd_default_send;
+            hd->hd_sd[i].recv_fn = httpd_default_recv;
+
+            /* Call user-defined session opening function */
+            if (hd->config.open_fn) {
+                esp_err_t ret = hd->config.open_fn(hd, hd->hd_sd[i].fd);
+                if (ret != ESP_OK) {
+                    httpd_sess_delete(hd, hd->hd_sd[i].fd);
+                    ESP_LOGD(TAG, LOG_FMT("open_fn failed for fd = %d"), newfd);
+                    return ret;
+                }
+            }
+            return ESP_OK;
+        }
+    }
+    ESP_LOGD(TAG, LOG_FMT("unable to launch session for fd = %d"), newfd);
+    return ESP_FAIL;
+}
+
+void httpd_sess_free_ctx(void *ctx, httpd_free_ctx_fn_t free_fn)
+{
+    if (ctx) {
+        if (free_fn) {
+            free_fn(ctx);
+        } else {
+            free(ctx);
+        }
+    }
+}
+
+void *httpd_sess_get_ctx(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *sd = httpd_sess_get(handle, sockfd);
+    if (sd == NULL) {
+        return NULL;
+    }
+
+    /* Check if the function has been called from inside a
+     * request handler, in which case fetch the context from
+     * the httpd_req_t structure */
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd->hd_req_aux.sd == sd) {
+        return hd->hd_req.sess_ctx;
+    }
+
+    return sd->ctx;
+}
+
+void httpd_sess_set_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn)
+{
+    struct sock_db *sd = httpd_sess_get(handle, sockfd);
+    if (sd == NULL) {
+        return;
+    }
+
+    /* Check if the function has been called from inside a
+     * request handler, in which case set the context inside
+     * the httpd_req_t structure */
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd->hd_req_aux.sd == sd) {
+        if (hd->hd_req.sess_ctx != ctx) {
+            /* Don't free previous context if it is in sockdb
+             * as it will be freed inside httpd_req_cleanup() */
+            if (sd->ctx != hd->hd_req.sess_ctx) {
+                /* Free previous context */
+                httpd_sess_free_ctx(hd->hd_req.sess_ctx, hd->hd_req.free_ctx);
+            }
+            hd->hd_req.sess_ctx = ctx;
+        }
+        hd->hd_req.free_ctx = free_fn;
+        return;
+    }
+
+    /* Else set the context inside the sock_db structure */
+    if (sd->ctx != ctx) {
+        /* Free previous context */
+        httpd_sess_free_ctx(sd->ctx, sd->free_ctx);
+        sd->ctx = ctx;
+    }
+    sd->free_ctx = free_fn;
+}
+
+void *httpd_sess_get_transport_ctx(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *sd = httpd_sess_get(handle, sockfd);
+    if (sd == NULL) {
+        return NULL;
+    }
+
+    return sd->transport_ctx;
+}
+
+void httpd_sess_set_transport_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn)
+{
+    struct sock_db *sd = httpd_sess_get(handle, sockfd);
+    if (sd == NULL) {
+        return;
+    }
+
+    if (sd->transport_ctx != ctx) {
+        /* Free previous transport context */
+        httpd_sess_free_ctx(sd->transport_ctx, sd->free_transport_ctx);
+        sd->transport_ctx = ctx;
+    }
+    sd->free_transport_ctx = free_fn;
+}
+
+void httpd_sess_set_descriptors(struct httpd_data *hd,
+                                fd_set *fdset, int *maxfd)
+{
+    int i;
+    *maxfd = -1;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd != -1) {
+            FD_SET(hd->hd_sd[i].fd, fdset);
+            if (hd->hd_sd[i].fd > *maxfd) {
+                *maxfd = hd->hd_sd[i].fd;
+            }
+        }
+    }
+}
+
+/** Check if a FD is valid */
+static int fd_is_valid(int fd)
+{
+    return fcntl(fd, F_GETFD) != -1 || errno != EBADF;
+}
+
+static inline uint64_t httpd_sess_get_lru_counter()
+{
+    static uint64_t lru_counter = 0;
+    return lru_counter++;
+}
+
+void httpd_sess_delete_invalid(struct httpd_data *hd)
+{
+    for (int i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd != -1 && !fd_is_valid(hd->hd_sd[i].fd)) {
+            ESP_LOGW(TAG, LOG_FMT("Closing invalid socket %d"), hd->hd_sd[i].fd);
+            httpd_sess_delete(hd, hd->hd_sd[i].fd);
+        }
+    }
+}
+
+int httpd_sess_delete(struct httpd_data *hd, int fd)
+{
+    ESP_LOGD(TAG, LOG_FMT("fd = %d"), fd);
+    int i;
+    int pre_sess_fd = -1;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd == fd) {
+            /* global close handler */
+            if (hd->config.close_fn) {
+                hd->config.close_fn(hd, fd);
+            }
+
+            /* release 'user' context */
+            if (hd->hd_sd[i].ctx) {
+                if (hd->hd_sd[i].free_ctx) {
+                    hd->hd_sd[i].free_ctx(hd->hd_sd[i].ctx);
+                } else {
+                    free(hd->hd_sd[i].ctx);
+                }
+                hd->hd_sd[i].ctx = NULL;
+                hd->hd_sd[i].free_ctx = NULL;
+            }
+
+            /* release 'transport' context */
+            if (hd->hd_sd[i].transport_ctx) {
+                if (hd->hd_sd[i].free_transport_ctx) {
+                    hd->hd_sd[i].free_transport_ctx(hd->hd_sd[i].transport_ctx);
+                } else {
+                    free(hd->hd_sd[i].transport_ctx);
+                }
+                hd->hd_sd[i].transport_ctx = NULL;
+                hd->hd_sd[i].free_transport_ctx = NULL;
+            }
+
+            /* mark session slot as available */
+            hd->hd_sd[i].fd = -1;
+            break;
+        } else if (hd->hd_sd[i].fd != -1) {
+            /* Return the fd just preceding the one being
+             * deleted so that iterator can continue from
+             * the correct fd */
+            pre_sess_fd = hd->hd_sd[i].fd;
+        }
+    }
+    return pre_sess_fd;
+}
+
+void httpd_sess_init(struct httpd_data *hd)
+{
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        hd->hd_sd[i].fd = -1;
+        hd->hd_sd[i].ctx = NULL;
+    }
+}
+
+bool httpd_sess_pending(struct httpd_data *hd, int fd)
+{
+    struct sock_db *sd = httpd_sess_get(hd, fd);
+    if (! sd) {
+        return ESP_FAIL;
+    }
+
+    if (sd->pending_fn) {
+        // test if there's any data to be read (besides read() function, which is handled by select() in the main httpd loop)
+        // this should check e.g. for the SSL data buffer
+        if (sd->pending_fn(hd, fd) > 0) return true;
+    }
+
+    return (sd->pending_len != 0);
+}
+
+/* This MUST return ESP_OK on successful execution. If any other
+ * value is returned, everything related to this socket will be
+ * cleaned up and the socket will be closed.
+ */
+esp_err_t httpd_sess_process(struct httpd_data *hd, int newfd)
+{
+    struct sock_db *sd = httpd_sess_get(hd, newfd);
+    if (! sd) {
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("httpd_req_new"));
+    if (httpd_req_new(hd, sd) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("httpd_req_delete"));
+    if (httpd_req_delete(hd) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("success"));
+    sd->lru_counter = httpd_sess_get_lru_counter();
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_update_lru_counter(httpd_handle_t handle, int sockfd)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Search for the socket database entry */
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd == sockfd) {
+            hd->hd_sd[i].lru_counter = httpd_sess_get_lru_counter();
+            return ESP_OK;
+        }
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t httpd_sess_close_lru(struct httpd_data *hd)
+{
+    uint64_t lru_counter = UINT64_MAX;
+    int lru_fd = -1;
+    int i;
+    for (i = 0; i < hd->config.max_open_sockets; i++) {
+        /* If a descriptor is -1, there is no need to close any session.
+         * So, we can return from here, without finding the Least Recently Used
+         * session
+         */
+        if (hd->hd_sd[i].fd == -1) {
+            return ESP_OK;
+        }
+        if (hd->hd_sd[i].lru_counter < lru_counter) {
+            lru_counter = hd->hd_sd[i].lru_counter;
+            lru_fd = hd->hd_sd[i].fd;
+        }
+    }
+    ESP_LOGD(TAG, LOG_FMT("fd = %d"), lru_fd);
+    return httpd_sess_trigger_close(hd, lru_fd);
+}
+
+int httpd_sess_iterate(struct httpd_data *hd, int start_fd)
+{
+    int start_index = 0;
+    int i;
+
+    if (start_fd != -1) {
+        /* Take our index to where this fd is stored */
+        for (i = 0; i < hd->config.max_open_sockets; i++) {
+            if (hd->hd_sd[i].fd == start_fd) {
+                start_index = i + 1;
+                break;
+            }
+        }
+    }
+
+    for (i = start_index; i < hd->config.max_open_sockets; i++) {
+        if (hd->hd_sd[i].fd != -1) {
+            return hd->hd_sd[i].fd;
+        }
+    }
+    return -1;
+}
+
+static void httpd_sess_close(void *arg)
+{
+    struct sock_db *sock_db = (struct sock_db *)arg;
+    if (sock_db) {
+        if (sock_db->lru_counter == 0) {
+            ESP_LOGD(TAG, "Skipping session close for %d as it seems to be a race condition", sock_db->fd);
+            return;
+        }
+        int fd = sock_db->fd;
+        struct httpd_data *hd = (struct httpd_data *) sock_db->handle;
+        httpd_sess_delete(hd, fd);
+        close(fd);
+    }
+}
+
+esp_err_t httpd_sess_trigger_close(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *sock_db = httpd_sess_get(handle, sockfd);
+    if (sock_db) {
+        return httpd_queue_work(handle, httpd_sess_close, sock_db);
+    }
+
+    return ESP_ERR_NOT_FOUND;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_txrx.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_txrx.c
@@ -1,0 +1,608 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+
+static const char *TAG = "httpd_txrx";
+
+esp_err_t httpd_sess_set_send_override(httpd_handle_t hd, int sockfd, httpd_send_func_t send_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->send_fn = send_func;
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_set_recv_override(httpd_handle_t hd, int sockfd, httpd_recv_func_t recv_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->recv_fn = recv_func;
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_set_pending_override(httpd_handle_t hd, int sockfd, httpd_pending_func_t pending_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->pending_fn = pending_func;
+    return ESP_OK;
+}
+
+int httpd_send(httpd_req_t *r, const char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    int ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
+        return ret;
+    }
+    return ret;
+}
+
+static esp_err_t httpd_send_all(httpd_req_t *r, const char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    int ret;
+
+    while (buf_len > 0) {
+        ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+        if (ret < 0) {
+            ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
+            return ESP_FAIL;
+        }
+        ESP_LOGD(TAG, LOG_FMT("sent = %d"), ret);
+        buf     += ret;
+        buf_len -= ret;
+    }
+    return ESP_OK;
+}
+
+static size_t httpd_recv_pending(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    size_t offset = sizeof(ra->sd->pending_data) - ra->sd->pending_len;
+
+    /* buf_len must not be greater than remaining_len */
+    buf_len = MIN(ra->sd->pending_len, buf_len);
+    memcpy(buf, ra->sd->pending_data + offset, buf_len);
+
+    ra->sd->pending_len -= buf_len;
+    return buf_len;
+}
+
+int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, bool halt_after_pending)
+{
+    ESP_LOGD(TAG, LOG_FMT("requested length = %d"), buf_len);
+
+    size_t pending_len = 0;
+    struct httpd_req_aux *ra = r->aux;
+
+    /* First fetch pending data from local buffer */
+    if (ra->sd->pending_len > 0) {
+        ESP_LOGD(TAG, LOG_FMT("pending length = %d"), ra->sd->pending_len);
+        pending_len = httpd_recv_pending(r, buf, buf_len);
+        buf     += pending_len;
+        buf_len -= pending_len;
+
+        /* If buffer filled then no need to recv.
+         * If asked to halt after receiving pending data then
+         * return with received length */
+        if (!buf_len || halt_after_pending) {
+            return pending_len;
+        }
+    }
+
+    /* Receive data of remaining length */
+    int ret = ra->sd->recv_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in recv_fn"));
+        if ((ret == HTTPD_SOCK_ERR_TIMEOUT) && (pending_len != 0)) {
+            /* If recv() timeout occurred, but pending data is
+             * present, return length of pending data.
+             * This behavior is similar to that of socket recv()
+             * function, which, in case has only partially read the
+             * requested length, due to timeout, returns with read
+             * length, rather than error */
+            return pending_len;
+        }
+        return ret;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("received length = %d"), ret + pending_len);
+    return ret + pending_len;
+}
+
+int httpd_recv(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    return httpd_recv_with_opt(r, buf, buf_len, false);
+}
+
+size_t httpd_unrecv(struct httpd_req *r, const char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    /* Truncate if external buf_len is greater than pending_data buffer size */
+    ra->sd->pending_len = MIN(sizeof(ra->sd->pending_data), buf_len);
+
+    /* Copy data into internal pending_data buffer with the exact offset
+     * such that it is right aligned inside the buffer */
+    size_t offset = sizeof(ra->sd->pending_data) - ra->sd->pending_len;
+    memcpy(ra->sd->pending_data + offset, buf, ra->sd->pending_len);
+    ESP_LOGD(TAG, LOG_FMT("length = %d"), ra->sd->pending_len);
+    return ra->sd->pending_len;
+}
+
+/**
+ * This API appends an additional header field-value pair in the HTTP response.
+ * But the header isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_hdr(httpd_req_t *r, const char *field, const char *value)
+{
+    if (r == NULL || field == NULL || value == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    struct httpd_data *hd = (struct httpd_data *) r->handle;
+
+    /* Number of additional headers is limited */
+    if (ra->resp_hdrs_count >= hd->config.max_resp_headers) {
+        return ESP_ERR_HTTPD_RESP_HDR;
+    }
+
+    /* Assign header field-value pair */
+    ra->resp_hdrs[ra->resp_hdrs_count].field = field;
+    ra->resp_hdrs[ra->resp_hdrs_count].value = value;
+    ra->resp_hdrs_count++;
+
+    ESP_LOGD(TAG, LOG_FMT("new header = %s: %s"), field, value);
+    return ESP_OK;
+}
+
+/**
+ * This API sets the status of the HTTP response to the value specified.
+ * But the status isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_status(httpd_req_t *r, const char *status)
+{
+    if (r == NULL || status == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->status = (char *)status;
+    return ESP_OK;
+}
+
+/**
+ * This API sets the method/type of the HTTP response to the value specified.
+ * But the method isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_type(httpd_req_t *r, const char *type)
+{
+    if (r == NULL || type == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->content_type = (char *)type;
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send(httpd_req_t *r, const char *buf, ssize_t buf_len)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char *httpd_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nContent-Length: %d\r\n";
+    const char *colon_separator = ": ";
+    const char *cr_lf_seperator = "\r\n";
+
+    if (buf_len == HTTPD_RESP_USE_STRLEN) {
+        buf_len = strlen(buf);
+    }
+
+    /* Request headers are no longer available */
+    ra->req_hdrs_count = 0;
+
+    /* Size of essential headers is limited by scratch buffer size */
+    if (snprintf(ra->scratch, sizeof(ra->scratch), httpd_hdr_str,
+                 ra->status, ra->content_type, buf_len) >= sizeof(ra->scratch)) {
+        return ESP_ERR_HTTPD_RESP_HDR;
+    }
+
+    /* Sending essential headers */
+    if (httpd_send_all(r, ra->scratch, strlen(ra->scratch)) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+
+    /* Sending additional headers based on set_header */
+    for (unsigned i = 0; i < ra->resp_hdrs_count; i++) {
+        /* Send header field */
+        if (httpd_send_all(r, ra->resp_hdrs[i].field, strlen(ra->resp_hdrs[i].field)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send ': ' */
+        if (httpd_send_all(r, colon_separator, strlen(colon_separator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send header value */
+        if (httpd_send_all(r, ra->resp_hdrs[i].value, strlen(ra->resp_hdrs[i].value)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send CR + LF */
+        if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+
+    /* End header section */
+    if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+
+    /* Sending content */
+    if (buf && buf_len) {
+        if (httpd_send_all(r, buf, buf_len) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    if (buf_len == HTTPD_RESP_USE_STRLEN) {
+        buf_len = strlen(buf);
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char *httpd_chunked_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nTransfer-Encoding: chunked\r\n";
+    const char *colon_separator = ": ";
+    const char *cr_lf_seperator = "\r\n";
+
+    /* Request headers are no longer available */
+    ra->req_hdrs_count = 0;
+
+    if (!ra->first_chunk_sent) {
+        /* Size of essential headers is limited by scratch buffer size */
+        if (snprintf(ra->scratch, sizeof(ra->scratch), httpd_chunked_hdr_str,
+                     ra->status, ra->content_type) >= sizeof(ra->scratch)) {
+            return ESP_ERR_HTTPD_RESP_HDR;
+        }
+
+        /* Sending essential headers */
+        if (httpd_send_all(r, ra->scratch, strlen(ra->scratch)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+
+        /* Sending additional headers based on set_header */
+        for (unsigned i = 0; i < ra->resp_hdrs_count; i++) {
+            /* Send header field */
+            if (httpd_send_all(r, ra->resp_hdrs[i].field, strlen(ra->resp_hdrs[i].field)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send ': ' */
+            if (httpd_send_all(r, colon_separator, strlen(colon_separator)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send header value */
+            if (httpd_send_all(r, ra->resp_hdrs[i].value, strlen(ra->resp_hdrs[i].value)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send CR + LF */
+            if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+        }
+
+        /* End header section */
+        if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        ra->first_chunk_sent = true;
+    }
+
+    /* Sending chunked content */
+    char len_str[10];
+    snprintf(len_str, sizeof(len_str), "%x\r\n", buf_len);
+    if (httpd_send_all(r, len_str, strlen(len_str)) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+
+    if (buf) {
+        if (httpd_send_all(r, buf, (size_t) buf_len) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+
+    /* Indicate end of chunk */
+    if (httpd_send_all(r, "\r\n", strlen("\r\n")) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const char *usr_msg)
+{
+    esp_err_t ret;
+    const char *msg;
+    const char *status;
+
+    switch (error) {
+        case HTTPD_501_METHOD_NOT_IMPLEMENTED:
+            status = "501 Method Not Implemented";
+            msg    = "Request method is not supported by server";
+            break;
+        case HTTPD_505_VERSION_NOT_SUPPORTED:
+            status = "505 Version Not Supported";
+            msg    = "HTTP version not supported by server";
+            break;
+        case HTTPD_400_BAD_REQUEST:
+            status = "400 Bad Request";
+            msg    = "Server unable to understand request due to invalid syntax";
+            break;
+        case HTTPD_404_NOT_FOUND:
+            status = "404 Not Found";
+            msg    = "This URI does not exist";
+            break;
+        case HTTPD_405_METHOD_NOT_ALLOWED:
+            status = "405 Method Not Allowed";
+            msg    = "Request method for this URI is not handled by server";
+            break;
+        case HTTPD_408_REQ_TIMEOUT:
+            status = "408 Request Timeout";
+            msg    = "Server closed this connection";
+            break;
+        case HTTPD_414_URI_TOO_LONG:
+            status = "414 URI Too Long";
+            msg    = "URI is too long for server to interpret";
+            break;
+        case HTTPD_411_LENGTH_REQUIRED:
+            status = "411 Length Required";
+            msg    = "Chunked encoding not supported by server";
+            break;
+        case HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE:
+            status = "431 Request Header Fields Too Large";
+            msg    = "Header fields are too long for server to interpret";
+            break;
+        case HTTPD_500_INTERNAL_SERVER_ERROR:
+        default:
+            status = "500 Internal Server Error";
+            msg    = "Server has encountered an unexpected error";
+    }
+
+    /* If user has provided custom message, override default message */
+    msg = usr_msg ? usr_msg : msg;
+    ESP_LOGW(TAG, LOG_FMT("%s - %s"), status, msg);
+
+    /* Set error code in HTTP response */
+    httpd_resp_set_status(req, status);
+    httpd_resp_set_type(req, HTTPD_TYPE_TEXT);
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* Use TCP_NODELAY option to force socket to send data in buffer
+     * This ensures that the error message is sent before the socket
+     * is closed */
+    struct httpd_req_aux *ra = req->aux;
+    int nodelay = 1;
+    if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+        /* If failed to turn on TCP_NODELAY, throw warning and continue */
+        ESP_LOGW(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+        nodelay = 0;
+    }
+#endif
+
+    /* Send HTTP error message */
+    ret = httpd_resp_send(req, msg, strlen(msg));
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* If TCP_NODELAY was set successfully above, time to disable it */
+    if (nodelay == 1) {
+        nodelay = 0;
+        if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+            /* If failed to turn off TCP_NODELAY, throw error and
+             * return failure to signal for socket closure */
+            ESP_LOGE(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+#endif
+
+    return ret;
+}
+
+esp_err_t httpd_register_err_handler(httpd_handle_t handle,
+                                     httpd_err_code_t error,
+                                     httpd_err_handler_func_t err_handler_fn)
+{
+    if (handle == NULL || error >= HTTPD_ERR_CODE_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    hd->err_handler_fns[error] = err_handler_fn;
+    return ESP_OK;
+}
+
+esp_err_t httpd_req_handle_err(httpd_req_t *req, httpd_err_code_t error)
+{
+    struct httpd_data *hd = (struct httpd_data *) req->handle;
+    esp_err_t ret;
+
+    /* Invoke custom error handler if configured */
+    if (hd->err_handler_fns[error]) {
+        ret = hd->err_handler_fns[error](req, error);
+
+        /* If error code is 500, force return failure
+         * irrespective of the handler's return value */
+        ret = (error == HTTPD_500_INTERNAL_SERVER_ERROR ? ESP_FAIL : ret);
+    } else {
+        /* If no handler is registered for this error default
+         * behavior is to send the HTTP error response and
+         * return failure for closure of underlying socket */
+        httpd_resp_send_err(req, error, NULL);
+        ret = ESP_FAIL;
+    }
+    return ret;
+}
+
+int httpd_req_recv(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    if (!httpd_valid_req(r)) {
+        ESP_LOGW(TAG, LOG_FMT("invalid request"));
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ESP_LOGD(TAG, LOG_FMT("remaining length = %d"), ra->remaining_len);
+
+    if (buf_len > ra->remaining_len) {
+        buf_len = ra->remaining_len;
+    }
+    if (buf_len == 0) {
+        return buf_len;
+    }
+
+    int ret = httpd_recv(r, buf, buf_len);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in httpd_recv"));
+        return ret;
+    }
+    ra->remaining_len -= ret;
+    ESP_LOGD(TAG, LOG_FMT("received length = %d"), ret);
+    return ret;
+}
+
+int httpd_req_to_sockfd(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return -1;
+    }
+
+    if (!httpd_valid_req(r)) {
+        ESP_LOGW(TAG, LOG_FMT("invalid request"));
+        return -1;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    return ra->sd->fd;
+}
+
+static int httpd_sock_err(const char *ctx, int sockfd)
+{
+    int errval;
+    int sock_err;
+    size_t sock_err_len = sizeof(sock_err);
+
+    if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &sock_err, &sock_err_len) < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error calling getsockopt : %d"), errno);
+        return HTTPD_SOCK_ERR_FAIL;
+    }
+    ESP_LOGW(TAG, LOG_FMT("error in %s : %d"), ctx, sock_err);
+
+    switch(sock_err) {
+    case EAGAIN:
+    case EINTR:
+        errval = HTTPD_SOCK_ERR_TIMEOUT;
+        break;
+    case EINVAL:
+    case EBADF:
+    case EFAULT:
+    case ENOTSOCK:
+        errval = HTTPD_SOCK_ERR_INVALID;
+        break;
+    default:
+        errval = HTTPD_SOCK_ERR_FAIL;
+    }
+    return errval;
+}
+
+int httpd_default_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags)
+{
+    (void)hd;
+    if (buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    int ret = send(sockfd, buf, buf_len, flags);
+    if (ret < 0) {
+        return httpd_sock_err("send", sockfd);
+    }
+    return ret;
+}
+
+int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags)
+{
+    (void)hd;
+    if (buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    int ret = recv(sockfd, buf, buf_len, flags);
+    if (ret < 0) {
+        return httpd_sock_err("recv", sockfd);
+    }
+    return ret;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_uri.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/httpd_uri.c
@@ -1,0 +1,317 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <http_parser.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+
+static const char *TAG = "httpd_uri";
+
+static bool httpd_uri_match_simple(const char *uri1, const char *uri2, size_t len2)
+{
+    return strlen(uri1) == len2 &&          // First match lengths
+        (strncmp(uri1, uri2, len2) == 0);   // Then match actual URIs
+}
+
+bool httpd_uri_match_wildcard(const char *template, const char *uri, size_t len)
+{
+    const size_t tpl_len = strlen(template);
+    size_t exact_match_chars = tpl_len;
+
+    /* Check for trailing question mark and asterisk */
+    const char last = (const char) (tpl_len > 0 ? template[tpl_len - 1] : 0);
+    const char prevlast = (const char) (tpl_len > 1 ? template[tpl_len - 2] : 0);
+    const bool asterisk = last == '*' || (prevlast == '*' && last == '?');
+    const bool quest = last == '?' || (prevlast == '?' && last == '*');
+
+    /* Minimum template string length must be:
+     *      0 : if neither of '*' and '?' are present
+     *      1 : if only '*' is present
+     *      2 : if only '?' is present
+     *      3 : if both are present
+     *
+     * The expression (asterisk + quest*2) serves as a
+     * case wise generator of these length values
+     */
+
+    /* abort in cases such as "?" with no preceding character (invalid template) */
+    if (exact_match_chars < asterisk + quest*2) {
+        return false;
+    }
+
+    /* account for special characters and the optional character if "?" is used */
+    exact_match_chars -= asterisk + quest*2;
+
+    if (len < exact_match_chars) {
+        return false;
+    }
+
+    if (!quest) {
+        if (!asterisk && len != exact_match_chars) {
+            /* no special characters and different length - strncmp would return false */
+            return false;
+        }
+        /* asterisk allows arbitrary trailing characters, we ignore these using
+         * exact_match_chars as the length limit */
+        return (strncmp(template, uri, exact_match_chars) == 0);
+    } else {
+        /* question mark present */
+        if (len > exact_match_chars && template[exact_match_chars] != uri[exact_match_chars]) {
+            /* the optional character is present, but different */
+            return false;
+        }
+        if (strncmp(template, uri, exact_match_chars) != 0) {
+            /* the mandatory part differs */
+            return false;
+        }
+        /* Now we know the URI is longer than the required part of template,
+         * the mandatory part matches, and if the optional character is present, it is correct.
+         * Match is OK if we have asterisk, i.e. any trailing characters are OK, or if
+         * there are no characters beyond the optional character. */
+        return asterisk || len <= exact_match_chars + 1;
+    }
+}
+
+/* Find handler with matching URI and method, and set
+ * appropriate error code if URI or method not found */
+static httpd_uri_t* httpd_find_uri_handler(struct httpd_data *hd,
+                                           const char *uri, size_t uri_len,
+                                           httpd_method_t method,
+                                           httpd_err_code_t *err)
+{
+    if (err) {
+        *err = HTTPD_404_NOT_FOUND;
+    }
+
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] = %s"), i, hd->hd_calls[i]->uri);
+
+        /* Check if custom URI matching function is set,
+         * else use simple string compare */
+        if (hd->config.uri_match_fn ?
+            hd->config.uri_match_fn(hd->hd_calls[i]->uri, uri, uri_len) :
+            httpd_uri_match_simple(hd->hd_calls[i]->uri, uri, uri_len)) {
+            /* URIs match. Now check if method is supported */
+            if (hd->hd_calls[i]->method == method) {
+                /* Match found! */
+                if (err) {
+                    /* Unset any error that may
+                     * have been set earlier */
+                    *err = 0;
+                }
+                return hd->hd_calls[i];
+            }
+            /* URI found but method not allowed.
+             * If URI is found later then this
+             * error must be set to 0 */
+            if (err) {
+                *err = HTTPD_405_METHOD_NOT_ALLOWED;
+            }
+        }
+    }
+    return NULL;
+}
+
+esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
+                                     const httpd_uri_t *uri_handler)
+{
+    if (handle == NULL || uri_handler == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+
+    /* Make sure another handler with matching URI and method
+     * is not already registered. This will also catch cases
+     * when a registered URI wildcard pattern already accounts
+     * for the new URI being registered */
+    if (httpd_find_uri_handler(handle, uri_handler->uri,
+                               strlen(uri_handler->uri),
+                               uri_handler->method, NULL) != NULL) {
+        ESP_LOGW(TAG, LOG_FMT("handler %s with method %d already registered"),
+                 uri_handler->uri, uri_handler->method);
+        return ESP_ERR_HTTPD_HANDLER_EXISTS;
+    }
+
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (hd->hd_calls[i] == NULL) {
+            hd->hd_calls[i] = malloc(sizeof(httpd_uri_t));
+            if (hd->hd_calls[i] == NULL) {
+                /* Failed to allocate memory */
+                return ESP_ERR_HTTPD_ALLOC_MEM;
+            }
+
+            /* Copy URI string */
+            hd->hd_calls[i]->uri = strdup(uri_handler->uri);
+            if (hd->hd_calls[i]->uri == NULL) {
+                /* Failed to allocate memory */
+                free(hd->hd_calls[i]);
+                return ESP_ERR_HTTPD_ALLOC_MEM;
+            }
+
+            /* Copy remaining members */
+            hd->hd_calls[i]->method   = uri_handler->method;
+            hd->hd_calls[i]->handler  = uri_handler->handler;
+            hd->hd_calls[i]->user_ctx = uri_handler->user_ctx;
+            ESP_LOGD(TAG, LOG_FMT("[%d] installed %s"), i, uri_handler->uri);
+            return ESP_OK;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] exists %s"), i, hd->hd_calls[i]->uri);
+    }
+    ESP_LOGW(TAG, LOG_FMT("no slots left for registering handler"));
+    return ESP_ERR_HTTPD_HANDLERS_FULL;
+}
+
+esp_err_t httpd_unregister_uri_handler(httpd_handle_t handle,
+                                       const char *uri, httpd_method_t method)
+{
+    if (handle == NULL || uri == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        if ((hd->hd_calls[i]->method == method) &&       // First match methods
+            (strcmp(hd->hd_calls[i]->uri, uri) == 0)) {  // Then match URI string
+            ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
+
+            free((char*)hd->hd_calls[i]->uri);
+            free(hd->hd_calls[i]);
+            hd->hd_calls[i] = NULL;
+
+            /* Shift the remaining non null handlers in the array
+             * forward by 1 so that order of insertion is maintained */
+            for (i += 1; i < hd->config.max_uri_handlers; i++) {
+                if (!hd->hd_calls[i]) {
+                    break;
+                }
+                hd->hd_calls[i-1] = hd->hd_calls[i];
+            }
+            /* Nullify the following non null entry */
+            hd->hd_calls[i-1] = NULL;
+            return ESP_OK;
+        }
+    }
+    ESP_LOGW(TAG, LOG_FMT("handler %s with method %d not found"), uri, method);
+    return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t httpd_unregister_uri(httpd_handle_t handle, const char *uri)
+{
+    if (handle == NULL || uri == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    bool found = false;
+
+    int i = 0, j = 0; // For keeping count of removed entries
+    for (; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        if (strcmp(hd->hd_calls[i]->uri, uri) == 0) {   // Match URI strings
+            ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, uri);
+
+            free((char*)hd->hd_calls[i]->uri);
+            free(hd->hd_calls[i]);
+            hd->hd_calls[i] = NULL;
+            found = true;
+
+            j++; // Update count of removed entries
+        } else {
+            /* Shift the remaining non null handlers in the array
+             * forward by j so that order of insertion is maintained */
+            hd->hd_calls[i-j] = hd->hd_calls[i];
+        }
+    }
+    /* Nullify the following non null entries */
+    for (int k = (i - j); k < i; k++) {
+        hd->hd_calls[k] = NULL;
+    }
+
+    if (!found) {
+        ESP_LOGW(TAG, LOG_FMT("no handler found for URI %s"), uri);
+    }
+    return (found ? ESP_OK : ESP_ERR_NOT_FOUND);
+}
+
+void httpd_unregister_all_uri_handlers(struct httpd_data *hd)
+{
+    for (unsigned i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
+
+        free((char*)hd->hd_calls[i]->uri);
+        free(hd->hd_calls[i]);
+        hd->hd_calls[i] = NULL;
+    }
+}
+
+esp_err_t httpd_uri(struct httpd_data *hd)
+{
+    httpd_uri_t            *uri = NULL;
+    httpd_req_t            *req = &hd->hd_req;
+    struct http_parser_url *res = &hd->hd_req_aux.url_parse_res;
+
+    /* For conveying URI not found/method not allowed */
+    httpd_err_code_t err = 0;
+
+    ESP_LOGD(TAG, LOG_FMT("request for %s with type %d"), req->uri, req->method);
+
+    /* URL parser result contains offset and length of path string */
+    if (res->field_set & (1 << UF_PATH)) {
+        uri = httpd_find_uri_handler(hd, req->uri + res->field_data[UF_PATH].off,
+                                     res->field_data[UF_PATH].len, req->method, &err);
+    }
+
+    /* If URI with method not found, respond with error code */
+    if (uri == NULL) {
+        switch (err) {
+            case HTTPD_404_NOT_FOUND:
+                ESP_LOGW(TAG, LOG_FMT("URI '%s' not found"), req->uri);
+                return httpd_req_handle_err(req, HTTPD_404_NOT_FOUND);
+            case HTTPD_405_METHOD_NOT_ALLOWED:
+                ESP_LOGW(TAG, LOG_FMT("Method '%d' not allowed for URI '%s'"),
+                         req->method, req->uri);
+                return httpd_req_handle_err(req, HTTPD_405_METHOD_NOT_ALLOWED);
+            default:
+                return ESP_FAIL;
+        }
+    }
+
+    /* Attach user context data (passed during URI registration) into request */
+    req->user_ctx = uri->user_ctx;
+
+    /* Invoke handler */
+    if (uri->handler(req) != ESP_OK) {
+        /* Handler returns error, this socket should be closed */
+        ESP_LOGW(TAG, LOG_FMT("uri handler execution failed"));
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/port/esp32/osal.h
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/port/esp32/osal.h
@@ -1,0 +1,64 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _OSAL_H_
+#define _OSAL_H_
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <esp_timer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OS_SUCCESS ESP_OK
+#define OS_FAIL    ESP_FAIL
+
+typedef TaskHandle_t othread_t;
+
+static inline int httpd_os_thread_create(othread_t *thread,
+                                 const char *name, uint16_t stacksize, int prio,
+                                 void (*thread_routine)(void *arg), void *arg)
+{
+    int ret = xTaskCreate(thread_routine, name, stacksize, arg, prio, thread);
+    if (ret == pdPASS) {
+        return OS_SUCCESS;
+    }
+    return OS_FAIL;
+}
+
+/* Only self delete is supported */
+static inline void httpd_os_thread_delete()
+{
+    vTaskDelete(xTaskGetCurrentTaskHandle());
+}
+
+static inline void httpd_os_thread_sleep(int msecs)
+{
+    vTaskDelay(msecs / portTICK_RATE_MS);
+}
+
+static inline othread_t httpd_os_thread_handle()
+{
+    return xTaskGetCurrentTaskHandle();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _OSAL_H_ */

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/util/ctrl_sock.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/util/ctrl_sock.c
@@ -1,0 +1,77 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "ctrl_sock.h"
+
+/* Control socket, because in some network stacks select can't be woken up any
+ * other way
+ */
+int cs_create_ctrl_sock(int port)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd < 0) {
+        return -1;
+    }
+
+    int ret;
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    inet_aton("127.0.0.1", &addr.sin_addr);
+    ret = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+    if (ret < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+void cs_free_ctrl_sock(int fd)
+{
+    close(fd);
+}
+
+int cs_send_to_ctrl_sock(int send_fd, int port, void *data, unsigned int data_len)
+{
+    int ret;
+    struct sockaddr_in to_addr;
+    to_addr.sin_family = AF_INET;
+    to_addr.sin_port = htons(port);
+    inet_aton("127.0.0.1", &to_addr.sin_addr);
+    ret = sendto(send_fd, data, data_len, 0, (struct sockaddr *)&to_addr, sizeof(to_addr));
+
+    if (ret < 0) {
+        return -1;
+    }
+    return ret;
+}
+
+int cs_recv_from_ctrl_sock(int fd, void *data, unsigned int data_len)
+{
+    int ret;
+    ret = recvfrom(fd, data, data_len, 0, NULL, NULL);
+
+    if (ret < 0) {
+        return -1;
+    }
+    return ret;
+}

--- a/vendors/espressif/esp-idf/components/esp_http_server/src/util/ctrl_sock.h
+++ b/vendors/espressif/esp-idf/components/esp_http_server/src/util/ctrl_sock.h
@@ -1,0 +1,99 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * \file ctrl_sock.h
+ * \brief Control Socket for select() wakeup
+ *
+ * LWIP doesn't allow an easy mechanism to on-demand wakeup a thread
+ * sleeping on select. This is a common requirement for sending
+ * control commands to a network server. This control socket API
+ * facilitates the same.
+ */
+#ifndef _CTRL_SOCK_H_
+#define _CTRL_SOCK_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create a control socket
+ *
+ *      LWIP doesn't allow an easy mechanism to on-demand wakeup a thread
+ *      sleeping on select. This is a common requirement for sending
+ *      control commands to a network server. This control socket API
+ *      facilitates the same.
+ *
+ *      This API will create a UDP control socket on the specified port. It
+ *      will return a socket descriptor that can then be added to your
+ *      fd_set in select()
+ *
+ * @param[in] port the local port on which the control socket will listen
+ *
+ * @return - the socket descriptor that can be added to the fd_set in select.
+ *         - an error code if less than zero
+ */
+int cs_create_ctrl_sock(int port);
+
+/**
+ * @brief Free the control socket
+ *
+ *      This frees up the control socket that was earlier created using
+ *      cs_create_ctrl_sock()
+ *
+ * @param[in] fd the socket descriptor associated with this control socket
+ */
+void cs_free_ctrl_sock(int fd);
+
+/**
+ * @brief Send data to control socket
+ *
+ *      This API sends data to the control socket. If a server is blocked
+ *      on select() with the control socket, this call will wake up that
+ *      server.
+ *
+ * @param[in] send_fd the socket for sending ctrl messages
+ * @param[in] port the port on which the control socket was created
+ * @param[in] data pointer to a buffer that contains data to send on the socket
+ * @param[in] data_len the length of the data contained in the buffer pointed to be data
+ *
+ * @return  - the number of bytes sent to the control socket
+ *          - an error code if less than zero
+ */
+int cs_send_to_ctrl_sock(int send_fd, int port, void *data, unsigned int data_len);
+
+/**
+ * @brief Receive data from control socket
+ *
+ *      This API receives any data that was sent to the control
+ *      socket. This will be typically called from the server thread to
+ *      process any commands on this socket.
+ *
+ * @param[in] fd the socket descriptor of the control socket
+ * @param[in] data pointer to a buffer that will be used to store
+ * received from the control socket
+ * @param[in] data_len the maximum length of the data that can be
+ * stored in the buffer pointed by data
+ *
+ * @return  - the number of bytes received from the control socket
+ *          - an error code if less than zero
+ */
+int cs_recv_from_ctrl_sock(int fd, void *data, unsigned int data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _CTRL_SOCK_H_ */

--- a/vendors/espressif/esp-idf/components/esp_http_server/test/CMakeLists.txt
+++ b/vendors/espressif/esp-idf/components/esp_http_server/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(COMPONENT_SRCDIRS ".")
+set(COMPONENT_ADD_INCLUDEDIRS ".")
+
+set(COMPONENT_REQUIRES unity test_utils esp_http_server)
+
+register_component()

--- a/vendors/espressif/esp-idf/components/esp_http_server/test/component.mk
+++ b/vendors/espressif/esp-idf/components/esp_http_server/test/component.mk
@@ -1,0 +1,1 @@
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive

--- a/vendors/espressif/esp-idf/components/esp_http_server/test/test_http_server.c
+++ b/vendors/espressif/esp-idf/components/esp_http_server/test/test_http_server.c
@@ -1,0 +1,253 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <esp_system.h>
+#include <esp_http_server.h>
+
+#include "unity.h"
+#include "test_utils.h"
+
+int pre_start_mem, post_stop_mem, post_stop_min_mem;
+bool basic_sanity = true;
+
+esp_err_t null_func(httpd_req_t *req)
+{
+    return ESP_OK;
+}
+
+httpd_uri_t handler_limit_uri (char* path)
+{
+    httpd_uri_t uri = {
+        .uri      = path,
+        .method   = HTTP_GET,
+        .handler  = null_func,
+        .user_ctx = NULL,
+    };
+    return uri;
+};
+
+static inline unsigned num_digits(unsigned x)
+{
+    unsigned digits = 1;
+    while ((x = x/10) != 0) {
+        digits++;
+    }
+    return digits;
+}
+
+#define HTTPD_TEST_MAX_URI_HANDLERS 8
+
+void test_handler_limit(httpd_handle_t hd)
+{
+    int i;
+    char x[HTTPD_TEST_MAX_URI_HANDLERS+1][num_digits(HTTPD_TEST_MAX_URI_HANDLERS)+1];
+    httpd_uri_t uris[HTTPD_TEST_MAX_URI_HANDLERS+1];
+
+    for (i = 0; i < HTTPD_TEST_MAX_URI_HANDLERS + 1; i++) {
+        sprintf(x[i],"%d",i);
+        uris[i] = handler_limit_uri(x[i]);
+    }
+
+    /* Register multiple instances of the same handler for MAX URI Handlers */
+    for (i = 0; i < HTTPD_TEST_MAX_URI_HANDLERS; i++) {
+        TEST_ASSERT(httpd_register_uri_handler(hd, &uris[i]) == ESP_OK);
+    }
+
+    /* Register the MAX URI + 1 Handlers should fail */
+    TEST_ASSERT(httpd_register_uri_handler(hd, &uris[HTTPD_TEST_MAX_URI_HANDLERS]) != ESP_OK);
+
+    /* Unregister the one of the Handler should pass */
+    TEST_ASSERT(httpd_unregister_uri_handler(hd, uris[0].uri, uris[0].method) == ESP_OK);
+
+    /* Unregister non added Handler should fail */
+    TEST_ASSERT(httpd_unregister_uri_handler(hd, uris[0].uri, uris[0].method) != ESP_OK);
+
+    /* Register the MAX URI Handler should pass */
+    TEST_ASSERT(httpd_register_uri_handler(hd, &uris[0]) == ESP_OK);
+
+    /* Reregister same instance of handler should fail */
+    TEST_ASSERT(httpd_register_uri_handler(hd, &uris[0]) != ESP_OK);
+
+    /* Register the MAX URI + 1 Handlers should fail */
+    TEST_ASSERT(httpd_register_uri_handler(hd, &uris[HTTPD_TEST_MAX_URI_HANDLERS]) != ESP_OK);
+
+    /* Unregister the same handler for MAX URI Handlers */
+    for (i = 0; i < HTTPD_TEST_MAX_URI_HANDLERS; i++) {
+        TEST_ASSERT(httpd_unregister_uri_handler(hd, uris[i].uri, uris[i].method) == ESP_OK);
+    }
+    basic_sanity = false;
+}
+
+/********************* Test Handler Limit End *******************/
+
+httpd_handle_t test_httpd_start(uint16_t id)
+{
+    httpd_handle_t hd;
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    config.max_uri_handlers = HTTPD_TEST_MAX_URI_HANDLERS;
+    config.server_port += id;
+    config.ctrl_port += id;
+    TEST_ASSERT(httpd_start(&hd, &config) == ESP_OK)
+    return hd;
+}
+
+#define SERVER_INSTANCES 2
+
+/* Currently this only tests for the number of tasks.
+ * Heap leakage is not tested as LWIP allocates memory
+ * which may not be freed immedietly causing erroneous
+ * evaluation. Another test to implement would be the
+ * monitoring of open sockets, but LWIP presently provides
+ * no such API for getting the number of open sockets.
+ */
+TEST_CASE("Leak Test", "[HTTP SERVER]")
+{
+    httpd_handle_t hd[SERVER_INSTANCES];
+    unsigned task_count;
+    bool res = true;
+
+    test_case_uses_tcpip();
+
+    task_count = uxTaskGetNumberOfTasks();
+    printf("Initial task count: %d\n", task_count);
+
+    pre_start_mem = esp_get_free_heap_size();
+
+    for (int i = 0; i < SERVER_INSTANCES; i++) {
+        hd[i] = test_httpd_start(i);
+        vTaskDelay(10);
+        unsigned num_tasks = uxTaskGetNumberOfTasks();
+        task_count++;
+        if (num_tasks != task_count) {
+            printf("Incorrect task count (starting): %d expected %d\n",
+                   num_tasks, task_count);
+            res = false;
+        }
+    }
+
+    for (int i = 0; i < SERVER_INSTANCES; i++) {
+        if (httpd_stop(hd[i]) != ESP_OK) {
+            printf("Failed to stop httpd task %d\n", i);
+            res = false;
+        }
+        vTaskDelay(10);
+        unsigned num_tasks = uxTaskGetNumberOfTasks();
+        task_count--;
+        if (num_tasks != task_count) {
+            printf("Incorrect task count (stopping): %d expected %d\n",
+                   num_tasks, task_count);
+            res = false;
+        }
+    }
+    post_stop_mem = esp_get_free_heap_size();
+    TEST_ASSERT(res == true);
+}
+
+TEST_CASE("Basic Functionality Tests", "[HTTP SERVER]")
+{
+    httpd_handle_t hd;
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+
+    test_case_uses_tcpip();
+
+    TEST_ASSERT(httpd_start(&hd, &config) == ESP_OK);
+    test_handler_limit(hd);
+    TEST_ASSERT(httpd_stop(hd) == ESP_OK);
+}
+
+TEST_CASE("URI Wildcard Matcher Tests", "[HTTP SERVER]")
+{
+    struct uritest {
+        const char *template;
+        const char *uri;
+        bool matches;
+    };
+
+    struct uritest uris[] = {
+        {"/", "/", true},
+        {"", "", true},
+        {"/", "", false},
+        {"/wrong", "/", false},
+        {"/", "/wrong", false},
+        {"/asdfghjkl/qwertrtyyuiuioo", "/asdfghjkl/qwertrtyyuiuioo", true},
+        {"/path", "/path", true},
+        {"/path", "/path/", false},
+        {"/path/", "/path", false},
+
+        {"?", "", false}, // this is not valid, but should not crash
+        {"?", "sfsdf", false},
+
+        {"/path/?", "/pa", false},
+        {"/path/?", "/path", true},
+        {"/path/?", "/path/", true},
+        {"/path/?", "/path/alalal", false},
+
+        {"/path/*", "/path", false},
+        {"/path/*", "/", false},
+        {"/path/*", "/path/", true},
+        {"/path/*", "/path/blabla", true},
+
+        {"*", "", true},
+        {"*", "/", true},
+        {"*", "/aaa", true},
+
+        {"/path/?*", "/pat", false},
+        {"/path/?*", "/pathb", false},
+        {"/path/?*", "/pathxx", false},
+        {"/path/?*", "/pathblabla", false},
+        {"/path/?*", "/path", true},
+        {"/path/?*", "/path/", true},
+        {"/path/?*", "/path/blabla", true},
+
+        {"/path/*?", "/pat", false},
+        {"/path/*?", "/pathb", false},
+        {"/path/*?", "/pathxx", false},
+        {"/path/*?", "/path", true},
+        {"/path/*?", "/path/", true},
+        {"/path/*?", "/path/blabla", true},
+
+        {"/path/*/xxx", "/path/", false},
+        {"/path/*/xxx", "/path/*/xxx", true},
+        {}
+    };
+
+    struct uritest *ut = &uris[0];
+
+    while(ut->template != 0) {
+        bool match = httpd_uri_match_wildcard(ut->template, ut->uri, strlen(ut->uri));
+        TEST_ASSERT(match == ut->matches);
+        ut++;
+    }
+}
+
+TEST_CASE("Max Allowed Sockets Test", "[HTTP SERVER]")
+{
+    test_case_uses_tcpip();
+
+    httpd_handle_t hd;
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+
+    /* Starting server with default config options should pass */
+    TEST_ASSERT(httpd_start(&hd, &config) == ESP_OK);
+    TEST_ASSERT(httpd_stop(hd) == ESP_OK);
+
+    /* Default value of max_open_sockets is already set as per
+     * maximum limit imposed by LWIP. Increasing this beyond the
+     * maximum allowed value, without increasing LWIP limit,
+     * should fail */
+    config.max_open_sockets += 1;
+    TEST_ASSERT(httpd_start(&hd, &config) != ESP_OK);
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Now that `LwIP` stack is supported for ESP32 (which in turn provides `posix` API), web server can also be supported. This PR pulls in required component. In addition also fixes minor issue in UART driver to correct critical section API.

Steps to use
---------------
```cmake -DVENDOR=espressif -DBOARD=esp32_wrover_kit -DCOMPILER=xtensa-esp32 -S . -B build  -DAFR_ESP_LWIP=1```
<Call `esp_http_server` APIs in application>

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.