### PR TITLE
Repair CBMC proof of IotHttpsClient_Disconnect.

### DIFF
--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -9,7 +9,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset strlen.0:5,IotListDouble_RemoveAll.0:2",
+    "--unwindset strlen.0:5,IotListDouble_RemoveAll.0:2,IotListDouble_Count.0:2",
 
     # uninitialized global variables have arbitrary values
     "--nondet-static",


### PR DESCRIPTION
IotDeQueue_Count added to debugging code in commit a62c57fe caused a loop unwinding assertion to fail.  This commit just unrolls the loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.