### PR TITLE
CBMC Windows fixes

### DIFF
--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -73,10 +73,10 @@ unpatch:
 #
 # Rules for building the CBMC harness
 
-queue_datastructure.h: $(filter-out $(ENTRY)_harness.goto, $(OBJS))
+queue_datastructure.h: $(H_OBJS_EXCEPT_HARNESS)
 	python3 @TYPE_HEADER_SCRIPT@ --binary $(FREERTOS)/freertos_kernel/queue.goto --c-file $(FREERTOS)/freertos_kernel/queue.c
 
-$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(filter-out $(ENTRY)_harness.goto, $(OBJS)) $(H_GENERATE_HEADER)
+$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(H_OBJS_EXCEPT_HARNESS) $(H_GENERATE_HEADER)
 	$(GOTO_CC) @COMPILE_ONLY@ @RULE_OUTPUT@ $(INC) $(CFLAGS) @RULE_INPUT@
 
 $(ENTRY)1.goto: $(OBJS)

--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -135,7 +135,7 @@ report: cbmc.txt property.xml coverage.xml
 	--srcdir $(FREERTOS) \
 	--blddir $(FREERTOS) \
 	--htmldir html \
-	--srcexclude "(./doc|./tests|./vendors)" \
+	--srcexclude "(.@FORWARD_SLASH@doc|.@FORWARD_SLASH@tests|.@FORWARD_SLASH@vendors)" \
 	--result cbmc.txt \
 	--property property.xml \
 	--block coverage.xml

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -42,6 +42,8 @@
 	"--pointer-check"
     ],
 
+    "FORWARD_SLASH": ["/"],
+
     "TYPE_HEADERS": [
         "$(FREERTOS)/freertos_kernel/queue.c"
     ]

--- a/tools/cbmc/proofs/make_proof_makefiles.py
+++ b/tools/cbmc/proofs/make_proof_makefiles.py
@@ -135,6 +135,16 @@ def dump_makefile(dyr, system):
     data = load_json_config_file(os.path.join(dyr, "Makefile.json"))
 
     makefile = collections.OrderedDict()
+
+    # Makefile.common expects a variable called OBJS_EXCEPT_HARNESS to be
+    # set to a list of all the object files except the harness.
+    if "OBJS" not in data:
+        logging.error(
+            "Expected a list of object files in %s/Makefile.json" % dyr)
+        exit(1)
+    makefile["OBJS_EXCEPT_HARNESS"] = " ".join(
+        o for o in data["OBJS"] if not o.endswith("_harness.goto"))
+
     so_far = collections.OrderedDict()
     for name, value in data.items():
         if isinstance(value, list):


### PR DESCRIPTION
One of the commits in this PR improves the performance of cbmc-viewer on windows by actually excluding the correct directories. The other fixes the common Makefile used by CBMC proofs so that it can also be used on Windows.