### PR TITLE
OTA fixes

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c
@@ -36,7 +36,7 @@
 
 /* OTA transport inteface includes. */
 
-#if ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT )
+#if ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) || ( configENABLED_CONTROL_PROTOCOL & OTA_CONTROL_OVER_MQTT )
     #include "mqtt/aws_iot_ota_mqtt.h"
 #endif
 

--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -584,6 +584,11 @@ static void _httpErrorCallback( void * pPrivateData,
     ( void ) responseHandle;
     ( void ) returnCode;
 
+    if( _httpDownloader.err == OTA_HTTP_ERR_NONE )
+    {
+        _httpDownloader.err = OTA_HTTP_ERR_GENERIC;
+    }
+
     IotLogError( "An error occurred for HTTP async request: %d", returnCode );
 }
 

--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -473,6 +473,8 @@ static void _httpReadReadyCallback( void * pPrivateData,
         OTA_GOTO_CLEANUP();
     }
 
+    OTA_FUNCTION_CLEANUP_BEGIN();
+
     /* The connection could be closed by S3 after 100 requests, so we need to check the value
      * of the "Connection" filed in HTTP header to see if we need to reconnect. */
     memset( connectionValueStr, 0, sizeof( connectionValueStr ) );
@@ -482,22 +484,21 @@ static void _httpReadReadyCallback( void * pPrivateData,
                                              connectionValueStr,
                                              sizeof( connectionValueStr ) );
 
-    /* Exit if there is any other error besides not found when parsing the http header. */
+    /* Check if there is any other error besides not found when parsing the http header. */
     if( ( httpsStatus != IOT_HTTPS_OK ) && ( httpsStatus != IOT_HTTPS_NOT_FOUND ) )
     {
         IotLogError( "Failed to read header Connection. Error code: %d.", httpsStatus );
         _httpDownloader.err = OTA_HTTP_ERR_GENERIC;
-        OTA_GOTO_CLEANUP();
     }
-
-    /* Check if the server returns a response with connection field set to "close". */
-    if( strncmp( "close", connectionValueStr, sizeof( "close" ) ) == 0 )
+    else
     {
-        IotLogInfo( "Connection has been closed by the HTTP server, reconnecting to the server..." );
-        _httpReconnect();
+        /* Check if the server returns a response with connection field set to "close". */
+        if( strncmp( "close", connectionValueStr, sizeof( "close" ) ) == 0 )
+        {
+            IotLogInfo( "Connection has been closed by the HTTP server, reconnecting to the server..." );
+            _httpReconnect();
+        }
     }
-
-    OTA_FUNCTION_CLEANUP_BEGIN();
 
     /* Cancel receiving the response in case of error, _httpErrorCallback will be invoked next.
      * If the HTTP error is IOT_HTTPS_NETWORK_ERROR, the connection will then be closed by the HTTP

--- a/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
+++ b/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
@@ -798,8 +798,8 @@ OTA_Err_t prvRequestFileBlock_Mqtt( OTA_AgentContext_t * pxAgentCtx )
 
                 if( eResult != IOT_MQTT_SUCCESS )
                 {
-                    /* Don't return an error. Let max momentum catch it since this may be intermittent. */
                     OTA_LOG_L1( "[%s] Failed: %s\r\n", OTA_METHOD_NAME, pcTopicBuffer );
+                    xErr = kOTA_Err_PublishFailed;
                 }
                 else
                 {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR addresses some issues in current OTA code,

- `aws_iot_ota_mqtt.h` should be included when MQTT is selected in data **or control**.
- When HTTP send fails, the error callback will be invoked directly, we need to set the error status in http downloader. Before this case is not handled.
- Now the "connection" field is always checked when receiving a HTTP response to see if we need to connect. Before if error happens during the response callback routine, this will not be executed.
- Fix the way that momentum is handled in OTA downloads. We should always increase the momentum after sending the request. Before the momentum is only increased if the request function returns failure. However, both MQTT and HTTP requests are async and it could return success but we still fail to receive the response and the OTA agent would just stuck here forever. Instead we can just rely on `prvProcessDataHandler` to reset the momentum, which is called after we successfully get and process a response.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.