### PR TITLE
Preserve patch line endings for cbmc patch files.

### DIFF
--- a/tools/cbmc/patches/.gitattributes
+++ b/tools/cbmc/patches/.gitattributes
@@ -1,0 +1,2 @@
+# It seems git apply does not want crlf line endings on Windows
+*.patch eol=lf


### PR DESCRIPTION
CBMC proofs start by patching the code with a few patch files to prepare the code for proof.  We apply the patch files using "git apply foo.patch".  It seems that the Windows git supplied by Visual Studio on Windows does not like crlf line endings in the patch files.  

This patch added a .gitattributes to the tools/cbmc/patches directory that forces eol=lf for the patch files in that directory.  We should probably be adding this to the top-level .gitattributes, but we keep it local to the patches directory to limit the blast radius of unintended consequences.

This has been test on macos, linux, and windows with the equivalent of the script

```
git clone https://github.com/markrtuttle/amazon-freertos.git debug
cd debug
git checkout preserve-patch-line-endings
git submodule update --init
cd tools/cbmc/proofs
prepare.py

for dir in \
    CheckOptions \
    CheckOptionsInner \
    CheckOptionsOuter \
    ReadNameField \
    SkipNameField \
    ProcessDHCPReplies \
    ParseDNSReply \
    HTTP/IotHttpsClient_AddHeader;
do
    make -C $dir cbmc;
done
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.