### PR TITLE
Pass a single input file to goto-cl

### DIFF
--- a/tools/cbmc/proofs/Makefile.template
+++ b/tools/cbmc/proofs/Makefile.template
@@ -76,7 +76,7 @@ unpatch:
 queue_datastructure.h: $(H_OBJS_EXCEPT_HARNESS)
 	python3 @TYPE_HEADER_SCRIPT@ --binary $(FREERTOS)/freertos_kernel/queue.goto --c-file $(FREERTOS)/freertos_kernel/queue.c
 
-$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(H_OBJS_EXCEPT_HARNESS) $(H_GENERATE_HEADER)
+$(ENTRY)_harness.goto: $(ENTRY)_harness.c $(H_GENERATE_HEADER)
 	$(GOTO_CC) @COMPILE_ONLY@ @RULE_OUTPUT@ $(INC) $(CFLAGS) @RULE_INPUT@
 
 $(ENTRY)1.goto: $(OBJS)


### PR DESCRIPTION
This commit fixes a build rule in the CBMC Makefile.common, where
multiple source files are passed to the goto-cl compiler. While this is
acceptable on Linux, the cl compiler errors out when given more than one
source file in /c mode.