### PR TITLE
Add eWiFiSecurityWPA2_ent into Wi-Fi Security types

### DIFF
--- a/libraries/abstractions/wifi/include/iot_wifi.h
+++ b/libraries/abstractions/wifi/include/iot_wifi.h
@@ -65,6 +65,7 @@ typedef enum
     eWiFiSecurityWEP,         /**< WEP Security. */
     eWiFiSecurityWPA,         /**< WPA Security. */
     eWiFiSecurityWPA2,        /**< WPA2 Security. */
+    eWiFiSecurityWPA2_ent,    /**< WPA2 Enterprise Security. */
     eWiFiSecurityNotSupported /**< Unknown Security. */
 } WIFISecurity_t;
 


### PR DESCRIPTION
Add eWiFiSecurityWPA2_ent into Wi-Fi Security types

Description
-----------
This commit adds eWiFiSecurityWPA2_ent into WIFISecurity structure to
let vendor be able to support Wi-Fi WPA2 enterprise security in the
future.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.