### PR TITLE
Renesas network interface: reverted change to FIT module

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -305,7 +305,15 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
         if( xBytesReceived < 0 )
         {
             /* This is an error. Logged. */
-            FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d\n", xBytesReceived ) );
+        	if( xBytesReceived == ETHER_ERR_LINK )
+        	{
+				/* Auto-negotiation is not completed, and transmission/
+				reception is not enabled. Will be logged elsewhere. */
+        	}
+        	else
+         	{
+        		FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d not %d\n", xBytesReceived, ETHER_ERR_LINK ) );
+        	}
         }
         else if( xBytesReceived > 0 )
         {
@@ -452,7 +460,6 @@ void prvLinkStatusChange( BaseType_t xStatus )
 {
     if( xReportedStatus != xStatus )
     {
-        FreeRTOS_printf( ( "prvLinkStatusChange( %d )\n", xStatus ) );
         xReportedStatus = xStatus;
     }
 }

--- a/vendors/renesas/FIT/RDP_v1.15_modified/r_ether_rx/src/r_ether_rx.c
+++ b/vendors/renesas/FIT/RDP_v1.15_modified/r_ether_rx/src/r_ether_rx.c
@@ -1016,13 +1016,12 @@ void R_ETHER_LinkProcess (uint32_t channel)
                     cb_arg.event_id = ETHER_CB_EVENT_ID_LINK_ON;
                     (*cb_func.pcb_func)((void *) &cb_arg);
                 }
-                lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
             }
             else
             {
                 /* When PHY auto-negotiation is not completed */
                 transfer_enable_flag[channel] = ETHER_FLAG_OFF;
-                lchng_flag[channel] = ETHER_FLAG_ON_LINK_OFF;
+                lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
             }
         }
         else
@@ -1060,13 +1059,12 @@ void R_ETHER_LinkProcess (uint32_t channel)
                 cb_arg.event_id = ETHER_CB_EVENT_ID_LINK_ON;
                 (*cb_func.pcb_func)((void *) &cb_arg);
             }
-            lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
         }
         else
         {
             /* When PHY auto-negotiation is not completed */
             transfer_enable_flag[channel] = ETHER_FLAG_OFF;
-            lchng_flag[channel] = ETHER_FLAG_ON_LINK_OFF;
+           	lchng_flag[channel] = ETHER_FLAG_ON_LINK_ON;
         }
 #endif
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In an earlier PR #1533, I made a change to:

    vendors\renesas\FIT\RDP_v1.15_modified\r_ether_rx\src\r_ether_rx.c

In this patch I revert that change. Apparently I was mistaken about the exact meaning of `ETHER_FLAG_ON_LINK_ON`/`OFF`. I communicated with the Renesas FIT-team about this.

In fact, the effect of this change is not noticeable: the Link Status detection remains the same.

I retested the demo application. Also I connected and disconnected the RX65N to a network switch while running. And finally: I started without a LAN, and only connected it after a while. That all worked as expected.

Within `NetworkInterface.c`, logging will be suppressed for errors in the link status:

~~~c
    if( xBytesReceived == ETHER_ERR_LINK )
    {
        /* Auto-negotiation is not completed, and transmission/
        reception is not enabled. Will be logged elsewhere. */
    }
    else
    {
        FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d not %d\n", xBytesReceived, ETHER_ERR_LINK ) );
    }
~~~

because they are logged here:

~~~c
    FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume %d\n", xPHYLinkStatus ) );
    FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", xPHYLinkStatus ) );
~~~


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.