### PR TITLE
Fix Infinite loop in BLE disconnect

### DIFF
--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -517,9 +517,15 @@ BTStatus_t IotBle_Off( void )
 
             if( pConnInfo != NULL )
             {
-                ( void ) _BTInterface.pBTLeAdapterInterface->pxDisconnect( _BTInterface.adapterIf,
+                status = _BTInterface.pBTLeAdapterInterface->pxDisconnect( _BTInterface.adapterIf,
                                                                            &bdAddr,
                                                                            connId );
+
+                if( status != eBTStatusSuccess )
+                {
+                    IotLogError( "Failed disconnect with Bluetooth status = %u", status );
+                    break;
+                }
             }
         } while( pConnInfo != NULL );
     }


### PR DESCRIPTION
Fix Infinite loop in BLE disconnect
Description
-----------
Shadow demo and MQTT demo on Nordic were not completing.
The root cause was that the demo was completing but it was ending up in
an infinite loop in BLE disconnect logic and thus blocking the lower
priority logging task . This prevented logs of demo completion to be not
printed.
Solution is done by exiting the infinite loop when there is error.

- [x ] I have tested my changes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.