### PR TITLE
Fix for IOT_SERIALIZER_SCALAR_NULL datatype.

### DIFF
--- a/libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c
+++ b/libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c
@@ -463,6 +463,7 @@ static void _appendData( _jsonContainer_t * pContainer,
 
         case IOT_SERIALIZER_SCALAR_NULL:
             strncpy( ( char * ) _jsonContainerPointer( pContainer ), _JSON_NULL_VALUE, _JSON_NULL_VALUE_LENGTH );
+            pContainer->offset += _JSON_NULL_VALUE_LENGTH;
             break;
 
         default:


### PR DESCRIPTION
The length of "null" element isn't included into container's offset calculation logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.