### PR TITLE
ulDNSHandlePacket() - check length before calculating payload size

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -916,18 +916,25 @@ for testing purposes, by the module iot_test_freertos_tcp.c
 uint32_t ulDNSHandlePacket( NetworkBufferDescriptor_t *pxNetworkBuffer )
 {
 DNSMessage_t *pxDNSMessageHeader;
-size_t uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+size_t uxPayloadSize;
 
-	if( uxPayloadSize >= sizeof( DNSMessage_t ) )
-	{
-		pxDNSMessageHeader =
-			( DNSMessage_t * ) ( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
+    /* Only proceed if the payload length indicated in the header
+    appears to be valid. */
+    if( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) )
+    {
+        uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
 
-		/* The parameter pdFALSE indicates that the reply was not expected. */
-		prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
-						  uxPayloadSize,
-						  pdFALSE );
-	}
+        if( uxPayloadSize >= sizeof( DNSMessage_t ) )
+        {
+            pxDNSMessageHeader =
+                ( DNSMessage_t * ) ( pxNetworkBuffer->pucEthernetBuffer + sizeof( UDPPacket_t ) );
+
+            /* The parameter pdFALSE indicates that the reply was not expected. */
+            prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
+                uxPayloadSize,
+                pdFALSE );
+        }
+    }
 
 	/* The packet was not consumed. */
 	return pdFAIL;


### PR DESCRIPTION
<!--- Title -->
Detect integer overflow in `ulDNSHandlePacket()`.

-----------
This PR fixes an integer overflow case introduced in [an earlier commit](https://github.com/aws/amazon-freertos/commit/93c0aba73fe69cd3b067941d83d3d5d4dfebaabd#diff-ab35dd7e800d6d3ecb19dfa767aeacd4R1615) and detected by a failing [`ulDNSHandlePacket()`](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/standard/freertos_plus_tcp/test/iot_test_freertos_tcp.c#L291) test.  See [here](https://github.com/aws/amazon-freertos/blob/release-candidate/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c#L1615) for another example of this overflow detection logic.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.