### PR TITLE
Fix: GGD Test failures on ST

### DIFF
--- a/libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h
+++ b/libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h
@@ -145,7 +145,7 @@ BaseType_t GGD_JSONRequestGetSize( Socket_t * pxSocket,
  *  GGD_JSONRequestStart.
  *
  * @note 1. Parse the HTML response to extract the JSON file.
- * This function allows the JSON file retrieval in chunck.
+ * This function allows the JSON file retrieval in chunks.
  * The user can call the function several time with small buffer size.
  * The JSON file will be retrieved bit by bit until
  * xJSONFileRetrieveCompleted is set to true.
@@ -161,7 +161,7 @@ BaseType_t GGD_JSONRequestGetSize( Socket_t * pxSocket,
  *
  * @param [in] ulBufferSize: Size of the memory buffer provided.
  *
- * @param [in] pulJSONFileSize: Size of JSON file to be retrieved.
+ * @param [in] ulJSONFileSize: Size of JSON file to be retrieved.
  *
  * @param [out] pulByteRead: Must be set to zero by the user
  * prior first calling of GGD_GetJSONFile. Then the number of
@@ -182,7 +182,7 @@ BaseType_t GGD_JSONRequestGetFile( Socket_t * pxSocket,
                                    const uint32_t ulBufferSize,
                                    uint32_t * pulByteRead,
                                    BaseType_t * pxJSONFileRetrieveCompleted,
-                                   const uint32_t pulJSONFileSize );
+                                   const uint32_t ulJSONFileSize );
 
 /*
  * @brief Need to be called if GGD_JSONRequestGetFile cannot be called.

--- a/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
@@ -411,7 +411,7 @@ BaseType_t GGD_JSONRequestGetFile( Socket_t * pxSocket,
                                    const uint32_t ulBufferSize,
                                    uint32_t * pulByteRead,
                                    BaseType_t * pxJSONFileRetrieveCompleted,
-                                   const uint32_t pulJSONFileSize )
+                                   const uint32_t ulJSONFileSize )
 {
     BaseType_t xStatus;
     uint32_t ulDataSizeRead;
@@ -433,11 +433,11 @@ BaseType_t GGD_JSONRequestGetFile( Socket_t * pxSocket,
         *pulByteRead += ulDataSizeRead;
 
         /* We retrieved more than expected, this is failed. */
-        if( *pulByteRead > ( pulJSONFileSize - ( uint32_t ) 1 ) )
+        if( *pulByteRead > ( ulJSONFileSize - ( uint32_t ) 1 ) )
         {
             ggdconfigPRINT( "JSON parsing - Received %ld, expected at most %ld \r\n",
                             *pulByteRead,
-                            pulJSONFileSize - ( uint32_t ) 1 );
+                            ulJSONFileSize - ( uint32_t ) 1 );
             xStatus = pdFAIL;
         }
     }
@@ -445,30 +445,29 @@ BaseType_t GGD_JSONRequestGetFile( Socket_t * pxSocket,
     if( xStatus == pdPASS )
     {
         /* We still have more to retrieve. */
-        if( *pulByteRead < ( pulJSONFileSize - ( uint32_t ) 1 ) )
+        if( *pulByteRead < ( ulJSONFileSize - ( uint32_t ) 1 ) )
         {
             *pxJSONFileRetrieveCompleted = pdFALSE;
+            ggdconfigPRINT( "JSON file retrieval incomplete, received %ld out of %ld bytes\r\n",
+                            *pulByteRead,
+                            ulJSONFileSize - ( uint32_t ) 1 );
         }
         else
         {
             /* Add the escape character. */
-            pcBuffer[ pulJSONFileSize - ( uint32_t ) 1 ] = '\0';
+            pcBuffer[ ulJSONFileSize - ( uint32_t ) 1 ] = '\0';
             *pxJSONFileRetrieveCompleted = pdTRUE;
+            ggdconfigPRINT( "JSON file retrieval completed\r\n" );
+
+            /* Close the connection. */
+            GGD_SecureConnect_Disconnect( pxSocket );
         }
     }
-
-    if( xStatus == pdFAIL )
+    else
     {
         ggdconfigPRINT( "JSON parsing - JSON file retrieval failed\r\n" );
         /* Don't forget to close the connection. */
         GGD_SecureConnect_Disconnect( pxSocket );
-    }
-    else
-    {
-        if( *pxJSONFileRetrieveCompleted == pdTRUE )
-        {
-            GGD_SecureConnect_Disconnect( pxSocket );
-        }
     }
 
     return xStatus;

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_greengrass_discovery.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_greengrass_discovery.c
@@ -1030,7 +1030,7 @@ TEST( Full_GGD, JSONRequestGetFile )
             xStatus = prvGGD_JSONRequestGetFileLoop( ulBufferSize,
                                                      &ulByteRead,
                                                      &xJSONFileRetrieveCompleted,
-                                                     ulJSONFileSize - 1 ); /* Remove one byte to the expected JSON file size. */
+                                                     ulJSONFileSize - 1 ); /* Remove one byte from the expected JSON file size. */
         }
 
         TEST_ASSERT_EQUAL_INT32( pdFAIL, xStatus );

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_greengrass_discovery.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_greengrass_discovery.c
@@ -331,7 +331,7 @@ TEST( Full_GGD, GetIPandCertificateFromJSON )
                                                   &ulByteRead,
                                                   &xJSONFileRetrieveCompleted,
                                                   ulJSONFileSize );
-            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize - ulByteRead ) > 0 && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
+            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize > ulByteRead ) && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
         }
 
         TEST_ASSERT_EQUAL_INT32( pdPASS, xStatus );
@@ -952,7 +952,7 @@ TEST( Full_GGD, JSONRequestGetFile )
                                                   &ulByteRead,
                                                   &xJSONFileRetrieveCompleted,
                                                   ulJSONFileSize );
-            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize - ulByteRead ) > 0 && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
+            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize > ulByteRead ) && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
         }
 
         TEST_ASSERT_EQUAL_INT32( SOCKETS_INVALID_SOCKET, xSocket );
@@ -999,7 +999,7 @@ TEST( Full_GGD, JSONRequestGetFile )
                                                   &ulByteRead,
                                                   &xJSONFileRetrieveCompleted,
                                                   ulJSONFileSize );
-            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize - ulByteRead ) > 0 && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
+            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize > ulByteRead ) && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
         }
 
         TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xStatus, "GGD_JSONRequestGetFile() failed to return pdPASS." );
@@ -1028,12 +1028,12 @@ TEST( Full_GGD, JSONRequestGetFile )
             do
             {
                 xStatus = GGD_JSONRequestGetFile( &xSocket,
-                                                  cBuffer,
-                                                  ulBufferSize,
+                                                  &cBuffer[ ulByteRead ],
+                                                  ulBufferSize - ulByteRead,
                                                   &ulByteRead,
                                                   &xJSONFileRetrieveCompleted,
                                                   ulJSONFileSize - 1 ); /* Remove one byte to the expected JSON file size. */
-            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize - ulByteRead ) > 0 && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
+            } while( ( xStatus == pdPASS ) && ( xJSONFileRetrieveCompleted != pdTRUE ) && ( ulBufferSize > ulByteRead ) && ( ++ulRequestLoopCounter < ggdTestMAX_REQUEST_LOOP_COUNT ) );
         }
 
         TEST_ASSERT_EQUAL_INT32( pdFAIL, xStatus );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
GGD_JSONRequestGetFile() would not receive the entire file
in one call on some boards. This adds a loop to receive the
file in chunks if the request was not completed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.