### PR TITLE
Let vendor choose which OTA backend to enable

### DIFF
--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -31,10 +31,9 @@ afr_module_sources(
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    PUBLIC "${inc_dir}"
-        "$<${AFR_IS_TESTING}:${inc_dir}/private>"
+    PUBLIC
+        "${inc_dir}"
     PRIVATE
-        "${inc_dir}/private"
         "${test_dir}"
 )
 

--- a/libraries/freertos_plus/aws/ota/CMakeLists.txt
+++ b/libraries/freertos_plus/aws/ota/CMakeLists.txt
@@ -21,13 +21,6 @@ afr_module_sources(
         "${src_dir}/aws_iot_ota_interface.c"
         "${src_dir}/aws_iot_ota_interface.h"
         "${src_dir}/aws_iot_ota_pal.h"
-        "${src_dir}/mqtt/aws_iot_ota_cbor_internal.h"
-        "${src_dir}/mqtt/aws_iot_ota_cbor.c"
-        "${src_dir}/mqtt/aws_iot_ota_cbor.h"
-        "${src_dir}/mqtt/aws_iot_ota_mqtt.c"
-        "${src_dir}/mqtt/aws_iot_ota_mqtt.h"
-        "${src_dir}/http/aws_iot_ota_http.c"
-        "${src_dir}/http/aws_iot_ota_http.h"
 )
 
 afr_module_include_dirs(
@@ -45,9 +38,6 @@ afr_module_dependencies(
         AFR::common
     PRIVATE
         AFR::${AFR_CURRENT_MODULE}::mcu_port
-        AFR::mqtt
-        AFR::https
-        3rdparty::tinycbor
         3rdparty::jsmn
 )
 
@@ -68,6 +58,38 @@ if(AFR_IS_TESTING)
         PRIVATE "${test_dir}"
     )
 endif()
+
+# Link to this INTERFACE target to enable the MQTT backend.
+afr_module(NAME ota_mqtt INTERFACE)
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        "${src_dir}/mqtt/aws_iot_ota_cbor_internal.h"
+        "${src_dir}/mqtt/aws_iot_ota_cbor.c"
+        "${src_dir}/mqtt/aws_iot_ota_cbor.h"
+        "${src_dir}/mqtt/aws_iot_ota_mqtt.c"
+        "${src_dir}/mqtt/aws_iot_ota_mqtt.h"
+)
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        AFR::mqtt
+        3rdparty::tinycbor
+)
+
+# Link to this INTERFACE target to enable the HTTP backend.
+afr_module(NAME ota_http INTERFACE)
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        "${src_dir}/http/aws_iot_ota_http.c"
+        "${src_dir}/http/aws_iot_ota_http.h"
+)
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        AFR::https
+)
 
 # OTA test
 afr_test_module()

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -286,6 +286,8 @@ target_link_libraries(
     INTERFACE
         AFR::crypto
         AFR::pkcs11
+        AFR::ota_mqtt
+        AFR::ota_http
 )
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
+++ b/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
@@ -251,7 +251,10 @@ target_sources(
 )
 target_link_libraries(
     AFR::ota::mcu_port
-    INTERFACE AFR::pkcs11
+    INTERFACE
+        AFR::pkcs11
+        AFR::ota_mqtt
+        AFR::ota_http
 )
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
@@ -158,7 +158,10 @@ target_sources(
 )
 target_link_libraries(
     AFR::ota::mcu_port
-    INTERFACE AFR::crypto
+    INTERFACE
+        AFR::crypto
+        AFR::ota_mqtt
+        AFR::ota_http
 )
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -432,6 +432,7 @@ target_link_libraries(
     AFR::ota::mcu_port
     INTERFACE
         AFR::crypto
+        AFR::ota_mqtt
 )
 
 # POSIX

--- a/vendors/pc/boards/windows/CMakeLists.txt
+++ b/vendors/pc/boards/windows/CMakeLists.txt
@@ -128,7 +128,10 @@ target_sources(
 )
 target_link_libraries(
     AFR::ota::mcu_port
-    INTERFACE AFR::crypto
+    INTERFACE
+        AFR::crypto
+        AFR::ota_mqtt
+        AFR::ota_http
 )
 
 # -------------------------------------------------------------------------------------------------

--- a/vendors/ti/boards/cc3220_launchpad/CMakeLists.txt
+++ b/vendors/ti/boards/cc3220_launchpad/CMakeLists.txt
@@ -169,6 +169,12 @@ target_sources(
     AFR::ota::mcu_port
     INTERFACE "${afr_ports_dir}/ota/aws_ota_pal.c"
 )
+target_link_libraries(
+    AFR::ota::mcu_port
+    INTERFACE
+        AFR::ota_mqtt
+        AFR::ota_http
+)
 
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS demos and tests

--- a/vendors/vendor/boards/board/CMakeLists.txt
+++ b/vendors/vendor/boards/board/CMakeLists.txt
@@ -206,6 +206,13 @@ afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")
 #     AFR::ota::mcu_port
 #     INTERFACE "${portable_dir}/ota/aws_ota_pal.c"
 # )
+# Choose which backend to enable. Link to AFR::ota_mqtt to enable MQTT, link to AFR:ota_http to enable HTTP.
+# target_link_libraries(
+#     AFR::ota::mcu_port
+#     INTERFACE
+#         AFR::ota_mqtt
+#         AFR::ota_http
+)
 
 # -------------------------------------------------------------------------------------------------
 # Amazon FreeRTOS demos and tests


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
We cannot automatically figure out which backend to enable in OTA. This PR refactors the OTA CMake file to let vendor choose which one to enable.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] ~My code is Linted.~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.