### PR TITLE
fIX: Shutdown OTA agent so that it reconnects after max errors

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -913,7 +913,7 @@ static OTA_Err_t prvInitFileHandler( OTA_EventData_t * pxEventData )
             /* Stop the request timer. */
             prvStopRequestTimer();
 
-            /* Send close file event. */
+            /* Send shutdown event. */
             xEventMsg.xEventId = eOTA_AgentEvent_Shutdown;
             OTA_SignalEvent( &xEventMsg );
 
@@ -962,7 +962,7 @@ static OTA_Err_t prvRequestDataHandler( OTA_EventData_t * pxEventData )
             /* Failed to send data request abort and close file. */
             ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, xErr );
 
-            /* Send close file event. */
+            /* Send shutdown event. */
             xEventMsg.xEventId = eOTA_AgentEvent_Shutdown;
             OTA_SignalEvent( &xEventMsg );
 

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -308,10 +308,8 @@ OTAStateTableEntry_t OTATransitionTable[] =
     { eOTA_AgentState_CreatingFile,        eOTA_AgentEvent_StartSelfTest,       prvInSelfTestHandler,  eOTA_AgentState_WaitingForJob       },
     { eOTA_AgentState_CreatingFile,        eOTA_AgentEvent_CreateFile,          prvInitFileHandler,    eOTA_AgentState_RequestingFileBlock },
     { eOTA_AgentState_CreatingFile,        eOTA_AgentEvent_RequestTimer,        prvInitFileHandler,    eOTA_AgentState_RequestingFileBlock },
-    { eOTA_AgentState_CreatingFile,        eOTA_AgentEvent_CloseFile,           prvCloseFileHandler,   eOTA_AgentState_WaitingForJob       },
     { eOTA_AgentState_RequestingFileBlock, eOTA_AgentEvent_RequestFileBlock,    prvRequestDataHandler, eOTA_AgentState_WaitingForFileBlock },
     { eOTA_AgentState_RequestingFileBlock, eOTA_AgentEvent_RequestTimer,        prvRequestDataHandler, eOTA_AgentState_WaitingForFileBlock },
-    { eOTA_AgentState_RequestingFileBlock, eOTA_AgentEvent_CloseFile,           prvCloseFileHandler,   eOTA_AgentState_WaitingForJob       },
     { eOTA_AgentState_WaitingForFileBlock, eOTA_AgentEvent_ReceivedFileBlock,   prvProcessDataHandler, eOTA_AgentState_WaitingForFileBlock },
     { eOTA_AgentState_WaitingForFileBlock, eOTA_AgentEvent_RequestTimer,        prvRequestDataHandler, eOTA_AgentState_WaitingForFileBlock },
     { eOTA_AgentState_WaitingForFileBlock, eOTA_AgentEvent_RequestFileBlock,    prvRequestDataHandler, eOTA_AgentState_WaitingForFileBlock },
@@ -916,7 +914,7 @@ static OTA_Err_t prvInitFileHandler( OTA_EventData_t * pxEventData )
             prvStopRequestTimer();
 
             /* Send close file event. */
-            xEventMsg.xEventId = eOTA_AgentEvent_CloseFile;
+            xEventMsg.xEventId = eOTA_AgentEvent_Shutdown;
             OTA_SignalEvent( &xEventMsg );
 
             /* Too many requests have been sent without a response or too many failures
@@ -965,7 +963,7 @@ static OTA_Err_t prvRequestDataHandler( OTA_EventData_t * pxEventData )
             ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, xErr );
 
             /* Send close file event. */
-            xEventMsg.xEventId = eOTA_AgentEvent_CloseFile;
+            xEventMsg.xEventId = eOTA_AgentEvent_Shutdown;
             OTA_SignalEvent( &xEventMsg );
 
             /* Too many requests have been sent without a response or too many failures


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
OTA shutdown so that OTA demo can reconnect when maximum retries are completed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.