### PR TITLE
Avoid "Error: No OTA data buffers available" on LPC54018

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
@@ -140,7 +140,7 @@
 
 /* Sets the length of the buffers into which logging messages are written - so
  * also defines the maximum length of each log message. */
-#define configLOGGING_MAX_MESSAGE_LENGTH            100
+#define configLOGGING_MAX_MESSAGE_LENGTH            128
 
 /* Set to 1 to prepend each log message with a message number, the task name,
  * and a time stamp. */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_ota_agent_config.h
@@ -100,7 +100,7 @@
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
  */
-#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       10U
 
 /**
  * @brief The protocol selected for OTA control operations.
@@ -136,11 +136,5 @@
   * Note - use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
    */
 #define configOTA_PRIMARY_DATA_PROTOCOL     ( OTA_DATA_OVER_MQTT )
-
-
- /**
-  * @brief Maximum number of entries in the OTA message queue. Larger values reduce packet drops.
-  */
-#define configOTA_NUM_MSG_Q_ENTRIES             40U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_ota_agent_config.h
@@ -100,7 +100,7 @@
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
  */
-#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       10U
 
 /**
  * @brief The protocol selected for OTA control operations.
@@ -136,11 +136,5 @@
   * Note - use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
    */
 #define configOTA_PRIMARY_DATA_PROTOCOL     ( OTA_DATA_OVER_MQTT )
-
-
- /**
-  * @brief Maximum number of entries in the OTA message queue. Larger values reduce packet drops.
-  */
-#define configOTA_NUM_MSG_Q_ENTRIES             40U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */


### PR DESCRIPTION
Tune number of buffers.

Same as https://github.com/aws/amazon-freertos/pull/1620 but for release-candidate.