### PR TITLE
FreeRTOS+TCP : Espressif ESP32 NetworkInterface

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -44,6 +44,10 @@ enum if_state_t {
 static const char *TAG = "NetInterface";
 volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 
+#if ( ipconfigHAS_PRINTF != 0 )
+    static void prvMonitorResources();
+#endif
+
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     static BaseType_t xMACAdrInitialized = pdFALSE;
@@ -78,6 +82,9 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
         }
     }
 
+#if ( ipconfigHAS_PRINTF != 0 )
+    prvMonitorResources();
+#endif
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
     }
@@ -105,6 +112,10 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
+#if ( ipconfigHAS_PRINTF != 0 )
+    prvMonitorResources();
+#endif
+
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");
         esp_wifi_internal_free_rx_buffer(eb);
@@ -114,10 +125,10 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(len, xDescriptorWaitTime);
     if (pxNetworkBuffer != NULL) {
 
-	/* Set the packet size, in case a larger buffer was returned. */
-	pxNetworkBuffer->xDataLength = len;
+        /* Set the packet size, in case a larger buffer was returned. */
+        pxNetworkBuffer->xDataLength = len;
 
-	/* Copy the packet data. */
+        /* Copy the packet data. */
         memcpy(pxNetworkBuffer->pucEthernetBuffer, buffer, len);
         xRxEvent.pvData = (void *) pxNetworkBuffer;
 
@@ -133,3 +144,50 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
         return ESP_FAIL;
     }
 }
+
+#if ( ipconfigHAS_PRINTF != 0 )
+    static void prvMonitorResources()
+    {
+        static UBaseType_t uxLastMinBufferCount = 0u;
+        static UBaseType_t uxCurrentBufferCount = 0u;
+        static size_t uxMinLastSize = 0uL;
+        size_t uxMinSize;
+
+        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
+
+        if( uxLastMinBufferCount != uxCurrentBufferCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentBufferCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
+        }
+
+        uxMinSize = xPortGetMinimumEverFreeHeapSize();
+
+        if( uxMinLastSize != uxMinSize )
+        {
+            uxMinLastSize = uxMinSize;
+            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
+        }
+
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                static UBaseType_t uxLastMinQueueSpace = 0;
+                UBaseType_t uxCurrentCount = 0u;
+
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
+
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+    }
+#endif /* ( ipconfigHAS_PRINTF != 0 ) */
+/*-----------------------------------------------------------*/

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -55,6 +55,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define ipconfigHAS_PRINTF    1
 #if ( ipconfigHAS_PRINTF == 1 )
     #define FreeRTOS_printf( X )    configPRINTF( X )
+	/* Allow monitoring the message queue of the IP-task. */
+	#define ipconfigCHECK_IP_QUEUE_SPACE	1
 #endif
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
@@ -65,6 +67,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
 #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* TX checksum offloading has NOT been implemented in the Wi-Fi of ESP32. */
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM     0
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
@@ -230,9 +235,10 @@ extern uint32_t ulRand();
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
+ * lower value can save RAM.
+ * When the distance between Wi-Fi station and access point is long, or when
+ * the signal passes through walls, packets may get lost.  In that case it
+ * helps to decrease the MTU. */
 #define ipconfigNETWORK_MTU                            1460
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -235,10 +235,7 @@ extern uint32_t ulRand();
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM.
- * When the distance between Wi-Fi station and access point is long, or when
- * the signal passes through walls, packets may get lost.  In that case it
- * helps to decrease the MTU. */
+ * lower value can save RAM. */
 #define ipconfigNETWORK_MTU                            1460
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -55,6 +55,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define ipconfigHAS_PRINTF    1
 #if ( ipconfigHAS_PRINTF == 1 )
     #define FreeRTOS_printf( X )    configPRINTF( X )
+	/* Allow monitoring the message queue of the IP-task. */
+	#define ipconfigCHECK_IP_QUEUE_SPACE	1
 #endif
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
@@ -65,6 +67,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
 #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* TX checksum offloading has NOT been implemented in the Wi-Fi of ESP32. */
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM     0
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
@@ -230,9 +235,10 @@ extern uint32_t ulRand();
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
+ * lower value can save RAM.
+ * When the distance between Wi-Fi station and access point is long, or when
+ * the signal passes through walls, packets may get lost.  In that case it
+ * helps to decrease the MTU. */
 #define ipconfigNETWORK_MTU                            1460
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -235,10 +235,7 @@ extern uint32_t ulRand();
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM.
- * When the distance between Wi-Fi station and access point is long, or when
- * the signal passes through walls, packets may get lost.  In that case it
- * helps to decrease the MTU. */
+ * lower value can save RAM. */
 #define ipconfigNETWORK_MTU                            1460
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used


### PR DESCRIPTION
<!--- Title -->

Description
-----------
While reviewing all major FreeRTOS+TCP network interfaces, ESP32 doesn't seem to need many changes, at most a bit of configuring.

It has a very basic NetworkInterface.c which can do initialisation, send and receive. It does not start its own task, a "deferred interrupt handler". In stead, the "wifi" task handles the reception and it will call `wlanif_input()` to forward a network packet to the IP-task.
The IP/task calls `xNetworkInterfaceOutput()` to send out a packet, as in any other implementation.

I thought I had found an "issue": during a performance test, many packets got lost. The IP-stack responded with selective ACK's, because packets were missing.

Normally, the following resources must be checked, beside the available heap:

1) The number of free network buffers
2) The number of free DMA buffers

ad 1) There are more than enough network buffers.
ad 2) I am not sure where the DMA buffers are configured, but that doesn't seem to be the problem.

What did help was to make the packets smaller, for instance:

~~~c
-	#define ipconfigNETWORK_MTU                            1460
+	#define ipconfigNETWORK_MTU                            1200
~~~

Now there was 0 packet loss!

**However**: it turned out that an MTU of 1460 **can work well**. Why? The physical distance between the ESP32 and my Wi-Fi modem was quite long, and the quality of the transport varied.

The TCP throughput can further be increased by using a large TCP windows size (up to 6 x MSS).
Using a window size longer that 6 x MSS will lead to a loss of packets, and thus retransmissions. That probably can be changed by reconfiguring the Wi-Fi module.

Running iperf3 in reverse mode (`-R`) also worked well with mentioned parameters. In reverse mode, the ESP32 will send as many TCP data as possible.


One change I would like to add is some logging about resources related to FreeRTOS+TCP. You find it in `portable\NetworkInterface\esp32\NetworkInterface.c`.

The logging may help users while developing their applications.

One remark about `demos\demo_runner\iot_demo_freertos.c` : I was surprised that the network will be shut down after the demo's are ready. I was testing with pings and found that they remained unanswered after the demo was done.

I was surprised that the default implementation of `configASSERT()` would not end in a for ever loop. It calls abort and thousands of new logging lines are produced. Why not just stop at that point?


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.