### PR TITLE
FreeRTOS+TCP : Revision of Xilinx Network Interface

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
 
@@ -50,9 +51,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Provided memory configured as uncached. */
 #include "uncached_memory.h"
 
-#ifndef	BMSR_LINK_STATUS
-	#define BMSR_LINK_STATUS            0x0004UL
+#ifndef niEMAC_HANDLER_TASK_PRIORITY
+	/* Define the priority of the task prvEMACHandlerTask(). */
+	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
 #endif
+
+#define niBMSR_LINK_STATUS         0x0004uL
 
 #ifndef	PHY_LS_HIGH_CHECK_TIME_MS
 	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
@@ -83,6 +87,13 @@ FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 	#define configEMAC_TASK_STACK_SIZE ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
+#if( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
+	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
+#endif
+
+#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
+#endif
 /*-----------------------------------------------------------*/
 
 /*
@@ -95,6 +106,10 @@ static BaseType_t prvGMACWaitLS( TickType_t xMaxTime );
  * A deferred interrupt handler for all MAC/DMA interrupt sources.
  */
 static void prvEMACHandlerTask( void *pvParameters );
+
+#if ( ipconfigHAS_PRINTF != 0 )
+    static void prvMonitorResources( void );
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -188,7 +203,7 @@ const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pd
 		possible priority to ensure the interrupt handler can return directly
 		to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
 		notify the task when there is something to process. */
-		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
 	}
 	else
 	{
@@ -206,7 +221,27 @@ const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pd
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer, BaseType_t bReleaseAfterSend )
 {
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+	#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+	{
+	ProtocolPacket_t *pxPacket;
+
+		/* If the peripheral must calculate the checksum, it wants
+		the protocol checksum to have a value of zero. */
+		pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
+		if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP )
+		{
+		IPHeader_t *pxIPHeader = &( pxPacket->xUDPPacket.xIPHeader );
+
+			pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t )0u;
+			pxIPHeader->usHeaderChecksum = 0u;
+			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+
+			usGenerateProtocolChecksum( (uint8_t*)&( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+		}
+	}
+	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0 )
 	{
 		iptraceNETWORK_INTERFACE_TRANSMIT();
 		emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
@@ -249,7 +284,7 @@ BaseType_t xReturn;
 		}
 		ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-		if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+		if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0 )
 		{
 			xReturn = pdTRUE;
 			break;
@@ -281,7 +316,7 @@ BaseType_t xGetPhyLinkStatus( void )
 {
 BaseType_t xReturn;
 
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) == 0 )
+	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0 )
 	{
 		xReturn = pdFALSE;
 	}
@@ -294,12 +329,57 @@ BaseType_t xReturn;
 }
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigHAS_PRINTF != 0 )
+    static void prvMonitorResources()
+    {
+        static UBaseType_t uxLastMinBufferCount = 0u;
+        static UBaseType_t uxCurrentBufferCount = 0u;
+        static size_t uxMinLastSize = 0uL;
+        size_t uxMinSize;
+
+        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
+
+        if( uxLastMinBufferCount != uxCurrentBufferCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentBufferCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
+        }
+
+        uxMinSize = xPortGetMinimumEverFreeHeapSize();
+
+		if( uxMinLastSize != uxMinSize )
+		{
+			uxMinLastSize = uxMinSize;
+			FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
+		}
+
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                static UBaseType_t uxLastMinQueueSpace = 0;
+                UBaseType_t uxCurrentCount = 0u;
+
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
+
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+    }
+#endif /* ( ipconfigHAS_PRINTF != 0 ) */
+/*-----------------------------------------------------------*/
+
 static void prvEMACHandlerTask( void *pvParameters )
 {
 TimeOut_t xPhyTime;
 TickType_t xPhyRemTime;
-UBaseType_t uxLastMinBufferCount = 0;
-UBaseType_t uxCurrentCount;
 BaseType_t xResult = 0;
 uint32_t xStatus;
 const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
@@ -316,30 +396,11 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
 	for( ;; )
 	{
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
-
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-		static UBaseType_t uxLastMinQueueSpace = 0;
-
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+        #if ( ipconfigHAS_PRINTF != 0 )
+            {
+                prvMonitorResources();
+            }
+        #endif /* ipconfigHAS_PRINTF != 0 ) */
 
 		if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
 		{
@@ -372,19 +433,26 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			vTaskSetTimeOutState( &xPhyTime );
 			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
 			xResult = 0;
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0u )
+			{
+				/* Indicate that the Link Status is high, so that
+				xNetworkInterfaceOutput() can send packets. */
+				ulPHYLinkStatus |= niBMSR_LINK_STATUS;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
+			}
 		}
 		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
 		{
 			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
 			{
 				ulPHYLinkStatus = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0 ) );
 			}
 
 			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0 )
 			{
 				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
 			}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -230,13 +230,9 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer, 
 		pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
 		if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP )
 		{
-		IPHeader_t *pxIPHeader = &( pxPacket->xUDPPacket.xIPHeader );
-
-			pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t )0u;
-			pxIPHeader->usHeaderChecksum = 0u;
-			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0UL, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
-
+			/* The EMAC will calculate the checksum of the IP-header.
+			It can only calculate protocol checksums of UDP and TCP,
+			so for ICMP and other protocols it must be done manually. */
 			usGenerateProtocolChecksum( (uint8_t*)&( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
 		}
 	}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/README.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/README.txt
@@ -5,9 +5,15 @@ NetworkInterface for Xilinx' Zynq
 Please include the following source files:
 
 	$(PLUS_TCP_PATH)/portable/NetworkInterface/Zynq/NetworkInterface.c
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/Zynq/uncached_memory.c
 	$(PLUS_TCP_PATH)/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
 	$(PLUS_TCP_PATH)/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
 	$(PLUS_TCP_PATH)/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
+
+The file uncached_memory.c can also be found in:
+
+	vendors\xilinx\boards\microzed\aws_demos\application_code\xilinx_code
+	vendors\xilinx\boards\microzed\aws_tests\application_code\xilinx_code
 
 And include the following source files from the Xilinx library:
 
@@ -23,3 +29,14 @@ The following source files are NOT used for the FreeRTOS+TCP interface:
 	$(CPU_PATH)/$(PROCESSOR)/libsrc/emacps_v2_0/src/xemacps_bdring.c
 	$(CPU_PATH)/$(PROCESSOR)/libsrc/emacps_v2_0/src/xemacps_hw.c
 	$(CPU_PATH)/$(PROCESSOR)/libsrc/emacps_v2_0/src/xemacps_sinit.c
+
+It is recommended to have these defined :
+
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    1
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM    1
+#define ipconfigUSE_LINKED_RX_MESSAGES            1
+
+It is obligatory to define:
+
+#define ipconfigZERO_COPY_RX_DRIVER               1
+#define ipconfigZERO_COPY_TX_DRIVER               1

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -26,7 +26,6 @@ extern "C" {
 #include <stdint.h>
 
 #include "xstatus.h"
-#include "sleep.h"
 #include "xparameters.h"
 #include "xparameters_ps.h"	/* defines XPAR values */
 #include "xil_types.h"
@@ -35,7 +34,6 @@ extern "C" {
 #include "xil_exception.h"
 #include "xpseudo_asm.h"
 #include "xil_cache.h"
-#include "xil_printf.h"
 #include "xuartps.h"
 #include "xscugic.h"
 #include "xemacps.h"		/* defines XEmacPs API */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -23,15 +23,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  http://www.FreeRTOS.org
 */
 
-#include "Zynq/x_emacpsif.h"
-#include "Zynq/x_topology.h"
-#include "xstatus.h"
-
-#include "xparameters.h"
-#include "xparameters_ps.h"
-#include "xil_exception.h"
-#include "xil_mmu.h"
-
 #include "FreeRTOS.h"
 #include "task.h"
 #include "timers.h"
@@ -42,6 +33,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
+
+#include "Zynq/x_emacpsif.h"
+#include "Zynq/x_topology.h"
+#include "xstatus.h"
+
+#include "xparameters.h"
+#include "xparameters_ps.h"
+#include "xil_exception.h"
+#include "xil_mmu.h"
 
 #include "uncached_memory.h"
 
@@ -56,7 +56,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 #define TX_OFFSET				ipconfigPACKET_FILLER_SIZE
 
-#define RX_BUFFER_ALIGNMENT	14
+#define dmaRX_TX_BUFFER_SIZE			1536
 
 /* Defined in NetworkInterface.c */
 extern TaskHandle_t xEMACTaskHandle;
@@ -120,8 +120,6 @@ size_t uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount
 		{
 			break;
 		}
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-#warning ipconfigZERO_COPY_TX_DRIVER is defined
 		{
 		void *pvBuffer = pxDMA_tx_buffers[ tail ];
 		NetworkBufferDescriptor_t *pxBuffer;
@@ -140,7 +138,6 @@ size_t uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount
 				}
 			}
 		}
-#endif
 		/* Clear all but the "used" and "wrap" bits. */
 		if( tail < ipconfigNIC_N_TX_DESC - 1 )
 		{
@@ -170,6 +167,11 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
 	xemacpsif = (xemacpsif_s *)(arg);
 
+	/* This function is called from an ISR. The driver has already cleared the
+	TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
+	But it forgets to do a read-back. Do so now to avoid ever-returning ISR's. */
+	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_TXSR_OFFSET);
+
 	/* In this port for FreeRTOS+TCP, the EMAC interrupts will only set a bit in
 	"isr_events". The task in NetworkInterface will wake-up and do the necessary work.
 	*/
@@ -188,7 +190,7 @@ static BaseType_t xValidLength( BaseType_t xLength )
 {
 BaseType_t xReturn;
 
-	if( ( xLength >= ( BaseType_t ) sizeof( struct xARP_PACKET ) ) && ( ( ( uint32_t ) xLength ) <= ipTOTAL_ETHERNET_FRAME_SIZE ) )
+	if( ( xLength >= ( BaseType_t ) sizeof( struct xARP_PACKET ) ) && ( ( ( uint32_t ) xLength ) <= dmaRX_TX_BUFFER_SIZE ) )
 	{
 		xReturn = pdTRUE;
 	}
@@ -207,12 +209,8 @@ int iHasSent = 0;
 uint32_t ulBaseAddress = xemacpsif->emacps.Config.BaseAddress;
 TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
 
-	#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	{
-		/* This driver wants to own all network buffers which are to be transmitted. */
-		configASSERT( iReleaseAfterSend != pdFALSE );
-	}
-	#endif
+	/* This driver wants to own all network buffers which are to be transmitted. */
+	configASSERT( iReleaseAfterSend != pdFALSE );
 
 	/* Open a do {} while ( 0 ) loop to be able to call break. */
 	do
@@ -235,7 +233,6 @@ TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
 			break;
 		}
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
 		/* Pass the pointer (and its ownership) directly to DMA. */
 		pxDMA_tx_buffers[ head ] = pxBuffer->pucEthernetBuffer;
 		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
@@ -244,15 +241,7 @@ TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
 		}
 		/* Buffer has been transferred, do not release it. */
 		iReleaseAfterSend = pdFALSE;
-#else
-		if( pxDMA_tx_buffers[ head ] == NULL )
-		{
-			FreeRTOS_printf( ( "emacps_send_message: pxDMA_tx_buffers[ %d ] == NULL\n", head ) );
-			break;
-		}
-		/* Copy the message to unbuffered space in RAM. */
-		memcpy( pxDMA_tx_buffers[ head ], pxBuffer->pucEthernetBuffer, pxBuffer->xDataLength );
-#endif
+
 		/* Packets will be sent one-by-one, so for each packet
 		the TXBUF_LAST bit will be set. */
 		ulFlags |= XEMACPS_TXBUF_LAST_MASK;
@@ -292,6 +281,8 @@ TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
 		/* Start transmit */
 		xemacpsif->txBusy = pdTRUE;
 		XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ( ulValue | XEMACPS_NWCTRL_STARTTX_MASK ) );
+		/* Read back the register to make sure the data is flushed. */
+		( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
 	}
 	dsb();
 
@@ -306,6 +297,11 @@ void emacps_recv_handler(void *arg)
 	xemacpsif = (xemacpsif_s *)(arg);
 	xemacpsif->isr_events |= EMAC_IF_RX_EVENT;
 
+	/* The driver has already cleared the FRAMERX, BUFFNA and error bits
+	in the XEMACPS_RXSR register,
+	But it forgets to do a read-back. Do so now. */
+	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXSR_OFFSET);
+
 	if( xEMACTaskHandle != NULL )
 	{
 		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
@@ -314,33 +310,35 @@ void emacps_recv_handler(void *arg)
 	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
-static NetworkBufferDescriptor_t *ethMsg = NULL;
-static NetworkBufferDescriptor_t *ethLast = NULL;
-
-static void passEthMessages( void )
+static void prvPassEthMessages( NetworkBufferDescriptor_t *pxDescriptor )
 {
 IPStackEvent_t xRxEvent;
 
 	xRxEvent.eEventType = eNetworkRxEvent;
-	xRxEvent.pvData = ( void * ) ethMsg;
+	xRxEvent.pvData = ( void * ) pxDescriptor;
 
 	if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
 	{
 		/* The buffer could not be sent to the stack so	must be released again.
 		This is a deferred handler taskr, not a real interrupt, so it is ok to
 		use the task level function here. */
-		do
+		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
 		{
-			NetworkBufferDescriptor_t *xNext = ethMsg->pxNextBuffer;
-			vReleaseNetworkBufferAndDescriptor( ethMsg );
-			ethMsg = xNext;
-		} while( ethMsg != NULL );
-
+			do
+			{
+				NetworkBufferDescriptor_t *pxNext = pxDescriptor->pxNextBuffer;
+				vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+				pxDescriptor = pxNext;
+			} while( pxDescriptor != NULL );
+		}
+		#else
+		{
+			vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+		}
+		#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
 		iptraceETHERNET_RX_EVENT_LOST();
-		FreeRTOS_printf( ( "passEthMessages: Can not queue return packet!\n" ) );
+		FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
 	}
-
-	ethMsg = ethLast = NULL;
 }
 
 int emacps_check_rx( xemacpsif_s *xemacpsif )
@@ -349,6 +347,10 @@ NetworkBufferDescriptor_t *pxBuffer, *pxNewBuffer;
 int rx_bytes;
 volatile int msgCount = 0;
 int head = xemacpsif->rxHead;
+#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+	NetworkBufferDescriptor_t *pxFirstDescriptor = NULL;
+	NetworkBufferDescriptor_t *pxLastDescriptor = NULL;
+#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
 
 	/* There seems to be an issue (SI# 692601), see comments below. */
 	resetrx_on_no_rxdata(xemacpsif);
@@ -364,12 +366,12 @@ int head = xemacpsif->rxHead;
 			break;
 		}
 
-		pxNewBuffer = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE + RX_BUFFER_ALIGNMENT, ( TickType_t ) 0 );
+		pxNewBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
 		if( pxNewBuffer == NULL )
 		{
 			/* A packet has been received, but there is no replacement for this Network Buffer.
 			The packet will be dropped, and it Network Buffer will stay in place. */
-			FreeRTOS_printf( ("emacps_check_rx: unable to allocate a Netwrok Buffer\n" ) );
+			FreeRTOS_printf( ("emacps_check_rx: unable to allocate a Network Buffer\n" ) );
 			pxNewBuffer = ( NetworkBufferDescriptor_t * )pxDMA_rx_buffers[ head ];
 		}
 		else
@@ -394,26 +396,35 @@ int head = xemacpsif->rxHead;
 			/* store it in the receive queue, where it'll be processed by a
 			different handler. */
 			iptraceNETWORK_INTERFACE_RECEIVE();
-			pxBuffer->pxNextBuffer = NULL;
-
-			if( ethMsg == NULL )
+			#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
 			{
-				// Becomes the first message
-				ethMsg = pxBuffer;
-			}
-			else if( ethLast != NULL )
-			{
-				// Add to the tail
-				ethLast->pxNextBuffer = pxBuffer;
-			}
+				pxBuffer->pxNextBuffer = NULL;
 
-			ethLast = pxBuffer;
+				if( pxFirstDescriptor == NULL )
+				{
+					// Becomes the first message
+					pxFirstDescriptor = pxBuffer;
+				}
+				else if( pxLastDescriptor != NULL )
+				{
+					// Add to the tail
+					pxLastDescriptor->pxNextBuffer = pxBuffer;
+				}
+
+				pxLastDescriptor = pxBuffer;
+			}
+			#else
+			{
+				prvPassEthMessages( pxBuffer );
+			}
+			#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+
 			msgCount++;
 		}
 		{
 			if( ucIsCachedMemory( pxNewBuffer->pucEthernetBuffer ) != 0 )
 			{
-				Xil_DCacheInvalidateRange( ( ( uint32_t )pxNewBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, (unsigned)ipTOTAL_ETHERNET_FRAME_SIZE + RX_BUFFER_ALIGNMENT);
+				Xil_DCacheInvalidateRange( ( ( uint32_t ) pxNewBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( unsigned ) dmaRX_TX_BUFFER_SIZE );
 			}
 			{
 				uint32_t addr = ( ( uint32_t )pxNewBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
@@ -422,8 +433,12 @@ int head = xemacpsif->rxHead;
 					addr |= XEMACPS_RXBUF_WRAP_MASK;
 				}
 				/* Clearing 'XEMACPS_RXBUF_NEW_MASK'       0x00000001 *< Used bit.. */
-				xemacpsif->rxSegments[ head ].address = addr;
 				xemacpsif->rxSegments[ head ].flags = 0;
+				xemacpsif->rxSegments[ head ].address = addr;
+				if (xemacpsif->rxSegments[ head ].address)
+				{
+					// Just to read it
+				}
 			}
 		}
 
@@ -434,10 +449,14 @@ int head = xemacpsif->rxHead;
 		xemacpsif->rxHead = head;
 	}
 
-	if( ethMsg != NULL )
+	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
 	{
-		passEthMessages( );
+		if( pxFirstDescriptor != NULL )
+		{
+			prvPassEthMessages( pxFirstDescriptor );
+		}
 	}
+	#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
 
 	return msgCount;
 }
@@ -455,11 +474,7 @@ unsigned char *ucTxBuffer;
 	{
 		xemacpsif->txSegments[ index ].address = ( uint32_t )ucTxBuffer;
 		xemacpsif->txSegments[ index ].flags = XEMACPS_TXBUF_USED_MASK;
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		pxDMA_tx_buffers[ index ] = ( void* )NULL;
-#else
-		pxDMA_tx_buffers[ index ] = ( void* )( ucTxBuffer + TX_OFFSET );
-#endif
+		pxDMA_tx_buffers[ index ] = ( unsigned char * )NULL;
 		ucTxBuffer += xemacpsif->uTxUnitSize;
 	}
 	xemacpsif->txSegments[ ipconfigNIC_N_TX_DESC - 1 ].flags =
@@ -480,7 +495,7 @@ XStatus init_dma(xemacpsif_s *xemacpsif)
 	xTxSize = ipconfigNIC_N_TX_DESC * sizeof( xemacpsif->txSegments[ 0 ] );
 
 	/* Also round-up to 4KB */
-	xemacpsif->uTxUnitSize = ( ipTOTAL_ETHERNET_FRAME_SIZE + 0x1000ul ) & ~0xffful;
+	xemacpsif->uTxUnitSize = ( dmaRX_TX_BUFFER_SIZE + 0x1000ul ) & ~0xffful;
 	/*
 	 * We allocate 65536 bytes for RX BDs which can accommodate a
 	 * maximum of 8192 BDs which is much more than any application
@@ -507,7 +522,7 @@ XStatus init_dma(xemacpsif_s *xemacpsif)
 		pxBuffer = pxDMA_rx_buffers[ iIndex ];
 		if( pxBuffer == NULL )
 		{
-			pxBuffer = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE + RX_BUFFER_ALIGNMENT, ( TickType_t ) 0 );
+			pxBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
 			if( pxBuffer == NULL )
 			{
 				FreeRTOS_printf( ("Unable to allocate a network buffer in recv_handler\n" ) );
@@ -523,7 +538,7 @@ XStatus init_dma(xemacpsif_s *xemacpsif)
 		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
 		{
 			Xil_DCacheInvalidateRange( ( ( uint32_t )pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE,
-				(unsigned)ipTOTAL_ETHERNET_FRAME_SIZE + RX_BUFFER_ALIGNMENT);
+				(unsigned)dmaRX_TX_BUFFER_SIZE );
 		}
 	}
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -167,8 +167,8 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
 	xemacpsif = (xemacpsif_s *)(arg);
 
-	/* This function is called from an ISR. The driver has already cleared the
-	TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
+	/* This function is called from an ISR. The Xilinx ISR-handler has already
+	cleared the TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
 	But it forgets to do a read-back. Do so now to avoid ever-returning ISR's. */
 	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_TXSR_OFFSET);
 
@@ -435,10 +435,8 @@ int head = xemacpsif->rxHead;
 				/* Clearing 'XEMACPS_RXBUF_NEW_MASK'       0x00000001 *< Used bit.. */
 				xemacpsif->rxSegments[ head ].flags = 0;
 				xemacpsif->rxSegments[ head ].address = addr;
-				if (xemacpsif->rxSegments[ head ].address)
-				{
-					// Just to read it
-				}
+				/* Make sure that the value has reached the peripheral by reading it back. */
+				( void ) xemacpsif->rxSegments[ head ].address;
 			}
 		}
 
@@ -494,8 +492,7 @@ XStatus init_dma(xemacpsif_s *xemacpsif)
 
 	xTxSize = ipconfigNIC_N_TX_DESC * sizeof( xemacpsif->txSegments[ 0 ] );
 
-	/* Also round-up to 4KB */
-	xemacpsif->uTxUnitSize = ( dmaRX_TX_BUFFER_SIZE + 0x1000ul ) & ~0xffful;
+	xemacpsif->uTxUnitSize = dmaRX_TX_BUFFER_SIZE;
 	/*
 	 * We allocate 65536 bytes for RX BDs which can accommodate a
 	 * maximum of 8192 BDs which is much more than any application

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
@@ -22,27 +22,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "Zynq/x_emacpsif.h"
-
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
 #include "queue.h"
 
-///* FreeRTOS+TCP includes. */
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
+#include "NetworkInterface.h"
+
+#include "Zynq/x_emacpsif.h"
 
 extern TaskHandle_t xEMACTaskHandle;
 
 /*** IMPORTANT: Define PEEP in xemacpsif.h and sys_arch_raw.c
  *** to run it on a PEEP board
  ***/
-
-unsigned int link_speed = 100;
 
 void setup_isr( xemacpsif_s *xemacpsif )
 {
@@ -141,8 +139,6 @@ int xResult;
 	return xResult;
 }
 
-BaseType_t xNetworkInterfaceInitialise( void );
-
 static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord)
 {
 	xemacpsif_s   *xemacpsif;
@@ -217,8 +213,6 @@ static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord)
 		FreeRTOS_printf( ( "emacps_handle_error: %s\n", last_err_msg ) );
 	}
 }
-
-extern XEmacPs_Config mac_config;
 
 void HandleTxErrors(xemacpsif_s *xemacpsif)
 {

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
@@ -159,12 +159,17 @@ int phy_detected = 0;
 #define EMAC0_BASE_ADDRESS				0xE000B000
 #define EMAC1_BASE_ADDRESS				0xE000C000
 
+#define PHY_ADDRESS_COUNT				32
+
+#define MINIMUM_SLEEP_TIME				2
+
+
 static int detect_phy(XEmacPs *xemacpsp)
 {
 	u16 id_lower, id_upper;
 	u32 phy_addr, id;
 
-	for (phy_addr = 0; phy_addr < 32; phy_addr++) {
+	for (phy_addr = 0; phy_addr < PHY_ADDRESS_COUNT; phy_addr++) {
 		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PHYSID1_OFFSET, &id_lower);
 
 		if ((id_lower != ( u16 )0xFFFFu) && (id_lower != ( u16 )0x0u)) {
@@ -338,7 +343,7 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 
 	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
 	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		vTaskDelay( 2 );
+		vTaskDelay( MINIMUM_SLEEP_TIME );
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
 #else
 		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2,
@@ -556,19 +561,19 @@ unsigned Phy_Setup (XEmacPs *xemacpsp)
 	link_speed = 1000;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	vTaskDelay( 2 );
+	vTaskDelay( MINIMUM_SLEEP_TIME );
 #elif	defined(ipconfigNIC_LINKSPEED100)
 	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
 	link_speed = 100;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	vTaskDelay( 2 );
+	vTaskDelay( MINIMUM_SLEEP_TIME );
 #elif	defined(ipconfigNIC_LINKSPEED10)
 	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
 	link_speed = 10;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	vTaskDelay( 2 );
+	vTaskDelay( MINIMUM_SLEEP_TIME );
 #endif
 	if (conv_present) {
 		XEmacPs_PhyWrite(xemacpsp, convphyaddr,

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
@@ -53,23 +53,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "Zynq/x_emacpsif.h"
-//#include "lwipopts.h"
-#include "xparameters_ps.h"
-#include "xparameters.h"
-
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
 #include "queue.h"
 #include "semphr.h"
 
-///* FreeRTOS+TCP includes. */
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
+
+#include "Zynq/x_emacpsif.h"
+#include "xparameters_ps.h"
+#include "xparameters.h"
+
 
 int phy_detected = 0;
 
@@ -99,6 +98,8 @@ int phy_detected = 0;
 
 #define IEEE_CONTROL_REG_OFFSET				0
 #define IEEE_STATUS_REG_OFFSET				1
+#define IEEE_PHYSID1_OFFSET					2
+#define IEEE_PHYSID2_OFFSET					3
 #define IEEE_AUTONEGO_ADVERTISE_REG			4
 #define IEEE_PARTNER_ABILITIES_1_REG_OFFSET	5
 #define IEEE_1000_ADVERTISE_REG_OFFSET		9
@@ -135,9 +136,6 @@ int phy_detected = 0;
 #define IEEE_PAUSE_MASK						0x0400
 #define IEEE_AUTONEG_ERROR_MASK				0x8000
 
-#define PHY_DETECT_REG  1
-#define PHY_DETECT_MASK 0x1808
-
 #define XEMACPS_GMII2RGMII_SPEED1000_FD		0x140
 #define XEMACPS_GMII2RGMII_SPEED100_FD		0x2100
 #define XEMACPS_GMII2RGMII_SPEED10_FD		0x100
@@ -163,19 +161,17 @@ int phy_detected = 0;
 
 static int detect_phy(XEmacPs *xemacpsp)
 {
-	u16 phy_reg;
-	u32 phy_addr;
+	u16 id_lower, id_upper;
+	u32 phy_addr, id;
 
-	for (phy_addr = 31; phy_addr > 0; phy_addr--) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_DETECT_REG,
-							&phy_reg);
+	for (phy_addr = 0; phy_addr < 32; phy_addr++) {
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PHYSID1_OFFSET, &id_lower);
 
-		if ((phy_reg != 0xFFFF) &&
-			((phy_reg & PHY_DETECT_MASK) == PHY_DETECT_MASK)) {
-			/* Found a valid PHY address */
-			FreeRTOS_printf( ("XEmacPs detect_phy: PHY detected at address %d.\r\n",
-																	phy_addr));
-			FreeRTOS_printf( ("XEmacPs detect_phy: PHY detected.\n" ) );
+		if ((id_lower != ( u16 )0xFFFFu) && (id_lower != ( u16 )0x0u)) {
+
+			XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PHYSID2_OFFSET, &id_upper);
+			id = ( ( ( uint32_t ) id_upper ) << 16 ) | ( id_lower & 0xFFF0 );
+			FreeRTOS_printf( ("XEmacPs detect_phy: %04lX at address %d.\n", id, phy_addr ) );
 			phy_detected = phy_addr;
 			return phy_addr;
 		}
@@ -238,8 +234,8 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 		if (partner_capabilities & IEEE_AN1_ABILITY_MASK_10MBPS)
 			return 10;
 
-		xil_printf("%s: unknown PHY link speed, setting TEMAC speed to be 10 Mbps\r\n",
-				__FUNCTION__);
+		FreeRTOS_printf( ( "%s: unknown PHY link speed, setting TEMAC speed to be 10 Mbps\n",
+				__FUNCTION__ ) );
 		return 10;
 
 	} else {
@@ -257,8 +253,8 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 				case (IEEE_CTRL_LINKSPEED_10M):
 					return 10;
 				default:
-					xil_printf("%s: unknown PHY link speed (%d), setting TEMAC speed to be 10 Mbps\r\n",
-							__FUNCTION__, phylinkspeed);
+					FreeRTOS_printf( ( "%s: unknown PHY link speed (%d), setting TEMAC speed to be 10 Mbps\n",
+							__FUNCTION__, phylinkspeed ) );
 					return 10;
 			}
 
@@ -282,7 +278,7 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 #else
 	u32 phy_addr = detect_phy(xemacpsp);
 #endif
-	xil_printf("Start PHY autonegotiation \r\n");
+	FreeRTOS_printf( ( "Start PHY autonegotiation \n" ) );
 
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
 #else
@@ -338,24 +334,24 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 			break;
 	}
 #endif
-	xil_printf("Waiting for PHY to complete autonegotiation.\r\n");
+	FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
 
 	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
 	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		sleep(1);
+		vTaskDelay( 2 );
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
 #else
 		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2,
 																	&temp);
 		if (temp & IEEE_AUTONEG_ERROR_MASK) {
-			xil_printf("Auto negotiation error \r\n");
+			FreeRTOS_printf( ( "Auto negotiation error \n" ) );
 		}
 #endif
 		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET,
 																&status);
 		}
 
-	xil_printf("autonegotiation complete \r\n");
+	FreeRTOS_printf( ( "autonegotiation complete \n" ) );
 
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
 #else
@@ -363,7 +359,7 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 #endif
 
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-	xil_printf("Waiting for Link to be up; Polling for SGMII core Reg \r\n");
+	FreeRTOS_printf( ( "Waiting for Link to be up; Polling for SGMII core Reg \n" ) );
 	XEmacPs_PhyRead(xemacpsp, phy_addr, 5, &temp);
 	while(!(temp & 0x8000)) {
 		XEmacPs_PhyRead(xemacpsp, phy_addr, 5, &temp);
@@ -380,7 +376,7 @@ unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
 		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
 		return 10;
 	} else {
-		xil_printf("get_IEEE_phy_speed(): Invalid speed bit value, Deafulting to Speed = 10 Mbps\r\n");
+		FreeRTOS_printf( ( "get_IEEE_phy_speed(): Invalid speed bit value, Deafulting to Speed = 10 Mbps\n" ) );
 		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
 		XEmacPs_PhyWrite(xemacpsp, phy_addr, 0, 0x0100);
 		return 10;
@@ -560,26 +556,26 @@ unsigned Phy_Setup (XEmacPs *xemacpsp)
 	link_speed = 1000;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	sleep(1);
+	vTaskDelay( 2 );
 #elif	defined(ipconfigNIC_LINKSPEED100)
 	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
 	link_speed = 100;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	sleep(1);
+	vTaskDelay( 2 );
 #elif	defined(ipconfigNIC_LINKSPEED10)
 	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
 	link_speed = 10;
 	configure_IEEE_phy_speed(xemacpsp, link_speed);
 	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	sleep(1);
+	vTaskDelay( 2 );
 #endif
 	if (conv_present) {
 		XEmacPs_PhyWrite(xemacpsp, convphyaddr,
 		XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting);
 	}
 
-	xil_printf("link speed: %d\r\n", link_speed);
+	FreeRTOS_printf( ( "link speed: %d\n", link_speed ) );
 	return link_speed;
 }
 

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -55,6 +55,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define ipconfigHAS_PRINTF    1
 #if ( ipconfigHAS_PRINTF == 1 )
     #define FreeRTOS_printf( X )    configPRINTF( X )
+	/* When logging is allowed, also enable checking the space in the
+	queue to the IP-task. */
+    #define ipconfigCHECK_IP_QUEUE_SPACE			1
 #endif
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
@@ -64,8 +67,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM		( 1 )
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM		1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM		1
+
+/* The Xilinx Zynq driver uses zero-copy techniques both for reception
+ * and transmission. */
+#define ipconfigZERO_COPY_RX_DRIVER					1
+#define ipconfigZERO_COPY_TX_DRIVER					1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
@@ -74,12 +82,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 10000 )
 #define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 10000 )
 
-/* Include support for LLMNR: Link-local Multicast Name Resolution
- * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 1 )
+/* Include support for LLMNR: Link-local Multicast Name Resolution.
+ * This protocol is considered unsafe and therefore it is disabled by default. */
+#define ipconfigUSE_LLMNR                          ( 0 )
 
-/* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 1 )
+/* Include support for NBNS: NetBIOS Name Service.
+ * This protocol is considered unsafe and therefore it is disabled by default. */
+#define ipconfigUSE_NBNS                           ( 0 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low


### PR DESCRIPTION
<!--- Title -->

Description
-----------
It is a long time that the network interface of Xilinx had an update in AWS/FreeRTOS repo.
All changes have been tested for a long time.

Here a summary:

Source file `x_emacpsif_physpeed.c` :

- Stopped using `xil_printf()`

- Solved some `#include` problems

- Make PHY detection better:
  - Start from address 0, not from 32
  - More informative output: "XEmacPs detect_phy: C9150010 at address 0"

- Replaced `sleep( 1 )` with the FreeRTOS API `vTaskDelay( 2 )`.


Source file `x_emacpsif_hw.c` :

- Solved some `#include` problems

- Some cleaning ( use headers in stead of local declarations of functions and variables )


Source file `x_emacpsif_dma.c` :

- Solved some `#include` problems

- Stopped using the macro's `ipTOTAL_ETHERNET_FRAME_SIZE` and `RX_BUFFER_ALIGNMENT`

Several **bugs are solved** by reading back registers in several places:

- In `emacps_send_handler()` : read-back the `XEMACPS_TXSR` registers in ISR context after clearing it
- In `emacps_send_message()` : read-back the `XEMACPS_NWCTRL` register after setting it
- In `emacps_recv_handler()` : read-back the `XEMACPS_RXSR` register in ISR context after clearing it
- In `emacps_check_rx()` : read-back the `address` field of a DMA descriptor to make sure it is set.

- The user is now free to use `ipconfigUSE_LINKED_RX_MESSAGES` or not. The option may increase performance because incoming network packets are linked together in a list and send as 1 queue message to the IP-task.

- Cleaned up some code:

~~~c
-static NetworkBufferDescriptor_t *ethMsg = NULL;
-static NetworkBufferDescriptor_t *ethLast = NULL;
~~~

These variables are now declared the stack.

- The ICMP-checksum offloading for outgoing packets didn't work. `xNetworkInterfaceOutput()` will now correct this.

- Added the function `prvMonitorResources()` that helps users monitor the essential resources while developing. The code is only included if FreeRTOS+TCP logging is used ( `ipconfigHAS_PRINTF` ).

- The PHY status: when a packet come in while the PHY was low, it is assume that it is high. However, the variable should be updated:

~~~c
    /* Indicate that the Link Status is high, so that
    xNetworkInterfaceOutput() can send packets. */
    ulPHYLinkStatus |= niBMSR_LINK_STATUS;
~~~


NB. I had problems linking the project within Eclipse on Windows 10. When calling the linker, the command line got larger than 8 KB ( 10 or 11 KB ), which was a problem for Windows.
I found a solution and described it [here](https://github.com/aws/amazon-freertos/issues/1555).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.