### PR TITLE
Add compile flags to fix warnings in compilation

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -42,6 +42,8 @@ target_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:${IDF_CXX_COMPILE_OPTIONS}>
 )
 
+add_compile_options(-Wno-unused-variable -Wno-unused-function -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-clobbered)
+
 # Compiler definitions/macros
 target_compile_definitions(
     AFR::compiler::mcu_port


### PR DESCRIPTION
Fix warnings while compiling a project on latest version of Amazon FreeRTOS.

Description
-----------
Compile flags are added in CMakeLists.txt, to eliminate warnings in compilation of aws_demos and aws_tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.