### PR TITLE
Add eWiFiSecurityWPA2_ent into Wi-Fi Security types

### DIFF
--- a/libraries/abstractions/wifi/include/iot_wifi.h
+++ b/libraries/abstractions/wifi/include/iot_wifi.h
@@ -65,6 +65,7 @@ typedef enum
     eWiFiSecurityWEP,         /**< WEP Security. */
     eWiFiSecurityWPA,         /**< WPA Security. */
     eWiFiSecurityWPA2,        /**< WPA2 Security. */
+    eWiFiSecurityWPA2_ent,    /**< WPA2 Enterprise Security. */
     eWiFiSecurityNotSupported /**< Unknown Security. */
 } WIFISecurity_t;
 

--- a/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
@@ -1210,9 +1210,8 @@ static esp_err_t WIFI_SetSecurity( WIFISecurity_t securityMode, wifi_auth_mode_t
         case eWiFiSecurityWPA2:
             *authmode = WIFI_AUTH_WPA2_PSK;
             break;
-        case eWiFiSecurityNotSupported:
+        default:
             return ESP_FAIL;
-            break;
     }
     return ESP_OK;
 }


### PR DESCRIPTION
Description
-----------

This commit adds eWiFiSecurityWPA2_ent into WIFISecurity structure to
let vendor be able to support Wi-Fi WPA2 enterprise security in the
future.

Since we have a pending release, the original PR is moved to release-candidate branch to run integration tests.
https://github.com/aws/amazon-freertos/pull/1595

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.