### PR TITLE
FreeRTOS+TCP : STM32Fxx network interface Updated

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Common/phyHandling.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Common/phyHandling.c
@@ -1,0 +1,687 @@
+/*
+ * Handling of Ethernet PHY's
+ * PHY's communicate with an EMAC either through
+ * a Media-Independent Interface (MII), or a Reduced Media-Independent Interface (RMII).
+ * The EMAC can poll for PHY ports on 32 different addresses. Each of the PHY ports
+ * shall be treated independently.
+ * 
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+#include "phyHandling.h"
+
+#define phyMIN_PHY_ADDRESS		0
+#define phyMAX_PHY_ADDRESS		31
+
+#if defined( PHY_LS_HIGH_CHECK_TIME_MS ) || defined( PHY_LS_LOW_CHECK_TIME_MS )
+	#warning please use the new defines with 'ipconfig' prefix
+#endif
+
+#ifndef	ipconfigPHY_LS_HIGH_CHECK_TIME_MS
+	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+	receiving packets. */
+	#define ipconfigPHY_LS_HIGH_CHECK_TIME_MS	15000
+#endif
+
+#ifndef	ipconfigPHY_LS_LOW_CHECK_TIME_MS
+	/* Check if the LinkSStatus in the PHY is still low every second. */
+	#define ipconfigPHY_LS_LOW_CHECK_TIME_MS	1000
+#endif
+
+/* Naming and numbering of basic PHY registers. */
+#define phyREG_00_BMCR				0x00u	/* Basic Mode Control Register. */
+#define phyREG_01_BMSR				0x01u	/* Basic Mode Status Register. */
+#define phyREG_02_PHYSID1			0x02u	/* PHYS ID 1 */
+#define phyREG_03_PHYSID2			0x03u	/* PHYS ID 2 */
+#define phyREG_04_ADVERTISE			0x04u	/* Advertisement control reg */
+
+/* Naming and numbering of extended PHY registers. */
+#define PHYREG_10_PHYSTS			0x10u	/* 16 PHY status register Offset */
+#define	phyREG_19_PHYCR				0x19u	/* 25 RW PHY Control Register */
+#define	phyREG_1F_PHYSPCS			0x1Fu	/* 31 RW PHY Special Control Status */
+
+/* Bit fields for 'phyREG_00_BMCR', the 'Basic Mode Control Register'. */
+#define phyBMCR_FULL_DUPLEX			0x0100u	/* Full duplex. */
+#define phyBMCR_AN_RESTART			0x0200u	/* Auto negotiation restart. */
+#define phyBMCR_ISOLATE				0x0400u /* 1 = Isolates 0 = Normal operation. */
+#define phyBMCR_AN_ENABLE			0x1000u	/* Enable auto negotiation. */
+#define phyBMCR_SPEED_100			0x2000u	/* Select 100Mbps. */
+#define phyBMCR_RESET				0x8000u	/* Reset the PHY. */
+
+/* Bit fields for 'phyREG_19_PHYCR', the 'PHY Control Register'. */
+#define PHYCR_MDIX_EN				0x8000u	/* Enable Auto MDIX. */
+#define PHYCR_MDIX_FORCE			0x4000u	/* Force MDIX crossed. */
+
+#define phyBMSR_AN_COMPLETE			0x0020u	/* Auto-Negotiation process completed */
+
+#define phyBMSR_LINK_STATUS			0x0004u
+
+#define phyPHYSTS_LINK_STATUS		0x0001u	/* PHY Link mask */
+#define phyPHYSTS_SPEED_STATUS		0x0002u	/* PHY Speed mask */
+#define phyPHYSTS_DUPLEX_STATUS		0x0004u	/* PHY Duplex mask */
+
+/* Bit fields for 'phyREG_1F_PHYSPCS
+	001 = 10BASE-T half-duplex
+	101 = 10BASE-T full-duplex
+	010 = 100BASE-TX half-duplex
+	110 = 100BASE-TX full-duplex
+*/
+#define phyPHYSPCS_SPEED_MASK		0x000Cu
+#define phyPHYSPCS_SPEED_10			0x0004u
+#define phyPHYSPCS_FULL_DUPLEX		0x0010u
+
+/*
+ * Description of all capabilities that can be advertised to
+ * the peer (usually a switch or router).
+ */
+#define phyADVERTISE_CSMA			0x0001u	/* Only selector supported. */
+#define phyADVERTISE_10HALF			0x0020u	/* Try for 10mbps half-duplex. */
+#define phyADVERTISE_10FULL			0x0040u	/* Try for 10mbps full-duplex. */
+#define phyADVERTISE_100HALF		0x0080u	/* Try for 100mbps half-duplex. */
+#define phyADVERTISE_100FULL		0x0100u	/* Try for 100mbps full-duplex. */
+
+#define phyADVERTISE_ALL			( phyADVERTISE_10HALF | phyADVERTISE_10FULL | \
+									  phyADVERTISE_100HALF | phyADVERTISE_100FULL )
+
+/* Send a reset commando to a set of PHY-ports. */
+static uint32_t xPhyReset( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+
+static BaseType_t xHas_1F_PHYSPCS( uint32_t ulPhyID )
+{
+BaseType_t xResult;
+
+	switch( ulPhyID )
+	{
+		case PHY_ID_LAN8720:
+		case PHY_ID_LAN8742A:
+		case PHY_ID_KSZ8041:
+/*
+		case PHY_ID_KSZ8051: // same ID as 8041
+		case PHY_ID_KSZ8081: // same ID as 8041
+*/
+		case PHY_ID_KSZ8081MNXIA:
+
+		case PHY_ID_KSZ8863:
+		default:
+			/* Most PHY's have a 1F_PHYSPCS */
+			xResult = pdTRUE;
+			break;
+		case PHY_ID_DP83848I:
+			xResult = pdFALSE;
+			break;
+	}
+	return xResult;
+}
+/*-----------------------------------------------------------*/
+
+static BaseType_t xHas_19_PHYCR( uint32_t ulPhyID )
+{
+BaseType_t xResult;
+
+	switch( ulPhyID )
+	{
+		case PHY_ID_LAN8742A:
+		case PHY_ID_DP83848I:
+			xResult = pdTRUE;
+			break;
+		default:
+			/* Most PHY's do not have a 19_PHYCR */
+			xResult = pdFALSE;
+			break;
+	}
+	return xResult;
+}
+/*-----------------------------------------------------------*/
+
+/* Initialise the struct and assign a PHY-read and -write function. */
+void vPhyInitialise( EthernetPhy_t *pxPhyObject, xApplicationPhyReadHook_t fnPhyRead, xApplicationPhyWriteHook_t fnPhyWrite )
+{
+	memset( ( void * )pxPhyObject, '\0', sizeof( *pxPhyObject ) );
+
+	pxPhyObject->fnPhyRead = fnPhyRead;
+	pxPhyObject->fnPhyWrite = fnPhyWrite;
+}
+/*-----------------------------------------------------------*/
+
+/* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
+BaseType_t xPhyDiscover( EthernetPhy_t *pxPhyObject )
+{
+BaseType_t xPhyAddress;
+
+	pxPhyObject->xPortCount = 0;
+
+	for( xPhyAddress = phyMIN_PHY_ADDRESS; xPhyAddress <= phyMAX_PHY_ADDRESS; xPhyAddress++ )
+	{
+	uint32_t ulLowerID;
+
+		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_03_PHYSID2, &ulLowerID );
+		/* A valid PHY id can not be all zeros or all ones. */
+		if( ( ulLowerID != ( uint16_t )~0u )  && ( ulLowerID != ( uint16_t )0u ) )
+		{
+		uint32_t ulUpperID;
+		uint32_t ulPhyID;
+
+			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_02_PHYSID1, &ulUpperID );
+			ulPhyID = ( ( ( uint32_t ) ulUpperID ) << 16 ) | ( ulLowerID & 0xFFF0 );
+
+			pxPhyObject->ucPhyIndexes[ pxPhyObject->xPortCount ] = xPhyAddress;
+			pxPhyObject->ulPhyIDs[ pxPhyObject->xPortCount ] = ulPhyID;
+
+			pxPhyObject->xPortCount++;
+
+			/* See if there is more storage space. */
+			if( pxPhyObject->xPortCount == ipconfigPHY_MAX_PORTS )
+			{
+				break;
+			}
+		}
+	}
+	if( pxPhyObject->xPortCount > 0 )
+	{
+		FreeRTOS_printf( ( "PHY ID %lX\n", pxPhyObject->ulPhyIDs[ 0 ] ) );
+	}
+
+	return pxPhyObject->xPortCount;
+}
+/*-----------------------------------------------------------*/
+
+/* Send a reset commando to a set of PHY-ports. */
+static uint32_t xPhyReset( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+{
+uint32_t ulDoneMask, ulConfig;
+TickType_t xRemainingTime;
+TimeOut_t xTimer;
+BaseType_t xPhyIndex;
+
+	/* A bit-mask ofPHY ports that are ready. */
+	ulDoneMask = 0ul;
+
+	/* Set the RESET bits high. */
+	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+	{
+	BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+		/* Read Control register. */
+		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+		pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig | phyBMCR_RESET );
+	}
+
+	xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( 1000UL );
+	vTaskSetTimeOutState( &xTimer );
+
+	/* The reset should last less than a second. */
+	for( ;; )
+	{
+		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+		{
+		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+			if( ( ulConfig & phyBMCR_RESET ) == 0 )
+			{
+				FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET %d ready\n", (int)xPhyIndex ) );
+				ulDoneMask |= ( 1ul << xPhyIndex );
+			}
+		}
+		if( ulDoneMask == ulPhyMask )
+		{
+			break;
+		}
+		if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
+		{
+			FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
+			break;
+		}
+		/* Block for a while */
+		vTaskDelay( pdMS_TO_TICKS( 50ul ) );
+	}
+
+	/* Clear the reset bits. */
+	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+	{
+	BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+		pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig & ~phyBMCR_RESET );
+	}
+
+	vTaskDelay( pdMS_TO_TICKS( 50ul ) );
+
+	return ulDoneMask;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPhyConfigure( EthernetPhy_t *pxPhyObject, const PhyProperties_t *pxPhyProperties )
+{
+uint32_t ulConfig, ulAdvertise;
+BaseType_t xPhyIndex;
+
+	if( pxPhyObject->xPortCount < 1 )
+	{
+		FreeRTOS_printf( ( "xPhyResetAll: No PHY's detected.\n" ) );
+		return -1;
+	}
+
+	/* The expected ID for the 'LAN8742A'  is 0x0007c130. */
+	/* The expected ID for the 'LAN8720'   is 0x0007c0f0. */
+	/* The expected ID for the 'DP83848I'  is 0x20005C90. */
+
+    /* Set advertise register. */
+	if( ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO ) && ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO ) )
+	{
+		ulAdvertise = phyADVERTISE_CSMA | phyADVERTISE_ALL;
+		/* Reset auto-negotiation capability. */
+	}
+	else
+	{
+		ulAdvertise = phyADVERTISE_CSMA;
+
+		if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO )
+		{
+			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
+			{
+				ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_100FULL;
+			}
+			else
+			{
+				ulAdvertise |= phyADVERTISE_10HALF | phyADVERTISE_100HALF;
+			}
+		}
+		else if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO )
+		{
+			if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_10 )
+			{
+				ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_10HALF;
+			}
+			else
+			{
+				ulAdvertise |= phyADVERTISE_100FULL | phyADVERTISE_100HALF;
+			}
+		}
+		else if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_100 )
+		{
+			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
+			{
+				ulAdvertise |= phyADVERTISE_100FULL;
+			}
+			else
+			{
+				ulAdvertise |= phyADVERTISE_100HALF;
+			}
+		}
+		else
+		{
+			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
+			{
+				ulAdvertise |= phyADVERTISE_10FULL;
+			}
+			else
+			{
+				ulAdvertise |= phyADVERTISE_10HALF;
+			}
+		}
+	}
+
+	/* Send a reset commando to a set of PHY-ports. */
+	xPhyReset( pxPhyObject, xPhyGetMask( pxPhyObject ) );
+
+	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+	{
+	BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+	uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
+
+		/* Write advertise register. */
+		pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, ulAdvertise );
+
+		/*
+				AN_EN        AN1         AN0       Forced Mode
+				  0           0           0        10BASE-T, Half-Duplex
+				  0           0           1        10BASE-T, Full-Duplex
+				  0           1           0        100BASE-TX, Half-Duplex
+				  0           1           1        100BASE-TX, Full-Duplex
+				AN_EN        AN1         AN0       Advertised Mode
+				  1           0           0        10BASE-T, Half/Full-Duplex
+				  1           0           1        100BASE-TX, Half/Full-Duplex
+				  1           1           0        10BASE-T Half-Duplex
+												   100BASE-TX, Half-Duplex
+				  1           1           1        10BASE-T, Half/Full-Duplex
+												   100BASE-TX, Half/Full-Duplex
+		*/
+
+		/* Read Control register. */
+		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+
+		ulConfig &= ~( phyBMCR_SPEED_100 | phyBMCR_FULL_DUPLEX );
+
+		ulConfig |= phyBMCR_AN_ENABLE;
+
+		if( ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_100 ) || ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO ) )
+		{
+			ulConfig |= phyBMCR_SPEED_100;
+		}
+		else if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_10 )
+		{
+			ulConfig &= ~phyBMCR_SPEED_100;
+		}
+
+		if( ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL ) || ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO ) )
+		{
+			ulConfig |= phyBMCR_FULL_DUPLEX;
+		}
+		else if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_HALF )
+		{
+			ulConfig &= ~phyBMCR_FULL_DUPLEX;
+		}
+
+		if( xHas_19_PHYCR( ulPhyID ) )
+		{
+		uint32_t ulPhyControl;
+			/* Read PHY Control register. */
+			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_19_PHYCR, &ulPhyControl );
+
+			/* Clear bits which might get set: */
+			ulPhyControl &= ~( PHYCR_MDIX_EN|PHYCR_MDIX_FORCE );
+
+			if( pxPhyProperties->ucMDI_X == PHY_MDIX_AUTO )
+			{
+				ulPhyControl |= PHYCR_MDIX_EN;
+			}
+			else if( pxPhyProperties->ucMDI_X == PHY_MDIX_CROSSED )
+			{
+				/* Force direct link = Use crossed RJ45 cable. */
+				ulPhyControl &= ~PHYCR_MDIX_FORCE;
+			}
+			else
+			{
+				/* Force crossed link = Use direct RJ45 cable. */
+				ulPhyControl |= PHYCR_MDIX_FORCE;
+			}
+			/* update PHY Control Register. */
+			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_19_PHYCR, ulPhyControl );
+		}
+
+		FreeRTOS_printf( ( "+TCP: advertise: %04lX config %04lX\n", ulAdvertise, ulConfig ) );
+	}
+
+	/* Keep these values for later use. */
+	pxPhyObject->ulBCRValue = ulConfig & ~phyBMCR_ISOLATE;
+	pxPhyObject->ulACRValue = ulAdvertise;
+
+	return 0;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPhyFixedValue( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+{
+BaseType_t xPhyIndex;
+uint32_t ulValue, ulBitMask = ( uint32_t )1u;
+
+	ulValue = ( uint32_t )0u;
+
+	if( pxPhyObject->xPhyPreferences.ucDuplex == PHY_DUPLEX_FULL )
+	{
+		ulValue |= phyBMCR_FULL_DUPLEX;
+	}
+	if( pxPhyObject->xPhyPreferences.ucSpeed == PHY_SPEED_100 )
+	{
+		ulValue |= phyBMCR_SPEED_100;
+	}
+
+	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+	{
+		if( ( ulPhyMask & ulBitMask ) != 0lu )
+		{
+		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+			/* Enable Auto-Negotiation. */
+			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulValue );
+		}
+	}
+	return 0;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+{
+uint32_t xPhyIndex, ulDoneMask, ulBitMask;
+uint32_t ulPHYLinkStatus, ulRegValue;
+TickType_t xRemainingTime;
+TimeOut_t xTimer;
+
+	if( ulPhyMask == ( uint32_t )0u )
+	{
+		return 0;
+	}
+	for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++ )
+	{
+		if( ( ulPhyMask & ( 1lu << xPhyIndex ) ) != 0lu )
+		{
+		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+			/* Enable Auto-Negotiation. */
+			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, pxPhyObject->ulACRValue);
+			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue | phyBMCR_AN_RESTART );
+		}
+	}
+	xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( 3000UL );
+	vTaskSetTimeOutState( &xTimer );
+	ulDoneMask = 0;
+	/* Wait until the auto-negotiation will be completed */
+	for( ;; )
+	{
+		ulBitMask = ( uint32_t )1u;
+		for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+		{
+			if( ( ulPhyMask & ulBitMask ) != 0lu )
+			{
+				if( ( ulDoneMask & ulBitMask ) == 0lu )
+				{
+				BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+					pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue );
+					if( ( ulRegValue & phyBMSR_AN_COMPLETE ) != 0 )
+					{
+						ulDoneMask |= ulBitMask;
+					}
+				}
+			}
+		}
+		if( ulPhyMask == ulDoneMask )
+		{
+			break;
+		}
+		if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
+		{
+			FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
+			break;
+		}
+		vTaskDelay( pdMS_TO_TICKS( 50 ) );
+	}
+
+	if( ulDoneMask != ( uint32_t)0u )
+	{
+		ulBitMask = ( uint32_t )1u;
+		pxPhyObject->ulLinkStatusMask &= ~( ulDoneMask );
+		for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+		{
+		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+		uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
+
+			if( ( ulDoneMask & ulBitMask ) == ( uint32_t )0u )
+			{
+				continue;
+			}
+
+			/* Clear the 'phyBMCR_AN_RESTART'  bit. */
+			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue );
+
+			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue);
+			if( ( ulRegValue & phyBMSR_LINK_STATUS ) != 0 )
+			{
+				ulPHYLinkStatus |= phyBMSR_LINK_STATUS;
+				pxPhyObject->ulLinkStatusMask |= ulBitMask;
+			}
+			else
+			{
+				ulPHYLinkStatus &= ~( phyBMSR_LINK_STATUS );
+			}
+
+			if( ulPhyID == PHY_ID_KSZ8081MNXIA )
+			{
+			uint32_t ulControlStatus;
+
+				pxPhyObject->fnPhyRead( xPhyAddress, 0x1E, &ulControlStatus);
+				switch( ulControlStatus & 0x07 )
+				{
+				case 0x01:
+				case 0x05:
+//	[001] = 10BASE-T half-duplex
+//	[101] = 10BASE-T full-duplex
+					/* 10 Mbps. */
+					ulRegValue |= phyPHYSTS_SPEED_STATUS;
+					break;
+				case 0x02:
+				case 0x06:
+//	[010] = 100BASE-TX half-duplex
+//	[110] = 100BASE-TX full-duplex
+					break;
+				}
+				switch( ulControlStatus & 0x07 )
+				{
+				case 0x05:
+				case 0x06:
+//	[101] = 10BASE-T full-duplex
+//	[110] = 100BASE-TX full-duplex
+					/* Full duplex. */
+					ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
+					break;
+				case 0x01:
+				case 0x02:
+//	[001] = 10BASE-T half-duplex
+//	[010] = 100BASE-TX half-duplex
+					break;
+				}
+			}
+			else if( xHas_1F_PHYSPCS( ulPhyID ) )
+			{
+			/* 31 RW PHY Special Control Status */
+			uint32_t ulControlStatus;
+
+				pxPhyObject->fnPhyRead( xPhyAddress, phyREG_1F_PHYSPCS, &ulControlStatus);
+				ulRegValue = 0;
+				if( ( ulControlStatus & phyPHYSPCS_FULL_DUPLEX ) != 0 )
+				{
+					ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
+				}
+				if( ( ulControlStatus & phyPHYSPCS_SPEED_MASK ) == phyPHYSPCS_SPEED_10 )
+				{
+					ulRegValue |= phyPHYSTS_SPEED_STATUS;
+				}
+			}
+			else
+			{
+				/* Read the result of the auto-negotiation. */
+				pxPhyObject->fnPhyRead( xPhyAddress, PHYREG_10_PHYSTS, &ulRegValue);
+			}
+
+			FreeRTOS_printf( ( ">> Autonego ready: %08lx: %s duplex %u mbit %s status\n",
+				ulRegValue,
+				( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) ? "full" : "half",
+				( ulRegValue & phyPHYSTS_SPEED_STATUS ) ? 10 : 100,
+				( ( ulPHYLinkStatus |= phyBMSR_LINK_STATUS ) != 0) ? "high" : "low" ) );
+			if( ( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) != ( uint32_t )0u )
+			{
+				pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_FULL;
+			}
+			else
+			{
+				pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_HALF;
+			}
+
+			if( ( ulRegValue & phyPHYSTS_SPEED_STATUS ) != 0 )
+			{
+				pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_10;
+			}
+			else
+			{
+				pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_100;
+			}
+		}
+	}	/* if( ulDoneMask != ( uint32_t)0u ) */
+
+	return 0;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadReception )
+{
+uint32_t ulStatus, ulBitMask = 1u;
+BaseType_t xPhyIndex;
+BaseType_t xNeedCheck = pdFALSE;
+
+	if( xHadReception > 0 )
+	{
+		/* A packet was received. No need to check for the PHY status now,
+		but set a timer to check it later on. */
+		vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
+		pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
+		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+		{
+			if( ( pxPhyObject->ulLinkStatusMask & ulBitMask ) == 0ul )
+			{
+				pxPhyObject->ulLinkStatusMask |= ulBitMask;
+				FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
+				xNeedCheck = pdTRUE;
+			}
+		}
+	}
+	else if( xTaskCheckForTimeOut( &( pxPhyObject->xLinkStatusTimer ), &( pxPhyObject->xLinkStatusRemaining ) ) != pdFALSE )
+	{
+		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+		{
+		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+			if( pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulStatus ) == 0 )
+			{
+				if( !!( pxPhyObject->ulLinkStatusMask & ulBitMask ) != !!( ulStatus & phyBMSR_LINK_STATUS ) )
+				{
+					if( ( ulStatus & phyBMSR_LINK_STATUS ) != 0 )
+					{
+						pxPhyObject->ulLinkStatusMask |= ulBitMask;
+					}
+					else
+					{
+						pxPhyObject->ulLinkStatusMask &= ~( ulBitMask );
+					}
+					FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
+					xNeedCheck = pdTRUE;
+				}
+			}
+		}
+		vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
+		if( ( pxPhyObject->ulLinkStatusMask & phyBMSR_LINK_STATUS ) != 0 )
+		{
+			pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
+		}
+		else
+		{
+			pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_LOW_CHECK_TIME_MS );
+		}
+	}
+	return xNeedCheck;
+}
+/*-----------------------------------------------------------*/

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -85,7 +85,7 @@ expansion. */
 	#warning Consider enabling checksum offloading
 #endif
 
-#ifned niDESCRIPTOR_WAIT_TIME_MS
+#ifndef niDESCRIPTOR_WAIT_TIME_MS
 	#define niDESCRIPTOR_WAIT_TIME_MS		250uL
 #endif
 
@@ -472,6 +472,7 @@ BaseType_t xResult;
 			{
 				xMacInitStatus = eMACFailed;
 			}
+		}
 	} /* if( xEMACTaskHandle == NULL ) */
 
 	if( xMacInitStatus != eMACPass )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -44,26 +44,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_DNS.h"
+#include "FreeRTOS_ARP.h"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
+#include "phyHandling.h"
 
 /* ST includes. */
-#include "stm32f4xx_hal.h"
-
-#ifndef	BMSR_LINK_STATUS
-	#define BMSR_LINK_STATUS            0x0004UL
+#if defined( STM32F7xx )
+	#include "stm32f7xx_hal.h"
+#elif defined( STM32F4xx )
+	#include "stm32f4xx_hal.h"
+#elif defined( STM32F2xx )
+	#include "stm32f2xx_hal.h"
+#elif !defined( _lint )	/* Lint does not like an #error */
+	#error What part?
 #endif
 
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
-#endif
-
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
-#endif
+#include "stm32fxx_hal_eth.h"
 
 /* Interrupt events to process.  Currently only the Rx event is processed
 although code for other events is included to allow for possible future
@@ -78,77 +75,15 @@ expansion. */
 	  ETH_DMA_IT_FBE | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R | \
 	  ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
 
-/* Naming and numbering of PHY registers. */
-#define PHY_REG_00_BMCR			0x00	/* Basic Mode Control Register */
-#define PHY_REG_01_BMSR			0x01	/* Basic Mode Status Register */
-#define PHY_REG_02_PHYSID1		0x02	/* PHYS ID 1 */
-#define PHY_REG_03_PHYSID2		0x03	/* PHYS ID 2 */
-#define PHY_REG_04_ADVERTISE	0x04	/* Advertisement control reg */
-
-#define PHY_ID_LAN8720		0x0007c0f0
-#define PHY_ID_DP83848I		0x20005C90
-
-#ifndef USE_STM324xG_EVAL
-	#define USE_STM324xG_EVAL	1
+#ifndef niEMAC_HANDLER_TASK_PRIORITY
+	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
 #endif
-
-#if( USE_STM324xG_EVAL == 0 )
-	#define EXPECTED_PHY_ID			PHY_ID_LAN8720
-	#define	PHY_REG_1F_PHYSPCS		0x1F	/* 31 RW PHY Special Control Status */
-	/* Use 3 bits in register 31 */
-	#define PHYSPCS_SPEED_MASK		0x0C
-	#define PHYSPCS_SPEED_10		0x04
-	#define PHYSPCS_SPEED_100		0x08
-	#define PHYSPCS_FULL_DUPLEX		0x10
-#else
-	#define EXPECTED_PHY_ID		PHY_ID_DP83848I
-
-	#define PHY_REG_10_PHY_SR		0x10	/* PHY status register Offset */
-	#define	PHY_REG_19_PHYCR		0x19	/* 25 RW PHY Control Register */
-#endif
-
-/* Some defines used internally here to indicate preferences about speed, MDIX
-(wired direct or crossed), and duplex (half or full). */
-#define	PHY_SPEED_10       1
-#define	PHY_SPEED_100      2
-#define	PHY_SPEED_AUTO     (PHY_SPEED_10|PHY_SPEED_100)
-
-#define	PHY_MDIX_DIRECT    1
-#define	PHY_MDIX_CROSSED   2
-#define	PHY_MDIX_AUTO      (PHY_MDIX_CROSSED|PHY_MDIX_DIRECT)
-
-#define	PHY_DUPLEX_HALF    1
-#define	PHY_DUPLEX_FULL    2
-#define	PHY_DUPLEX_AUTO    (PHY_DUPLEX_FULL|PHY_DUPLEX_HALF)
-
-#define PHY_AUTONEGO_COMPLETE    ((uint16_t)0x0020)  /*!< Auto-Negotiation process completed   */
-
-/*
- * Description of all capabilities that can be advertised to
- * the peer (usually a switch or router).
- */
-#define ADVERTISE_CSMA			0x0001		/* Only selector supported. */
-#define ADVERTISE_10HALF		0x0020		/* Try for 10mbps half-duplex. */
-#define ADVERTISE_10FULL		0x0040		/* Try for 10mbps full-duplex. */
-#define ADVERTISE_100HALF		0x0080		/* Try for 100mbps half-duplex. */
-#define ADVERTISE_100FULL		0x0100		/* Try for 100mbps full-duplex. */
-
-#define ADVERTISE_ALL			( ADVERTISE_10HALF | ADVERTISE_10FULL | \
-								  ADVERTISE_100HALF | ADVERTISE_100FULL)
-
-/*
- * Value for the 'PHY_REG_00_BMCR', the PHY's Basic Mode Control Register
- */
-#define BMCR_FULLDPLX			0x0100		/* Full duplex. */
-#define BMCR_ANRESTART			0x0200		/* Auto negotiation restart. */
-#define BMCR_ANENABLE			0x1000		/* Enable auto negotiation. */
-#define BMCR_SPEED100			0x2000		/* Select 100Mbps. */
-#define BMCR_RESET				0x8000		/* Reset the PHY. */
-
-#define PHYCR_MDIX_EN			0x8000		/* Enable Auto MDIX. */
-#define PHYCR_MDIX_FORCE		0x4000		/* Force MDIX crossed. */
 
 #define ipFRAGMENT_OFFSET_BIT_MASK		( ( uint16_t ) 0x0fff ) /* The bits in the two byte IP header field that make up the fragment offset value. */
+
+#if( ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
+	#warning Consider enabling checksum offloading
+#endif
 
 /*
  * Most users will want a PHY that negotiates about
@@ -191,6 +126,22 @@ FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 	#define configEMAC_TASK_STACK_SIZE ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
+/* Two choices must be made: RMII versus MII,
+and the index of the PHY in use ( between 0 and 31 ). */
+#ifndef ipconfigUSE_RMII
+	#ifdef STM32F7xx
+		#define ipconfigUSE_RMII	1
+	#else
+		#define ipconfigUSE_RMII	0
+	#endif /* STM32F7xx */
+#endif /* ipconfigUSE_RMII */
+
+#if( ipconfigUSE_RMII != 0 )
+	#warning Using RMII, make sure if this is correct
+#else
+	#warning Using MII, make sure if this is correct
+#endif
+
 /*-----------------------------------------------------------*/
 
 /*
@@ -231,43 +182,30 @@ static void prvDMATxDescListInit( void );
  */
 static void prvDMARxDescListInit( void );
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	/* After packets have been sent, the network
-	buffers will be released. */
-	static void vClearTXBuffers( void );
-#endif /* ipconfigZERO_COPY_TX_DRIVER */
+/* After packets have been sent, the network
+buffers will be released. */
+static void vClearTXBuffers( void );
 
 /*-----------------------------------------------------------*/
-
-typedef struct _PhyProperties_t
-{
-	uint8_t speed;
-	uint8_t mdix;
-	uint8_t duplex;
-	uint8_t spare;
-} PhyProperties_t;
 
 /* Bit map of outstanding ETH interrupt events for processing.  Currently only
 the Rx interrupt is handled, although code is included for other events to
 enable future expansion. */
 static volatile uint32_t ulISREvents;
 
-/* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
-static uint32_t ulPHYLinkStatus = 0;
-
 #if( ipconfigUSE_LLMNR == 1 )
 	static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
+static EthernetPhy_t xPhyObject;
+
 /* Ethernet handle. */
 static ETH_HandleTypeDef xETH;
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	/* xTXDescriptorSemaphore is a counting semaphore with
-	a maximum count of ETH_TXBUFNB, which is the number of
-	DMA TX descriptors. */
-	static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
-#endif /* ipconfigZERO_COPY_TX_DRIVER */
+/* xTXDescriptorSemaphore is a counting semaphore with
+a maximum count of ETH_TXBUFNB, which is the number of
+DMA TX descriptors. */
+static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 /*
  * Note: it is adviced to define both
@@ -282,30 +220,34 @@ static ETH_HandleTypeDef xETH;
  * TX buffers are allocated in a zero-copy driver.
  */
 /* MAC buffers: ---------------------------------------------------------*/
-__ALIGN_BEGIN ETH_DMADescTypeDef  DMARxDscrTab[ ETH_RXBUFNB ] __ALIGN_END;/* Ethernet Rx MA Descriptor */
+
+/* Put the DMA descriptors in '.first_data'.
+This is important for STM32F7, which has an L1 data cache.
+The first 64KB of the SRAM is not cached. */
+
+/* Ethernet Rx MA Descriptor */
+__attribute__ ((aligned (32)))
+__attribute__ ((section(".first_data")))
+	ETH_DMADescTypeDef  DMARxDscrTab[ ETH_RXBUFNB ];
+
 #if( ipconfigZERO_COPY_RX_DRIVER == 0 )
-	__ALIGN_BEGIN uint8_t Rx_Buff[ ETH_RXBUFNB ][ ETH_RX_BUF_SIZE ] __ALIGN_END; /* Ethernet Receive Buffer */
+	/* Ethernet Receive Buffer */
+	__ALIGN_BEGIN uint8_t Rx_Buff[ ETH_RXBUFNB ][ ETH_RX_BUF_SIZE ] __ALIGN_END;
 #endif
 
-__ALIGN_BEGIN ETH_DMADescTypeDef  DMATxDscrTab[ ETH_TXBUFNB ] __ALIGN_END;/* Ethernet Tx DMA Descriptor */
+/* Ethernet Tx DMA Descriptor */
+__attribute__ ((aligned (32)))
+__attribute__ ((section(".first_data")))
+	ETH_DMADescTypeDef  DMATxDscrTab[ ETH_TXBUFNB ];
+
 #if( ipconfigZERO_COPY_TX_DRIVER == 0 )
-	__ALIGN_BEGIN uint8_t Tx_Buff[ ETH_TXBUFNB ][ ETH_TX_BUF_SIZE ] __ALIGN_END; /* Ethernet Transmit Buffer */
+	/* Ethernet Transmit Buffer */
+	__ALIGN_BEGIN uint8_t Tx_Buff[ ETH_TXBUFNB ][ ETH_TX_BUF_SIZE ] __ALIGN_END;
 #endif
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	/* DMATxDescToClear points to the next TX DMA descriptor
-	that must be cleared by vClearTXBuffers(). */
-	static __IO ETH_DMADescTypeDef  *DMATxDescToClear;
-#endif
-
-/* Value to be written into the 'Basic mode Control Register'. */
-static uint32_t ulBCRvalue;
-
-/* Value to be written into the 'Advertisement Control Register'. */
-static uint32_t ulACRValue;
-
-/* ucMACAddress as it appears in main.c */
-extern const uint8_t ucMACAddress[ 6 ];
+/* DMATxDescToClear points to the next TX DMA descriptor
+that must be cleared by vClearTXBuffers(). */
+static __IO ETH_DMADescTypeDef  *DMATxDescToClear;
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
 handle is used so direct notifications can be sent to the task for all EMAC/DMA
@@ -316,28 +258,28 @@ static TaskHandle_t xEMACTaskHandle = NULL;
 const PhyProperties_t xPHYProperties =
 {
 	#if( ipconfigETHERNET_AN_ENABLE != 0 )
-		.speed = PHY_SPEED_AUTO,
-		.duplex = PHY_DUPLEX_AUTO,
+		.ucSpeed = PHY_SPEED_AUTO,
+		.ucDuplex = PHY_DUPLEX_AUTO,
 	#else
 		#if( ipconfigETHERNET_USE_100MB != 0 )
-			.speed = PHY_SPEED_100,
+			.ucSpeed = PHY_SPEED_100,
 		#else
-			.speed = PHY_SPEED_10,
+			.ucSpeed = PHY_SPEED_10,
 		#endif
 
 		#if( ipconfigETHERNET_USE_FULL_DUPLEX != 0 )
-			.duplex = PHY_DUPLEX_FULL,
+			.ucDuplex = PHY_DUPLEX_FULL,
 		#else
-			.duplex = PHY_DUPLEX_HALF,
+			.ucDuplex = PHY_DUPLEX_HALF,
 		#endif
 	#endif
 
 	#if( ipconfigETHERNET_AN_ENABLE != 0 ) && ( ipconfigETHERNET_AUTO_CROSS_ENABLE != 0 )
-		.mdix = PHY_MDIX_AUTO,
+		.ucMDI_X = PHY_MDIX_AUTO,
 	#elif( ipconfigETHERNET_CROSSED_LINK != 0 )
-		.mdix = PHY_MDIX_CROSSED,
+		.ucMDI_X = PHY_MDIX_CROSSED,
 	#else
-		.mdix = PHY_MDIX_DIRECT,
+		.ucMDI_X = PHY_MDIX_DIRECT,
 	#endif
 };
 
@@ -346,6 +288,8 @@ const PhyProperties_t xPHYProperties =
 void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef *heth )
 {
 BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+	( void ) heth;
 
 	/* Ethernet RX-Complete callback function, elsewhere declared as weak. */
     ulISREvents |= EMAC_IF_RX_EVENT;
@@ -358,46 +302,46 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef *heth )
+void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef *heth )
+{
+BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+	( void ) heth;
+
+	/* This call-back is only useful in case packets are being sent
+	zero-copy.  Once they're sent, the buffers will be released
+	by the function vClearTXBuffers(). */
+	ulISREvents |= EMAC_IF_TX_EVENT;
+	/* Wakeup the prvEMACHandlerTask. */
+	if( xEMACTaskHandle != NULL )
 	{
-	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-		/* This call-back is only useful in case packets are being sent
-		zero-copy.  Once they're sent, the buffers will be released
-		by the function vClearTXBuffers(). */
-		ulISREvents |= EMAC_IF_TX_EVENT;
-		/* Wakeup the prvEMACHandlerTask. */
-		if( xEMACTaskHandle != NULL )
-		{
-			vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-			portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-		}
-
+		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+		portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 	}
-#endif /* ipconfigZERO_COPY_TX_DRIVER */
-
+}
 /*-----------------------------------------------------------*/
 
+static void vClearTXBuffers()
+{
+__IO ETH_DMADescTypeDef  *txLastDescriptor = xETH.TxDesc;
+size_t uxCount = ( ( UBaseType_t ) ETH_TXBUFNB ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
 #if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	static void vClearTXBuffers()
-	{
-	__IO ETH_DMADescTypeDef  *txLastDescriptor = xETH.TxDesc;
 	NetworkBufferDescriptor_t *pxNetworkBuffer;
 	uint8_t *ucPayLoad;
-	size_t uxCount = ( ( UBaseType_t ) ETH_TXBUFNB ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
+#endif
 
-		/* This function is called after a TX-completion interrupt.
-		It will release each Network Buffer used in xNetworkInterfaceOutput().
-		'uxCount' represents the number of descriptors given to DMA for transmission.
-		After sending a packet, the DMA will clear the 'ETH_DMATXDESC_OWN' bit. */
-		while( ( uxCount > 0 ) && ( ( DMATxDescToClear->Status & ETH_DMATXDESC_OWN ) == 0 ) )
+	/* This function is called after a TX-completion interrupt.
+	It will release each Network Buffer used in xNetworkInterfaceOutput().
+	'uxCount' represents the number of descriptors given to DMA for transmission.
+	After sending a packet, the DMA will clear the 'ETH_DMATXDESC_OWN' bit. */
+	while( ( uxCount > 0 ) && ( ( DMATxDescToClear->Status & ETH_DMATXDESC_OWN ) == 0 ) )
+	{
+		if( ( DMATxDescToClear == txLastDescriptor ) && ( uxCount != ETH_TXBUFNB ) )
 		{
-			if( ( DMATxDescToClear == txLastDescriptor ) && ( uxCount != ETH_TXBUFNB ) )
-			{
-				break;
-			}
-
+			break;
+		}
+		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
+		{
 			ucPayLoad = ( uint8_t * )DMATxDescToClear->Buffer1Addr;
 
 			if( ucPayLoad != NULL )
@@ -409,15 +353,16 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 				}
 				DMATxDescToClear->Buffer1Addr = ( uint32_t )0u;
 			}
-
-			DMATxDescToClear = ( ETH_DMADescTypeDef * )( DMATxDescToClear->Buffer2NextDescAddr );
-
-			uxCount--;
-			/* Tell the counting semaphore that one more TX descriptor is available. */
-			xSemaphoreGive( xTXDescriptorSemaphore );
 		}
+		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+
+		DMATxDescToClear = ( ETH_DMADescTypeDef * )( DMATxDescToClear->Buffer2NextDescAddr );
+
+		uxCount--;
+		/* Tell the counting semaphore that one more TX descriptor is available. */
+		xSemaphoreGive( xTXDescriptorSemaphore );
 	}
-#endif /* ipconfigZERO_COPY_TX_DRIVER */
+}
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
@@ -427,15 +372,11 @@ BaseType_t xResult;
 
 	if( xEMACTaskHandle == NULL )
 	{
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
+		if( xTXDescriptorSemaphore == NULL )
 		{
-			if( xTXDescriptorSemaphore == NULL )
-			{
-				xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TXBUFNB, ( UBaseType_t ) ETH_TXBUFNB );
-				configASSERT( xTXDescriptorSemaphore );
-			}
+			xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TXBUFNB, ( UBaseType_t ) ETH_TXBUFNB );
+			configASSERT( xTXDescriptorSemaphore );
 		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
 
 		/* Initialise ETH */
 
@@ -443,17 +384,35 @@ BaseType_t xResult;
 		xETH.Init.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE;
 		xETH.Init.Speed = ETH_SPEED_100M;
 		xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
-		xETH.Init.PhyAddress = 1;
+		/* Value of PhyAddress doesn't matter, will be probed for. */
+		xETH.Init.PhyAddress = 0;
 
-		xETH.Init.MACAddr = ( uint8_t *) ucMACAddress;
+		xETH.Init.MACAddr = ( uint8_t * ) FreeRTOS_GetMACAddress();
 		xETH.Init.RxMode = ETH_RXINTERRUPT_MODE;
 
-		/* using the ETH_CHECKSUM_BY_HARDWARE option:
-		both the IP and the protocol checksums will be calculated
-		by the peripheral. */
-		xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE;
+		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+		{
+			/* using the ETH_CHECKSUM_BY_HARDWARE option:
+			both the IP and the protocol checksums will be calculated
+			by the peripheral. */
+			xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE;
+		}
+		#else
+		{
+			xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE;
+		}
+		#endif
 
-		xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_MII;
+		#if( ipconfigUSE_RMII != 0 )
+		{
+			xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_RMII;
+		}
+		#else
+		{
+			xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_MII;
+		}
+		#endif /* ipconfigUSE_RMII */
+
 		hal_eth_init_status = HAL_ETH_Init( &xETH );
 
 		/* Only for inspection by debugger. */
@@ -467,12 +426,8 @@ BaseType_t xResult;
 		memset( &DMATxDscrTab, '\0', sizeof( DMATxDscrTab ) );
 		memset( &DMARxDscrTab, '\0', sizeof( DMARxDscrTab ) );
 
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			/* Initialize Tx Descriptors list: Chain Mode */
-			DMATxDescToClear = DMATxDscrTab;
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+		/* Initialize Tx Descriptors list: Chain Mode */
+		DMATxDescToClear = DMATxDscrTab;
 
 		/* Initialise TX-descriptors. */
 		prvDMATxDescListInit();
@@ -494,10 +449,10 @@ BaseType_t xResult;
 		possible priority to ensure the interrupt handler can return directly
 		to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
 		notify the task when there is something to process. */
-		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
 	} /* if( xEMACTaskHandle == NULL ) */
 
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+	if( xPhyObject.ulLinkStatusMask != 0 )
 	{
 		xETH.Instance->DMAIER |= ETH_DMA_ALL_INTS;
 		xResult = pdPASS;
@@ -506,9 +461,8 @@ BaseType_t xResult;
 	else
 	{
 		/* For now pdFAIL will be returned. But prvEMACHandlerTask() is running
-		and it will keep on checking the PHY and set ulPHYLinkStatus when necessary. */
+		and it will keep on checking the PHY and set 'ulLinkStatusMask' when necessary. */
 		xResult = pdFAIL;
-		FreeRTOS_printf( ( "Link Status still low\n" ) ) ;
 	}
 	/* When returning non-zero, the stack will become active and
     start DHCP (in configured) */
@@ -541,6 +495,10 @@ BaseType_t xIndex;
 		{
 			/* Set the DMA Tx descriptors checksum insertion for TCP, UDP, and ICMP */
 			pxDMADescriptor->Status |= ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL;
+		}
+		else
+		{
+			pxDMADescriptor->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL );
 		}
 
 		/* Initialize the next descriptor with the Next Descriptor Polling Enable */
@@ -625,6 +583,8 @@ static void prvMACAddressConfig(ETH_HandleTypeDef *heth, uint32_t ulIndex, uint8
 {
 uint32_t ulTempReg;
 
+	( void ) heth;
+
 	/* Calculate the selected MAC address high register. */
 	ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
 
@@ -647,46 +607,46 @@ __IO ETH_DMADescTypeDef *pxDmaTxDesc;
 /* Do not wait too long for a free TX DMA buffer. */
 const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
 
-	#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-	{
-	ProtocolPacket_t *pxPacket;
-
-		/* If the peripheral must calculate the checksum, it wants
-		the protocol checksum to have a value of zero. */
-		pxPacket = ( ProtocolPacket_t * ) ( pxDescriptor->pucEthernetBuffer );
-
-		if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP )
-		{
-			pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t )0u;
-		}
-	}
-	#endif
-
 	/* Open a do {} while ( 0 ) loop to be able to call break. */
 	do
 	{
-		if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+		if( xCheckLoopback( pxDescriptor, bReleaseAfterSend ) != 0 )
 		{
-			#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
+			/* The packet has been sent back to the IP-task.
+			The IP-task will further handle it.
+			Do not release the descriptor. */
+			bReleaseAfterSend = pdFALSE;
+			break;
+		}
+		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+		{
+		ProtocolPacket_t *pxPacket;
+
+			/* If the peripheral must calculate the checksum, it wants
+			the protocol checksum to have a value of zero. */
+			pxPacket = ( ProtocolPacket_t * ) ( pxDescriptor->pucEthernetBuffer );
+
+			if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
 			{
-				if( xTXDescriptorSemaphore == NULL )
-				{
-					break;
-				}
-				if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
-				{
-					/* Time-out waiting for a free TX descriptor. */
-					break;
-				}
+				pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t )0u;
 			}
-			#endif /* ipconfigZERO_COPY_TX_DRIVER */
+		}
+		#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+		if( xPhyObject.ulLinkStatusMask != 0 )
+		{
+			if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+			{
+				/* Time-out waiting for a free TX descriptor. */
+				break;
+			}
 
 			/* This function does the actual transmission of the packet. The packet is
 			contained in 'pxDescriptor' that is passed to the function. */
 			pxDmaTxDesc = xETH.TxDesc;
 
 			/* Is this buffer available? */
-			if( ( pxDmaTxDesc->Status & ETH_DMATXDESC_OWN ) == 0 )
+			configASSERT ( ( pxDmaTxDesc->Status & ETH_DMATXDESC_OWN ) == 0 );
+
 			{
 				/* Is this buffer available? */
 				/* Get bytes in current buffer. */
@@ -701,19 +661,31 @@ const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
 				{
 					/* Copy the bytes. */
 					memcpy( ( void * ) pxDmaTxDesc->Buffer1Addr, pxDescriptor->pucEthernetBuffer, ulTransmitSize );
-					pxDmaTxDesc->Status |= ETH_DMATXDESC_CIC_TCPUDPICMP_FULL;
 				}
 				#else
 				{
+					configASSERT( bReleaseAfterSend != 0 );
+
 					/* Move the buffer. */
 					pxDmaTxDesc->Buffer1Addr = ( uint32_t )pxDescriptor->pucEthernetBuffer;
-					/* Ask to set the IPv4 checksum.
-					Also need an Interrupt on Completion so that 'vClearTXBuffers()' will be called.. */
-					pxDmaTxDesc->Status |= ETH_DMATXDESC_CIC_TCPUDPICMP_FULL | ETH_DMATXDESC_IC;
 					/* The Network Buffer has been passed to DMA, no need to release it. */
 					bReleaseAfterSend = pdFALSE_UNSIGNED;
 				}
 				#endif /* ipconfigZERO_COPY_TX_DRIVER */
+
+				/* Ask to set the IPv4 checksum.
+				Also need an Interrupt on Completion so that 'vClearTXBuffers()' will be called.. */
+				#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+				{
+					pxDmaTxDesc->Status |= ETH_DMATXDESC_CIC_TCPUDPICMP_FULL | ETH_DMATXDESC_IC;
+				}
+				#else
+				{
+					pxDmaTxDesc->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CIC );
+					pxDmaTxDesc->Status |= ETH_DMATXDESC_IC;
+				}
+				#endif
+				
 
 				/* Prepare transmit descriptors to give to DMA. */
 
@@ -721,12 +693,22 @@ const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
 				pxDmaTxDesc->Status |= ETH_DMATXDESC_FS | ETH_DMATXDESC_LS;
 				/* Set frame size */
 				pxDmaTxDesc->ControlBufferSize = ( ulTransmitSize & ETH_DMATXDESC_TBS1 );
+
+				#if( NETWORK_BUFFERS_CACHED	!= 0 )
+				{
+				BaseType_t xlength = CACHE_LINE_SIZE * ( ( ulTransmitSize + NETWORK_BUFFER_HEADER_SIZE + CACHE_LINE_SIZE - 1 ) / CACHE_LINE_SIZE );
+				uint32_t *pulBuffer = ( uint32_t )( pxDescriptor->pucEthernetBuffer - NETWORK_BUFFER_HEADER_SIZE );
+					cache_clean_invalidate_by_addr( pulBuffer, xlength );
+				}
+				#endif
+
 				/* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
 				pxDmaTxDesc->Status |= ETH_DMATXDESC_OWN;
 
 				/* Point to next descriptor */
 				xETH.TxDesc = ( ETH_DMADescTypeDef * ) ( xETH.TxDesc->Buffer2NextDescAddr );
-	
+				/* Ensure completion of memory access */
+				__DSB();
 				/* Resume DMA transmission*/
 				xETH.Instance->DMATPDR = 0;
 				iptraceNETWORK_INTERFACE_TRANSMIT();
@@ -801,20 +783,24 @@ const ProtocolPacket_t *pxProtPacket = ( const ProtocolPacket_t * )pcBuffer;
 
 		if( pxIPHeader->ucProtocol == ipPROTOCOL_UDP )
 		{
-			uint16_t port = pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort;
+		uint16_t usSourcePort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usSourcePort );
+		uint16_t usDestinationPort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort );
 
-			if( ( xPortHasUDPSocket( port ) == pdFALSE )
+			if( ( xPortHasUDPSocket( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort ) == pdFALSE )
 			#if ipconfigUSE_LLMNR == 1
-				&& ( port != FreeRTOS_ntohs( ipLLMNR_PORT ) )
+				&& ( usDestinationPort != ipLLMNR_PORT )
+				&& ( usSourcePort != ipLLMNR_PORT )
 			#endif
 			#if ipconfigUSE_NBNS == 1
-				&& ( port != FreeRTOS_ntohs( ipNBNS_PORT ) )
+				&& ( usDestinationPort != ipNBNS_PORT )
+				&& ( usSourcePort != ipNBNS_PORT )
 			#endif
 			#if ipconfigUSE_DNS == 1
-				&& ( pxProtPacket->xUDPPacket.xUDPHeader.usSourcePort != FreeRTOS_ntohs( ipDNS_PORT ) )
+				&& ( usSourcePort != ipDNS_PORT )
 			#endif
 				) {
 				/* Drop this packet, not for this device. */
+				/* FreeRTOS_printf( ( "Drop: UDP port %d -> %d\n", usSourcePort, usDestinationPort ) ); */
 				return pdFALSE;
 			}
 		}
@@ -824,20 +810,59 @@ const ProtocolPacket_t *pxProtPacket = ( const ProtocolPacket_t * )pcBuffer;
 }
 /*-----------------------------------------------------------*/
 
+static void prvPassEthMessages( NetworkBufferDescriptor_t *pxDescriptor )
+{
+IPStackEvent_t xRxEvent;
+
+	xRxEvent.eEventType = eNetworkRxEvent;
+	xRxEvent.pvData = ( void * ) pxDescriptor;
+
+	if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
+	{
+		/* The buffer could not be sent to the stack so	must be released again.
+		This is a deferred handler taskr, not a real interrupt, so it is ok to
+		use the task level function here. */
+		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+		{
+			do
+			{
+				NetworkBufferDescriptor_t *pxNext = pxDescriptor->pxNextBuffer;
+				vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+				pxDescriptor = pxNext;
+			} while( pxDescriptor != NULL );
+		}
+		#else
+		{
+			vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+		}
+		#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+		iptraceETHERNET_RX_EVENT_LOST();
+		FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
+	}
+	else
+	{
+		iptraceNETWORK_INTERFACE_RECEIVE();
+	}
+}
+
 static BaseType_t prvNetworkInterfaceInput( void )
 {
 NetworkBufferDescriptor_t *pxCurDescriptor;
 NetworkBufferDescriptor_t *pxNewDescriptor = NULL;
-BaseType_t xReceivedLength, xAccepted;
+#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+	NetworkBufferDescriptor_t *pxFirstDescriptor = NULL;
+	NetworkBufferDescriptor_t *pxLastDescriptor = NULL;
+#endif
+BaseType_t xReceivedLength = 0;
 __IO ETH_DMADescTypeDef *pxDMARxDescriptor;
-xIPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 uint8_t *pucBuffer;
 
 	pxDMARxDescriptor = xETH.RxDesc;
 
-	if( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_OWN) == 0 )
+	while( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_OWN ) == 0u )
 	{
+	BaseType_t xAccepted = pdTRUE;
 		/* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
 		xReceivedLength = ( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_FL ) >> ETH_DMARXDESC_FRAMELENGTHSHIFT ) - 4;
 
@@ -847,18 +872,13 @@ uint8_t *pucBuffer;
 		/* Chained Mode */    
 		/* Selects the next DMA Rx descriptor list for next buffer to read */ 
 		xETH.RxDesc = ( ETH_DMADescTypeDef* )pxDMARxDescriptor->Buffer2NextDescAddr;
-	}
-	else
-	{
-		xReceivedLength = 0;
-	}
 
-	/* Obtain the size of the packet and put it into the "usReceivedLength" variable. */
-	/* In order to make the code easier and faster, only packets in a single buffer
-	will be accepted.  This can be done by making the buffers large enough to
-	hold a complete Ethernet packet (1536 bytes). */
-	if( xReceivedLength > 0ul && xReceivedLength < ETH_RX_BUF_SIZE ) 
-	{
+		/* In order to make the code easier and faster, only packets in a single buffer
+		will be accepted.  This can be done by making the buffers large enough to
+		hold a complete Ethernet packet (1536 bytes).
+		Therefore, two sanity checks: */
+		configASSERT( xReceivedLength <= ETH_RX_BUF_SIZE );
+
 		if( ( pxDMARxDescriptor->Status & ( ETH_DMARXDESC_CE | ETH_DMARXDESC_IPV4HCE | ETH_DMARXDESC_FT ) ) != ETH_DMARXDESC_FT )
 		{
 			/* Not an Ethernet frame-type or a checmsum error. */
@@ -904,20 +924,28 @@ uint8_t *pucBuffer;
 		if( xAccepted != pdFALSE )
 		{
 			pxCurDescriptor->xDataLength = xReceivedLength;
-			xRxEvent.pvData = ( void * ) pxCurDescriptor;
+			#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+			{
+				pxCurDescriptor->pxNextBuffer = NULL;
 
-			/* Pass the data to the TCP/IP task for processing. */
-			if( xSendEventStructToIPTask( &xRxEvent, xDescriptorWaitTime ) == pdFALSE )
-			{
-				/* Could not send the descriptor into the TCP/IP stack, it
-				must be released. */
-				vReleaseNetworkBufferAndDescriptor( pxCurDescriptor );
-				iptraceETHERNET_RX_EVENT_LOST();
+				if( pxFirstDescriptor == NULL )
+				{
+					// Becomes the first message
+					pxFirstDescriptor = pxCurDescriptor;
+				}
+				else if( pxLastDescriptor != NULL )
+				{
+					// Add to the tail
+					pxLastDescriptor->pxNextBuffer = pxCurDescriptor;
+				}
+
+				pxLastDescriptor = pxCurDescriptor;
 			}
-			else
+			#else
 			{
-				iptraceNETWORK_INTERFACE_RECEIVE();
+				prvPassEthMessages( pxCurDescriptor );
 			}
+			#endif
 		}
 
 		/* Release descriptors to DMA */
@@ -940,6 +968,8 @@ uint8_t *pucBuffer;
 		pxDMARxDescriptor->ControlBufferSize = ETH_DMARXDESC_RCH | (uint32_t)ETH_RX_BUF_SIZE;  
 		pxDMARxDescriptor->Status = ETH_DMARXDESC_OWN;
 
+		/* Ensure completion of memory access */
+		__DSB();
 		/* When Rx Buffer unavailable flag is set clear it and resume
 		reception. */
 		if( ( xETH.Instance->DMASR & ETH_DMASR_RBUS ) != 0 )
@@ -950,311 +980,138 @@ uint8_t *pucBuffer;
 			/* Resume DMA reception. */
 			xETH.Instance->DMARPDR = 0;
 		}
+		pxDMARxDescriptor = xETH.RxDesc;
 	}
+
+	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+	{
+		if( pxFirstDescriptor != NULL )
+		{
+			prvPassEthMessages( pxFirstDescriptor );
+		}
+	}
+	#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
 
 	return ( xReceivedLength > 0 );
 }
 /*-----------------------------------------------------------*/
 
-void vMACBProbePhy( void )
+
+BaseType_t xSTM32_PhyRead( BaseType_t xAddress, BaseType_t xRegister, uint32_t *pulValue )
 {
-uint32_t ulConfig, ulAdvertise, ulLower, ulUpper, ulMACPhyID, ulValue;
-TimeOut_t xPhyTime;
-TickType_t xRemTime = 0;
-#if( EXPECTED_PHY_ID == PHY_ID_DP83848I )
-	uint32_t ulPhyControl;
-#endif
+uint16_t usPrevAddress = xETH.Init.PhyAddress;
+BaseType_t xResult;
+HAL_StatusTypeDef xHALResult;
 
-	HAL_ETH_ReadPHYRegister(&xETH, PHY_REG_03_PHYSID2, &ulLower);
-	HAL_ETH_ReadPHYRegister(&xETH, PHY_REG_02_PHYSID1, &ulUpper);
+	xETH.Init.PhyAddress = xAddress;
+	xHALResult = HAL_ETH_ReadPHYRegister( &xETH, ( uint16_t )xRegister, pulValue );
+	xETH.Init.PhyAddress = usPrevAddress;
 
-	ulMACPhyID = ( ( ulUpper << 16 ) & 0xFFFF0000 ) | ( ulLower & 0xFFF0 );
-
-	/* The expected ID for the 'LAN8720' is 0x0007c0f0. */
-	/* The expected ID for the 'DP83848I' is 0x20005C90. */
-
-	FreeRTOS_printf( ( "PHY ID %lX (%s)\n", ulMACPhyID,
-		( ulMACPhyID == EXPECTED_PHY_ID ) ? "OK" : "Unknown" ) );
-
-	/* Remove compiler warning if FreeRTOS_printf() is not defined. */
-	( void ) ulMACPhyID;
-
-    /* Set advertise register. */
-	if( ( xPHYProperties.speed == PHY_SPEED_AUTO ) && ( xPHYProperties.duplex == PHY_DUPLEX_AUTO ) )
+	if( xHALResult == HAL_OK )
 	{
-		ulAdvertise = ADVERTISE_CSMA | ADVERTISE_ALL;
-		/* Reset auto-negotiation capability. */
+		xResult = 0;
 	}
 	else
 	{
-		ulAdvertise = ADVERTISE_CSMA;
-
-		if( xPHYProperties.speed == PHY_SPEED_AUTO )
-		{
-			if( xPHYProperties.duplex == PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= ADVERTISE_10FULL | ADVERTISE_100FULL;
-			}
-			else
-			{
-				ulAdvertise |= ADVERTISE_10HALF | ADVERTISE_100HALF;
-			}
-		}
-		else if( xPHYProperties.duplex == PHY_DUPLEX_AUTO )
-		{
-			if( xPHYProperties.speed == PHY_SPEED_10 )
-			{
-				ulAdvertise |= ADVERTISE_10FULL | ADVERTISE_10HALF;
-			}
-			else
-			{
-				ulAdvertise |= ADVERTISE_100FULL | ADVERTISE_100HALF;
-			}
-		}
-		else if( xPHYProperties.speed == PHY_SPEED_100 )
-		{
-			if( xPHYProperties.duplex == PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= ADVERTISE_100FULL;
-			}
-			else
-			{
-				ulAdvertise |= ADVERTISE_100HALF;
-			}
-		}
-		else
-		{
-			if( xPHYProperties.duplex == PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= ADVERTISE_10FULL;
-			}
-			else
-			{
-				ulAdvertise |= ADVERTISE_10HALF;
-			}
-		}
+		xResult = -1;
 	}
+	return xResult;
+}
+/*-----------------------------------------------------------*/
 
-	/* Read Control register. */
-	HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_00_BMCR, &ulConfig );
+BaseType_t xSTM32_PhyWrite( BaseType_t xAddress, BaseType_t xRegister, uint32_t ulValue )
+{
+uint16_t usPrevAddress = xETH.Init.PhyAddress;
+BaseType_t xResult;
+HAL_StatusTypeDef xHALResult;
 
-	HAL_ETH_WritePHYRegister( &xETH, PHY_REG_00_BMCR, ulConfig | BMCR_RESET );
-	xRemTime = ( TickType_t ) pdMS_TO_TICKS( 1000UL );
-	vTaskSetTimeOutState( &xPhyTime );
+	xETH.Init.PhyAddress = xAddress;
+	xHALResult = HAL_ETH_WritePHYRegister( &xETH, ( uint16_t )xRegister, ulValue );
+	xETH.Init.PhyAddress = usPrevAddress;
 
-	for( ; ; )
+	if( xHALResult == HAL_OK )
 	{
-		HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_00_BMCR, &ulValue );
-		if( ( ulValue & BMCR_RESET ) == 0 )
-		{
-			FreeRTOS_printf( ( "BMCR_RESET ready\n" ) );
-			break;
-		}
-		if( xTaskCheckForTimeOut( &xPhyTime, &xRemTime ) != pdFALSE )
-		{
-			FreeRTOS_printf( ( "BMCR_RESET timed out\n" ) );
-			break;
-		}
+		xResult = 0;
 	}
-	HAL_ETH_WritePHYRegister( &xETH, PHY_REG_00_BMCR, ulConfig & ~BMCR_RESET );
-
-	vTaskDelay( pdMS_TO_TICKS( 50ul ) );
-
-    /* Write advertise register. */
-	HAL_ETH_WritePHYRegister( &xETH, PHY_REG_04_ADVERTISE, ulAdvertise );
-
-	/*
-			AN_EN        AN1         AN0       Forced Mode
-			  0           0           0        10BASE-T, Half-Duplex
-			  0           0           1        10BASE-T, Full-Duplex
-			  0           1           0        100BASE-TX, Half-Duplex
-			  0           1           1        100BASE-TX, Full-Duplex
-			AN_EN        AN1         AN0       Advertised Mode
-			  1           0           0        10BASE-T, Half/Full-Duplex
-			  1           0           1        100BASE-TX, Half/Full-Duplex
-			  1           1           0        10BASE-T Half-Duplex
-											   100BASE-TX, Half-Duplex
-			  1           1           1        10BASE-T, Half/Full-Duplex
-											   100BASE-TX, Half/Full-Duplex
-	*/
-
-    /* Read Control register. */
-	HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_00_BMCR, &ulConfig );
-
-	ulConfig &= ~( BMCR_ANRESTART | BMCR_ANENABLE | BMCR_SPEED100 | BMCR_FULLDPLX );
-
-	/* HT 12/9/14: always set AN-restart and AN-enable, even though the choices
-	are limited. */
-	ulConfig |= (BMCR_ANRESTART | BMCR_ANENABLE);
-
-	if( xPHYProperties.speed == PHY_SPEED_100 )
+	else
 	{
-		ulConfig |= BMCR_SPEED100;
+		xResult = -1;
 	}
-	else if( xPHYProperties.speed == PHY_SPEED_10 )
-	{
-		ulConfig &= ~BMCR_SPEED100;
-	}
+	return xResult;
+}
+/*-----------------------------------------------------------*/
 
-	if( xPHYProperties.duplex == PHY_DUPLEX_FULL )
-	{
-		ulConfig |= BMCR_FULLDPLX;
-	}
-	else if( xPHYProperties.duplex == PHY_DUPLEX_HALF )
-	{
-		ulConfig &= ~BMCR_FULLDPLX;
-	}
-
-	#if( EXPECTED_PHY_ID == PHY_ID_LAN8720 )
-	{
-	}
-	#elif( EXPECTED_PHY_ID == PHY_ID_DP83848I )
-	{
-		/* Read PHY Control register. */
-		HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_19_PHYCR, &ulPhyControl );
-
-		/* Clear bits which might get set: */
-		ulPhyControl &= ~( PHYCR_MDIX_EN|PHYCR_MDIX_FORCE );
-
-		if( xPHYProperties.mdix == PHY_MDIX_AUTO )
-		{
-			ulPhyControl |= PHYCR_MDIX_EN;
-		}
-		else if( xPHYProperties.mdix == PHY_MDIX_CROSSED )
-		{
-			/* Force direct link = Use crossed RJ45 cable. */
-			ulPhyControl &= ~PHYCR_MDIX_FORCE;
-		}
-		else
-		{
-			/* Force crossed link = Use direct RJ45 cable. */
-			ulPhyControl |= PHYCR_MDIX_FORCE;
-		}
-		/* update PHY Control Register. */
-		HAL_ETH_WritePHYRegister( &xETH, PHY_REG_19_PHYCR, ulPhyControl );
-	}
-	#endif
-	FreeRTOS_printf( ( "+TCP: advertise: %lX config %lX\n", ulAdvertise, ulConfig ) );
-
-	/* Now the two values to global values for later use. */
-	ulBCRvalue = ulConfig;
-	ulACRValue = ulAdvertise;
+void vMACBProbePhy( void )
+{
+	vPhyInitialise( &xPhyObject, xSTM32_PhyRead, xSTM32_PhyWrite );
+	xPhyDiscover( &xPhyObject );
+	xPhyConfigure( &xPhyObject, &xPHYProperties );
 }
 /*-----------------------------------------------------------*/
 
 static void prvEthernetUpdateConfig( BaseType_t xForce )
 {
-__IO uint32_t ulTimeout = 0;
-uint32_t ulRegValue = 0;
+	FreeRTOS_printf( ( "prvEthernetUpdateConfig: LS mask %02lX Force %d\n",
+		xPhyObject.ulLinkStatusMask,
+		( int )xForce ) );
 
-	FreeRTOS_printf( ( "prvEthernetUpdateConfig: LS %d Force %d\n",
-		( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ,
-		xForce ) );
-
-	if( ( xForce != pdFALSE ) || ( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) )
+	if( ( xForce != pdFALSE ) || ( xPhyObject.ulLinkStatusMask != 0 ) )
 	{
 		/* Restart the auto-negotiation. */
 		if( xETH.Init.AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE )
 		{
-			/* Enable Auto-Negotiation. */
-			HAL_ETH_WritePHYRegister( &xETH, PHY_REG_00_BMCR, ulBCRvalue | BMCR_ANRESTART );
-			HAL_ETH_WritePHYRegister( &xETH, PHY_REG_04_ADVERTISE, ulACRValue);
+			xPhyStartAutoNegotiation( &xPhyObject, xPhyGetMask( &xPhyObject ) );
 
-			/* Wait until the auto-negotiation will be completed */
-			do
+			/* Configure the MAC with the Duplex Mode fixed by the
+			auto-negotiation process. */
+			if( xPhyObject.xPhyProperties.ucDuplex == PHY_DUPLEX_FULL )
 			{
-				ulTimeout++;
-				HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_01_BMSR, &ulRegValue );
-			} while( ( ( ulRegValue & PHY_AUTONEGO_COMPLETE) == 0 ) && ( ulTimeout < PHY_READ_TO ) );
-
-			HAL_ETH_WritePHYRegister( &xETH, PHY_REG_00_BMCR, ulBCRvalue & ~BMCR_ANRESTART );
-
-			if( ulTimeout < PHY_READ_TO )
+				xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
+			}
+			else
 			{
-				/* Reset Timeout counter. */
-				ulTimeout = 0;
+				xETH.Init.DuplexMode = ETH_MODE_HALFDUPLEX;
+			}
 
-				HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_01_BMSR, &ulRegValue);
-				if( ( ulRegValue & BMSR_LINK_STATUS ) != 0 )
-				{
-					ulPHYLinkStatus |= BMSR_LINK_STATUS;
-				}
-				else
-				{
-					ulPHYLinkStatus &= ~( BMSR_LINK_STATUS );
-				}
-
-				#if( EXPECTED_PHY_ID == PHY_ID_LAN8720 )
-				{
-				/* 31 RW PHY Special Control Status */
-				uint32_t ulControlStatus;
-
-					HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_1F_PHYSPCS, &ulControlStatus);
-					ulRegValue = 0;
-					if( ( ulControlStatus & PHYSPCS_FULL_DUPLEX ) != 0 )
-					{
-						ulRegValue |= PHY_DUPLEX_STATUS;
-					}
-					if( ( ulControlStatus & PHYSPCS_SPEED_MASK ) == PHYSPCS_SPEED_10 )
-					{
-						ulRegValue |= PHY_SPEED_STATUS;
-					}
-
-				}
-				#elif( EXPECTED_PHY_ID == PHY_ID_DP83848I )
-				{
-					/* Read the result of the auto-negotiation. */
-					HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_10_PHY_SR, &ulRegValue);
-				}
-				#endif
-				FreeRTOS_printf( ( ">> Autonego ready: %08lx: %s duplex %u mbit %s status\n",
-					ulRegValue,
-					(ulRegValue & PHY_DUPLEX_STATUS) ? "full" : "half",
-					(ulRegValue & PHY_SPEED_STATUS) ? 10 : 100,
-					((ulPHYLinkStatus |= BMSR_LINK_STATUS) != 0) ? "high" : "low" ) );
-
-				/* Configure the MAC with the Duplex Mode fixed by the
-				auto-negotiation process. */
-				if( ( ulRegValue & PHY_DUPLEX_STATUS ) != ( uint32_t ) RESET )
-				{
-					/* Set Ethernet duplex mode to Full-duplex following the
-					auto-negotiation. */
-					xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
-				}
-				else
-				{
-					/* Set Ethernet duplex mode to Half-duplex following the
-					auto-negotiation. */
-					xETH.Init.DuplexMode = ETH_MODE_HALFDUPLEX;
-				}
-
-				/* Configure the MAC with the speed fixed by the
-				auto-negotiation process. */
-				if( ( ulRegValue & PHY_SPEED_STATUS) != 0 )
-				{
-					/* Set Ethernet speed to 10M following the
-					auto-negotiation. */
-					xETH.Init.Speed = ETH_SPEED_10M;
-				}
-				else
-				{
-					/* Set Ethernet speed to 100M following the
-					auto-negotiation. */
-					xETH.Init.Speed = ETH_SPEED_100M;
-				}
-			}	/* if( ulTimeout < PHY_READ_TO ) */
+			/* Configure the MAC with the speed fixed by the
+			auto-negotiation process. */
+			if( xPhyObject.xPhyProperties.ucSpeed == PHY_SPEED_10 )
+			{
+				xETH.Init.Speed = ETH_SPEED_10M;
+			}
+			else
+			{
+				xETH.Init.Speed = ETH_SPEED_100M;
+			}
 		}
 		else /* AutoNegotiation Disable */
 		{
-		uint16_t usValue;
-
 			/* Check parameters */
 			assert_param( IS_ETH_SPEED( xETH.Init.Speed ) );
 			assert_param( IS_ETH_DUPLEX_MODE( xETH.Init.DuplexMode ) );
 
-			/* Set MAC Speed and Duplex Mode to PHY */
-			usValue = ( uint16_t ) ( xETH.Init.DuplexMode >> 3 ) | ( uint16_t ) ( xETH.Init.Speed >> 1 );
-			HAL_ETH_WritePHYRegister( &xETH, PHY_REG_00_BMCR, usValue );
+			if( xETH.Init.DuplexMode == ETH_MODE_FULLDUPLEX )
+			{
+				xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_HALF;
+			}
+			else
+			{
+				xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_FULL;
+			}
+
+			if( xETH.Init.Speed == ETH_SPEED_10M )
+			{
+				xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_10;
+			}
+			else
+			{
+				xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_100;
+			}
+
+			xPhyObject.xPhyPreferences.ucMDI_X = PHY_MDIX_AUTO;
+
+			/* Use predefined (fixed) configuration. */
+			xPhyFixedValue( &xPhyObject, xPhyGetMask( &xPhyObject ) );
 		}
 
 		/* ETHERNET MAC Re-Configuration */
@@ -1275,7 +1132,7 @@ BaseType_t xGetPhyLinkStatus( void )
 {
 BaseType_t xReturn;
 
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+	if( xPhyObject.ulLinkStatusMask != 0 )
 	{
 		xReturn = pdPASS;
 	}
@@ -1288,27 +1145,41 @@ BaseType_t xReturn;
 }
 /*-----------------------------------------------------------*/
 
+/* Uncomment this in case BufferAllocation_1.c is used. */
+
+#define niBUFFER_1_PACKET_SIZE		1536
+
+void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+{
+static __attribute__ ((section(".first_data"))) uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__ ( ( aligned( 32 ) ) );
+uint8_t *ucRAMBuffer = ucNetworkPackets;
+uint32_t ul;
+
+	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+	{
+		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+		ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+	}
+}
+/*-----------------------------------------------------------*/
+
 static void prvEMACHandlerTask( void *pvParameters )
 {
-TimeOut_t xPhyTime;
-TickType_t xPhyRemTime;
 UBaseType_t uxLastMinBufferCount = 0;
 #if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
 UBaseType_t uxLastMinQueueSpace = 0;
 #endif
 UBaseType_t uxCurrentCount;
-BaseType_t xResult = 0;
-uint32_t xStatus;
+BaseType_t xResult;
 const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
 	/* Remove compiler warnings about unused parameters. */
 	( void ) pvParameters;
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-
 	for( ;; )
 	{
+		xResult = 0;
 		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 		if( uxLastMinBufferCount != uxCurrentCount )
 		{
@@ -1319,7 +1190,6 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
 		}
 
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
 		if( xTXDescriptorSemaphore != NULL )
 		{
 		static UBaseType_t uxLowestSemCount = ( UBaseType_t ) ETH_TXBUFNB - 1;
@@ -1332,7 +1202,7 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			}
 
 		}
-		#endif
+
 		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
 		{
 			uxCurrentCount = uxGetMinimumIPQueueSpace();
@@ -1357,24 +1227,14 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			ulISREvents &= ~EMAC_IF_RX_EVENT;
 
 			xResult = prvNetworkInterfaceInput();
-			if( xResult > 0 )
-			{
-			  	while( prvNetworkInterfaceInput() > 0 )
-				{
-				}
-			}
 		}
 
 		if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
 		{
 			/* Code to release TX buffers if zero-copy is used. */
 			ulISREvents &= ~EMAC_IF_TX_EVENT;
-			#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-			{
-				/* Check if DMA packets have been delivered. */
-				vClearTXBuffers();
-			}
-			#endif
+			/* Check if DMA packets have been delivered. */
+			vClearTXBuffers();
 		}
 
 		if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
@@ -1382,34 +1242,10 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			/* Future extension: logging about errors that occurred. */
 			ulISREvents &= ~EMAC_IF_ERR_EVENT;
 		}
-
-		if( xResult > 0 )
+		if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != 0 )
 		{
-			/* A packet was received. No need to check for the PHY status now,
-			but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-		}
-		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-		{
-			HAL_ETH_ReadPHYRegister( &xETH, PHY_REG_01_BMSR, &xStatus );
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
-			{
-				ulPHYLinkStatus = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
-				prvEthernetUpdateConfig( pdFALSE );
-			}
-
-			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
+			/* Something has changed to a Link Status, need re-check. */
+			prvEthernetUpdateConfig( pdFALSE );
 		}
 	}
 }
@@ -1419,3 +1255,4 @@ void ETH_IRQHandler( void )
 {
 	HAL_ETH_IRQHandler( &xETH );
 }
+

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/readme.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/readme.txt
@@ -1,0 +1,60 @@
+This is a FreeeRTOS+TCP driver that works for both STM32F4xx and STM32F7xx parts.
+
+The code of stm32fxx_hal_eth.c is based on both drivers as provided by ST.
+
+These modules should be included:
+
+    NetworkInterface.c
+	stm32fxx_hal_eth.c
+
+It is assumed that one of these words are defined:
+
+	STM32F7xx
+	STM32F407xx
+	STM32F417xx
+	STM32F427xx
+	STM32F437xx
+	STM32F429xx
+	STM32F439xx
+
+The driver has been tested on both Eval and Discovery boards with both STM32F4 and STM32F7.
+
+Recommened settings for STM32Fxx Network Interface:
+
+// Defined in FreeRTOSIPConfig.h
+
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES   1
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM        1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM        1
+#define ipconfigZERO_COPY_RX_DRIVER                   1
+#define ipconfigZERO_COPY_TX_DRIVER                   1
+#define ipconfigUSE_LINKED_RX_MESSAGES                1
+
+// Defined in stm32f4xx_hal_conf.h
+#define ETH_RXBUFNB                                   3 or 4
+#define ETH_TXBUFNB                                   2 or 3
+#define ETH_RX_BUF_SIZE                               ( ipconfigNETWORK_MTU + 36 )
+#define ETH_TX_BUF_SIZE                               ( ipconfigNETWORK_MTU + 36 )
+
+The best size for 'ETH_RXBUFNB' and 'ETH_TXBUFNB' depends on the speed of the CPU. These macro's define the number of DMA buffers for reception and for transmission.
+In general, if the CPU is very fast, you will need less buffers. You can obtain an estimate empirically.
+
+The optimal value of 'ETH_RX_BUF_SIZE' and 'ETH_TX_BUF_SIZE' depends on the actual value of 'ipconfigNETWORK_MTU'.
+When MTU is 1500, MTU+36 becomes a well-aligned buffer of 1536 bytes ( 0x600 ).
+When MTU is 1200, MTU+48 will make 1248 ( 0x4E0 ), which is also well aligned.
+
+Having well aligned buffers is important for CPU with memory cache. Often the caching system divides memory in blocks of 32 bytes. When two buffers share the same cache buffer, you are bound to see data errors.
+
+Without memory caching, let the size be at least a multiple of 8 ( for DMA ), and make it at least "ipconfigNETWORK_MTU + 14".
+
+The driver contains these files:
+
+	stm32fxx_hal_eth.c
+	stm32f2xx_hal_eth.h
+	stm32f4xx_hal_eth.h
+	stm32f7xx_hal_eth.h
+	stm32fxx_hal_eth.h
+
+These files are copied from ST's HAL library. These work both for STM32F4 and STM32F7.
+Please remove or rename these files from the HAL distribution that you are using.
+

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f2xx_hal_eth.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f2xx_hal_eth.h
@@ -1,0 +1,6 @@
+/*
+ * The Ethernet header files for STM32F2, STM32F4 and STM32F7 have been merged to
+ * a single module that works for both parts: "stm32fxx_hal_eth"
+ */
+
+#include "stm32fxx_hal_eth.h"

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f4xx_hal_eth.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f4xx_hal_eth.h
@@ -1,0 +1,6 @@
+/*
+ * The Ethernet header files for STM32F2, STM32F4 and STM32F7 have been merged to
+ * a single module that works for both parts: "stm32fxx_hal_eth"
+ */
+
+#include "stm32fxx_hal_eth.h"

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f7xx_hal_eth.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32f7xx_hal_eth.h
@@ -1,0 +1,6 @@
+/*
+ * The Ethernet header files for STM32F2, STM32F4 and STM32F7 have been merged to
+ * a single module that works for both parts: "stm32fxx_hal_eth"
+ */
+
+#include "stm32fxx_hal_eth.h"

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.c
@@ -1,0 +1,1468 @@
+/**
+  ******************************************************************************
+  * @file    stm32fxx_hal_eth.c
+  * @author  MCD Application Team
+  * @version V1.3.2
+  * @date    26-June-2015
+  * @brief   ETH HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Ethernet (ETH) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Errors functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#)Declare a ETH_HandleTypeDef handle structure, for example:
+         ETH_HandleTypeDef  heth;
+
+      (#)Fill parameters of Init structure in heth handle
+
+      (#)Call HAL_ETH_Init() API to initialize the Ethernet peripheral (MAC, DMA, ...)
+
+      (#)Initialize the ETH low level resources through the HAL_ETH_MspInit() API:
+          (##) Enable the Ethernet interface clock using
+               (+++) __HAL_RCC_ETHMAC_CLK_ENABLE();
+               (+++) __HAL_RCC_ETHMACTX_CLK_ENABLE();
+               (+++) __HAL_RCC_ETHMACRX_CLK_ENABLE();
+
+          (##) Initialize the related GPIO clocks
+          (##) Configure Ethernet pin-out
+          (##) Configure Ethernet NVIC interrupt (IT mode)
+
+      (#)Initialize Ethernet DMA Descriptors in chain mode and point to allocated buffers:
+          (##) HAL_ETH_DMATxDescListInit(); for Transmission process
+          (##) HAL_ETH_DMARxDescListInit(); for Reception process
+
+      (#)Enable MAC and DMA transmission and reception:
+          (##) HAL_ETH_Start();
+
+      (#)Prepare ETH DMA TX Descriptors and give the hand to ETH DMA to transfer
+         the frame to MAC TX FIFO:
+         (##) HAL_ETH_TransmitFrame();
+
+      (#)Poll for a received frame in ETH RX DMA Descriptors and get received
+         frame parameters
+         (##) HAL_ETH_GetReceivedFrame(); (should be called into an infinite loop)
+
+      (#) Get a received frame when an ETH RX interrupt occurs:
+         (##) HAL_ETH_GetReceivedFrame_IT(); (called in IT mode only)
+
+      (#) Communicate with external PHY device:
+         (##) Read a specific register from the PHY
+              HAL_ETH_ReadPHYRegister();
+         (##) Write data to a specific RHY register:
+              HAL_ETH_WritePHYRegister();
+
+      (#) Configure the Ethernet MAC after ETH peripheral initialization
+          HAL_ETH_ConfigMAC(); all MAC parameters should be filled.
+
+      (#) Configure the Ethernet DMA after ETH peripheral initialization
+          HAL_ETH_ConfigDMA(); all DMA parameters should be filled.
+
+      -@- The PTP protocol and the DMA descriptors ring mode are not supported
+          in this driver
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+
+#if defined(STM32F7xx)
+	#include "stm32f7xx_hal.h"
+	#define stm_is_F7	1
+#elif defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
+	#include "stm32f4xx_hal.h"
+	#define stm_is_F4	1
+#elif defined(STM32F2xx)
+	#include "stm32f2xx_hal.h"
+	#define stm_is_F2	1
+#else
+	#error For what part should this be compiled?
+#endif
+
+#include "stm32fxx_hal_eth.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ETH ETH
+  * @brief ETH HAL module driver
+  * @{
+  */
+
+#if !defined( ARRAY_SIZE )
+	#define ARRAY_SIZE( x ) ( sizeof ( x ) / sizeof ( x )[ 0 ] )
+#endif
+
+#ifdef HAL_ETH_MODULE_ENABLED
+
+#if( stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 )
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup ETH_Private_Constants ETH Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup ETH_Private_Functions ETH Private Functions
+  * @{
+  */
+static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err);
+static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr);
+static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth);
+static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth);
+static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth);
+static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth);
+static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth);
+static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth);
+static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth);
+static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth);
+static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth);
+
+/**
+  * @}
+  */
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup ETH_Exported_Functions ETH Exported Functions
+  * @{
+  */
+
+/** @defgroup ETH_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief   Initialization and Configuration functions
+  *
+  @verbatim
+  ===============================================================================
+            ##### Initialization and de-initialization functions #####
+  ===============================================================================
+  [..]  This section provides functions allowing to:
+      (+) Initialize and configure the Ethernet peripheral
+      (+) De-initialize the Ethernet peripheral
+
+  @endverbatim
+  * @{
+  */
+extern void vMACBProbePhy ( void );
+
+/**
+  * @brief  Initializes the Ethernet MAC and DMA according to default
+  *         parameters.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
+{
+	uint32_t tmpreg = 0uL;
+	uint32_t hclk = 60000000uL;
+	uint32_t err = ETH_SUCCESS;
+
+	/* Check the ETH peripheral state */
+	if( heth == NULL )
+	{
+		return HAL_ERROR;
+	}
+
+	/* Check parameters */
+	assert_param(IS_ETH_AUTONEGOTIATION(heth->Init.AutoNegotiation));
+	assert_param(IS_ETH_RX_MODE(heth->Init.RxMode));
+	assert_param(IS_ETH_CHECKSUM_MODE(heth->Init.ChecksumMode));
+	assert_param(IS_ETH_MEDIA_INTERFACE(heth->Init.MediaInterface));
+
+	if( heth->State == HAL_ETH_STATE_RESET )
+	{
+		/* Init the low level hardware : GPIO, CLOCK, NVIC. */
+		HAL_ETH_MspInit( heth );
+	}
+
+	/* Enable SYSCFG Clock */
+	__HAL_RCC_SYSCFG_CLK_ENABLE();
+
+	/* Select MII or RMII Mode*/
+	SYSCFG->PMC &= ~(SYSCFG_PMC_MII_RMII_SEL);
+	SYSCFG->PMC |= (uint32_t)heth->Init.MediaInterface;
+
+	/* Ethernet Software reset */
+	/* Set the SWR bit: resets all MAC subsystem internal registers and logic */
+	/* After reset all the registers holds their respective reset values */
+	/* Also enable EDFE: Enhanced descriptor format enable. */
+	heth->Instance->DMABMR |= ETH_DMABMR_SR | ETH_DMABMR_EDE;
+
+	/* Wait for software reset */
+	while ((heth->Instance->DMABMR & ETH_DMABMR_SR) != (uint32_t)RESET)
+	{
+		/* If your program hangs here, please check the value of 'ipconfigUSE_RMII'. */
+	}
+
+	/*-------------------------------- MAC Initialization ----------------------*/
+	/* Get the ETHERNET MACMIIAR value */
+	tmpreg = heth->Instance->MACMIIAR;
+	/* Clear CSR Clock Range CR[2:0] bits */
+	tmpreg &= ETH_MACMIIAR_CR_MASK;
+
+	/* Get hclk frequency value (e.g. 168,000,000) */
+	hclk = HAL_RCC_GetHCLKFreq();
+
+	/* Set CR bits depending on hclk value */
+	if(( hclk >= 20000000uL ) && ( hclk < 35000000uL ) )
+	{
+		/* CSR Clock Range between 20-35 MHz */
+		tmpreg |= ( uint32_t) ETH_MACMIIAR_CR_Div16;
+	}
+	else if( ( hclk >= 35000000uL ) && ( hclk < 60000000uL ) )
+	{
+	/* CSR Clock Range between 35-60 MHz */
+	tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div26;
+	}
+	else if( ( hclk >= 60000000uL ) && ( hclk < 100000000uL ) )
+	{
+		/* CSR Clock Range between 60-100 MHz */
+		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div42;
+	}
+	else if( ( hclk >= 100000000uL ) && ( hclk < 150000000uL ) )
+	{
+		/* CSR Clock Range between 100-150 MHz */
+		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div62;
+	}
+	else /* ( ( hclk >= 150000000uL ) && ( hclk <= 183000000uL ) ) */
+	{
+		/* CSR Clock Range between 150-183 MHz */
+		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div102;
+	}
+
+	/* Write to ETHERNET MAC MIIAR: Configure the ETHERNET CSR Clock Range */
+	heth->Instance->MACMIIAR = (uint32_t)tmpreg;
+
+	/* Initialise the MACB and set all PHY properties */
+	vMACBProbePhy();
+
+	/* Config MAC and DMA */
+	ETH_MACDMAConfig(heth, err);
+
+	/* Set ETH HAL State to Ready */
+	heth->State= HAL_ETH_STATE_READY;
+
+	/* Return function status */
+	return HAL_OK;
+}
+
+/**
+  * @brief  De-Initializes the ETH peripheral.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth)
+{
+	/* Set the ETH peripheral state to BUSY */
+	heth->State = HAL_ETH_STATE_BUSY;
+
+	/* De-Init the low level hardware : GPIO, CLOCK, NVIC. */
+	HAL_ETH_MspDeInit( heth );
+
+	/* Set ETH HAL state to Disabled */
+	heth->State= HAL_ETH_STATE_RESET;
+
+	/* Release Lock */
+	__HAL_UNLOCK( heth );
+
+	/* Return function status */
+	return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the ETH MSP.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_MspInit could be implemented in the user file
+  */
+  ( void ) heth;
+}
+
+/**
+  * @brief  DeInitializes ETH MSP.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_MspDeInit could be implemented in the user file
+  */
+  ( void ) heth;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Exported_Functions_Group2 IO operation functions
+  *  @brief   Data transfers functions
+  *
+  @verbatim
+  ==============================================================================
+                          ##### IO operation functions #####
+  ==============================================================================
+  [..]  This section provides functions allowing to:
+        (+) Transmit a frame
+            HAL_ETH_TransmitFrame();
+        (+) Receive a frame
+            HAL_ETH_GetReceivedFrame();
+            HAL_ETH_GetReceivedFrame_IT();
+        (+) Read from an External PHY register
+            HAL_ETH_ReadPHYRegister();
+        (+) Write to an External PHY register
+            HAL_ETH_WritePHYRegister();
+
+  @endverbatim
+
+  * @{
+  */
+
+#define ETH_DMA_ALL_INTS \
+	( ETH_DMA_IT_TST | ETH_DMA_IT_PMT | ETH_DMA_IT_MMC | ETH_DMA_IT_NIS | ETH_DMA_IT_AIS | ETH_DMA_IT_ER | \
+	ETH_DMA_IT_FBE | ETH_DMA_IT_ET | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R | \
+	ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
+
+//#define ETH_DMA_ALL_INTS		ETH_DMA_IT_RBU | ETH_DMA_FLAG_T | ETH_DMA_FLAG_AIS
+
+#define INT_MASK		( ( uint32_t ) ~ ( ETH_DMA_IT_TBU ) )
+void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
+{
+	uint32_t dmasr;
+
+	dmasr = heth->Instance->DMASR & ETH_DMA_ALL_INTS;
+	heth->Instance->DMASR = dmasr;
+
+	/* Frame received */
+	if( ( dmasr & ( ETH_DMA_FLAG_R | ETH_DMA_IT_RBU ) ) != 0 )
+	{
+		/* Receive complete callback */
+		HAL_ETH_RxCpltCallback( heth );
+	}
+	/* Frame transmitted */
+	if( ( dmasr & ( ETH_DMA_FLAG_T ) ) != 0 )
+	{
+		/* Transfer complete callback */
+		HAL_ETH_TxCpltCallback( heth );
+	}
+
+	/* ETH DMA Error */
+	if( ( dmasr & ( ETH_DMA_FLAG_AIS ) ) != 0 )
+	{
+		/* Ethernet Error callback */
+		HAL_ETH_ErrorCallback( heth );
+	}
+}
+
+/**
+  * @brief  Tx Transfer completed callbacks.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxCpltCallback could be implemented in the user file
+  */
+  ( void ) heth;
+}
+
+/**
+  * @brief  Rx Transfer completed callbacks.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxCpltCallback could be implemented in the user file
+  */
+  ( void ) heth;
+}
+
+/**
+  * @brief  Ethernet transfer error callbacks
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxCpltCallback could be implemented in the user file
+  */
+  ( void ) heth;
+}
+
+/**
+  * @brief  Reads a PHY register
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param PHYReg: PHY register address, is the index of one of the 32 PHY register.
+  *                This parameter can be one of the following values:
+  *                   PHY_BCR: Transceiver Basic Control Register,
+  *                   PHY_BSR: Transceiver Basic Status Register.
+  *                   More PHY register could be read depending on the used PHY
+  * @param RegValue: PHY register value
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue)
+{
+uint32_t tmpreg = 0uL;
+uint32_t tickstart = 0uL;
+HAL_StatusTypeDef xResult;
+
+	/* Check parameters */
+	assert_param(IS_ETH_PHY_ADDRESS(heth->Init.PhyAddress));
+
+	/* Check the ETH peripheral state */
+	if( heth->State == HAL_ETH_STATE_BUSY_RD )
+	{
+		xResult = HAL_BUSY;
+	}
+	else
+	{
+		__HAL_LOCK( heth );
+
+		/* Set ETH HAL State to BUSY_RD */
+		heth->State = HAL_ETH_STATE_BUSY_RD;
+
+		/* Get the ETHERNET MACMIIAR value */
+		tmpreg = heth->Instance->MACMIIAR;
+
+		/* Keep only the CSR Clock Range CR[2:0] bits value */
+		tmpreg &= ~ETH_MACMIIAR_CR_MASK;
+
+		/* Prepare the MII address register value */
+		tmpreg |= ( ( ( uint32_t )heth->Init.PhyAddress << 11) & ETH_MACMIIAR_PA );    /* Set the PHY device address   */
+		tmpreg |= ( ( ( uint32_t )PHYReg << 6 ) & ETH_MACMIIAR_MR );                   /* Set the PHY register address */
+		tmpreg &= ~ETH_MACMIIAR_MW;                                           /* Set the read mode            */
+		tmpreg |= ETH_MACMIIAR_MB;                                            /* Set the MII Busy bit         */
+
+		/* Write the result value into the MII Address register */
+		heth->Instance->MACMIIAR = tmpreg;
+
+		/* Get tick */
+		tickstart = HAL_GetTick();
+
+		/* Check for the Busy flag */
+		while( 1 )
+		{
+			tmpreg = heth->Instance->MACMIIAR;
+
+			if( ( tmpreg & ETH_MACMIIAR_MB ) == 0uL )
+			{
+				/* Get MACMIIDR value */
+				*RegValue = ( uint32_t ) heth->Instance->MACMIIDR;
+				xResult = HAL_OK;
+				break;
+			}
+			/* Check for the Timeout */
+			if( ( HAL_GetTick( ) - tickstart ) > PHY_READ_TO )
+			{
+				xResult = HAL_TIMEOUT;
+				break;
+			}
+
+		}
+
+		/* Set ETH HAL State to READY */
+		heth->State = HAL_ETH_STATE_READY;
+
+		/* Process Unlocked */
+		__HAL_UNLOCK( heth );
+	}
+
+	/* Return function status */
+	return xResult;
+}
+
+/**
+  * @brief  Writes to a PHY register.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  PHYReg: PHY register address, is the index of one of the 32 PHY register.
+  *          This parameter can be one of the following values:
+  *             PHY_BCR: Transceiver Control Register.
+  *             More PHY register could be written depending on the used PHY
+  * @param  RegValue: the value to write
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue)
+{
+uint32_t tmpreg = 0;
+uint32_t tickstart = 0;
+HAL_StatusTypeDef xResult;
+
+	/* Check parameters */
+	assert_param( IS_ETH_PHY_ADDRESS( heth->Init.PhyAddress ) );
+
+	/* Check the ETH peripheral state */
+	if( heth->State == HAL_ETH_STATE_BUSY_WR )
+	{
+		xResult = HAL_BUSY;
+	}
+	else
+	{
+		__HAL_LOCK( heth );
+
+		/* Set ETH HAL State to BUSY_WR */
+		heth->State = HAL_ETH_STATE_BUSY_WR;
+
+		/* Get the ETHERNET MACMIIAR value */
+		tmpreg = heth->Instance->MACMIIAR;
+
+		/* Keep only the CSR Clock Range CR[2:0] bits value */
+		tmpreg &= ~ETH_MACMIIAR_CR_MASK;
+
+		/* Prepare the MII register address value */
+		tmpreg |= ( ( ( uint32_t ) heth->Init.PhyAddress << 11 ) & ETH_MACMIIAR_PA ); /* Set the PHY device address */
+		tmpreg |= ( ( ( uint32_t ) PHYReg << 6 ) & ETH_MACMIIAR_MR );                 /* Set the PHY register address */
+		tmpreg |= ETH_MACMIIAR_MW;                                          /* Set the write mode */
+		tmpreg |= ETH_MACMIIAR_MB;                                          /* Set the MII Busy bit */
+
+		/* Give the value to the MII data register */
+		heth->Instance->MACMIIDR = ( uint16_t ) RegValue;
+
+		/* Write the result value into the MII Address register */
+		heth->Instance->MACMIIAR = tmpreg;
+
+		/* Get tick */
+		tickstart = HAL_GetTick();
+
+		/* Check for the Busy flag */
+		while( 1 )
+		{
+			tmpreg = heth->Instance->MACMIIAR;
+
+			if( ( tmpreg & ETH_MACMIIAR_MB ) == 0ul )
+			{
+				xResult = HAL_OK;
+				break;
+			}
+			/* Check for the Timeout */
+			if( ( HAL_GetTick( ) - tickstart ) > PHY_WRITE_TO )
+			{
+				xResult = HAL_TIMEOUT;
+				break;
+			}
+		}
+
+		/* Set ETH HAL State to READY */
+		heth->State = HAL_ETH_STATE_READY;
+		/* Process Unlocked */
+		__HAL_UNLOCK( heth );
+	}
+
+	/* Return function status */
+	return xResult;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                  ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Enable MAC and DMA transmission and reception.
+          HAL_ETH_Start();
+      (+) Disable MAC and DMA transmission and reception.
+          HAL_ETH_Stop();
+      (+) Set the MAC configuration in runtime mode
+          HAL_ETH_ConfigMAC();
+      (+) Set the DMA configuration in runtime mode
+          HAL_ETH_ConfigDMA();
+
+@endverbatim
+  * @{
+  */
+
+ /**
+  * @brief  Enables Ethernet MAC and DMA reception/transmission
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef *heth )
+{
+	/* Process Locked */
+	__HAL_LOCK( heth );
+
+	/* Set the ETH peripheral state to BUSY */
+	heth->State = HAL_ETH_STATE_BUSY;
+
+	/* Enable transmit state machine of the MAC for transmission on the MII */
+	ETH_MACTransmissionEnable( heth );
+
+	/* Enable receive state machine of the MAC for reception from the MII */
+	ETH_MACReceptionEnable( heth );
+
+	/* Flush Transmit FIFO */
+	ETH_FlushTransmitFIFO( heth );
+
+	/* Start DMA transmission */
+	ETH_DMATransmissionEnable( heth );
+
+	/* Start DMA reception */
+	ETH_DMAReceptionEnable( heth );
+
+	/* Set the ETH state to READY*/
+	heth->State= HAL_ETH_STATE_READY;
+
+	/* Process Unlocked */
+	__HAL_UNLOCK( heth );
+
+	/* Return function status */
+	return HAL_OK;
+}
+
+/**
+  * @brief  Stop Ethernet MAC and DMA reception/transmission
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
+{
+  /* Process Locked */
+  __HAL_LOCK( heth );
+
+  /* Set the ETH peripheral state to BUSY */
+  heth->State = HAL_ETH_STATE_BUSY;
+
+  /* Stop DMA transmission */
+  ETH_DMATransmissionDisable( heth );
+
+  /* Stop DMA reception */
+  ETH_DMAReceptionDisable( heth );
+
+  /* Disable receive state machine of the MAC for reception from the MII */
+  ETH_MACReceptionDisable( heth );
+
+  /* Flush Transmit FIFO */
+  ETH_FlushTransmitFIFO( heth );
+
+  /* Disable transmit state machine of the MAC for transmission on the MII */
+  ETH_MACTransmissionDisable( heth );
+
+  /* Set the ETH state*/
+  heth->State = HAL_ETH_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK( heth );
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+static void vRegisterDelay()
+{
+uint32_t uxCount;
+	/*
+	 * Regarding the HAL delay functions, I noticed that HAL delay is being used to workaround the
+	 * "Successive write operations to the same register might not be fully taken into account" errata.
+	 * The workaround requires a delay of four TX_CLK/RX_CLK clock cycles. For a 10 Mbit connection,
+	 * these clocks are running at 2.5 MHz, so this delay would be at most 1.6 microseconds.
+	 * 180 Mhz = 288 loops
+	 * 168 Mhz = 269 loops
+	 * 100 Mhz = 160 loops
+	 *  84 Mhz = 134 loops
+	 */
+	#define WAIT_TIME_NS	1600uL			/* 1.6 microseconds */
+	#define CPU_MAX_FREQ	SystemCoreClock	/* 84, 100, 168 or 180 MHz */
+	uint32_t NOP_COUNT = ( WAIT_TIME_NS * ( CPU_MAX_FREQ / 1000uL ) ) / 1000000uL;
+	for( uxCount = NOP_COUNT; uxCount > 0uL; uxCount-- )
+	{
+		__NOP();
+	}
+}
+
+static void prvWriteMACFCR( ETH_HandleTypeDef *heth, uint32_t ulValue)
+{
+	/* Enable the MAC transmission */
+	heth->Instance->MACFCR = ulValue;
+
+	/* Wait until the write operation will be taken into account:
+	at least four TX_CLK/RX_CLK clock cycles.
+	Read it back, wait a ms and */
+	( void ) heth->Instance->MACFCR;
+
+	vRegisterDelay();
+
+	heth->Instance->MACFCR = ulValue;
+}
+
+static void prvWriteDMAOMR( ETH_HandleTypeDef *heth, uint32_t ulValue)
+{
+	/* Enable the MAC transmission */
+	heth->Instance->DMAOMR = ulValue;
+
+	/* Wait until the write operation will be taken into account:
+	at least four TX_CLK/RX_CLK clock cycles.
+	Read it back, wait a ms and */
+	( void ) heth->Instance->DMAOMR;
+
+	vRegisterDelay();
+
+	heth->Instance->DMAOMR = ulValue;
+}
+
+static void prvWriteMACCR( ETH_HandleTypeDef *heth, uint32_t ulValue)
+{
+	/* Enable the MAC transmission */
+	heth->Instance->MACCR = ulValue;
+
+	/* Wait until the write operation will be taken into account:
+	at least four TX_CLK/RX_CLK clock cycles.
+	Read it back, wait a ms and */
+	( void ) heth->Instance->MACCR;
+
+	vRegisterDelay();
+
+	heth->Instance->MACCR = ulValue;
+}
+
+/**
+  * @brief  Set ETH MAC Configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  macconf: MAC Configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf)
+{
+	uint32_t tmpreg = 0uL;
+
+	/* Process Locked */
+	__HAL_LOCK( heth );
+
+	/* Set the ETH peripheral state to BUSY */
+	heth->State= HAL_ETH_STATE_BUSY;
+
+	assert_param(IS_ETH_SPEED(heth->Init.Speed));
+	assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode));
+
+	if (macconf != NULL)
+	{
+		/* Check the parameters */
+		assert_param(IS_ETH_WATCHDOG(macconf->Watchdog));
+		assert_param(IS_ETH_JABBER(macconf->Jabber));
+		assert_param(IS_ETH_INTER_FRAME_GAP(macconf->InterFrameGap));
+		assert_param(IS_ETH_CARRIER_SENSE(macconf->CarrierSense));
+		assert_param(IS_ETH_RECEIVE_OWN(macconf->ReceiveOwn));
+		assert_param(IS_ETH_LOOPBACK_MODE(macconf->LoopbackMode));
+		assert_param(IS_ETH_CHECKSUM_OFFLOAD(macconf->ChecksumOffload));
+		assert_param(IS_ETH_RETRY_TRANSMISSION(macconf->RetryTransmission));
+		assert_param(IS_ETH_AUTOMATIC_PADCRC_STRIP(macconf->AutomaticPadCRCStrip));
+		assert_param(IS_ETH_BACKOFF_LIMIT(macconf->BackOffLimit));
+		assert_param(IS_ETH_DEFERRAL_CHECK(macconf->DeferralCheck));
+		assert_param(IS_ETH_RECEIVE_ALL(macconf->ReceiveAll));
+		assert_param(IS_ETH_SOURCE_ADDR_FILTER(macconf->SourceAddrFilter));
+		assert_param(IS_ETH_CONTROL_FRAMES(macconf->PassControlFrames));
+		assert_param(IS_ETH_BROADCAST_FRAMES_RECEPTION(macconf->BroadcastFramesReception));
+		assert_param(IS_ETH_DESTINATION_ADDR_FILTER(macconf->DestinationAddrFilter));
+		assert_param(IS_ETH_PROMISCUOUS_MODE(macconf->PromiscuousMode));
+		assert_param(IS_ETH_MULTICAST_FRAMES_FILTER(macconf->MulticastFramesFilter));
+		assert_param(IS_ETH_UNICAST_FRAMES_FILTER(macconf->UnicastFramesFilter));
+		assert_param(IS_ETH_PAUSE_TIME(macconf->PauseTime));
+		assert_param(IS_ETH_ZEROQUANTA_PAUSE(macconf->ZeroQuantaPause));
+		assert_param(IS_ETH_PAUSE_LOW_THRESHOLD(macconf->PauseLowThreshold));
+		assert_param(IS_ETH_UNICAST_PAUSE_FRAME_DETECT(macconf->UnicastPauseFrameDetect));
+		assert_param(IS_ETH_RECEIVE_FLOWCONTROL(macconf->ReceiveFlowControl));
+		assert_param(IS_ETH_TRANSMIT_FLOWCONTROL(macconf->TransmitFlowControl));
+		assert_param(IS_ETH_VLAN_TAG_COMPARISON(macconf->VLANTagComparison));
+		assert_param(IS_ETH_VLAN_TAG_IDENTIFIER(macconf->VLANTagIdentifier));
+
+		/*------------------------ ETHERNET MACCR Configuration --------------------*/
+		/* Get the ETHERNET MACCR value */
+		tmpreg = heth->Instance->MACCR;
+		/* Clear WD, PCE, PS, TE and RE bits */
+		tmpreg &= ETH_MACCR_CLEAR_MASK;
+
+		tmpreg |= (uint32_t)(
+			macconf->Watchdog |
+			macconf->Jabber |
+			macconf->InterFrameGap |
+			macconf->CarrierSense |
+			heth->Init.Speed |
+			macconf->ReceiveOwn |
+			macconf->LoopbackMode |
+			heth->Init.DuplexMode |
+			macconf->ChecksumOffload |
+			macconf->RetryTransmission |
+			macconf->AutomaticPadCRCStrip |
+			macconf->BackOffLimit |
+			macconf->DeferralCheck);
+
+		/* Write to ETHERNET MACCR */
+		prvWriteMACCR( heth, tmpreg );
+
+		/*----------------------- ETHERNET MACFFR Configuration --------------------*/
+		/* Write to ETHERNET MACFFR */
+		heth->Instance->MACFFR = (uint32_t)(
+			macconf->ReceiveAll |
+			macconf->SourceAddrFilter |
+			macconf->PassControlFrames |
+			macconf->BroadcastFramesReception |
+			macconf->DestinationAddrFilter |
+			macconf->PromiscuousMode |
+			macconf->MulticastFramesFilter |
+			macconf->UnicastFramesFilter);
+
+		/* Wait until the write operation will be taken into account :
+		at least four TX_CLK/RX_CLK clock cycles */
+		tmpreg = heth->Instance->MACFFR;
+		vRegisterDelay();
+		heth->Instance->MACFFR = tmpreg;
+
+		/*--------------- ETHERNET MACHTHR and MACHTLR Configuration ---------------*/
+		/* Write to ETHERNET MACHTHR */
+		heth->Instance->MACHTHR = (uint32_t)macconf->HashTableHigh;
+
+		/* Write to ETHERNET MACHTLR */
+		heth->Instance->MACHTLR = (uint32_t)macconf->HashTableLow;
+		/*----------------------- ETHERNET MACFCR Configuration --------------------*/
+
+		/* Get the ETHERNET MACFCR value */
+		tmpreg = heth->Instance->MACFCR;
+		/* Clear xx bits */
+		tmpreg &= ETH_MACFCR_CLEAR_MASK;
+
+		tmpreg |= (uint32_t)((
+			macconf->PauseTime << 16) |
+			macconf->ZeroQuantaPause |
+			macconf->PauseLowThreshold |
+			macconf->UnicastPauseFrameDetect |
+			macconf->ReceiveFlowControl |
+			macconf->TransmitFlowControl);
+
+		/* Write to ETHERNET MACFCR */
+		prvWriteMACFCR( heth, tmpreg );
+
+		/*----------------------- ETHERNET MACVLANTR Configuration -----------------*/
+		heth->Instance->MACVLANTR = (uint32_t)(macconf->VLANTagComparison |
+		macconf->VLANTagIdentifier);
+
+		/* Wait until the write operation will be taken into account :
+		at least four TX_CLK/RX_CLK clock cycles */
+		tmpreg = heth->Instance->MACVLANTR;
+		vRegisterDelay();
+		heth->Instance->MACVLANTR = tmpreg;
+	}
+	else /* macconf == NULL : here we just configure Speed and Duplex mode */
+	{
+		/*------------------------ ETHERNET MACCR Configuration --------------------*/
+		/* Get the ETHERNET MACCR value */
+		tmpreg = heth->Instance->MACCR;
+
+		/* Clear FES and DM bits */
+		tmpreg &= ~( ( uint32_t ) 0x00004800uL );
+
+		tmpreg |= (uint32_t)(heth->Init.Speed | heth->Init.DuplexMode);
+
+		/* Write to ETHERNET MACCR */
+		prvWriteMACCR( heth, tmpreg );
+	}
+
+	/* Set the ETH state to Ready */
+	heth->State= HAL_ETH_STATE_READY;
+
+	/* Process Unlocked */
+	__HAL_UNLOCK( heth );
+
+	/* Return function status */
+	return HAL_OK;
+}
+
+/**
+  * @brief  Sets ETH DMA Configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  dmaconf: DMA Configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf)
+{
+	uint32_t tmpreg = 0uL;
+
+	/* Process Locked */
+	__HAL_LOCK( heth );
+
+	/* Set the ETH peripheral state to BUSY */
+	heth->State= HAL_ETH_STATE_BUSY;
+
+	/* Check parameters */
+	assert_param(IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(dmaconf->DropTCPIPChecksumErrorFrame));
+	assert_param(IS_ETH_RECEIVE_STORE_FORWARD(dmaconf->ReceiveStoreForward));
+	assert_param(IS_ETH_FLUSH_RECEIVE_FRAME(dmaconf->FlushReceivedFrame));
+	assert_param(IS_ETH_TRANSMIT_STORE_FORWARD(dmaconf->TransmitStoreForward));
+	assert_param(IS_ETH_TRANSMIT_THRESHOLD_CONTROL(dmaconf->TransmitThresholdControl));
+	assert_param(IS_ETH_FORWARD_ERROR_FRAMES(dmaconf->ForwardErrorFrames));
+	assert_param(IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(dmaconf->ForwardUndersizedGoodFrames));
+	assert_param(IS_ETH_RECEIVE_THRESHOLD_CONTROL(dmaconf->ReceiveThresholdControl));
+	assert_param(IS_ETH_SECOND_FRAME_OPERATE(dmaconf->SecondFrameOperate));
+	assert_param(IS_ETH_ADDRESS_ALIGNED_BEATS(dmaconf->AddressAlignedBeats));
+	assert_param(IS_ETH_FIXED_BURST(dmaconf->FixedBurst));
+	assert_param(IS_ETH_RXDMA_BURST_LENGTH(dmaconf->RxDMABurstLength));
+	assert_param(IS_ETH_TXDMA_BURST_LENGTH(dmaconf->TxDMABurstLength));
+	assert_param(IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(dmaconf->EnhancedDescriptorFormat));
+	assert_param(IS_ETH_DMA_DESC_SKIP_LENGTH(dmaconf->DescriptorSkipLength));
+	assert_param(IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(dmaconf->DMAArbitration));
+
+	/*----------------------- ETHERNET DMAOMR Configuration --------------------*/
+	/* Get the ETHERNET DMAOMR value */
+	tmpreg = heth->Instance->DMAOMR;
+	/* Clear xx bits */
+	tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+
+	tmpreg |= (uint32_t)(
+		dmaconf->DropTCPIPChecksumErrorFrame |
+		dmaconf->ReceiveStoreForward |
+		dmaconf->FlushReceivedFrame |
+		dmaconf->TransmitStoreForward |
+		dmaconf->TransmitThresholdControl |
+		dmaconf->ForwardErrorFrames |
+		dmaconf->ForwardUndersizedGoodFrames |
+		dmaconf->ReceiveThresholdControl |
+		dmaconf->SecondFrameOperate);
+
+	/* Write to ETHERNET DMAOMR */
+	prvWriteDMAOMR( heth, tmpreg );
+
+	/*----------------------- ETHERNET DMABMR Configuration --------------------*/
+	heth->Instance->DMABMR = (uint32_t)(dmaconf->AddressAlignedBeats |
+	dmaconf->FixedBurst |
+	dmaconf->RxDMABurstLength | /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
+	dmaconf->TxDMABurstLength |
+	dmaconf->EnhancedDescriptorFormat |
+	(dmaconf->DescriptorSkipLength << 2) |
+	dmaconf->DMAArbitration |
+	ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+
+	/* Wait until the write operation will be taken into account:
+	at least four TX_CLK/RX_CLK clock cycles */
+	tmpreg = heth->Instance->DMABMR;
+	vRegisterDelay();
+	heth->Instance->DMABMR = tmpreg;
+
+	/* Set the ETH state to Ready */
+	heth->State= HAL_ETH_STATE_READY;
+
+	/* Process Unlocked */
+	__HAL_UNLOCK( heth );
+
+	/* Return function status */
+	return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Exported_Functions_Group4 Peripheral State functions
+  *  @brief   Peripheral State functions
+  *
+  @verbatim
+  ===============================================================================
+                         ##### Peripheral State functions #####
+  ===============================================================================
+  [..]
+  This subsection permits to get in run-time the status of the peripheral
+  and the data flow.
+       (+) Get the ETH handle state:
+           HAL_ETH_GetState();
+
+
+  @endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the ETH HAL state
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL state
+  */
+HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth)
+{
+  /* Return ETH state */
+  return heth->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup ETH_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Configures Ethernet MAC and DMA with default parameters.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  err: Ethernet Init error
+  * @retval HAL status
+  */
+static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err)
+{
+  ETH_MACInitTypeDef macinit;
+  ETH_DMAInitTypeDef dmainit;
+  uint32_t tmpreg = 0uL;
+
+  if (err != ETH_SUCCESS) /* Auto-negotiation failed */
+  {
+    /* Set Ethernet duplex mode to Full-duplex */
+    heth->Init.DuplexMode = ETH_MODE_FULLDUPLEX;
+
+    /* Set Ethernet speed to 100M */
+    heth->Init.Speed = ETH_SPEED_100M;
+  }
+
+  /* Ethernet MAC default initialization **************************************/
+  macinit.Watchdog = ETH_WATCHDOG_ENABLE;
+  macinit.Jabber = ETH_JABBER_ENABLE;
+  macinit.InterFrameGap = ETH_INTERFRAMEGAP_96BIT;
+  macinit.CarrierSense = ETH_CARRIERSENCE_ENABLE;
+  macinit.ReceiveOwn = ETH_RECEIVEOWN_ENABLE;
+  macinit.LoopbackMode = ETH_LOOPBACKMODE_DISABLE;
+  if(heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE)
+  {
+    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
+  }
+  else
+  {
+    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
+  }
+  macinit.RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE;
+  macinit.AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE;
+  macinit.BackOffLimit = ETH_BACKOFFLIMIT_10;
+  macinit.DeferralCheck = ETH_DEFFERRALCHECK_DISABLE;
+  macinit.ReceiveAll = ETH_RECEIVEAll_DISABLE;
+  macinit.SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE;
+  macinit.PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL;
+  macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
+  macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
+  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE;
+  macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
+  macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;
+  macinit.HashTableHigh = 0x0uL;
+  macinit.HashTableLow = 0x0uL;
+  macinit.PauseTime = 0x0uL;
+  macinit.ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE;
+  macinit.PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4;
+  macinit.UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE;
+  macinit.ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE;
+  macinit.TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE;
+  macinit.VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT;
+  macinit.VLANTagIdentifier = 0x0uL;
+
+  /*------------------------ ETHERNET MACCR Configuration --------------------*/
+  /* Get the ETHERNET MACCR value */
+  tmpreg = heth->Instance->MACCR;
+  /* Clear WD, PCE, PS, TE and RE bits */
+  tmpreg &= ETH_MACCR_CLEAR_MASK;
+  /* Set the WD bit according to ETH Watchdog value */
+  /* Set the JD: bit according to ETH Jabber value */
+  /* Set the IFG bit according to ETH InterFrameGap value */
+  /* Set the DCRS bit according to ETH CarrierSense value */
+  /* Set the FES bit according to ETH Speed value */
+  /* Set the DO bit according to ETH ReceiveOwn value */
+  /* Set the LM bit according to ETH LoopbackMode value */
+  /* Set the DM bit according to ETH Mode value */
+  /* Set the IPCO bit according to ETH ChecksumOffload value */
+  /* Set the DR bit according to ETH RetryTransmission value */
+  /* Set the ACS bit according to ETH AutomaticPadCRCStrip value */
+  /* Set the BL bit according to ETH BackOffLimit value */
+  /* Set the DC bit according to ETH DeferralCheck value */
+  tmpreg |= (uint32_t)(macinit.Watchdog |
+                       macinit.Jabber |
+                       macinit.InterFrameGap |
+                       macinit.CarrierSense |
+                       heth->Init.Speed |
+                       macinit.ReceiveOwn |
+                       macinit.LoopbackMode |
+                       heth->Init.DuplexMode |
+                       macinit.ChecksumOffload |
+                       macinit.RetryTransmission |
+                       macinit.AutomaticPadCRCStrip |
+                       macinit.BackOffLimit |
+                       macinit.DeferralCheck);
+
+  /* Write to ETHERNET MACCR */
+  prvWriteMACCR( heth, tmpreg );
+
+  /*----------------------- ETHERNET MACFFR Configuration --------------------*/
+  /* Set the RA bit according to ETH ReceiveAll value */
+  /* Set the SAF and SAIF bits according to ETH SourceAddrFilter value */
+  /* Set the PCF bit according to ETH PassControlFrames value */
+  /* Set the DBF bit according to ETH BroadcastFramesReception value */
+  /* Set the DAIF bit according to ETH DestinationAddrFilter value */
+  /* Set the PR bit according to ETH PromiscuousMode value */
+  /* Set the PM, HMC and HPF bits according to ETH MulticastFramesFilter value */
+  /* Set the HUC and HPF bits according to ETH UnicastFramesFilter value */
+  /* Write to ETHERNET MACFFR */
+  heth->Instance->MACFFR = (uint32_t)(macinit.ReceiveAll |
+                                        macinit.SourceAddrFilter |
+                                        macinit.PassControlFrames |
+                                        macinit.BroadcastFramesReception |
+                                        macinit.DestinationAddrFilter |
+                                        macinit.PromiscuousMode |
+                                        macinit.MulticastFramesFilter |
+                                        macinit.UnicastFramesFilter);
+
+   /* Wait until the write operation will be taken into account:
+      at least four TX_CLK/RX_CLK clock cycles */
+   tmpreg = heth->Instance->MACFFR;
+   vRegisterDelay();
+   heth->Instance->MACFFR = tmpreg;
+
+   /*--------------- ETHERNET MACHTHR and MACHTLR Configuration --------------*/
+   /* Write to ETHERNET MACHTHR */
+   heth->Instance->MACHTHR = (uint32_t)macinit.HashTableHigh;
+
+   /* Write to ETHERNET MACHTLR */
+   heth->Instance->MACHTLR = (uint32_t)macinit.HashTableLow;
+   /*----------------------- ETHERNET MACFCR Configuration -------------------*/
+
+   /* Get the ETHERNET MACFCR value */
+   tmpreg = heth->Instance->MACFCR;
+   /* Clear xx bits */
+   tmpreg &= ETH_MACFCR_CLEAR_MASK;
+
+   /* Set the PT bit according to ETH PauseTime value */
+   /* Set the DZPQ bit according to ETH ZeroQuantaPause value */
+   /* Set the PLT bit according to ETH PauseLowThreshold value */
+   /* Set the UP bit according to ETH UnicastPauseFrameDetect value */
+   /* Set the RFE bit according to ETH ReceiveFlowControl value */
+   /* Set the TFE bit according to ETH TransmitFlowControl value */
+   tmpreg |= (uint32_t)((macinit.PauseTime << 16) |
+                        macinit.ZeroQuantaPause |
+                        macinit.PauseLowThreshold |
+                        macinit.UnicastPauseFrameDetect |
+                        macinit.ReceiveFlowControl |
+                        macinit.TransmitFlowControl);
+
+   /* Write to ETHERNET MACFCR */
+   prvWriteMACFCR( heth, tmpreg );
+
+   /*----------------------- ETHERNET MACVLANTR Configuration ----------------*/
+   /* Set the ETV bit according to ETH VLANTagComparison value */
+   /* Set the VL bit according to ETH VLANTagIdentifier value */
+   heth->Instance->MACVLANTR = (uint32_t)(macinit.VLANTagComparison |
+                                            macinit.VLANTagIdentifier);
+
+    /* Wait until the write operation will be taken into account:
+       at least four TX_CLK/RX_CLK clock cycles */
+    tmpreg = heth->Instance->MACVLANTR;
+    vRegisterDelay();
+    heth->Instance->MACVLANTR = tmpreg;
+
+    /* Ethernet DMA default initialization ************************************/
+    dmainit.DropTCPIPChecksumErrorFrame = ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE;
+    dmainit.ReceiveStoreForward = ETH_RECEIVESTOREFORWARD_ENABLE;
+    dmainit.FlushReceivedFrame = ETH_FLUSHRECEIVEDFRAME_ENABLE;
+    dmainit.TransmitStoreForward = ETH_TRANSMITSTOREFORWARD_ENABLE;
+    dmainit.TransmitThresholdControl = ETH_TRANSMITTHRESHOLDCONTROL_64BYTES;
+    dmainit.ForwardErrorFrames = ETH_FORWARDERRORFRAMES_DISABLE;
+    dmainit.ForwardUndersizedGoodFrames = ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE;
+    dmainit.ReceiveThresholdControl = ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES;
+    dmainit.SecondFrameOperate = ETH_SECONDFRAMEOPERARTE_ENABLE;
+    dmainit.AddressAlignedBeats = ETH_ADDRESSALIGNEDBEATS_ENABLE;
+    dmainit.FixedBurst = ETH_FIXEDBURST_ENABLE;
+    dmainit.RxDMABurstLength = ETH_RXDMABURSTLENGTH_32BEAT;
+    dmainit.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
+    dmainit.EnhancedDescriptorFormat = ETH_DMAENHANCEDDESCRIPTOR_ENABLE;
+    dmainit.DescriptorSkipLength = 0x0uL;
+    dmainit.DMAArbitration = ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1;
+
+    /* Get the ETHERNET DMAOMR value */
+    tmpreg = heth->Instance->DMAOMR;
+    /* Clear xx bits */
+    tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+
+    /* Set the DT bit according to ETH DropTCPIPChecksumErrorFrame value */
+    /* Set the RSF bit according to ETH ReceiveStoreForward value */
+    /* Set the DFF bit according to ETH FlushReceivedFrame value */
+    /* Set the TSF bit according to ETH TransmitStoreForward value */
+    /* Set the TTC bit according to ETH TransmitThresholdControl value */
+    /* Set the FEF bit according to ETH ForwardErrorFrames value */
+    /* Set the FUF bit according to ETH ForwardUndersizedGoodFrames value */
+    /* Set the RTC bit according to ETH ReceiveThresholdControl value */
+    /* Set the OSF bit according to ETH SecondFrameOperate value */
+    tmpreg |= (uint32_t)(dmainit.DropTCPIPChecksumErrorFrame |
+                         dmainit.ReceiveStoreForward |
+                         dmainit.FlushReceivedFrame |
+                         dmainit.TransmitStoreForward |
+                         dmainit.TransmitThresholdControl |
+                         dmainit.ForwardErrorFrames |
+                         dmainit.ForwardUndersizedGoodFrames |
+                         dmainit.ReceiveThresholdControl |
+                         dmainit.SecondFrameOperate);
+
+    /* Write to ETHERNET DMAOMR */
+    prvWriteDMAOMR( heth, tmpreg );
+
+    /*----------------------- ETHERNET DMABMR Configuration ------------------*/
+    /* Set the AAL bit according to ETH AddressAlignedBeats value */
+    /* Set the FB bit according to ETH FixedBurst value */
+    /* Set the RPBL and 4*PBL bits according to ETH RxDMABurstLength value */
+    /* Set the PBL and 4*PBL bits according to ETH TxDMABurstLength value */
+    /* Set the Enhanced DMA descriptors bit according to ETH EnhancedDescriptorFormat value*/
+    /* Set the DSL bit according to ETH DesciptorSkipLength value */
+    /* Set the PR and DA bits according to ETH DMAArbitration value */
+    heth->Instance->DMABMR = (uint32_t)(dmainit.AddressAlignedBeats |
+                                          dmainit.FixedBurst |
+                                          dmainit.RxDMABurstLength |    /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
+                                          dmainit.TxDMABurstLength |
+                                          dmainit.EnhancedDescriptorFormat |
+                                          (dmainit.DescriptorSkipLength << 2) |
+                                          dmainit.DMAArbitration |
+                                          ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+
+     /* Wait until the write operation will be taken into account:
+        at least four TX_CLK/RX_CLK clock cycles */
+     tmpreg = heth->Instance->DMABMR;
+     vRegisterDelay();
+     heth->Instance->DMABMR = tmpreg;
+
+     if(heth->Init.RxMode == ETH_RXINTERRUPT_MODE)
+     {
+       /* Enable the Ethernet Rx Interrupt */
+       __HAL_ETH_DMA_ENABLE_IT(( heth ), ETH_DMA_IT_NIS | ETH_DMA_IT_R);
+     }
+
+     /* Initialize MAC address in ethernet MAC */
+     ETH_MACAddressConfig(heth, ETH_MAC_ADDRESS0, heth->Init.MACAddr);
+}
+
+/**
+  * @brief  Configures the selected MAC address.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  MacAddr: The MAC address to configure
+  *          This parameter can be one of the following values:
+  *             @arg ETH_MAC_Address0: MAC Address0
+  *             @arg ETH_MAC_Address1: MAC Address1
+  *             @arg ETH_MAC_Address2: MAC Address2
+  *             @arg ETH_MAC_Address3: MAC Address3
+  * @param  Addr: Pointer to MAC address buffer data (6 bytes)
+  * @retval HAL status
+  */
+static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr)
+{
+	uint32_t tmpreg;
+
+	( void ) heth;
+
+	/* Check the parameters */
+	assert_param( IS_ETH_MAC_ADDRESS0123( MacAddr ) );
+
+	/* Calculate the selected MAC address high register */
+	/* Register ETH_MACA0HR: Bit 31 MO: Always 1. */
+	tmpreg = 0x80000000uL | ( ( uint32_t )Addr[ 5 ] << 8) | (uint32_t)Addr[ 4 ];
+	/* Load the selected MAC address high register */
+	( * ( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + MacAddr ) ) ) = tmpreg;
+	/* Calculate the selected MAC address low register */
+	tmpreg = ( ( uint32_t )Addr[ 3 ] << 24 ) | ( ( uint32_t )Addr[ 2 ] << 16 ) | ( ( uint32_t )Addr[ 1 ] << 8 ) | Addr[ 0 ];
+
+	/* Load the selected MAC address low register */
+	( * ( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + MacAddr ) ) ) = tmpreg;
+}
+
+/**
+  * @brief  Enables the MAC transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth)
+{
+	uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_TE;
+
+	prvWriteMACCR( heth, tmpreg );
+}
+
+/**
+  * @brief  Disables the MAC transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth)
+{
+	uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_TE );
+
+	prvWriteMACCR( heth, tmpreg );
+}
+
+/**
+  * @brief  Enables the MAC reception.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth)
+{
+	__IO uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_RE;
+
+	prvWriteMACCR( heth, tmpreg );
+}
+
+/**
+  * @brief  Disables the MAC reception.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth)
+{
+	__IO uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_RE );
+
+	prvWriteMACCR( heth, tmpreg );
+}
+
+/**
+  * @brief  Enables the DMA transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth)
+{
+	/* Enable the DMA transmission */
+	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_ST;
+
+	prvWriteDMAOMR( heth, tmpreg );
+}
+
+/**
+  * @brief  Disables the DMA transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth)
+{
+	/* Disable the DMA transmission */
+	__IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_ST );
+
+	prvWriteDMAOMR( heth, tmpreg );
+}
+
+/**
+  * @brief  Enables the DMA reception.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth)
+{
+	/* Enable the DMA reception */
+	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_SR;
+
+	prvWriteDMAOMR( heth, tmpreg );
+}
+
+/**
+  * @brief  Disables the DMA reception.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth)
+{
+	/* Disable the DMA reception */
+	__IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_SR );
+
+	prvWriteDMAOMR( heth, tmpreg );
+}
+
+/**
+  * @brief  Clears the ETHERNET transmit FIFO.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth)
+{
+	/* Set the Flush Transmit FIFO bit */
+	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_FTF;
+
+	prvWriteDMAOMR( heth, tmpreg );
+}
+
+/**
+  * @}
+  */
+#endif /* stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 */
+
+#endif /* HAL_ETH_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -1,0 +1,2262 @@
+/**
+  ******************************************************************************
+  * @file    stm32fxx_hal_eth.h
+  * @author  MCD Application Team
+  * @version V1.2.2
+  * @date    14-April-2017
+  * @brief   Header file of ETH HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32Fxx_HAL_ETH_H
+#define __STM32Fxx_HAL_ETH_H
+
+/* make sure that the original ETH headers files won't be included after this. */
+#define __STM32F2xx_HAL_ETH_H
+#define __STM32F4xx_HAL_ETH_H
+#define __STM32F7xx_HAL_ETH_H
+
+#if defined(STM32F7xx)
+	#include "stm32f7xx_hal_def.h"
+#elif defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
+	#include "stm32f4xx_hal_def.h"
+#elif defined(STM32F2xx)
+	#include "stm32f2xx_hal_def.h"
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup STM32Fxx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ETH
+  * @{
+  */
+
+/** @addtogroup ETH_Private_Macros
+  * @{
+  */
+#define IS_ETH_PHY_ADDRESS(ADDRESS) ((ADDRESS) <= 0x20)
+#define IS_ETH_AUTONEGOTIATION(CMD) (((CMD) == ETH_AUTONEGOTIATION_ENABLE) || \
+                                     ((CMD) == ETH_AUTONEGOTIATION_DISABLE))
+#define IS_ETH_SPEED(SPEED) (((SPEED) == ETH_SPEED_10M) || \
+                             ((SPEED) == ETH_SPEED_100M))
+#define IS_ETH_DUPLEX_MODE(MODE)  (((MODE) == ETH_MODE_FULLDUPLEX) || \
+                                  ((MODE) == ETH_MODE_HALFDUPLEX))
+#define IS_ETH_DUPLEX_MODE(MODE)  (((MODE) == ETH_MODE_FULLDUPLEX) || \
+                                  ((MODE) == ETH_MODE_HALFDUPLEX))
+#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
+                                 ((MODE) == ETH_RXINTERRUPT_MODE))
+#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
+                                 ((MODE) == ETH_RXINTERRUPT_MODE))
+#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
+                                 ((MODE) == ETH_RXINTERRUPT_MODE))
+#define IS_ETH_CHECKSUM_MODE(MODE)    (((MODE) == ETH_CHECKSUM_BY_HARDWARE) || \
+                                      ((MODE) == ETH_CHECKSUM_BY_SOFTWARE))
+#define IS_ETH_MEDIA_INTERFACE(MODE)         (((MODE) == ETH_MEDIA_INTERFACE_MII) || \
+                                              ((MODE) == ETH_MEDIA_INTERFACE_RMII))
+#define IS_ETH_WATCHDOG(CMD) (((CMD) == ETH_WATCHDOG_ENABLE) || \
+                              ((CMD) == ETH_WATCHDOG_DISABLE))
+#define IS_ETH_JABBER(CMD) (((CMD) == ETH_JABBER_ENABLE) || \
+                            ((CMD) == ETH_JABBER_DISABLE))
+#define IS_ETH_INTER_FRAME_GAP(GAP) (((GAP) == ETH_INTERFRAMEGAP_96BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_88BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_80BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_72BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_64BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_56BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_48BIT) || \
+                                     ((GAP) == ETH_INTERFRAMEGAP_40BIT))
+#define IS_ETH_CARRIER_SENSE(CMD) (((CMD) == ETH_CARRIERSENCE_ENABLE) || \
+                                   ((CMD) == ETH_CARRIERSENCE_DISABLE))
+#define IS_ETH_RECEIVE_OWN(CMD) (((CMD) == ETH_RECEIVEOWN_ENABLE) || \
+                                 ((CMD) == ETH_RECEIVEOWN_DISABLE))
+#define IS_ETH_LOOPBACK_MODE(CMD) (((CMD) == ETH_LOOPBACKMODE_ENABLE) || \
+                                   ((CMD) == ETH_LOOPBACKMODE_DISABLE))
+#define IS_ETH_CHECKSUM_OFFLOAD(CMD) (((CMD) == ETH_CHECKSUMOFFLAOD_ENABLE) || \
+                                      ((CMD) == ETH_CHECKSUMOFFLAOD_DISABLE))
+#define IS_ETH_RETRY_TRANSMISSION(CMD) (((CMD) == ETH_RETRYTRANSMISSION_ENABLE) || \
+                                        ((CMD) == ETH_RETRYTRANSMISSION_DISABLE))
+#define IS_ETH_AUTOMATIC_PADCRC_STRIP(CMD) (((CMD) == ETH_AUTOMATICPADCRCSTRIP_ENABLE) || \
+                                            ((CMD) == ETH_AUTOMATICPADCRCSTRIP_DISABLE))
+#define IS_ETH_BACKOFF_LIMIT(LIMIT) (((LIMIT) == ETH_BACKOFFLIMIT_10) || \
+                                     ((LIMIT) == ETH_BACKOFFLIMIT_8) || \
+                                     ((LIMIT) == ETH_BACKOFFLIMIT_4) || \
+                                     ((LIMIT) == ETH_BACKOFFLIMIT_1))
+#define IS_ETH_DEFERRAL_CHECK(CMD) (((CMD) == ETH_DEFFERRALCHECK_ENABLE) || \
+                                    ((CMD) == ETH_DEFFERRALCHECK_DISABLE))
+#define IS_ETH_RECEIVE_ALL(CMD) (((CMD) == ETH_RECEIVEALL_ENABLE) || \
+                                 ((CMD) == ETH_RECEIVEAll_DISABLE))
+#define IS_ETH_SOURCE_ADDR_FILTER(CMD) (((CMD) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE) || \
+                                        ((CMD) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE) || \
+                                        ((CMD) == ETH_SOURCEADDRFILTER_DISABLE))
+#define IS_ETH_CONTROL_FRAMES(PASS) (((PASS) == ETH_PASSCONTROLFRAMES_BLOCKALL) || \
+                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDALL) || \
+                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER))
+#define IS_ETH_BROADCAST_FRAMES_RECEPTION(CMD) (((CMD) == ETH_BROADCASTFRAMESRECEPTION_ENABLE) || \
+                                                ((CMD) == ETH_BROADCASTFRAMESRECEPTION_DISABLE))
+#define IS_ETH_DESTINATION_ADDR_FILTER(FILTER) (((FILTER) == ETH_DESTINATIONADDRFILTER_NORMAL) || \
+                                                ((FILTER) == ETH_DESTINATIONADDRFILTER_INVERSE))
+#define IS_ETH_PROMISCUOUS_MODE(CMD) (((CMD) == ETH_PROMISCUOUS_MODE_ENABLE) || \
+                                      ((CMD) == ETH_PROMISCUOUS_MODE_DISABLE))
+#define IS_ETH_MULTICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE) || \
+                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_HASHTABLE) || \
+                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECT) || \
+                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_NONE))
+#define IS_ETH_UNICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE) || \
+                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_HASHTABLE) || \
+                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECT))
+#define IS_ETH_PAUSE_TIME(TIME) ((TIME) <= 0xFFFF)
+#define IS_ETH_ZEROQUANTA_PAUSE(CMD)   (((CMD) == ETH_ZEROQUANTAPAUSE_ENABLE) || \
+                                        ((CMD) == ETH_ZEROQUANTAPAUSE_DISABLE))
+#define IS_ETH_PAUSE_LOW_THRESHOLD(THRESHOLD) (((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS4) || \
+                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS28) || \
+                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS144) || \
+                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS256))
+#define IS_ETH_UNICAST_PAUSE_FRAME_DETECT(CMD) (((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE) || \
+                                                ((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE))
+#define IS_ETH_RECEIVE_FLOWCONTROL(CMD) (((CMD) == ETH_RECEIVEFLOWCONTROL_ENABLE) || \
+                                         ((CMD) == ETH_RECEIVEFLOWCONTROL_DISABLE))
+#define IS_ETH_TRANSMIT_FLOWCONTROL(CMD) (((CMD) == ETH_TRANSMITFLOWCONTROL_ENABLE) || \
+                                          ((CMD) == ETH_TRANSMITFLOWCONTROL_DISABLE))
+#define IS_ETH_VLAN_TAG_COMPARISON(COMPARISON) (((COMPARISON) == ETH_VLANTAGCOMPARISON_12BIT) || \
+                                                ((COMPARISON) == ETH_VLANTAGCOMPARISON_16BIT))
+#define IS_ETH_VLAN_TAG_IDENTIFIER(IDENTIFIER) ((IDENTIFIER) <= 0xFFFF)
+#define IS_ETH_MAC_ADDRESS0123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS0) || \
+                                         ((ADDRESS) == ETH_MAC_ADDRESS1) || \
+                                         ((ADDRESS) == ETH_MAC_ADDRESS2) || \
+                                         ((ADDRESS) == ETH_MAC_ADDRESS3))
+#define IS_ETH_MAC_ADDRESS123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS1) || \
+                                        ((ADDRESS) == ETH_MAC_ADDRESS2) || \
+                                        ((ADDRESS) == ETH_MAC_ADDRESS3))
+#define IS_ETH_MAC_ADDRESS_FILTER(FILTER) (((FILTER) == ETH_MAC_ADDRESSFILTER_SA) || \
+                                           ((FILTER) == ETH_MAC_ADDRESSFILTER_DA))
+#define IS_ETH_MAC_ADDRESS_MASK(MASK) (((MASK) == ETH_MAC_ADDRESSMASK_BYTE6) || \
+                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE5) || \
+                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE4) || \
+                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE3) || \
+                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE2) || \
+                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE1))
+#define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(CMD) (((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE) || \
+                                               ((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE))
+#define IS_ETH_RECEIVE_STORE_FORWARD(CMD) (((CMD) == ETH_RECEIVESTOREFORWARD_ENABLE) || \
+                                           ((CMD) == ETH_RECEIVESTOREFORWARD_DISABLE))
+#define IS_ETH_FLUSH_RECEIVE_FRAME(CMD) (((CMD) == ETH_FLUSHRECEIVEDFRAME_ENABLE) || \
+                                         ((CMD) == ETH_FLUSHRECEIVEDFRAME_DISABLE))
+#define IS_ETH_TRANSMIT_STORE_FORWARD(CMD) (((CMD) == ETH_TRANSMITSTOREFORWARD_ENABLE) || \
+                                            ((CMD) == ETH_TRANSMITSTOREFORWARD_DISABLE))
+#define IS_ETH_TRANSMIT_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_256BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_40BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES) || \
+                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES))
+#define IS_ETH_FORWARD_ERROR_FRAMES(CMD) (((CMD) == ETH_FORWARDERRORFRAMES_ENABLE) || \
+                                          ((CMD) == ETH_FORWARDERRORFRAMES_DISABLE))
+#define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(CMD) (((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE) || \
+                                                    ((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE))
+#define IS_ETH_RECEIVE_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES) || \
+                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES) || \
+                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES) || \
+                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES))
+#define IS_ETH_SECOND_FRAME_OPERATE(CMD) (((CMD) == ETH_SECONDFRAMEOPERARTE_ENABLE) || \
+                                          ((CMD) == ETH_SECONDFRAMEOPERARTE_DISABLE))
+#define IS_ETH_ADDRESS_ALIGNED_BEATS(CMD) (((CMD) == ETH_ADDRESSALIGNEDBEATS_ENABLE) || \
+                                           ((CMD) == ETH_ADDRESSALIGNEDBEATS_DISABLE))
+#define IS_ETH_FIXED_BURST(CMD) (((CMD) == ETH_FIXEDBURST_ENABLE) || \
+                                 ((CMD) == ETH_FIXEDBURST_DISABLE))
+#define IS_ETH_RXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_RXDMABURSTLENGTH_1BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_2BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_8BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_16BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_32BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_4BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_8BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_16BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT) || \
+                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT))
+#define IS_ETH_TXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_TXDMABURSTLENGTH_1BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_2BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_8BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_16BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_32BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_4BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_8BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_16BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT) || \
+                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT))
+#define IS_ETH_DMA_DESC_SKIP_LENGTH(LENGTH) ((LENGTH) <= 0x1F)
+#define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(RATIO) (((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1) || \
+                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1) || \
+                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1) || \
+                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1) || \
+                                                       ((RATIO) == ETH_DMAARBITRATION_RXPRIORTX))
+#define IS_ETH_DMATXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMATXDESC_OWN) || \
+                                         ((FLAG) == ETH_DMATXDESC_IC) || \
+                                         ((FLAG) == ETH_DMATXDESC_LS) || \
+                                         ((FLAG) == ETH_DMATXDESC_FS) || \
+                                         ((FLAG) == ETH_DMATXDESC_DC) || \
+                                         ((FLAG) == ETH_DMATXDESC_DP) || \
+                                         ((FLAG) == ETH_DMATXDESC_TTSE) || \
+                                         ((FLAG) == ETH_DMATXDESC_TER) || \
+                                         ((FLAG) == ETH_DMATXDESC_TCH) || \
+                                         ((FLAG) == ETH_DMATXDESC_TTSS) || \
+                                         ((FLAG) == ETH_DMATXDESC_IHE) || \
+                                         ((FLAG) == ETH_DMATXDESC_ES) || \
+                                         ((FLAG) == ETH_DMATXDESC_JT) || \
+                                         ((FLAG) == ETH_DMATXDESC_FF) || \
+                                         ((FLAG) == ETH_DMATXDESC_PCE) || \
+                                         ((FLAG) == ETH_DMATXDESC_LCA) || \
+                                         ((FLAG) == ETH_DMATXDESC_NC) || \
+                                         ((FLAG) == ETH_DMATXDESC_LCO) || \
+                                         ((FLAG) == ETH_DMATXDESC_EC) || \
+                                         ((FLAG) == ETH_DMATXDESC_VF) || \
+                                         ((FLAG) == ETH_DMATXDESC_CC) || \
+                                         ((FLAG) == ETH_DMATXDESC_ED) || \
+                                         ((FLAG) == ETH_DMATXDESC_UF) || \
+                                         ((FLAG) == ETH_DMATXDESC_DB))
+#define IS_ETH_DMA_TXDESC_SEGMENT(SEGMENT) (((SEGMENT) == ETH_DMATXDESC_LASTSEGMENTS) || \
+                                            ((SEGMENT) == ETH_DMATXDESC_FIRSTSEGMENT))
+#define IS_ETH_DMA_TXDESC_CHECKSUM(CHECKSUM) (((CHECKSUM) == ETH_DMATXDESC_CHECKSUMBYPASS) || \
+                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMIPV4HEADER) || \
+                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT) || \
+                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL))
+#define IS_ETH_DMATXDESC_BUFFER_SIZE(SIZE) ((SIZE) <= 0x1FFF)
+#define IS_ETH_DMARXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMARXDESC_OWN) || \
+                                         ((FLAG) == ETH_DMARXDESC_AFM) || \
+                                         ((FLAG) == ETH_DMARXDESC_ES) || \
+                                         ((FLAG) == ETH_DMARXDESC_DE) || \
+                                         ((FLAG) == ETH_DMARXDESC_SAF) || \
+                                         ((FLAG) == ETH_DMARXDESC_LE) || \
+                                         ((FLAG) == ETH_DMARXDESC_OE) || \
+                                         ((FLAG) == ETH_DMARXDESC_VLAN) || \
+                                         ((FLAG) == ETH_DMARXDESC_FS) || \
+                                         ((FLAG) == ETH_DMARXDESC_LS) || \
+                                         ((FLAG) == ETH_DMARXDESC_IPV4HCE) || \
+                                         ((FLAG) == ETH_DMARXDESC_LC) || \
+                                         ((FLAG) == ETH_DMARXDESC_FT) || \
+                                         ((FLAG) == ETH_DMARXDESC_RWT) || \
+                                         ((FLAG) == ETH_DMARXDESC_RE) || \
+                                         ((FLAG) == ETH_DMARXDESC_DBE) || \
+                                         ((FLAG) == ETH_DMARXDESC_CE) || \
+                                         ((FLAG) == ETH_DMARXDESC_MAMPCE))
+#define IS_ETH_DMA_RXDESC_BUFFER(BUFFER) (((BUFFER) == ETH_DMARXDESC_BUFFER1) || \
+                                          ((BUFFER) == ETH_DMARXDESC_BUFFER2))
+#define IS_ETH_PMT_GET_FLAG(FLAG) (((FLAG) == ETH_PMT_FLAG_WUFR) || \
+                                   ((FLAG) == ETH_PMT_FLAG_MPR))
+#define IS_ETH_DMA_FLAG(FLAG) ((((FLAG) & (uint32_t)0xC7FE1800) == 0x00) && ((FLAG) != 0x00))
+#define IS_ETH_DMA_GET_FLAG(FLAG) (((FLAG) == ETH_DMA_FLAG_TST) || ((FLAG) == ETH_DMA_FLAG_PMT) || \
+                                   ((FLAG) == ETH_DMA_FLAG_MMC) || ((FLAG) == ETH_DMA_FLAG_DATATRANSFERERROR) || \
+                                   ((FLAG) == ETH_DMA_FLAG_READWRITEERROR) || ((FLAG) == ETH_DMA_FLAG_ACCESSERROR) || \
+                                   ((FLAG) == ETH_DMA_FLAG_NIS) || ((FLAG) == ETH_DMA_FLAG_AIS) || \
+                                   ((FLAG) == ETH_DMA_FLAG_ER) || ((FLAG) == ETH_DMA_FLAG_FBE) || \
+                                   ((FLAG) == ETH_DMA_FLAG_ET) || ((FLAG) == ETH_DMA_FLAG_RWT) || \
+                                   ((FLAG) == ETH_DMA_FLAG_RPS) || ((FLAG) == ETH_DMA_FLAG_RBU) || \
+                                   ((FLAG) == ETH_DMA_FLAG_R) || ((FLAG) == ETH_DMA_FLAG_TU) || \
+                                   ((FLAG) == ETH_DMA_FLAG_RO) || ((FLAG) == ETH_DMA_FLAG_TJT) || \
+                                   ((FLAG) == ETH_DMA_FLAG_TBU) || ((FLAG) == ETH_DMA_FLAG_TPS) || \
+                                   ((FLAG) == ETH_DMA_FLAG_T))
+#define IS_ETH_MAC_IT(IT) ((((IT) & (uint32_t)0xFFFFFDF1) == 0x00) && ((IT) != 0x00))
+#define IS_ETH_MAC_GET_IT(IT) (((IT) == ETH_MAC_IT_TST) || ((IT) == ETH_MAC_IT_MMCT) || \
+                               ((IT) == ETH_MAC_IT_MMCR) || ((IT) == ETH_MAC_IT_MMC) || \
+                               ((IT) == ETH_MAC_IT_PMT))
+#define IS_ETH_MAC_GET_FLAG(FLAG) (((FLAG) == ETH_MAC_FLAG_TST) || ((FLAG) == ETH_MAC_FLAG_MMCT) || \
+                                   ((FLAG) == ETH_MAC_FLAG_MMCR) || ((FLAG) == ETH_MAC_FLAG_MMC) || \
+                                   ((FLAG) == ETH_MAC_FLAG_PMT))
+#define IS_ETH_DMA_IT(IT) ((((IT) & (uint32_t)0xC7FE1800) == 0x00) && ((IT) != 0x00))
+#define IS_ETH_DMA_GET_IT(IT) (((IT) == ETH_DMA_IT_TST) || ((IT) == ETH_DMA_IT_PMT) || \
+                               ((IT) == ETH_DMA_IT_MMC) || ((IT) == ETH_DMA_IT_NIS) || \
+                               ((IT) == ETH_DMA_IT_AIS) || ((IT) == ETH_DMA_IT_ER) || \
+                               ((IT) == ETH_DMA_IT_FBE) || ((IT) == ETH_DMA_IT_ET) || \
+                               ((IT) == ETH_DMA_IT_RWT) || ((IT) == ETH_DMA_IT_RPS) || \
+                               ((IT) == ETH_DMA_IT_RBU) || ((IT) == ETH_DMA_IT_R) || \
+                               ((IT) == ETH_DMA_IT_TU) || ((IT) == ETH_DMA_IT_RO) || \
+                               ((IT) == ETH_DMA_IT_TJT) || ((IT) == ETH_DMA_IT_TBU) || \
+                               ((IT) == ETH_DMA_IT_TPS) || ((IT) == ETH_DMA_IT_T))
+#define IS_ETH_DMA_GET_OVERFLOW(OVERFLOW) (((OVERFLOW) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER) || \
+                                           ((OVERFLOW) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER))
+#define IS_ETH_MMC_IT(IT) (((((IT) & (uint32_t)0xFFDF3FFF) == 0x00) || (((IT) & (uint32_t)0xEFFDFF9F) == 0x00)) && \
+                           ((IT) != 0x00))
+#define IS_ETH_MMC_GET_IT(IT) (((IT) == ETH_MMC_IT_TGF) || ((IT) == ETH_MMC_IT_TGFMSC) || \
+                               ((IT) == ETH_MMC_IT_TGFSC) || ((IT) == ETH_MMC_IT_RGUF) || \
+                               ((IT) == ETH_MMC_IT_RFAE) || ((IT) == ETH_MMC_IT_RFCE))
+#define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(CMD) (((CMD) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE) || \
+                                                ((CMD) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE))
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup ETH_Private_Defines
+  * @{
+  */
+/* Delay to wait when writing to some Ethernet registers */
+#define ETH_REG_WRITE_DELAY ((uint32_t)0x00000001U)
+
+/* Ethernet Errors */
+#define  ETH_SUCCESS            ((uint32_t)0U)
+#define  ETH_ERROR              ((uint32_t)1U)
+
+/* Ethernet DMA Tx descriptors Collision Count Shift */
+#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT         ((uint32_t)3U)
+
+/* Ethernet DMA Tx descriptors Buffer2 Size Shift */
+#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
+
+/* Ethernet DMA Rx descriptors Frame Length Shift */
+#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT           ((uint32_t)16U)
+
+/* Ethernet DMA Rx descriptors Buffer2 Size Shift */
+#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
+
+/* Ethernet DMA Rx descriptors Frame length Shift */
+#define  ETH_DMARXDESC_FRAMELENGTHSHIFT            ((uint32_t)16U)
+
+/* Ethernet MAC address offsets */
+#define ETH_MAC_ADDR_HBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x40U)  /* Ethernet MAC address high offset */
+#define ETH_MAC_ADDR_LBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x44U)  /* Ethernet MAC address low offset */
+
+/* Ethernet MACMIIAR register Mask */
+#define ETH_MACMIIAR_CR_MASK    ((uint32_t)0xFFFFFFE3U)
+
+/* Ethernet MACCR register Mask */
+#define ETH_MACCR_CLEAR_MASK    ((uint32_t)0xFF20810FU)
+
+/* Ethernet MACFCR register Mask */
+#define ETH_MACFCR_CLEAR_MASK   ((uint32_t)0x0000FF41U)
+
+/* Ethernet DMAOMR register Mask */
+#define ETH_DMAOMR_CLEAR_MASK   ((uint32_t)0xF8DE3F23U)
+
+/* Ethernet Remote Wake-up frame register length */
+#define ETH_WAKEUP_REGISTER_LENGTH      8U
+
+/* Ethernet Missed frames counter Shift */
+#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT     17U
+ /**
+  * @}
+  */
+
+#ifdef _lint
+	#ifdef __IO
+		#undef __IO
+	#endif
+	#define __IO
+
+	#ifdef ETH_TypeDef
+		#undef ETH_TypeDef
+	#endif
+	#define ETH_TypeDef	void
+
+	#ifdef HAL_LockTypeDef
+		#undef HAL_LockTypeDef
+	#endif
+	#define HAL_LockTypeDef	unsigned
+
+	#ifdef ETH_RX_BUF_SIZE
+		#undef ETH_RX_BUF_SIZE
+	#endif
+	#define ETH_RX_BUF_SIZE	1536
+
+	#ifdef ETH_TX_BUF_SIZE
+		#undef ETH_TX_BUF_SIZE
+	#endif
+	#define ETH_TX_BUF_SIZE	1536
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ETH_Exported_Types ETH Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_ETH_STATE_RESET             = 0x00U,    /*!< Peripheral not yet Initialized or disabled         */
+  HAL_ETH_STATE_READY             = 0x01U,    /*!< Peripheral Initialized and ready for use           */
+  HAL_ETH_STATE_BUSY              = 0x02U,    /*!< an internal process is ongoing                     */
+  HAL_ETH_STATE_BUSY_TX           = 0x12U,    /*!< Data Transmission process is ongoing               */
+  HAL_ETH_STATE_BUSY_RX           = 0x22U,    /*!< Data Reception process is ongoing                  */
+  HAL_ETH_STATE_BUSY_TX_RX        = 0x32U,    /*!< Data Transmission and Reception process is ongoing */
+  HAL_ETH_STATE_BUSY_WR           = 0x42U,    /*!< Write process is ongoing                           */
+  HAL_ETH_STATE_BUSY_RD           = 0x82U,    /*!< Read process is ongoing                            */
+  HAL_ETH_STATE_TIMEOUT           = 0x03U,    /*!< Timeout state                                      */
+  HAL_ETH_STATE_ERROR             = 0x04U     /*!< Reception process is ongoing                       */
+}HAL_ETH_StateTypeDef;
+
+/**
+  * @brief  ETH Init Structure definition
+  */
+
+typedef struct
+{
+  uint32_t             AutoNegotiation;           /*!< Selects or not the AutoNegotiation mode for the external PHY
+                                                           The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
+                                                           and the mode (half/full-duplex).
+                                                           This parameter can be a value of @ref ETH_AutoNegotiation */
+
+  uint32_t             Speed;                     /*!< Sets the Ethernet speed: 10/100 Mbps.
+                                                           This parameter can be a value of @ref ETH_Speed */
+
+  uint32_t             DuplexMode;                /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                                                           This parameter can be a value of @ref ETH_Duplex_Mode */
+
+  uint16_t             PhyAddress;                /*!< Ethernet PHY address.
+                                                           This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+
+  uint8_t             *MACAddr;                   /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+
+  uint32_t             RxMode;                    /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
+                                                           This parameter can be a value of @ref ETH_Rx_Mode */
+
+  uint32_t             ChecksumMode;              /*!< Selects if the checksum is check by hardware or by software.
+                                                         This parameter can be a value of @ref ETH_Checksum_Mode */
+
+  uint32_t             MediaInterface    ;               /*!< Selects the media-independent interface or the reduced media-independent interface.
+                                                         This parameter can be a value of @ref ETH_Media_Interface */
+
+} ETH_InitTypeDef;
+
+
+ /**
+  * @brief  ETH MAC Configuration Structure definition
+  */
+
+typedef struct
+{
+  uint32_t             Watchdog;                  /*!< Selects or not the Watchdog timer
+                                                           When enabled, the MAC allows no more then 2048 bytes to be received.
+                                                           When disabled, the MAC can receive up to 16384 bytes.
+                                                           This parameter can be a value of @ref ETH_Watchdog */
+
+  uint32_t             Jabber;                    /*!< Selects or not Jabber timer
+                                                           When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                                           When disabled, the MAC can send up to 16384 bytes.
+                                                           This parameter can be a value of @ref ETH_Jabber */
+
+  uint32_t             InterFrameGap;             /*!< Selects the minimum IFG between frames during transmission.
+                                                           This parameter can be a value of @ref ETH_Inter_Frame_Gap */
+
+  uint32_t             CarrierSense;              /*!< Selects or not the Carrier Sense.
+                                                           This parameter can be a value of @ref ETH_Carrier_Sense */
+
+  uint32_t             ReceiveOwn;                /*!< Selects or not the ReceiveOwn,
+                                                           ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
+                                                           in Half-Duplex mode.
+                                                           This parameter can be a value of @ref ETH_Receive_Own */
+
+  uint32_t             LoopbackMode;              /*!< Selects or not the internal MAC MII Loopback mode.
+                                                           This parameter can be a value of @ref ETH_Loop_Back_Mode */
+
+  uint32_t             ChecksumOffload;           /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
+                                                           This parameter can be a value of @ref ETH_Checksum_Offload */
+
+  uint32_t             RetryTransmission;         /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
+                                                           when a collision occurs (Half-Duplex mode).
+                                                           This parameter can be a value of @ref ETH_Retry_Transmission */
+
+  uint32_t             AutomaticPadCRCStrip;      /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
+                                                           This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
+
+  uint32_t             BackOffLimit;              /*!< Selects the BackOff limit value.
+                                                           This parameter can be a value of @ref ETH_Back_Off_Limit */
+
+  uint32_t             DeferralCheck;             /*!< Selects or not the deferral check function (Half-Duplex mode).
+                                                           This parameter can be a value of @ref ETH_Deferral_Check */
+
+  uint32_t             ReceiveAll;                /*!< Selects or not all frames reception by the MAC (No filtering).
+                                                           This parameter can be a value of @ref ETH_Receive_All */
+
+  uint32_t             SourceAddrFilter;          /*!< Selects the Source Address Filter mode.
+                                                           This parameter can be a value of @ref ETH_Source_Addr_Filter */
+
+  uint32_t             PassControlFrames;         /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
+                                                           This parameter can be a value of @ref ETH_Pass_Control_Frames */
+
+  uint32_t             BroadcastFramesReception;  /*!< Selects or not the reception of Broadcast Frames.
+                                                           This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
+
+  uint32_t             DestinationAddrFilter;     /*!< Sets the destination filter mode for both unicast and multicast frames.
+                                                           This parameter can be a value of @ref ETH_Destination_Addr_Filter */
+
+  uint32_t             PromiscuousMode;           /*!< Selects or not the Promiscuous Mode
+                                                           This parameter can be a value of @ref ETH_Promiscuous_Mode */
+
+  uint32_t             MulticastFramesFilter;     /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                                           This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
+
+  uint32_t             UnicastFramesFilter;       /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                                           This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
+
+  uint32_t             HashTableHigh;             /*!< This field holds the higher 32 bits of Hash table.
+                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+
+  uint32_t             HashTableLow;              /*!< This field holds the lower 32 bits of Hash table.
+                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
+
+  uint32_t             PauseTime;                 /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
+                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+
+  uint32_t             ZeroQuantaPause;           /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
+                                                           This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
+
+  uint32_t             PauseLowThreshold;         /*!< This field configures the threshold of the PAUSE to be checked for
+                                                           automatic retransmission of PAUSE Frame.
+                                                           This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+
+  uint32_t             UnicastPauseFrameDetect;   /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
+                                                           unicast address and unique multicast address).
+                                                           This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
+
+  uint32_t             ReceiveFlowControl;        /*!< Enables or disables the MAC to decode the received Pause frame and
+                                                           disable its transmitter for a specified time (Pause Time)
+                                                           This parameter can be a value of @ref ETH_Receive_Flow_Control */
+
+  uint32_t             TransmitFlowControl;       /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
+                                                           or the MAC back-pressure operation (Half-Duplex mode)
+                                                           This parameter can be a value of @ref ETH_Transmit_Flow_Control */
+
+  uint32_t             VLANTagComparison;         /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
+                                                           comparison and filtering.
+                                                           This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
+
+  uint32_t             VLANTagIdentifier;         /*!< Holds the VLAN tag identifier for receive frames */
+
+} ETH_MACInitTypeDef;
+
+
+/**
+  * @brief  ETH DMA Configuration Structure definition
+  */
+
+typedef struct
+{
+ uint32_t              DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
+                                                             This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
+
+  uint32_t             ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
+                                                             This parameter can be a value of @ref ETH_Receive_Store_Forward */
+
+  uint32_t             FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
+                                                             This parameter can be a value of @ref ETH_Flush_Received_Frame */
+
+  uint32_t             TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
+                                                             This parameter can be a value of @ref ETH_Transmit_Store_Forward */
+
+  uint32_t             TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
+                                                             This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
+
+  uint32_t             ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
+                                                             This parameter can be a value of @ref ETH_Forward_Error_Frames */
+
+  uint32_t             ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+                                                             and length less than 64 bytes) including pad-bytes and CRC)
+                                                             This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
+
+  uint32_t             ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
+                                                             This parameter can be a value of @ref ETH_Receive_Threshold_Control */
+
+  uint32_t             SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+                                                             frame of Transmit data even before obtaining the status for the first frame.
+                                                             This parameter can be a value of @ref ETH_Second_Frame_Operate */
+
+  uint32_t             AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
+                                                             This parameter can be a value of @ref ETH_Address_Aligned_Beats */
+
+  uint32_t             FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
+                                                             This parameter can be a value of @ref ETH_Fixed_Burst */
+
+  uint32_t             RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                                             This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+
+  uint32_t             TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                                             This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+
+  uint32_t             EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
+                                                             This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
+
+  uint32_t             DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+                                                             This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+
+  uint32_t             DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
+                                                             This parameter can be a value of @ref ETH_DMA_Arbitration */
+} ETH_DMAInitTypeDef;
+
+
+/**
+  * @brief  ETH DMA Descriptors data structure definition
+  */
+
+typedef struct
+{
+  __IO uint32_t   Status;           /*!< Status */
+
+  uint32_t   ControlBufferSize;     /*!< Control and Buffer1, Buffer2 lengths */
+
+  uint32_t   Buffer1Addr;           /*!< Buffer1 address pointer */
+
+  uint32_t   Buffer2NextDescAddr;   /*!< Buffer2 or next descriptor address pointer */
+
+  /*!< Enhanced Ethernet DMA PTP Descriptors */
+  uint32_t   ExtendedStatus;        /*!< Extended status for PTP receive descriptor */
+
+  uint32_t   Reserved1;             /*!< Reserved */
+
+  uint32_t   TimeStampLow;          /*!< Time Stamp Low value for transmit and receive */
+
+  uint32_t   TimeStampHigh;         /*!< Time Stamp High value for transmit and receive */
+
+} ETH_DMADescTypeDef;
+
+
+/**
+  * @brief  Received Frame Informations structure definition
+  */
+typedef struct
+{
+  ETH_DMADescTypeDef *FSRxDesc;          /*!< First Segment Rx Desc */
+
+  ETH_DMADescTypeDef *LSRxDesc;          /*!< Last Segment Rx Desc */
+
+  uint32_t  SegCount;                    /*!< Segment count */
+
+  uint32_t length;                       /*!< Frame length */
+
+  uint32_t buffer;                       /*!< Frame buffer */
+
+} ETH_DMARxFrameInfos;
+
+
+/**
+  * @brief  ETH Handle Structure definition
+  */
+
+typedef struct
+{
+  ETH_TypeDef                *Instance;     /*!< Register base address       */
+
+  ETH_InitTypeDef            Init;          /*!< Ethernet Init Configuration */
+
+  uint32_t                   LinkStatus;    /*!< Ethernet link status        */
+
+  ETH_DMADescTypeDef         *RxDesc;       /*!< Rx descriptor to Get        */
+
+  ETH_DMADescTypeDef         *TxDesc;       /*!< Tx descriptor to Set        */
+
+  ETH_DMARxFrameInfos        RxFrameInfos;  /*!< last Rx frame infos         */
+
+  __IO HAL_ETH_StateTypeDef  State;         /*!< ETH communication state     */
+
+  HAL_LockTypeDef            Lock;          /*!< ETH Lock                    */
+
+} ETH_HandleTypeDef;
+
+ /**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup ETH_Exported_Constants ETH Exported Constants
+  * @{
+  */
+
+/** @defgroup ETH_Buffers_setting ETH Buffers setting
+  * @{
+  */
+#define ETH_MAX_PACKET_SIZE    ((uint32_t)1536U)    /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
+#define ETH_HEADER               ((uint32_t)14U)    /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+#define ETH_CRC                   ((uint32_t)4U)    /*!< Ethernet CRC */
+#define ETH_EXTRA                 ((uint32_t)2U)    /*!< Extra bytes in some cases */
+#define ETH_VLAN_TAG              ((uint32_t)4U)    /*!< optional 802.1q VLAN Tag */
+#define ETH_MIN_ETH_PAYLOAD       ((uint32_t)46U)    /*!< Minimum Ethernet payload size */
+#define ETH_MAX_ETH_PAYLOAD       ((uint32_t)1500U)    /*!< Maximum Ethernet payload size */
+#define ETH_JUMBO_FRAME_PAYLOAD   ((uint32_t)9000U)    /*!< Jumbo frame payload size */
+
+ /* Ethernet driver receive buffers are organized in a chained linked-list, when
+    an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
+    to the driver receive buffers memory.
+
+    Depending on the size of the received Ethernet packet and the size of
+    each Ethernet driver receive buffer, the received packet can take one or more
+    Ethernet driver receive buffer.
+
+    In below are defined the size of one Ethernet driver receive buffer ETH_RX_BUF_SIZE
+    and the total count of the driver receive buffers ETH_RXBUFNB.
+
+    The configured value for ETH_RX_BUF_SIZE and ETH_RXBUFNB are only provided as
+    example, they can be reconfigured in the application layer to fit the application
+    needs */
+
+/* Here we configure each Ethernet driver receive buffer to fit the Max size Ethernet
+   packet */
+#ifndef ETH_RX_BUF_SIZE
+ #error please define ETH_RX_BUF_SIZE
+ #define ETH_RX_BUF_SIZE         ETH_MAX_PACKET_SIZE
+#endif
+
+/* 5 Ethernet driver receive buffers are used (in a chained linked list)*/
+#ifndef ETH_RXBUFNB
+ #define ETH_RXBUFNB             ((uint32_t)5U)     /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
+#endif
+
+
+ /* Ethernet driver transmit buffers are organized in a chained linked-list, when
+    an Ethernet packet is transmitted, Tx-DMA will transfer the packet from the
+    driver transmit buffers memory to the TxFIFO.
+
+    Depending on the size of the Ethernet packet to be transmitted and the size of
+    each Ethernet driver transmit buffer, the packet to be transmitted can take
+    one or more Ethernet driver transmit buffer.
+
+    In below are defined the size of one Ethernet driver transmit buffer ETH_TX_BUF_SIZE
+    and the total count of the driver transmit buffers ETH_TXBUFNB.
+
+    The configured value for ETH_TX_BUF_SIZE and ETH_TXBUFNB are only provided as
+    example, they can be reconfigured in the application layer to fit the application
+    needs */
+
+/* Here we configure each Ethernet driver transmit buffer to fit the Max size Ethernet
+   packet */
+#ifndef ETH_TX_BUF_SIZE
+ #error please define ETH_TX_BUF_SIZE
+ #define ETH_TX_BUF_SIZE         ETH_MAX_PACKET_SIZE
+#endif
+
+/* 5 Ethernet driver transmit buffers are used (in a chained linked list)*/
+#ifndef ETH_TXBUFNB
+ #define ETH_TXBUFNB             ((uint32_t)5U)      /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
+#endif
+
+ /**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_TX_Descriptor ETH DMA TX Descriptor
+  * @{
+  */
+
+/*
+   DMA Tx Descriptor
+  -----------------------------------------------------------------------------------------------
+  TDES0 | OWN(31) | CTRL[30:26] | Reserved[25:24] | CTRL[23:20] | Reserved[19:17] | Status[16:0] |
+  -----------------------------------------------------------------------------------------------
+  TDES1 | Reserved[31:29] | Buffer2 ByteCount[28:16] | Reserved[15:13] | Buffer1 ByteCount[12:0] |
+  -----------------------------------------------------------------------------------------------
+  TDES2 |                         Buffer1 Address [31:0]                                         |
+  -----------------------------------------------------------------------------------------------
+  TDES3 |                   Buffer2 Address [31:0] / Next Descriptor Address [31:0]              |
+  -----------------------------------------------------------------------------------------------
+*/
+
+/**
+  * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
+  */
+#define ETH_DMATXDESC_OWN                     ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine */
+#define ETH_DMATXDESC_IC                      ((uint32_t)0x40000000U)  /*!< Interrupt on Completion */
+#define ETH_DMATXDESC_LS                      ((uint32_t)0x20000000U)  /*!< Last Segment */
+#define ETH_DMATXDESC_FS                      ((uint32_t)0x10000000U)  /*!< First Segment */
+#define ETH_DMATXDESC_DC                      ((uint32_t)0x08000000U)  /*!< Disable CRC */
+#define ETH_DMATXDESC_DP                      ((uint32_t)0x04000000U)  /*!< Disable Padding */
+#define ETH_DMATXDESC_TTSE                    ((uint32_t)0x02000000U)  /*!< Transmit Time Stamp Enable */
+#define ETH_DMATXDESC_CIC                     ((uint32_t)0x00C00000U)  /*!< Checksum Insertion Control: 4 cases */
+#define ETH_DMATXDESC_CIC_BYPASS              ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is bypassed */
+#define ETH_DMATXDESC_CIC_IPV4HEADER          ((uint32_t)0x00400000U)  /*!< IPV4 header Checksum Insertion */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT  ((uint32_t)0x00800000U)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL     ((uint32_t)0x00C00000U)  /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+#define ETH_DMATXDESC_TER                     ((uint32_t)0x00200000U)  /*!< Transmit End of Ring */
+#define ETH_DMATXDESC_TCH                     ((uint32_t)0x00100000U)  /*!< Second Address Chained */
+#define ETH_DMATXDESC_TTSS                    ((uint32_t)0x00020000U)  /*!< Tx Time Stamp Status */
+#define ETH_DMATXDESC_IHE                     ((uint32_t)0x00010000U)  /*!< IP Header Error */
+#define ETH_DMATXDESC_ES                      ((uint32_t)0x00008000U)  /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
+#define ETH_DMATXDESC_JT                      ((uint32_t)0x00004000U)  /*!< Jabber Timeout */
+#define ETH_DMATXDESC_FF                      ((uint32_t)0x00002000U)  /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
+#define ETH_DMATXDESC_PCE                     ((uint32_t)0x00001000U)  /*!< Payload Checksum Error */
+#define ETH_DMATXDESC_LCA                     ((uint32_t)0x00000800U)  /*!< Loss of Carrier: carrier lost during transmission */
+#define ETH_DMATXDESC_NC                      ((uint32_t)0x00000400U)  /*!< No Carrier: no carrier signal from the transceiver */
+#define ETH_DMATXDESC_LCO                     ((uint32_t)0x00000200U)  /*!< Late Collision: transmission aborted due to collision */
+#define ETH_DMATXDESC_EC                      ((uint32_t)0x00000100U)  /*!< Excessive Collision: transmission aborted after 16 collisions */
+#define ETH_DMATXDESC_VF                      ((uint32_t)0x00000080U)  /*!< VLAN Frame */
+#define ETH_DMATXDESC_CC                      ((uint32_t)0x00000078U)  /*!< Collision Count */
+#define ETH_DMATXDESC_ED                      ((uint32_t)0x00000004U)  /*!< Excessive Deferral */
+#define ETH_DMATXDESC_UF                      ((uint32_t)0x00000002U)  /*!< Underflow Error: late data arrival from the memory */
+#define ETH_DMATXDESC_DB                      ((uint32_t)0x00000001U)  /*!< Deferred Bit */
+
+/**
+  * @brief  Bit definition of TDES1 register
+  */
+#define ETH_DMATXDESC_TBS2  ((uint32_t)0x1FFF0000U)  /*!< Transmit Buffer2 Size */
+#define ETH_DMATXDESC_TBS1  ((uint32_t)0x00001FFFU)  /*!< Transmit Buffer1 Size */
+
+/**
+  * @brief  Bit definition of TDES2 register
+  */
+#define ETH_DMATXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
+
+/**
+  * @brief  Bit definition of TDES3 register
+  */
+#define ETH_DMATXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
+
+  /*---------------------------------------------------------------------------------------------
+  TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
+  -----------------------------------------------------------------------------------------------
+  TDES7 |                         Transmit Time Stamp High [31:0]                                |
+  ----------------------------------------------------------------------------------------------*/
+
+/* Bit definition of TDES6 register */
+ #define ETH_DMAPTPTXDESC_TTSL  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp Low */
+
+/* Bit definition of TDES7 register */
+ #define ETH_DMAPTPTXDESC_TTSH  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp High */
+
+/**
+  * @}
+  */
+/** @defgroup ETH_DMA_RX_Descriptor ETH DMA RX Descriptor
+  * @{
+  */
+
+/*
+  DMA Rx Descriptor
+  --------------------------------------------------------------------------------------------------------------------
+  RDES0 | OWN(31) |                                             Status [30:0]                                          |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES1 | CTRL(31) | Reserved[30:29] | Buffer2 ByteCount[28:16] | CTRL[15:14] | Reserved(13) | Buffer1 ByteCount[12:0] |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES2 |                                       Buffer1 Address [31:0]                                                 |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES3 |                          Buffer2 Address [31:0] / Next Descriptor Address [31:0]                             |
+  ---------------------------------------------------------------------------------------------------------------------
+*/
+
+/**
+  * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
+  */
+#define ETH_DMARXDESC_OWN         ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine  */
+#define ETH_DMARXDESC_AFM         ((uint32_t)0x40000000U)  /*!< DA Filter Fail for the rx frame  */
+#define ETH_DMARXDESC_FL          ((uint32_t)0x3FFF0000U)  /*!< Receive descriptor frame length  */
+#define ETH_DMARXDESC_ES          ((uint32_t)0x00008000U)  /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
+#define ETH_DMARXDESC_DE          ((uint32_t)0x00004000U)  /*!< Descriptor error: no more descriptors for receive frame  */
+#define ETH_DMARXDESC_SAF         ((uint32_t)0x00002000U)  /*!< SA Filter Fail for the received frame */
+#define ETH_DMARXDESC_LE          ((uint32_t)0x00001000U)  /*!< Frame size not matching with length field */
+#define ETH_DMARXDESC_OE          ((uint32_t)0x00000800U)  /*!< Overflow Error: Frame was damaged due to buffer overflow */
+#define ETH_DMARXDESC_VLAN        ((uint32_t)0x00000400U)  /*!< VLAN Tag: received frame is a VLAN frame */
+#define ETH_DMARXDESC_FS          ((uint32_t)0x00000200U)  /*!< First descriptor of the frame  */
+#define ETH_DMARXDESC_LS          ((uint32_t)0x00000100U)  /*!< Last descriptor of the frame  */
+#define ETH_DMARXDESC_IPV4HCE     ((uint32_t)0x00000080U)  /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
+#define ETH_DMARXDESC_LC          ((uint32_t)0x00000040U)  /*!< Late collision occurred during reception   */
+#define ETH_DMARXDESC_FT          ((uint32_t)0x00000020U)  /*!< Frame type - Ethernet, otherwise 802.3    */
+#define ETH_DMARXDESC_RWT         ((uint32_t)0x00000010U)  /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
+#define ETH_DMARXDESC_RE          ((uint32_t)0x00000008U)  /*!< Receive error: error reported by MII interface  */
+#define ETH_DMARXDESC_DBE         ((uint32_t)0x00000004U)  /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
+#define ETH_DMARXDESC_CE          ((uint32_t)0x00000002U)  /*!< CRC error */
+#define ETH_DMARXDESC_MAMPCE      ((uint32_t)0x00000001U)  /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
+
+/**
+  * @brief  Bit definition of RDES1 register
+  */
+#define ETH_DMARXDESC_DIC   ((uint32_t)0x80000000U)  /*!< Disable Interrupt on Completion */
+#define ETH_DMARXDESC_RBS2  ((uint32_t)0x1FFF0000U)  /*!< Receive Buffer2 Size */
+#define ETH_DMARXDESC_RER   ((uint32_t)0x00008000U)  /*!< Receive End of Ring */
+#define ETH_DMARXDESC_RCH   ((uint32_t)0x00004000U)  /*!< Second Address Chained */
+#define ETH_DMARXDESC_RBS1  ((uint32_t)0x00001FFFU)  /*!< Receive Buffer1 Size */
+
+/**
+  * @brief  Bit definition of RDES2 register
+  */
+#define ETH_DMARXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
+
+/**
+  * @brief  Bit definition of RDES3 register
+  */
+#define ETH_DMARXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
+
+/*---------------------------------------------------------------------------------------------------------------------
+  RDES4 |                   Reserved[31:15]              |             Extended Status [14:0]                          |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES5 |                                            Reserved[31:0]                                                    |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES6 |                                       Receive Time Stamp Low [31:0]                                          |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES7 |                                       Receive Time Stamp High [31:0]                                         |
+  --------------------------------------------------------------------------------------------------------------------*/
+
+/* Bit definition of RDES4 register */
+#define ETH_DMAPTPRXDESC_PTPV                            ((uint32_t)0x00002000U)  /* PTP Version */
+#define ETH_DMAPTPRXDESC_PTPFT                           ((uint32_t)0x00001000U)  /* PTP Frame Type */
+#define ETH_DMAPTPRXDESC_PTPMT                           ((uint32_t)0x00000F00U)  /* PTP Message Type */
+  #define ETH_DMAPTPRXDESC_PTPMT_SYNC                      ((uint32_t)0x00000100U)  /* SYNC message (all clock types) */
+  #define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                  ((uint32_t)0x00000200U)  /* FollowUp message (all clock types) */
+  #define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                  ((uint32_t)0x00000300U)  /* DelayReq message (all clock types) */
+  #define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                 ((uint32_t)0x00000400U)  /* DelayResp message (all clock types) */
+  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE        ((uint32_t)0x00000500U)  /* PdelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
+  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG          ((uint32_t)0x00000600U)  /* PdelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
+  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL ((uint32_t)0x00000700U)  /* PdelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
+#define ETH_DMAPTPRXDESC_IPV6PR                          ((uint32_t)0x00000080U)  /* IPv6 Packet Received */
+#define ETH_DMAPTPRXDESC_IPV4PR                          ((uint32_t)0x00000040U)  /* IPv4 Packet Received */
+#define ETH_DMAPTPRXDESC_IPCB                            ((uint32_t)0x00000020U)  /* IP Checksum Bypassed */
+#define ETH_DMAPTPRXDESC_IPPE                            ((uint32_t)0x00000010U)  /* IP Payload Error */
+#define ETH_DMAPTPRXDESC_IPHE                            ((uint32_t)0x00000008U)  /* IP Header Error */
+#define ETH_DMAPTPRXDESC_IPPT                            ((uint32_t)0x00000007U)  /* IP Payload Type */
+  #define ETH_DMAPTPRXDESC_IPPT_UDP                      ((uint32_t)0x00000001U)  /* UDP payload encapsulated in the IP datagram */
+  #define ETH_DMAPTPRXDESC_IPPT_TCP                      ((uint32_t)0x00000002U)  /* TCP payload encapsulated in the IP datagram */
+  #define ETH_DMAPTPRXDESC_IPPT_ICMP                     ((uint32_t)0x00000003U)  /* ICMP payload encapsulated in the IP datagram */
+
+/* Bit definition of RDES6 register */
+#define ETH_DMAPTPRXDESC_RTSL  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp Low */
+
+/* Bit definition of RDES7 register */
+#define ETH_DMAPTPRXDESC_RTSH  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp High */
+/**
+  * @}
+  */
+ /** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
+  * @{
+  */
+#define ETH_AUTONEGOTIATION_ENABLE     ((uint32_t)0x00000001U)
+#define ETH_AUTONEGOTIATION_DISABLE    ((uint32_t)0x00000000U)
+
+/**
+  * @}
+  */
+/** @defgroup ETH_Speed ETH Speed
+  * @{
+  */
+#define ETH_SPEED_10M        ((uint32_t)0x00000000U)
+#define ETH_SPEED_100M       ((uint32_t)0x00004000U)
+
+/**
+  * @}
+  */
+/** @defgroup ETH_Duplex_Mode ETH Duplex Mode
+  * @{
+  */
+#define ETH_MODE_FULLDUPLEX       ((uint32_t)0x00000800U)
+#define ETH_MODE_HALFDUPLEX       ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+/** @defgroup ETH_Rx_Mode ETH Rx Mode
+  * @{
+  */
+#define ETH_RXPOLLING_MODE      ((uint32_t)0x00000000U)
+#define ETH_RXINTERRUPT_MODE    ((uint32_t)0x00000001U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Checksum_Mode ETH Checksum Mode
+  * @{
+  */
+#define ETH_CHECKSUM_BY_HARDWARE      ((uint32_t)0x00000000U)
+#define ETH_CHECKSUM_BY_SOFTWARE      ((uint32_t)0x00000001U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Media_Interface ETH Media Interface
+  * @{
+  */
+#define ETH_MEDIA_INTERFACE_MII       ((uint32_t)0x00000000U)
+#define ETH_MEDIA_INTERFACE_RMII      ((uint32_t)SYSCFG_PMC_MII_RMII_SEL)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Watchdog ETH Watchdog
+  * @{
+  */
+#define ETH_WATCHDOG_ENABLE       ((uint32_t)0x00000000U)
+#define ETH_WATCHDOG_DISABLE      ((uint32_t)0x00800000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Jabber ETH Jabber
+  * @{
+  */
+#define ETH_JABBER_ENABLE    ((uint32_t)0x00000000U)
+#define ETH_JABBER_DISABLE   ((uint32_t)0x00400000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap
+  * @{
+  */
+#define ETH_INTERFRAMEGAP_96BIT   ((uint32_t)0x00000000U)  /*!< minimum IFG between frames during transmission is 96Bit */
+#define ETH_INTERFRAMEGAP_88BIT   ((uint32_t)0x00020000U)  /*!< minimum IFG between frames during transmission is 88Bit */
+#define ETH_INTERFRAMEGAP_80BIT   ((uint32_t)0x00040000U)  /*!< minimum IFG between frames during transmission is 80Bit */
+#define ETH_INTERFRAMEGAP_72BIT   ((uint32_t)0x00060000U)  /*!< minimum IFG between frames during transmission is 72Bit */
+#define ETH_INTERFRAMEGAP_64BIT   ((uint32_t)0x00080000U)  /*!< minimum IFG between frames during transmission is 64Bit */
+#define ETH_INTERFRAMEGAP_56BIT   ((uint32_t)0x000A0000U)  /*!< minimum IFG between frames during transmission is 56Bit */
+#define ETH_INTERFRAMEGAP_48BIT   ((uint32_t)0x000C0000U)  /*!< minimum IFG between frames during transmission is 48Bit */
+#define ETH_INTERFRAMEGAP_40BIT   ((uint32_t)0x000E0000U)  /*!< minimum IFG between frames during transmission is 40Bit */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Carrier_Sense ETH Carrier Sense
+  * @{
+  */
+#define ETH_CARRIERSENCE_ENABLE   ((uint32_t)0x00000000U)
+#define ETH_CARRIERSENCE_DISABLE  ((uint32_t)0x00010000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Own ETH Receive Own
+  * @{
+  */
+#define ETH_RECEIVEOWN_ENABLE     ((uint32_t)0x00000000U)
+#define ETH_RECEIVEOWN_DISABLE    ((uint32_t)0x00002000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode
+  * @{
+  */
+#define ETH_LOOPBACKMODE_ENABLE        ((uint32_t)0x00001000U)
+#define ETH_LOOPBACKMODE_DISABLE       ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Checksum_Offload ETH Checksum Offload
+  * @{
+  */
+#define ETH_CHECKSUMOFFLAOD_ENABLE     ((uint32_t)0x00000400U)
+#define ETH_CHECKSUMOFFLAOD_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Retry_Transmission ETH Retry Transmission
+  * @{
+  */
+#define ETH_RETRYTRANSMISSION_ENABLE   ((uint32_t)0x00000000U)
+#define ETH_RETRYTRANSMISSION_DISABLE  ((uint32_t)0x00000200U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
+  * @{
+  */
+#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ((uint32_t)0x00000080U)
+#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
+  * @{
+  */
+#define ETH_BACKOFFLIMIT_10  ((uint32_t)0x00000000U)
+#define ETH_BACKOFFLIMIT_8   ((uint32_t)0x00000020U)
+#define ETH_BACKOFFLIMIT_4   ((uint32_t)0x00000040U)
+#define ETH_BACKOFFLIMIT_1   ((uint32_t)0x00000060U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Deferral_Check ETH Deferral Check
+  * @{
+  */
+#define ETH_DEFFERRALCHECK_ENABLE       ((uint32_t)0x00000010U)
+#define ETH_DEFFERRALCHECK_DISABLE      ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_All ETH Receive All
+  * @{
+  */
+#define ETH_RECEIVEALL_ENABLE     ((uint32_t)0x80000000U)
+#define ETH_RECEIVEAll_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
+  * @{
+  */
+#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE       ((uint32_t)0x00000200U)
+#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE      ((uint32_t)0x00000300U)
+#define ETH_SOURCEADDRFILTER_DISABLE             ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
+  * @{
+  */
+#define ETH_PASSCONTROLFRAMES_BLOCKALL                ((uint32_t)0x00000040U)  /*!< MAC filters all control frames from reaching the application */
+#define ETH_PASSCONTROLFRAMES_FORWARDALL              ((uint32_t)0x00000080U)  /*!< MAC forwards all control frames to application even if they fail the Address Filter */
+#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ((uint32_t)0x000000C0U)  /*!< MAC forwards control frames that pass the Address Filter. */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
+  * @{
+  */
+#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ((uint32_t)0x00000000U)
+#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ((uint32_t)0x00000020U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
+  * @{
+  */
+#define ETH_DESTINATIONADDRFILTER_NORMAL    ((uint32_t)0x00000000U)
+#define ETH_DESTINATIONADDRFILTER_INVERSE   ((uint32_t)0x00000008U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
+  * @{
+  */
+#define ETH_PROMISCUOUS_MODE_ENABLE     ((uint32_t)0x00000001U)
+#define ETH_PROMISCUOUS_MODE_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
+  * @{
+  */
+#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ((uint32_t)0x00000404U)
+#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ((uint32_t)0x00000004U)
+#define ETH_MULTICASTFRAMESFILTER_PERFECT             ((uint32_t)0x00000000U)
+#define ETH_MULTICASTFRAMESFILTER_NONE                ((uint32_t)0x00000010U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
+  * @{
+  */
+#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ((uint32_t)0x00000402U)
+#define ETH_UNICASTFRAMESFILTER_HASHTABLE        ((uint32_t)0x00000002U)
+#define ETH_UNICASTFRAMESFILTER_PERFECT          ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
+  * @{
+  */
+#define ETH_ZEROQUANTAPAUSE_ENABLE     ((uint32_t)0x00000000U)
+#define ETH_ZEROQUANTAPAUSE_DISABLE    ((uint32_t)0x00000080U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
+  * @{
+  */
+#define ETH_PAUSELOWTHRESHOLD_MINUS4        ((uint32_t)0x00000000U)  /*!< Pause time minus 4 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS28       ((uint32_t)0x00000010U)  /*!< Pause time minus 28 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS144      ((uint32_t)0x00000020U)  /*!< Pause time minus 144 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS256      ((uint32_t)0x00000030U)  /*!< Pause time minus 256 slot times */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
+  * @{
+  */
+#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE  ((uint32_t)0x00000008U)
+#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
+  * @{
+  */
+#define ETH_RECEIVEFLOWCONTROL_ENABLE       ((uint32_t)0x00000004U)
+#define ETH_RECEIVEFLOWCONTROL_DISABLE      ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
+  * @{
+  */
+#define ETH_TRANSMITFLOWCONTROL_ENABLE      ((uint32_t)0x00000002U)
+#define ETH_TRANSMITFLOWCONTROL_DISABLE     ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
+  * @{
+  */
+#define ETH_VLANTAGCOMPARISON_12BIT    ((uint32_t)0x00010000U)
+#define ETH_VLANTAGCOMPARISON_16BIT    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_addresses ETH MAC addresses
+  * @{
+  */
+#define ETH_MAC_ADDRESS0     ((uint32_t)0x00000000U)
+#define ETH_MAC_ADDRESS1     ((uint32_t)0x00000008U)
+#define ETH_MAC_ADDRESS2     ((uint32_t)0x00000010U)
+#define ETH_MAC_ADDRESS3     ((uint32_t)0x00000018U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA
+  * @{
+  */
+#define ETH_MAC_ADDRESSFILTER_SA       ((uint32_t)0x00000000U)
+#define ETH_MAC_ADDRESSFILTER_DA       ((uint32_t)0x00000008U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_addresses_filter_Mask_bytes ETH MAC addresses filter Mask bytes
+  * @{
+  */
+#define ETH_MAC_ADDRESSMASK_BYTE6      ((uint32_t)0x20000000U)  /*!< Mask MAC Address high reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE5      ((uint32_t)0x10000000U)  /*!< Mask MAC Address high reg bits [7:0] */
+#define ETH_MAC_ADDRESSMASK_BYTE4      ((uint32_t)0x08000000U)  /*!< Mask MAC Address low reg bits [31:24] */
+#define ETH_MAC_ADDRESSMASK_BYTE3      ((uint32_t)0x04000000U)  /*!< Mask MAC Address low reg bits [23:16] */
+#define ETH_MAC_ADDRESSMASK_BYTE2      ((uint32_t)0x02000000U)  /*!< Mask MAC Address low reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE1      ((uint32_t)0x01000000U)  /*!< Mask MAC Address low reg bits [70] */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_Debug_flags ETH MAC Debug flags
+  * @{
+  */
+#ifndef ETH_MAC_TXFIFO_FULL
+	#define ETH_MAC_TXFIFO_FULL          ((uint32_t)0x02000000)  /* Tx FIFO full */
+	#define ETH_MAC_TXFIFONOT_EMPTY      ((uint32_t)0x01000000)  /* Tx FIFO not empty */
+	#define ETH_MAC_TXFIFO_WRITE_ACTIVE  ((uint32_t)0x00400000)  /* Tx FIFO write active */
+	#define ETH_MAC_TXFIFO_IDLE     ((uint32_t)0x00000000)  /* Tx FIFO read status: Idle */
+	#define ETH_MAC_TXFIFO_READ     ((uint32_t)0x00100000)  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+	#define ETH_MAC_TXFIFO_WAITING  ((uint32_t)0x00200000)  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+	#define ETH_MAC_TXFIFO_WRITING  ((uint32_t)0x00300000)  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+	#define ETH_MAC_TRANSMISSION_PAUSE     ((uint32_t)0x00080000)  /* MAC transmitter in pause */
+	#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            ((uint32_t)0x00000000)  /* MAC transmit frame controller: Idle */
+	#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         ((uint32_t)0x00020000)  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+	#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   ((uint32_t)0x00040000)  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+	#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    ((uint32_t)0x00060000)  /* MAC transmit frame controller: Transferring input frame for transmission */
+	#define ETH_MAC_MII_TRANSMIT_ACTIVE      ((uint32_t)0x00010000)  /* MAC MII transmit engine active */
+	#define ETH_MAC_RXFIFO_EMPTY             ((uint32_t)0x00000000)  /* Rx FIFO fill level: empty */
+	#define ETH_MAC_RXFIFO_BELOW_THRESHOLD   ((uint32_t)0x00000100)  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+	#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD   ((uint32_t)0x00000200)  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+	#define ETH_MAC_RXFIFO_FULL              ((uint32_t)0x00000300)  /* Rx FIFO fill level: full */
+	#define ETH_MAC_READCONTROLLER_IDLE            ((uint32_t)0x00000060)  /* Rx FIFO read controller IDLE state */
+	#define ETH_MAC_READCONTROLLER_READING_DATA    ((uint32_t)0x00000060)  /* Rx FIFO read controller Reading frame data */
+	#define ETH_MAC_READCONTROLLER_READING_STATUS  ((uint32_t)0x00000060)  /* Rx FIFO read controller Reading frame status (or time-stamp) */
+	#define ETH_MAC_READCONTROLLER_ FLUSHING       ((uint32_t)0x00000060)  /* Rx FIFO read controller Flushing the frame data and status */
+	#define ETH_MAC_RXFIFO_WRITE_ACTIVE     ((uint32_t)0x00000010)  /* Rx FIFO write controller active */
+	#define ETH_MAC_SMALL_FIFO_NOTACTIVE    ((uint32_t)0x00000000)  /* MAC small FIFO read / write controllers not active */
+	#define ETH_MAC_SMALL_FIFO_READ_ACTIVE  ((uint32_t)0x00000002)  /* MAC small FIFO read controller active */
+	#define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE ((uint32_t)0x00000004)  /* MAC small FIFO write controller active */
+	#define ETH_MAC_SMALL_FIFO_RW_ACTIVE    ((uint32_t)0x00000006)  /* MAC small FIFO read / write controllers active */
+	#define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   ((uint32_t)0x00000001)  /* MAC MII receive protocol engine active */
+#else
+	/* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Drop_TCP_IP_Checksum_Error_Frame ETH Drop TCP IP Checksum Error Frame
+  * @{
+  */
+#define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE   ((uint32_t)0x00000000U)
+#define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE  ((uint32_t)0x04000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
+  * @{
+  */
+#define ETH_RECEIVESTOREFORWARD_ENABLE      ((uint32_t)0x02000000U)
+#define ETH_RECEIVESTOREFORWARD_DISABLE     ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Flush_Received_Frame ETH Flush Received Frame
+  * @{
+  */
+#define ETH_FLUSHRECEIVEDFRAME_ENABLE       ((uint32_t)0x00000000U)
+#define ETH_FLUSHRECEIVEDFRAME_DISABLE      ((uint32_t)0x01000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
+  * @{
+  */
+#define ETH_TRANSMITSTOREFORWARD_ENABLE     ((uint32_t)0x00200000U)
+#define ETH_TRANSMITSTOREFORWARD_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Transmit_Threshold_Control ETH Transmit Threshold Control
+  * @{
+  */
+#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ((uint32_t)0x00004000U)  /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ((uint32_t)0x00008000U)  /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ((uint32_t)0x0000C000U)  /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ((uint32_t)0x00010000U)  /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ((uint32_t)0x00014000U)  /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ((uint32_t)0x00018000U)  /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ((uint32_t)0x0001C000U)  /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Forward_Error_Frames ETH Forward Error Frames
+  * @{
+  */
+#define ETH_FORWARDERRORFRAMES_ENABLE       ((uint32_t)0x00000080U)
+#define ETH_FORWARDERRORFRAMES_DISABLE      ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Forward_Undersized_Good_Frames ETH Forward Undersized Good Frames
+  * @{
+  */
+#define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE   ((uint32_t)0x00000040U)
+#define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE  ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Threshold_Control ETH Receive Threshold Control
+  * @{
+  */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES      ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES      ((uint32_t)0x00000008U)  /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES      ((uint32_t)0x00000010U)  /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES     ((uint32_t)0x00000018U)  /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
+  * @{
+  */
+#define ETH_SECONDFRAMEOPERARTE_ENABLE       ((uint32_t)0x00000004U)
+#define ETH_SECONDFRAMEOPERARTE_DISABLE      ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Address_Aligned_Beats ETH Address Aligned Beats
+  * @{
+  */
+#define ETH_ADDRESSALIGNEDBEATS_ENABLE      ((uint32_t)0x02000000U)
+#define ETH_ADDRESSALIGNEDBEATS_DISABLE     ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Fixed_Burst ETH Fixed Burst
+  * @{
+  */
+#define ETH_FIXEDBURST_ENABLE     ((uint32_t)0x00010000U)
+#define ETH_FIXEDBURST_DISABLE    ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
+  * @{
+  */
+#define ETH_RXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
+#define ETH_RXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
+#define ETH_RXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
+  * @{
+  */
+#define ETH_TXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+#define ETH_TXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+#define ETH_TXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Enhanced_descriptor_format ETH DMA Enhanced descriptor format
+  * @{
+  */
+#define ETH_DMAENHANCEDDESCRIPTOR_ENABLE              ((uint32_t)0x00000080U)
+#define ETH_DMAENHANCEDDESCRIPTOR_DISABLE             ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
+  * @{
+  */
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1   ((uint32_t)0x00000000U)
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1   ((uint32_t)0x00004000U)
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1   ((uint32_t)0x00008000U)
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1   ((uint32_t)0x0000C000U)
+#define ETH_DMAARBITRATION_RXPRIORTX             ((uint32_t)0x00000002U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Tx_descriptor_segment ETH DMA Tx descriptor segment
+  * @{
+  */
+#define ETH_DMATXDESC_LASTSEGMENTS      ((uint32_t)0x40000000U)  /*!< Last Segment */
+#define ETH_DMATXDESC_FIRSTSEGMENT      ((uint32_t)0x20000000U)  /*!< First Segment */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Tx_descriptor_Checksum_Insertion_Control ETH DMA Tx descriptor Checksum Insertion Control
+  * @{
+  */
+#define ETH_DMATXDESC_CHECKSUMBYPASS             ((uint32_t)0x00000000U)   /*!< Checksum engine bypass */
+#define ETH_DMATXDESC_CHECKSUMIPV4HEADER         ((uint32_t)0x00400000U)   /*!< IPv4 header checksum insertion  */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT  ((uint32_t)0x00800000U)   /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL     ((uint32_t)0x00C00000U)   /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers
+  * @{
+  */
+#define ETH_DMARXDESC_BUFFER1     ((uint32_t)0x00000000U)  /*!< DMA Rx Desc Buffer1 */
+#define ETH_DMARXDESC_BUFFER2     ((uint32_t)0x00000001U)  /*!< DMA Rx Desc Buffer2 */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_PMT_Flags ETH PMT Flags
+  * @{
+  */
+#define ETH_PMT_FLAG_WUFFRPR      ((uint32_t)0x80000000U)  /*!< Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_PMT_FLAG_WUFR         ((uint32_t)0x00000040U)  /*!< Wake-Up Frame Received */
+#define ETH_PMT_FLAG_MPR          ((uint32_t)0x00000020U)  /*!< Magic Packet Received */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MMC_Tx_Interrupts ETH MMC Tx Interrupts
+  * @{
+  */
+#define ETH_MMC_IT_TGF       ((uint32_t)0x00200000U)  /*!< When Tx good frame counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFMSC    ((uint32_t)0x00008000U)  /*!< When Tx good multi col counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFSC     ((uint32_t)0x00004000U)  /*!< When Tx good single col counter reaches half the maximum value */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MMC_Rx_Interrupts ETH MMC Rx Interrupts
+  * @{
+  */
+#define ETH_MMC_IT_RGUF      ((uint32_t)0x10020000U)  /*!< When Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMC_IT_RFAE      ((uint32_t)0x10000040U)  /*!< When Rx alignment error counter reaches half the maximum value */
+#define ETH_MMC_IT_RFCE      ((uint32_t)0x10000020U)  /*!< When Rx crc error counter reaches half the maximum value */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_Flags ETH MAC Flags
+  * @{
+  */
+#define ETH_MAC_FLAG_TST     ((uint32_t)0x00000200U)  /*!< Time stamp trigger flag (on MAC) */
+#define ETH_MAC_FLAG_MMCT    ((uint32_t)0x00000040U)  /*!< MMC transmit flag  */
+#define ETH_MAC_FLAG_MMCR    ((uint32_t)0x00000020U)  /*!< MMC receive flag */
+#define ETH_MAC_FLAG_MMC     ((uint32_t)0x00000010U)  /*!< MMC flag (on MAC) */
+#define ETH_MAC_FLAG_PMT     ((uint32_t)0x00000008U)  /*!< PMT flag (on MAC) */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Flags ETH DMA Flags
+  * @{
+  */
+#define ETH_DMA_FLAG_TST               ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_FLAG_PMT               ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_FLAG_MMC               ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_FLAG_DATATRANSFERERROR ((uint32_t)0x00800000U)  /*!< Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMA_FLAG_READWRITEERROR    ((uint32_t)0x01000000U)  /*!< Error bits 0-write transfer, 1-read transfer */
+#define ETH_DMA_FLAG_ACCESSERROR       ((uint32_t)0x02000000U)  /*!< Error bits 0-data buffer, 1-desc. access */
+#define ETH_DMA_FLAG_NIS               ((uint32_t)0x00010000U)  /*!< Normal interrupt summary flag */
+#define ETH_DMA_FLAG_AIS               ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary flag */
+#define ETH_DMA_FLAG_ER                ((uint32_t)0x00004000U)  /*!< Early receive flag */
+#define ETH_DMA_FLAG_FBE               ((uint32_t)0x00002000U)  /*!< Fatal bus error flag */
+#define ETH_DMA_FLAG_ET                ((uint32_t)0x00000400U)  /*!< Early transmit flag */
+#define ETH_DMA_FLAG_RWT               ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout flag */
+#define ETH_DMA_FLAG_RPS               ((uint32_t)0x00000100U)  /*!< Receive process stopped flag */
+#define ETH_DMA_FLAG_RBU               ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable flag */
+#define ETH_DMA_FLAG_R                 ((uint32_t)0x00000040U)  /*!< Receive flag */
+#define ETH_DMA_FLAG_TU                ((uint32_t)0x00000020U)  /*!< Underflow flag */
+#define ETH_DMA_FLAG_RO                ((uint32_t)0x00000010U)  /*!< Overflow flag */
+#define ETH_DMA_FLAG_TJT               ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout flag */
+#define ETH_DMA_FLAG_TBU               ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable flag */
+#define ETH_DMA_FLAG_TPS               ((uint32_t)0x00000002U)  /*!< Transmit process stopped flag */
+#define ETH_DMA_FLAG_T                 ((uint32_t)0x00000001U)  /*!< Transmit flag */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
+  * @{
+  */
+#define ETH_MAC_IT_TST       ((uint32_t)0x00000200U)  /*!< Time stamp trigger interrupt (on MAC) */
+#define ETH_MAC_IT_MMCT      ((uint32_t)0x00000040U)  /*!< MMC transmit interrupt */
+#define ETH_MAC_IT_MMCR      ((uint32_t)0x00000020U)  /*!< MMC receive interrupt */
+#define ETH_MAC_IT_MMC       ((uint32_t)0x00000010U)  /*!< MMC interrupt (on MAC) */
+#define ETH_MAC_IT_PMT       ((uint32_t)0x00000008U)  /*!< PMT interrupt (on MAC) */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
+  * @{
+  */
+#define ETH_DMA_IT_TST       ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_IT_PMT       ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_IT_MMC       ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_IT_NIS       ((uint32_t)0x00010000U)  /*!< Normal interrupt summary */
+#define ETH_DMA_IT_AIS       ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary */
+#define ETH_DMA_IT_ER        ((uint32_t)0x00004000U)  /*!< Early receive interrupt */
+#define ETH_DMA_IT_FBE       ((uint32_t)0x00002000U)  /*!< Fatal bus error interrupt */
+#define ETH_DMA_IT_ET        ((uint32_t)0x00000400U)  /*!< Early transmit interrupt */
+#define ETH_DMA_IT_RWT       ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout interrupt */
+#define ETH_DMA_IT_RPS       ((uint32_t)0x00000100U)  /*!< Receive process stopped interrupt */
+#define ETH_DMA_IT_RBU       ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable interrupt */
+#define ETH_DMA_IT_R         ((uint32_t)0x00000040U)  /*!< Receive interrupt */
+#define ETH_DMA_IT_TU        ((uint32_t)0x00000020U)  /*!< Underflow interrupt */
+#define ETH_DMA_IT_RO        ((uint32_t)0x00000010U)  /*!< Overflow interrupt */
+#define ETH_DMA_IT_TJT       ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout interrupt */
+#define ETH_DMA_IT_TBU       ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable interrupt */
+#define ETH_DMA_IT_TPS       ((uint32_t)0x00000002U)  /*!< Transmit process stopped interrupt */
+#define ETH_DMA_IT_T         ((uint32_t)0x00000001U)  /*!< Transmit interrupt */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state
+  * @{
+  */
+#define ETH_DMA_TRANSMITPROCESS_STOPPED     ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Tx Command issued */
+#define ETH_DMA_TRANSMITPROCESS_FETCHING    ((uint32_t)0x00100000U)  /*!< Running - fetching the Tx descriptor */
+#define ETH_DMA_TRANSMITPROCESS_WAITING     ((uint32_t)0x00200000U)  /*!< Running - waiting for status */
+#define ETH_DMA_TRANSMITPROCESS_READING     ((uint32_t)0x00300000U)  /*!< Running - reading the data from host memory */
+#define ETH_DMA_TRANSMITPROCESS_SUSPENDED   ((uint32_t)0x00600000U)  /*!< Suspended - Tx Descriptor unavailable */
+#define ETH_DMA_TRANSMITPROCESS_CLOSING     ((uint32_t)0x00700000U)  /*!< Running - closing Rx descriptor */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state
+  * @{
+  */
+#define ETH_DMA_RECEIVEPROCESS_STOPPED      ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Rx Command issued */
+#define ETH_DMA_RECEIVEPROCESS_FETCHING     ((uint32_t)0x00020000U)  /*!< Running - fetching the Rx descriptor */
+#define ETH_DMA_RECEIVEPROCESS_WAITING      ((uint32_t)0x00060000U)  /*!< Running - waiting for packet */
+#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ((uint32_t)0x00080000U)  /*!< Suspended - Rx Descriptor unavailable */
+#define ETH_DMA_RECEIVEPROCESS_CLOSING      ((uint32_t)0x000A0000U)  /*!< Running - closing descriptor */
+#define ETH_DMA_RECEIVEPROCESS_QUEUING      ((uint32_t)0x000E0000U)  /*!< Running - queuing the receive frame into host memory */
+
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_overflow ETH DMA overflow
+  * @{
+  */
+#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER      ((uint32_t)0x10000000U)  /*!< Overflow bit for FIFO overflow counter */
+#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ((uint32_t)0x00010000U)  /*!< Overflow bit for missed frame counter */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_EXTI_LINE_WAKEUP ETH EXTI LINE WAKEUP
+  * @{
+  */
+#define ETH_EXTI_LINE_WAKEUP              ((uint32_t)0x00080000U)  /*!< External interrupt line 19 Connected to the ETH EXTI Line */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup ETH_Exported_Macros ETH Exported Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+
+/** @brief Reset ETH handle state
+  * @param  __HANDLE__: specifies the ETH handle.
+  * @retval None
+  */
+#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ETH_STATE_RESET)
+
+/**
+  * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag of TDES0 to check.
+  * @retval the ETH_DMATxDescFlag (SET or RESET).
+  */
+#define __HAL_ETH_DMATXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->TxDesc->Status & (__FLAG__) == (__FLAG__))
+
+/**
+  * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag of RDES0 to check.
+  * @retval the ETH_DMATxDescFlag (SET or RESET).
+  */
+#define __HAL_ETH_DMARXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->RxDesc->Status & (__FLAG__) == (__FLAG__))
+
+/**
+  * @brief  Enables the specified DMA Rx Desc receive interrupt.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMARXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->RxDesc->ControlBufferSize &=(~(uint32_t)ETH_DMARXDESC_DIC))
+
+/**
+  * @brief  Disables the specified DMA Rx Desc receive interrupt.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMARXDESC_DISABLE_IT(__HANDLE__)                         ((__HANDLE__)->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC)
+
+/**
+  * @brief  Set the specified DMA Rx Desc Own bit.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMARXDESC_SET_OWN_BIT(__HANDLE__)                           ((__HANDLE__)->RxDesc->Status |= ETH_DMARXDESC_OWN)
+
+/**
+  * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
+  * @param  __HANDLE__: ETH Handle
+  * @retval The Transmit descriptor collision counter value.
+  */
+#define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT(__HANDLE__)                   (((__HANDLE__)->TxDesc->Status & ETH_DMATXDESC_CC) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT)
+
+/**
+  * @brief  Set the specified DMA Tx Desc Own bit.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_SET_OWN_BIT(__HANDLE__)                       ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_OWN)
+
+/**
+  * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_IC)
+
+/**
+  * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_DISABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_IC)
+
+/**
+  * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __CHECKSUM__: specifies is the DMA Tx desc checksum insertion.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_DMATXDESC_CHECKSUMBYPASS : Checksum bypass
+  *     @arg ETH_DMATXDESC_CHECKSUMIPV4HEADER : IPv4 header checksum
+  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT : TCP/UDP/ICMP checksum. Pseudo header checksum is assumed to be present
+  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION(__HANDLE__, __CHECKSUM__)     ((__HANDLE__)->TxDesc->Status |= (__CHECKSUM__))
+
+/**
+  * @brief  Enables the DMA Tx Desc CRC.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_CRC_ENABLE(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DC)
+
+/**
+  * @brief  Disables the DMA Tx Desc CRC.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_CRC_DISABLE(__HANDLE__)                         ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DC)
+
+/**
+  * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE(__HANDLE__)            ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DP)
+
+/**
+  * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE(__HANDLE__)           ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DP)
+
+/**
+ * @brief  Enables the specified Ethernet MAC interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
+  *   enabled or disabled.
+  *   This parameter can be any combination of the following values:
+  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
+  *     @arg ETH_MAC_IT_PMT : PMT interrupt
+  * @retval None
+  */
+#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIMR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disables the specified Ethernet MAC interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
+  *   enabled or disabled.
+  *   This parameter can be any combination of the following values:
+  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
+  *     @arg ETH_MAC_IT_PMT : PMT interrupt
+  * @retval None
+  */
+#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->MACIMR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Initiate a Pause Control Frame (Full-duplex only).
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME(__HANDLE__)              ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
+
+/**
+  * @brief  Checks whether the Ethernet flow control busy bit is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @retval The new state of flow control busy status bit (SET or RESET).
+  */
+#define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS(__HANDLE__)               (((__HANDLE__)->Instance->MACFCR & ETH_MACFCR_FCBBPA) == ETH_MACFCR_FCBBPA)
+
+/**
+  * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE(__HANDLE__)          ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
+
+/**
+  * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE(__HANDLE__)         ((__HANDLE__)->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA)
+
+/**
+  * @brief  Checks whether the specified Ethernet MAC flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag to check.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_MAC_FLAG_TST  : Time stamp trigger flag
+  *     @arg ETH_MAC_FLAG_MMCT : MMC transmit flag
+  *     @arg ETH_MAC_FLAG_MMCR : MMC receive flag
+  *     @arg ETH_MAC_FLAG_MMC  : MMC flag
+  *     @arg ETH_MAC_FLAG_PMT  : PMT flag
+  * @retval The state of Ethernet MAC flag.
+  */
+#define __HAL_ETH_MAC_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->MACSR &( __FLAG__)) == ( __FLAG__))
+
+/**
+  * @brief  Enables the specified Ethernet DMA interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
+  *   enabled @ref ETH_DMA_Interrupts
+  * @retval None
+  */
+#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->DMAIER |= (__INTERRUPT__))
+
+/**
+  * @brief  Disables the specified Ethernet DMA interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
+  *   disabled. @ref ETH_DMA_Interrupts
+  * @retval None
+  */
+#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->DMAIER &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Clears the Ethernet DMA IT pending bit.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
+  * @retval None
+  */
+#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->DMASR =(__INTERRUPT__))
+
+/**
+  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
+* @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Flags
+  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+  */
+#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMASR &( __FLAG__)) == ( __FLAG__))
+
+/**
+  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag to clear. @ref ETH_DMA_Flags
+  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+  */
+#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->DMASR = (__FLAG__))
+
+/**
+  * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __OVERFLOW__: specifies the DMA overflow flag to check.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_DMA_OVERFLOW_RXFIFOCOUNTER : Overflow for FIFO Overflows Counter
+  *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
+  * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
+  */
+#define __HAL_ETH_GET_DMA_OVERFLOW_STATUS(__HANDLE__, __OVERFLOW__)       (((__HANDLE__)->Instance->DMAMFBOCR & (__OVERFLOW__)) == (__OVERFLOW__))
+
+/**
+  * @brief  Set the DMA Receive status watchdog timer register value
+  * @param  __HANDLE__: ETH Handle
+  * @param  __VALUE__: DMA Receive status watchdog timer register value
+  * @retval None
+  */
+#define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER(__HANDLE__, __VALUE__)       ((__HANDLE__)->Instance->DMARSWTR = (__VALUE__))
+
+/**
+  * @brief  Enables any unicast packet filtered by the MAC address
+  *   recognition to be a wake-up frame.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU)
+
+/**
+  * @brief  Disables any unicast packet filtered by the MAC address
+  *   recognition to be a wake-up frame.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU)
+
+/**
+  * @brief  Enables the MAC Wake-Up Frame Detection.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE)
+
+/**
+  * @brief  Disables the MAC Wake-Up Frame Detection.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
+
+/**
+  * @brief  Enables the MAC Magic Packet Detection.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE)
+
+/**
+  * @brief  Disables the MAC Magic Packet Detection.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
+
+/**
+  * @brief  Enables the MAC Power Down.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_POWER_DOWN_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD)
+
+/**
+  * @brief  Disables the MAC Power Down.
+  * @param  __HANDLE__: ETH Handle
+  * @retval None
+  */
+#define __HAL_ETH_POWER_DOWN_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD)
+
+/**
+  * @brief  Checks whether the specified Ethernet PMT flag is set or not.
+  * @param  __HANDLE__: ETH Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_PMT_FLAG_WUFFRPR : Wake-Up Frame Filter Register Pointer Reset
+  *     @arg ETH_PMT_FLAG_WUFR    : Wake-Up Frame Received
+  *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
+  * @retval The new state of Ethernet PMT Flag (SET or RESET).
+  */
+#define __HAL_ETH_GET_PMT_FLAG_STATUS(__HANDLE__, __FLAG__)               (((__HANDLE__)->Instance->MACPMTCSR &( __FLAG__)) == ( __FLAG__))
+
+/**
+  * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
+  * @param   __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MMC_COUNTER_FULL_PRESET(__HANDLE__)                     ((__HANDLE__)->Instance->MMCCR |= (ETH_MMCCR_MCFHP | ETH_MMCCR_MCP))
+
+/**
+  * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MMC_COUNTER_HALF_PRESET(__HANDLE__)                     do{(__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCFHP;\
+                                                                          (__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCP;} while (0)
+
+/**
+  * @brief  Enables the MMC Counter Freeze.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE(__HANDLE__)                  ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCF)
+
+/**
+  * @brief  Disables the MMC Counter Freeze.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE(__HANDLE__)                 ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCF)
+
+/**
+  * @brief  Enables the MMC Reset On Read.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_ROR)
+
+/**
+  * @brief  Disables the MMC Reset On Read.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_ROR)
+
+/**
+  * @brief  Enables the MMC Counter Stop Rollover.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE(__HANDLE__)            ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_CSR)
+
+/**
+  * @brief  Disables the MMC Counter Stop Rollover.
+  * @param  __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE(__HANDLE__)           ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CSR)
+
+/**
+  * @brief  Resets the MMC Counters.
+  * @param   __HANDLE__: ETH Handle.
+  * @retval None
+  */
+#define __HAL_ETH_MMC_COUNTERS_RESET(__HANDLE__)                         ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CR)
+
+/**
+  * @brief  Enables the specified Ethernet MMC Rx interrupts.
+  * @param   __HANDLE__: ETH Handle.
+  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
+  * @retval None
+  */
+#define __HAL_ETH_MMC_RX_IT_ENABLE(__HANDLE__, __INTERRUPT__)               (__HANDLE__)->Instance->MMCRIMR &= ~((__INTERRUPT__) & 0xEFFFFFFF)
+/**
+  * @brief  Disables the specified Ethernet MMC Rx interrupts.
+  * @param   __HANDLE__: ETH Handle.
+  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
+  * @retval None
+  */
+#define __HAL_ETH_MMC_RX_IT_DISABLE(__HANDLE__, __INTERRUPT__)              (__HANDLE__)->Instance->MMCRIMR |= ((__INTERRUPT__) & 0xEFFFFFFF)
+/**
+  * @brief  Enables the specified Ethernet MMC Tx interrupts.
+  * @param   __HANDLE__: ETH Handle.
+  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
+  * @retval None
+  */
+#define __HAL_ETH_MMC_TX_IT_ENABLE(__HANDLE__, __INTERRUPT__)            ((__HANDLE__)->Instance->MMCRIMR &= ~ (__INTERRUPT__))
+
+/**
+  * @brief  Disables the specified Ethernet MMC Tx interrupts.
+  * @param   __HANDLE__: ETH Handle.
+  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+  *   This parameter can be one of the following values:
+  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
+  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
+  * @retval None
+  */
+#define __HAL_ETH_MMC_TX_IT_DISABLE(__HANDLE__, __INTERRUPT__)           ((__HANDLE__)->Instance->MMCRIMR |= (__INTERRUPT__))
+
+/**
+  * @brief  Enables the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR |= (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Disables the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief Enable event on ETH External event line.
+  * @retval None.
+  */
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()  EXTI->EMR |= (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief Disable event on ETH External event line
+  * @retval None.
+  */
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT() EXTI->EMR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Get flag of the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()     EXTI->PR & (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Clear flag of the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR = (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Enables rising edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
+
+/**
+  * @brief  Disables the rising edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Enables falling edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR |= (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Disables falling edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER()  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;\
+                                                              EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
+
+/**
+  * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
+  * @retval None
+  */
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER()  EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
+                                                               EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief Generate a Software interrupt on selected EXTI line.
+  * @retval None.
+  */
+#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()                  EXTI->SWIER|= ETH_EXTI_LINE_WAKEUP
+
+/**
+  * @}
+  */
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup ETH_Exported_Functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+
+/** @addtogroup ETH_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth);
+void HAL_ETH_MspInit(ETH_HandleTypeDef *heth);
+void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
+HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
+
+/**
+  * @}
+  */
+/* IO operation functions  ****************************************************/
+
+/** @addtogroup ETH_Exported_Functions_Group2
+  * @{
+  */
+HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameLength);
+HAL_StatusTypeDef HAL_ETH_GetReceivedFrame(ETH_HandleTypeDef *heth);
+/* Communication with PHY functions*/
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue);
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth);
+void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
+/* Callback in non blocking modes (Interrupt) */
+void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);
+void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth);
+void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+
+/** @addtogroup ETH_Exported_Functions_Group3
+  * @{
+  */
+
+HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf);
+HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+
+/** @addtogroup ETH_Exported_Functions_Group4
+  * @{
+  */
+HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32Fxx_HAL_ETH_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
@@ -1,0 +1,119 @@
+/*
+ * Handling of Ethernet PHY's
+ * PHY's communicate with an EMAC either through
+ * a Media-Independent Interface (MII), or a Reduced Media-Independent Interface (RMII).
+ * The EMAC can poll for PHY ports on 32 different addresses. Each of the PHY ports
+ * shall be treated independently.
+ * 
+ */
+
+#ifndef PHYHANDLING_H
+
+#define PHYHANDLING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifndef ipconfigPHY_MAX_PORTS
+	/* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
+	#define	ipconfigPHY_MAX_PORTS	4
+#endif
+
+/* A generic user-provided function that reads from the PHY-port at 'xAddress'( 0-based ). A 16-bit value shall be stored in
+  '*pusValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
+  Return non-zero in case the action failed. */
+typedef BaseType_t ( *xApplicationPhyReadHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t *pulValue );
+
+/* A generic user-provided function that writes 'usValue' to the
+   PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
+   Return non-zero in case the action failed. */
+typedef BaseType_t ( *xApplicationPhyWriteHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t ulValue );
+
+typedef struct xPhyProperties
+{
+	uint8_t ucSpeed;
+	uint8_t ucMDI_X;		/* MDI-X : Medium Dependent Interface - Crossover */
+	uint8_t ucDuplex;
+	uint8_t ucSpare;
+} PhyProperties_t;
+
+typedef struct xEthernetPhy
+{
+	xApplicationPhyReadHook_t fnPhyRead;
+	xApplicationPhyWriteHook_t fnPhyWrite;
+	uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
+	uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
+	TimeOut_t xLinkStatusTimer;
+	TickType_t xLinkStatusRemaining;
+	BaseType_t xPortCount;
+	uint32_t ulBCRValue;
+	uint32_t ulACRValue;
+	uint32_t ulLinkStatusMask;
+	PhyProperties_t xPhyPreferences;
+	PhyProperties_t xPhyProperties;
+} EthernetPhy_t;
+
+/* Some defines used internally here to indicate preferences about speed, MDIX
+(wired direct or crossed), and duplex (half or full). */
+
+/* Values for PhyProperties_t::ucSpeed : */
+#define	PHY_SPEED_10		1
+#define	PHY_SPEED_100		2
+#define	PHY_SPEED_AUTO		3
+
+/* Values for PhyProperties_t::ucMDI_X : */
+#define	PHY_MDIX_DIRECT		1
+#define	PHY_MDIX_CROSSED	2
+#define	PHY_MDIX_AUTO		3
+
+/* Values for PhyProperties_t::ucDuplex : */
+#define	PHY_DUPLEX_HALF		1
+#define	PHY_DUPLEX_FULL		2
+#define	PHY_DUPLEX_AUTO		3
+
+/* ID's of supported PHY's : */
+#define PHY_ID_LAN8742A		0x0007c130
+#define PHY_ID_LAN8720		0x0007c0f0
+
+#define PHY_ID_KSZ8041		0x000010A1
+#define PHY_ID_KSZ8051		0x000010A1
+#define PHY_ID_KSZ8081		0x000010A1
+
+#define PHY_ID_KSZ8863		0x00221430
+#define PHY_ID_KSZ8081MNXIA 0x00221560
+
+#define PHY_ID_DP83848I		0x20005C90
+
+
+/* Initialise the struct and assign a PHY-read and -write function. */
+void vPhyInitialise( EthernetPhy_t *pxPhyObject, xApplicationPhyReadHook_t fnPhyRead, xApplicationPhyWriteHook_t fnPhyWrite );
+
+/* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
+BaseType_t xPhyDiscover( EthernetPhy_t *pxPhyObject );
+
+/* Send a reset commando to the connected PHY ports and send configuration. */
+BaseType_t xPhyConfigure( EthernetPhy_t *pxPhyObject, const PhyProperties_t *pxPhyProperties );
+
+/* Give a commando to start auto negotiation on a set of PHY port's. */
+BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+
+/* Do not use auto negotiation but use predefined values from 'pxPhyObject->xPhyPreferences'. */
+BaseType_t xPhyFixedValue( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+
+/* Check the current Link Status.
+'xHadReception' : make this true if a packet has been received since the
+last call to this function. */
+BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadReception );
+
+static __inline uint32_t xPhyGetMask( EthernetPhy_t *pxPhyObject )
+{
+	return ( ( ( uint32_t ) 1u ) << pxPhyObject-> xPortCount ) - 1;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
@@ -109,7 +109,7 @@ BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadRecep
 
 /* Get the bitmask of a given 'EthernetPhy_t'. */
 #define xPhyGetMask( pxPhyObject ) \
-	( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1 )
+	( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/include/phyHandling.h
@@ -22,11 +22,11 @@ extern "C" {
 #endif
 
 /* A generic user-provided function that reads from the PHY-port at 'xAddress'( 0-based ). A 16-bit value shall be stored in
-  '*pusValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
+  '*pulValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
   Return non-zero in case the action failed. */
 typedef BaseType_t ( *xApplicationPhyReadHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t *pulValue );
 
-/* A generic user-provided function that writes 'usValue' to the
+/* A generic user-provided function that writes 'ulValue' to the
    PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
    Return non-zero in case the action failed. */
 typedef BaseType_t ( *xApplicationPhyWriteHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t ulValue );
@@ -93,10 +93,10 @@ void vPhyInitialise( EthernetPhy_t *pxPhyObject, xApplicationPhyReadHook_t fnPhy
 /* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
 BaseType_t xPhyDiscover( EthernetPhy_t *pxPhyObject );
 
-/* Send a reset commando to the connected PHY ports and send configuration. */
+/* Send a reset command to the connected PHY ports and send configuration. */
 BaseType_t xPhyConfigure( EthernetPhy_t *pxPhyObject, const PhyProperties_t *pxPhyProperties );
 
-/* Give a commando to start auto negotiation on a set of PHY port's. */
+/* Give a command to start auto negotiation on a set of PHY port's. */
 BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
 
 /* Do not use auto negotiation but use predefined values from 'pxPhyObject->xPhyPreferences'. */
@@ -107,10 +107,9 @@ BaseType_t xPhyFixedValue( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
 last call to this function. */
 BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadReception );
 
-static __inline uint32_t xPhyGetMask( EthernetPhy_t *pxPhyObject )
-{
-	return ( ( ( uint32_t ) 1u ) << pxPhyObject-> xPortCount ) - 1;
-}
+/* Get the bitmask of a given 'EthernetPhy_t'. */
+#define xPhyGetMask( pxPhyObject ) \
+	( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1 )
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
# Network Interface for STM32F2x, F4x, and F7x

<!--- Title -->

Description
-----------
Source file `networkInterface.c` :

- `ipconfigZERO_COPY_TX_DRIVER` : The driver was supposed to work for both the zero-copy and the copy-implementation. However, the copy-version was never fully implemented. In this version, both copy and zero-copy can be used..

- `ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM` / `ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM` : both enabled and disabled can be used int the new release.
Normally one will enable the automatic offloading of checksums because it helps the performance. Only for testing purposes, it can be handy to change this.

- PHY handling: the handling of the connected PHY is now done in a separate module: `Common/phyHandler.c`. It recognises the attached PHY automatically and starts auto negotiation. Also it can poll for the PHY Link Status.

- Stopped referring to the global variable: 
~~~c
    extern const uint8_t ucMACAddress[ 6 ];
~~~
Now using `FreeRTOS_GetMACAddress()` in stead.

- Introduction of a new macro `ipconfigUSE_RMII`. Shall be defined as `1` if a RMII interface is being used. Please check your board.

- Introduction of a new macro `NETWORK_BUFFERS_CACHED`: true if the memory is being cached ( STM32F7xx only ). I am sorry to tell that this option is not yet fully implemented. On a STM32F7xx, the driver works well if memory caching is not enabled ( `SCB_DisableDCache()` ).

- Implementation of linked messages ( `ipconfigUSE_LINKED_RX_MESSAGES` ). Especially on a LAN, it may enhance the performance. Both options can be used: with and without linked RX messages.

The following files have been added ( compare to the current version in [AWS/FreeRTOS](https://github.com/aws/amazon-freertos/tree/master/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx):

    stm32fxx_hal_eth.c
    stm32fxx_hal_eth.h
    stm32f2xx_hal_eth.h
    stm32f4xx_hal_eth.h
    stm32f7xx_hal_eth.h

Source file `stm32fxx_hal_eth.c` :

- Removed code that is never used, like configuring the PHY, DMA buffers and their handling, `HAL_ETH_TransmitFrame()`, `HAL_ETH_GetReceivedFrame()`
PHY-read and PHY-write are kept.

- Added support for stm32f2xx

- After changing a register in the ETH peripheral, the register must be read-back, and set again after a short delay:

~~~c
    MACFCR = ulValue;    /* Set it */
    ( void ) MACFCR;    /* Read it back. */
    vRegisterDelay();    /* Short delay. */
    MACFCR = ulValue;    /* Set it again. */
~~~

`vRegisterDelay()` was introduced to get a more precise and shorter delay than calling `HAL_Delay(1)`.

Source file `stm32fxx_hal_eth.h` :

- Avoid conflicts with `stm32_hal_legacy.h`. There is some overlap between the 2 header files that can cause conflicts for the compiler. This was solved ( avoided ) by adding:

~~~c
#ifndef ETH_MAC_TXFIFO_FULL
    #define ETH_MAC_TXFIFO_FULL          ((uint32_t)0x02000000)  /* Tx FIFO full */
    ...
#endif
~~~

The FreeRTOS+TCP driver is not used in any of the demo or testing projects on [AWS/FreeRTOS](https://github.com/aws/amazon-freertos/). The is one demo project for a STM32L475. That is a project using Wi-Fi and it doesn't make use of FreeRTOS+TCP.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.