### PR TITLE
fix: Disable ALPN for GGD demo

### DIFF
--- a/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
+++ b/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
@@ -155,6 +155,8 @@ static IotMqttError_t _mqttConnect( GGD_HostAddressData_t * pxHostAddressData,
     xCredentials.rootCaSize = ( size_t ) pxHostAddressData->ulCertificateSize;
     /* Disable SNI. */
     xCredentials.disableSni = true;
+    /* ALPN is not needed. */
+    xCredentials.pAlpnProtos = NULL;
 
     /* Set the server info. */
     xServerInfo.pHostName = pxHostAddressData->pcHostAddress;


### PR DESCRIPTION

<!--- Title -->

Description
-----------
The Greengrass demo enabled ALPN by default, but this causes the demo to error on boards where ALPN has not been implemented. ALPN is not needed by Greengrass, and is not used in other demos.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.