### PR TITLE
Replace eUartCompleted with eUartWriteCompleted and eUartReadCompleted

### DIFF
--- a/libraries/abstractions/common_io/include/iot_uart.h
+++ b/libraries/abstractions/common_io/include/iot_uart.h
@@ -60,9 +60,10 @@
  */
 typedef enum
 {
-    eUartCompleted = IOT_UART_SUCCESS,            /*!< UART operation completed successfully. */
-    eUartLastWriteFailed = IOT_UART_WRITE_FAILED, /*!< UART driver returns error when performing write operation. */
-    eUartLastReadFailed = IOT_UART_READ_FAILED,   /*!< UART driver returns error when performing read operation. */
+    eUartWriteCompleted,        /*!< UART operation write completed successfully. */
+    eUartReadCompleted,         /*!< UART operation read completed successfully. */
+    eUartLastWriteFailed,       /*!< UART driver returns error when performing write operation. */
+    eUartLastReadFailed,        /*!< UART driver returns error when performing read operation. */
 } IotUARTOperationStatus_t;
 
 /**
@@ -80,8 +81,8 @@ typedef enum
  */
 typedef enum
 {
-    eUartStopBitsOne, /*!< UART stop bits is 1. */
-    eUartStopBitsTwo, /*!< UART stop bits is 2. */
+    eUartStopBitsOne, /*!< UART stop bits is 1 bit per frame. */
+    eUartStopBitsTwo, /*!< UART stop bits is 2 bit per frame. */
 } IotUARTStopBits_t;
 
 /**
@@ -159,7 +160,7 @@ typedef struct
  *  IotUARTHandle_t xOpen;
  *  int32_t lRead, lWrite, lClose;
  *  BaseType_t xCallbackReturn;
- *  uint8_t ucPort = 1; /* Each UART peripheral will be assigned an integer.
+ *  uint8_t ucPort = 1; // Each UART peripheral will be assigned an integer.
  *
  *  xOpen = iot_uart_open( ucPort );
  *  if( xOpen != NULL )


### PR DESCRIPTION


<!--- Title -->
Replace eUartCompleted with eUartWriteCompleted and eUartReadComplete to differentiate read/write status.

Description
-----------
<!--- Describe your changes in detail -->
We cannot differentiate write and read status from iot_uart's user viewpoint.
We change the IOstatus to differentiate write and read

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.