### PR TITLE
Need to differentiate read/write complete status

### DIFF
--- a/libraries/abstractions/common_io/include/iot_uart.h
+++ b/libraries/abstractions/common_io/include/iot_uart.h
@@ -60,9 +60,10 @@
  */
 typedef enum
 {
-    eUartCompleted = IOT_UART_SUCCESS,            /*!< UART operation completed successfully. */
-    eUartLastWriteFailed = IOT_UART_WRITE_FAILED, /*!< UART driver returns error when performing write operation. */
-    eUartLastReadFailed = IOT_UART_READ_FAILED,   /*!< UART driver returns error when performing read operation. */
+    eUartWriteCompleted,        /*!< UART operation write completed successfully. */
+    eUartReadCompleted,         /*!< UART operation read completed successfully. */
+    eUartLastWriteFailed,       /*!< UART driver returns error when performing write operation. */
+    eUartLastReadFailed,        /*!< UART driver returns error when performing read operation. */
 } IotUARTOperationStatus_t;
 
 /**
@@ -80,8 +81,8 @@ typedef enum
  */
 typedef enum
 {
-    eUartStopBitsOne, /*!< UART stop bits is 1. */
-    eUartStopBitsTwo, /*!< UART stop bits is 2. */
+    eUartStopBitsOne, /*!< UART stop bits is 1 bit per frame. */
+    eUartStopBitsTwo, /*!< UART stop bits is 2 bit per frame. */
 } IotUARTStopBits_t;
 
 /**
@@ -159,7 +160,7 @@ typedef struct
  *  IotUARTHandle_t xOpen;
  *  int32_t lRead, lWrite, lClose;
  *  BaseType_t xCallbackReturn;
- *  uint8_t ucPort = 1; /* Each UART peripheral will be assigned an integer.
+ *  uint8_t ucPort = 1; // Each UART peripheral will be assigned an integer.
  *
  *  xOpen = iot_uart_open( ucPort );
  *  if( xOpen != NULL )

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -471,7 +471,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
     int32_t lRead, lWrite, lClose;
     BaseType_t xCallbackReturn;
     uint8_t ucPort = ustestIotUartPort;
-    volatile IotUARTOperationStatus_t xCallbackStatus = eUartCompleted;
+    volatile IotUARTOperationStatus_t xCallbackStatus = eUartLastWriteFailed;
 
     xUartHandle = iot_uart_open( ucPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
@@ -483,13 +483,18 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
         lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
+        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
+
+        TEST_ASSERT_EQUAL( eUartWriteCompleted, xCallbackStatus );
+
         lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
 
         xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
         TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
-        TEST_ASSERT_EQUAL( eUartCompleted, xCallbackStatus );
+        TEST_ASSERT_EQUAL( eUartReadCompleted, xCallbackStatus );
 
         TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
     }
@@ -510,7 +515,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
     IotUARTHandle_t xUartHandle;
     int32_t lWrite, lClose, lCancel;
     BaseType_t xCallbackReturn;
-    volatile IotUARTOperationStatus_t xCallbackStatus = eUartCompleted;
+    volatile IotUARTOperationStatus_t xCallbackStatus = eUartLastWriteFailed;
 
     uint8_t cSmallBuf[ 2 ] = { 'H', 'I' };
     uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };


### PR DESCRIPTION
<!--- Title -->
Need to differentiate read/write complete status

Description
-----------
<!--- Describe your changes in detail -->
For console application which calling iot_uart, it's possible that console application will need to differentiate write and read complete status.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.