### PR TITLE
Fix a dependency parsing bug in CMake from #1161

### DIFF
--- a/tools/cmake/afr_module.cmake
+++ b/tools/cmake/afr_module.cmake
@@ -335,8 +335,8 @@ function(afr_resolve_dependencies)
     # If neither demos nor tests are enabled, then don't search the aws_demos/aws_tests targets.
     if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
         __search_afr_dependencies(${exe_target} dependencies)
+        afr_module_dependencies(${exe_base} INTERFACE ${dependencies})
     endif()
-    afr_module_dependencies(${exe_base} INTERFACE ${dependencies})
 
     # Make sure kernel can be enabled first.
     __resolve_dependencies(kernel)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fix a bug introduced in #1161, address issue #1652. See details in commit message.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.