### PR TITLE
Convert all paths to be absolute so the tests do not have to be run in the specific folder.

### DIFF
--- a/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_adc_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_adc_test.py
@@ -31,8 +31,11 @@ import csv
 from time import sleep
 import argparse
 import os, sys
-parentdir = os.path.dirname(os.getcwd())
-sys.path.insert(0,parentdir)
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
+sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 
 
@@ -55,7 +58,7 @@ class TestAdcAssisted(test_template):
         # self.platform_ref_voltage = float(input())
         self.platform_ref_voltage = 1.8
 
-    shell_script = "./test_iot_runonPI_adc.sh"
+    shell_script = "%s/test_iot_runonPI_adc.sh" % scriptdir
 
     def test_IotAdcPrintReadSample(self):
         """

--- a/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_runonPI_adc.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_runonPI_adc.sh
@@ -24,7 +24,7 @@
 
 
 
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 IP=$1
 shift
 LOGINID=$1
@@ -35,7 +35,7 @@ shift
 if [ "$1" == "-p" ]; then
     #Secure copy the test_iot_adc_rp3.py from Host to RP3
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "mkdir -p /home/pi/Tests"
-    sshpass -p ${PASSWD} scp ./test_iot_adc_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
+    sshpass -p ${PASSWD} scp ${DIR}/test_iot_adc_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
 elif [ ! -z $1 ]; then
     #Set dac output voltage
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "python /home/pi/Tests/test_iot_adc_rp3.py $1"

--- a/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_gpio_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_gpio_test.py
@@ -30,7 +30,10 @@ import os, sys
 import argparse
 import socket
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 
@@ -55,8 +58,8 @@ class TestGpioAssisted(test_template):
         self._pwd = pwd
         self._cr = csv_handler
 
-    shell_script = './test_iot_runonPI_gpio.sh'
-    rpi_output_file = "./gpio_rpi_res.txt"
+    shell_script = "%s/test_iot_runonPI_gpio.sh" % scriptdir
+    rpi_output_file = "%s/gpio_rpi_res.txt" % scriptdir
     port = 50007
 
     def test_AssistedIotGpioModeWritePushPullTrue(self):

--- a/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_runonPI_gpio.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_runonPI_gpio.sh
@@ -25,7 +25,7 @@
 
 
 # This is a shell script to secure copy the GPIO_RP3 to RP3
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 IP=$1
 shift
 LOGINID=$1
@@ -35,7 +35,7 @@ shift
 if [ "$1" == "-p" ]; then
     #Secure copy the test_iot_gpio_rp3.py from Host to RP3
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "mkdir -p /home/pi/Tests"
-    sshpass -p ${PASSWD} scp ./test_iot_gpio_rp3.py ${LOGINID}@${IP}:/home/pi/Tests/
+    sshpass -p ${PASSWD} scp ${DIR}/test_iot_gpio_rp3.py ${LOGINID}@${IP}:/home/pi/Tests/
 elif [ "$1" == "-w" ]; then
 
     #Open a SSH connection to RP3 and run the test_iot_gpio_rp3.py to read the GPIO pin status

--- a/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_pwm_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_pwm_test.py
@@ -34,7 +34,10 @@ import math
 import os
 import argparse
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 import socket
@@ -58,8 +61,8 @@ class TestPwmAssisted(test_template):
         self._pwd = pwd
         self._cr = csv_handler
 
-    shell_script = "./test_iot_runonPI_pwm.sh"
-    rpi_output_file = "./pwm_rpi_res.txt"
+    shell_script = "%s/test_iot_runonPI_pwm.sh" % scriptdir
+    rpi_output_file = "%s/pwm_rpi_res.txt" % scriptdir
     port = 50007
 
     def test_IotPwmAccuracy(self):

--- a/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_runonPI_pwm.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_runonPI_pwm.sh
@@ -26,7 +26,7 @@
 
 
 
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 IP=$1
 shift
 LOGINID=$1
@@ -37,7 +37,7 @@ shift
 if [ "$1" == "-p" ]; then
     #Secure copy the test_iot_read_PWM.py and test_iot_wave_PWM.py from Host to RP3
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "mkdir -p /home/pi/Tests"
-    sshpass -p ${PASSWD} scp ./test_iot_pwm_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
+    sshpass -p ${PASSWD} scp ${DIR}/test_iot_pwm_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
 elif [ "$1" == "-c" ]; then
     #Delete the result file on rpi
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "rm /home/pi/Tests/pwm_rpi_res.txt"
@@ -49,5 +49,5 @@ else
     #Kill demon
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} 'sudo killall pigpiod'
     #Copy back result
-    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/pwm_rpi_res.txt .
+    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/pwm_rpi_res.txt ${DIR}
 fi

--- a/libraries/abstractions/common_io/test/test_scripts/spi_master/test_iot_spi_master_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/spi_master/test_iot_spi_master_test.py
@@ -33,7 +33,10 @@ import subprocess
 import ast
 import random
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 
@@ -103,7 +106,7 @@ class TestSPIMasterAssisted(test_template):
     """
     Test class for spi master tests.
     """
-    shell_script = "./test_iot_spi_master_pyb.sh"
+    shell_script = "%s/test_iot_spi_master_pyb.sh" % scriptdir
 
     def __init__(self, serial, ip, login, pwd, csv_handler):
         self._func_list = [self.test_IotSPI_WriteSyncAssisted,

--- a/libraries/abstractions/common_io/test/test_scripts/test_iot_test_template.py
+++ b/libraries/abstractions/common_io/test/test_scripts/test_iot_test_template.py
@@ -25,6 +25,7 @@
 import subprocess
 import os
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 
 class test_template(ABC):
@@ -41,6 +42,11 @@ class test_template(ABC):
     shell_script = ''
     rpi_output_file = ''
 
+    def print_result(self, testcase, result, extra = None):
+        if extra == None:
+            extra = "%s %sed" % (testcase, result)
+        print("%s [INFO] %s 0  %s  :  %s" % (str(datetime.now()), testcase, result.upper(), extra))
+        self._cr.writerow({'test name': testcase, 'test result': result})
     def auto_run(self):
         # print('hardware ready? (y/n)')
         # string = str(input())
@@ -53,16 +59,14 @@ class test_template(ABC):
 
         if skip_test == True:
             for f in self._func_list:
-                print(f.__name__, ": ", 'skipped')
-                self._cr.writerow({'test name': f.__name__, 'test result': 'skipped'})
+                self.print_result(f.__name__, "Skip")
         else:
             print("tests start")
             if self.shell_script:
                 subprocess.call([self.shell_script, self._ip, self._login, self._pwd, '-p'])
             for f in self._func_list:
                 result = f()
-                print(f.__name__, ": ", result)
-                self._cr.writerow({'test name': f.__name__, 'test result': result})
+                self.print_result(f.__name__, result)
 
     def run_shell_script(self, cmd):
         cmd_l = cmd.split()

--- a/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_runonPI_tsensor.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_runonPI_tsensor.sh
@@ -24,7 +24,7 @@
 # http://www.FreeRTOS.org
 
 
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 IP=$1
 shift
 LOGINID=$1
@@ -35,12 +35,12 @@ shift
 if [ "$1" == "-p" ]; then
     #Secure copy test script from Host ubuntu to RP3
     sshpass -p "${PASSWD}" ssh ${LOGINID}@${IP} "mkdir -p /home/pi/Tests"
-    sshpass -p "${PASSWD}" scp ./test_iot_tsensor_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
+    sshpass -p "${PASSWD}" scp ${DIR}/test_iot_tsensor_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
 elif [ "$1" == "-c" ]; then
     #Delete the result file on rpi
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "rm /home/pi/Tests/tsensor_rpi_res.txt"
 else
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "python /home/pi/Tests/test_iot_tsensor_rp3.py > /home/pi/Tests/tsensor_rpi_res.txt"
     #Copy back result
-    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/tsensor_rpi_res.txt .
+    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/tsensor_rpi_res.txt ${DIR}
 fi

--- a/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_tsensor_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_tsensor_test.py
@@ -28,7 +28,10 @@ import csv
 import os, sys
 import argparse
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 
@@ -47,8 +50,8 @@ class TestTsensorAssisted(test_template):
         self._pwd = pwd
         self._cr = csv_handler
 
-    shell_script = "./test_iot_runonPI_tsensor.sh"
-    rpi_output_file = "./tsensor_rpi_res.txt"
+    shell_script = "%s/test_iot_runonPI_tsensor.sh" % scriptdir
+    rpi_output_file = "%s/tsensor_rpi_res.txt" % scriptdir
 
     def test_IotTsensorTemp(self):
         """

--- a/libraries/abstractions/common_io/test/test_scripts/uart/test_iot_runonPI_uart.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/uart/test_iot_runonPI_uart.sh
@@ -24,7 +24,7 @@
 
 
 
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 IP=$1
 shift
 LOGINID=$1
@@ -35,7 +35,7 @@ shift
 if [ "$1" == "-p" ]; then
     #Secure copy the test_iot_uart_rp3.py from Host to RP3
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "mkdir -p /home/pi/Tests"
-    sshpass -p ${PASSWD} scp ./test_iot_uart_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
+    sshpass -p ${PASSWD} scp ${DIR}/test_iot_uart_rp3.py ${LOGINID}@${IP}:/home/pi/Tests
 elif [ "$1" == "-c" ]; then
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "rm /home/pi/Tests/uart_res.txt"
 else

--- a/libraries/abstractions/common_io/test/test_scripts/uart/test_iot_uart_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/uart/test_iot_uart_test.py
@@ -32,7 +32,10 @@ import socket
 from time import sleep
 import threading
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 
@@ -42,7 +45,7 @@ class TestUartAssisted(test_template):
     Test class for uart tests.
     """
 
-    rpi_output_file = "./uart_res.txt"
+    rpi_output_file = "%s/uart_res.txt"% scriptdir
 
     def __init__(self, serial, ip, login, pwd, csv_handler):
         self._func_list = [self.test_IotUartWriteReadAsync,
@@ -56,7 +59,7 @@ class TestUartAssisted(test_template):
         self._pwd = pwd
         self._cr = csv_handler
 
-    shell_script = "./test_iot_runonPI_uart.sh"
+    shell_script = "%s/test_iot_runonPI_uart.sh"% scriptdir
     port = 50007
 
     def test_IotUartWriteReadAsync(self):
@@ -223,7 +226,7 @@ class TestUartAssisted(test_template):
         return "Pass" if pi_result and dut_result else "Fail"
 
     def clean(self):
-        os.remove("./uart_res.txt")
+        os.remove(self.rpi_output_file)
         self.run_shell_script(
             " ".join([self.shell_script, self._ip, self._login, self._pwd, "-c"])
         )

--- a/libraries/abstractions/common_io/test/test_scripts/usb_device/test_iot_usb_device_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/usb_device/test_iot_usb_device_test.py
@@ -33,7 +33,10 @@ import re
 import threading
 import random
 
-parentdir = os.path.dirname(os.getcwd())
+scriptdir = os.path.abspath(sys.path[0])
+parentdir = os.path.dirname(scriptdir)
+print("Script Dir: %s" % scriptdir)
+print("Parent Dir: %s" % parentdir)
 sys.path.insert(0, parentdir)
 from test_iot_test_template import test_template
 


### PR DESCRIPTION


<!--- Title -->

Description
-----------
Convert all paths to be absolute so the tests do not have to be run in the specific folder.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.