### PR TITLE
Fix BLE enable disable sequence

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -134,6 +134,7 @@ static void _onNetworkStateChangeCallback( uint32_t network,
 
         /* Disable the disconnected networks to save power and reclaim any unused memory. */
         disconnectedNetworks = configENABLED_NETWORKS & ( ~demoConnectedNetwork );
+
         if( disconnectedNetworks != AWSIOT_NETWORK_TYPE_NONE )
         {
             AwsIotNetworkManager_DisableNetwork( disconnectedNetworks );
@@ -162,6 +163,7 @@ static void _onNetworkStateChangeCallback( uint32_t network,
 
         /* Re-enable all the networks for the demo for reconnection. */
         disconnectedNetworks = configENABLED_NETWORKS & ( ~demoConnectedNetwork );
+
         if( disconnectedNetworks != AWSIOT_NETWORK_TYPE_NONE )
         {
             AwsIotNetworkManager_EnableNetwork( disconnectedNetworks );
@@ -270,7 +272,6 @@ static int _initialize( demoContext_t * pContext )
             demoConnectedNetwork = _waitForDemoNetworkConnection( pContext );
         }
     }
-
 
     if( status == EXIT_FAILURE )
     {

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -320,6 +320,8 @@ static IotNetworkManager_t networkManager =
         static bool bleInited = false;
         BTStatus_t status;
 
+        bleNetwork.state = eNetworkStateDisabled;
+
         if( bleInited == false )
         {
             if( IotBle_Init() == eBTStatusSuccess )
@@ -332,15 +334,10 @@ static IotNetworkManager_t networkManager =
                 ret = false;
             }
         }
-        else
+
+        if( ret == true )
         {
             status = IotBle_On();
-
-            if( status == eBTStatusSuccess )
-            {
-                status = IotBle_StartAdv( NULL );
-            }
-
             if( status != eBTStatusSuccess )
             {
                 IotLogError( "Failed to toggle BLE on." );
@@ -352,6 +349,11 @@ static IotNetworkManager_t networkManager =
         {
             /* Register BLE Connection callback */
             ret = _bleRegisterUnregisterCb( false );
+        }
+
+        if( ret == false )
+        {
+            bleNetwork.state = eNetworkStateUnknown;
         }
 
         return ret;
@@ -366,13 +368,6 @@ static IotNetworkManager_t networkManager =
         /* Unregister the callbacks */
         ret = _bleRegisterUnregisterCb( true );
 
-        if( ret == true )
-        {
-            if( IotBle_StopAdv( NULL ) != eBTStatusSuccess )
-            {
-                ret = false;
-            }
-        }
 
         if( ret == true )
         {

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -493,6 +493,7 @@ static IotNetworkManager_t networkManager =
 
         #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
             vWiFiConnectTaskDestroy();
+            IotBleWifiProv_Deinit();
         #endif
 
         if( WIFI_IsConnected() == pdTRUE )

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -338,6 +338,7 @@ static IotNetworkManager_t networkManager =
         if( ret == true )
         {
             status = IotBle_On();
+
             if( status != eBTStatusSuccess )
             {
                 IotLogError( "Failed to toggle BLE on." );
@@ -367,7 +368,6 @@ static IotNetworkManager_t networkManager =
 
         /* Unregister the callbacks */
         ret = _bleRegisterUnregisterCb( true );
-
 
         if( ret == true )
         {

--- a/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
@@ -151,4 +151,12 @@ void IotBleDataTransfer_Close( IotBleDataTransferChannel_t * pChannel );
  */
 void IotBleDataTransfer_Reset( IotBleDataTransferChannel_t * pChannel );
 
+
+/**
+ * @brief Cleanup the BLE data transfer services.
+ *
+ * @return true/false if the cleanup was successful or not.
+ */
+bool IotBleDataTransfer_Cleanup( void );
+
 #endif /* IOT_BLE_DATA_TRANSFER_H */

--- a/libraries/c_sdk/standard/ble/include/iot_ble_device_information.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_device_information.h
@@ -48,10 +48,25 @@
 /**
  * @brief Creates and starts Amazon FreeRTOS device information service
  *
- * @return pdTRUE if the service is initialized successfully, pdFALSE otherwise
+ * @return true if the service is initialized successfully, false otherwise
  */
 /* @[declare_iotbledeviceinfo_init] */
 bool IotBleDeviceInfo_Init( void );
 /* @[declare_iotbledeviceinfo_init] */
+
+/**
+ * @function_page{IotBleDeviceInfo_Cleanup,iotbledeviceinfo,cleanup}
+ * @function_snippet{iotbledeviceinfo,cleanup,this}
+ * @copydoc IotBleDeviceInfo_Cleanup
+ */
+
+/**
+ * @brief Cleanup device information service.
+ *
+ * @return true If the cleanup is successful false otherwise.
+ */
+/* @[declare_iotbledeviceinfo_cleanup] */
+bool IotBleDeviceInfo_Cleanup( void );
+/* @[declare_iotbledeviceinfo_cleanup] */
 
 #endif /* IOT_BLE_DEVICE_INFORMATION_H_ */

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -311,6 +311,7 @@ void _registerBleAdapterCb( BTStatus_t status,
     IotSemaphore_Post( &_BTInterface.callbackSemaphore );
 }
 
+
 /*-----------------------------------------------------------*/
 
 void _advStatusCb( BTStatus_t status,
@@ -341,9 +342,19 @@ void _advStatusCb( BTStatus_t status,
 void _bleStartAdvCb( BTStatus_t status )
 {
     IotSemaphore_Post( &_BTInterface.callbackSemaphore );
+    _BTInterface.cbStatus = status;
 }
 
 /*-----------------------------------------------------------*/
+
+
+void _bleStopAdvCb( BTStatus_t status )
+{
+    IotSemaphore_Post( &_BTInterface.callbackSemaphore );
+    _BTInterface.cbStatus = status;
+}
+
+/*------------------------------------------------------------*/
 
 void _setAdvDataCb( BTStatus_t status )
 {
@@ -353,7 +364,7 @@ void _setAdvDataCb( BTStatus_t status )
 
 /*-----------------------------------------------------------*/
 
-BTStatus_t _startAllServices()
+BTStatus_t _startGATTServices()
 {
     BTStatus_t ret = eBTStatusSuccess;
     bool status = true;
@@ -380,7 +391,35 @@ BTStatus_t _startAllServices()
 
     return ret;
 }
+
 /*-----------------------------------------------------------*/
+
+BTStatus_t _stopGATTServices()
+{
+
+    BTStatus_t ret = eBTStatusSuccess;
+    bool status = true;
+
+#if ( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
+    status = IotBleDeviceInfo_Cleanup();
+#endif
+
+#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
+    if( status == true )
+    {
+        status = IotBleDataTransfer_Cleanup();
+    }
+#endif
+
+    if( status == false )
+    {
+        ret = eBTStatusFail;
+    }
+
+    return ret;
+}
+
+/*---------------------------------------------------------------*/
 
 BTStatus_t _setAdvData( IotBleAdvertisementParams_t * pAdvParams )
 {
@@ -472,143 +511,37 @@ BTStatus_t IotBle_ConnParameterUpdateRequest( const BTBdaddr_t * pBdAddr,
 BTStatus_t IotBle_On( void )
 {
     BTStatus_t status = eBTStatusSuccess;
-
-    /* Currently Disabled due to a bug with ESP32 : https://github.com/espressif/esp-idf/issues/2070 */
-
-    status = _BTInterface.pBTInterface->pxEnable( 0 );
-
-    if( status == eBTStatusSuccess )
-    {
-        IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
-    }
-    else
-    {
-        IotLogError( "Could not enable the stack." );
-    }
-
-    return status;
-}
-
-/*-----------------------------------------------------------*/
-
-BTStatus_t IotBle_Off( void )
-{
-    BTStatus_t status = eBTStatusSuccess;
-    IotLink_t * pConnectionListHead, * pConnectionListElem;
-    IotBleConnectionInfoListElement_t * pConnInfo;
-    BTBdaddr_t bdAddr;
-    uint16_t connId;
-
-    status = IotBle_GetConnectionInfoList( &pConnectionListHead );
-
-    if( status == eBTStatusSuccess )
-    {
-        do
-        {
-            pConnInfo = NULL;
-            IotMutex_Lock( &_BTInterface.threadSafetyMutex );
-            /* Get the event associated to the callback */
-            IotContainers_ForEach( pConnectionListHead, pConnectionListElem )
-            {
-                pConnInfo = IotLink_Container( IotBleConnectionInfoListElement_t, pConnectionListElem, connectionList );
-                memcpy( &bdAddr, &pConnInfo->remoteBdAddr, sizeof( BTBdaddr_t ) );
-                connId = pConnInfo->connId;
-                break;
-            }
-
-            IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
-
-            if( pConnInfo != NULL )
-            {
-                status = _BTInterface.pBTLeAdapterInterface->pxDisconnect( _BTInterface.adapterIf,
-                                                                           &bdAddr,
-                                                                           connId );
-
-                if( status != eBTStatusSuccess )
-                {
-                    IotLogError( "Failed disconnect with Bluetooth status = %u", status );
-                    break;
-                }
-            }
-        } while( pConnInfo != NULL );
-    }
-
-    /* Currently Disabled due to a bug with ESP32 : https://github.com/espressif/esp-idf/issues/2070 */
-
-    /* _BTInterface.p_BTInterface->pxDisable(); */
-    return status;
-}
-
-/*-----------------------------------------------------------*/
-
-BTStatus_t IotBle_Init( void )
-{
-    BTStatus_t status = eBTStatusSuccess;
     uint16_t index;
-    bool createdThreadSafetyMutex = false;
-    bool createdWaitCbMutex = false;
-    bool createdCallbackSemaphore = false;
-
     uint32_t nbProperties = sizeof( _deviceProperties ) / sizeof( _deviceProperties[ 0 ] );
 
-    _BTInterface.pBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
 
-    if( _BTInterface.pBTInterface != NULL )
+    status = _BTInterface.pBTInterface->pxBtManagerInit( &_BTManagerCb );
+
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+
+       IotLogError("status 1 = %d", status );
+
+
+    if( status == eBTStatusSuccess )
     {
-        if( IotMutex_Create( &_BTInterface.threadSafetyMutex, false ) == true )
-        {
-            createdThreadSafetyMutex = true;
-
-            if( IotMutex_Create( &_BTInterface.waitCbMutex, false ) == true )
-            {
-                createdWaitCbMutex = true;
-            }
-            else
-            {
-                status = eBTStatusNoMem;
-                IotLogError( "Cannot create mutex." );
-            }
-        }
-        else
-        {
-            status = eBTStatusNoMem;
-            IotLogError( "Cannot create mutex." );
-        }
-
+        status = _BTInterface.pBTInterface->pxEnable( 0 );
         if( status == eBTStatusSuccess )
         {
-            if( IotSemaphore_Create( &_BTInterface.callbackSemaphore, 0, 1 ) == true )
-            {
-                createdCallbackSemaphore = true;
-            }
-            else
-            {
-                status = eBTStatusNoMem;
-                IotLogError( "Cannot create semaphore." );
-            }
-        }
-
-        status = _BTInterface.pBTInterface->pxBtManagerInit( &_BTManagerCb );
-        _BTInterface.pBTLeAdapterInterface = ( BTBleAdapter_t * ) _BTInterface.pBTInterface->pxGetLeAdapter();
-    }
-    else
-    {
-        status = eBTStatusParamInvalid;
-    }
-
-    if( ( _BTInterface.pBTLeAdapterInterface != NULL ) && ( status == eBTStatusSuccess ) )
-    {
-        status = IotBle_On();
-
-        if( status == eBTStatusSuccess )
-        {
-            status = _BTInterface.pBTLeAdapterInterface->pxBleAdapterInit( &_BTBleAdapterCb );
+            IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
         }
     }
-    else
+
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+
+    IotLogError("status 1 = %d", status );
+
+    if( status == eBTStatusSuccess )
     {
-        status = eBTStatusFail;
+        status = _BTInterface.pBTLeAdapterInterface->pxBleAdapterInit( &_BTBleAdapterCb );
     }
+
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 2 = %d", status );
 
     /* Register application. */
     if( status == eBTStatusSuccess )
@@ -621,6 +554,8 @@ BTStatus_t IotBle_Init( void )
             status = _BTInterface.cbStatus;
         }
     }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 3 = %d", status );
 
     /* Set GAP properties. */
     if( status == eBTStatusSuccess )
@@ -646,62 +581,47 @@ BTStatus_t IotBle_Init( void )
             }
         }
     }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 4 = %d", status );
+
 
     /* Initialize the GATT server. */
     if( status == eBTStatusSuccess )
     {
-        _BTInterface.pGattServerInterface = ( BTGattServerInterface_t * ) _BTInterface.pBTLeAdapterInterface->ppvGetGattServerInterface();
-
-        if( _BTInterface.pGattServerInterface != NULL )
+        if( _BTInterface.pGattServerInterface->pxGattServerInit( &_BTGattServerCb ) == eBTStatusSuccess )
         {
-            if( _BTInterface.pGattServerInterface->pxGattServerInit( &_BTGattServerCb ) == eBTStatusSuccess )
-            {
-                status = _BTInterface.pGattServerInterface->pxRegisterServer( ( BTUuid_t * ) &_serverUUID );
+            status = _BTInterface.pGattServerInterface->pxRegisterServer( ( BTUuid_t * ) &_serverUUID );
 
-                if( status == eBTStatusSuccess )
-                {
-                    IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
-                    status = _BTInterface.cbStatus;
-                }
-            }
-            else
+            if( status == eBTStatusSuccess )
             {
-                status = eBTStatusFail;
-                IotLogError( "Cannot initialize GATT interface." );
+                IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+                status = _BTInterface.cbStatus;
             }
         }
         else
         {
             status = eBTStatusFail;
-            IotLogError( "Cannot get GATT server interface." );
+            IotLogError( "Cannot initialize GATT interface." );
         }
     }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 5 = %d", status );
 
-    /* Initialize lists. */
+
+    /* Start GATT services. */
     if( status == eBTStatusSuccess )
     {
-        IotListDouble_Create( &_BTInterface.serviceListHead );
-        IotListDouble_Create( &_BTInterface.connectionListHead );
-
-        /* Initialize the event list. */
-        for( index = 0; index < eNbEvents; index++ )
-        {
-            IotListDouble_Create( &_BTInterface.subscrEventListHead[ index ] );
-        }
+       status = _startGATTServices();
     }
 
-    /* Start services. */
-    if( status == eBTStatusSuccess )
-    {
-        status = _startAllServices();
-    }
+    IotLogError("status 6 = %d", status );
 
     /* Initialize advertisement and scan response. */
     if( status == eBTStatusSuccess )
     {
-        #if ( IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG == 1 )
-            IotBle_SetCustomAdvCb( &_advParams, &_scanRespParams );
-        #endif
+#if ( IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG == 1 )
+        IotBle_SetCustomAdvCb( &_advParams, &_scanRespParams );
+#endif
 
         status = _setAdvData( &_advParams );
         IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -712,17 +632,194 @@ BTStatus_t IotBle_Init( void )
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
         }
     }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 7 = %d", status );
+
 
     /* Start advertisement. */
     if( status == eBTStatusSuccess )
     {
-        IotBle_StartAdv( &_bleStartAdvCb );
+        status = IotBle_StartAdv( &_bleStartAdvCb );
+        if( status == eBTStatusSuccess )
+        {
+            IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+            status = _BTInterface.cbStatus;
+        }
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 8 = %d", status );
+
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+BTStatus_t IotBle_Off( void )
+{
+    BTStatus_t status = eBTStatusSuccess;
+    IotLink_t * pConnectionListHead, * pConnectionListElem;
+    IotBleConnectionInfoListElement_t * pConnInfo;
+    BTBdaddr_t bdAddr;
+    uint16_t connId;
+
+    /* Stop the advertisement to avoid new connections to the device. */
+    status = IotBle_StopAdv( &_bleStopAdvCb );
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 1 = %d", status );
+    if( status == eBTStatusSuccess )
+    {
         IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+        status = _BTInterface.cbStatus;
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 2 = %d", status );
+
+
+    /* Iterate through the list of open connections and send a disconnect to the peer. */
+    if( status == eBTStatusSuccess )
+    {
+        /* Iterate through the connection list and trigger disconnect for each connections.
+         * Since disconnect callback gets triggered from BLE event loop and acquires lock
+         * to remove connections from the list, we need to release the lock first before
+         * invoking the disconnect API.
+         */
+        status = IotBle_GetConnectionInfoList( &pConnectionListHead );
+        IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+        IotLogError("status 3 = %d", status );
+        if( status == eBTStatusSuccess )
+        {
+            do
+            {
+                pConnInfo = NULL;
+                IotMutex_Lock( &_BTInterface.threadSafetyMutex );
+                /* Get the event associated to the callback */
+                IotContainers_ForEach( pConnectionListHead, pConnectionListElem )
+                {
+                    pConnInfo = IotLink_Container( IotBleConnectionInfoListElement_t, pConnectionListElem, connectionList );
+                    memcpy( &bdAddr, &pConnInfo->remoteBdAddr, sizeof( BTBdaddr_t ) );
+                    connId = pConnInfo->connId;
+                    break;
+                }
+
+                IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+
+                if( pConnInfo != NULL )
+                {
+                    status = _BTInterface.pBTLeAdapterInterface->pxDisconnect( _BTInterface.adapterIf,
+                            &bdAddr,
+                            connId );
+
+                    if( status != eBTStatusSuccess )
+                    {
+                        IotLogError( "Failed to disconnect bluetooth connection, status = %u", status );
+                        break;
+                    }
+                }
+            } while( pConnInfo != NULL );
+        }
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 4 = %d", status );
+
+    /* Stop all GATT services */
+    if( status == eBTStatusSuccess )
+    {
+        status = _stopGATTServices();
     }
 
-    /* Clean up memory. */
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 5 = %d", status );
+
+    if( status == eBTStatusSuccess )
+    {
+        status = _BTInterface.pGattServerInterface->pxUnregisterServer( _BTInterface.serverIf );
+        if( status == eBTStatusSuccess )
+        {
+            IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+            status = _BTInterface.cbStatus;
+        }
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 6 = %d", status );
+
+    if( status == eBTStatusSuccess )
+    {
+        status = _BTInterface.pBTLeAdapterInterface->pxUnregisterBleApp( _BTInterface.adapterIf );
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 7 = %d", status );
+
+    /* Disable BLE stack. */
+    if( status == eBTStatusSuccess )
+    {
+        status = _BTInterface.pBTInterface->pxDisable();
+        if( status == eBTStatusSuccess )
+        {
+            IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+        }
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 8 = %d", status );
+
+
+    /* Cleanup BLE stack. */
+    if( status == eBTStatusSuccess )
+    {
+        status = _BTInterface.pBTInterface->pxBtManagerCleanup();
+    }
+    IotLogError(" Heap available %u, ever %u", xPortGetFreeHeapSize(), xPortGetMinimumEverFreeHeapSize() );
+    IotLogError("status 9 = %d", status );
+
+    return status;
+}
+
+BTStatus_t _createSyncrhonizationObjects( void )
+{
+    bool createdThreadSafetyMutex = false;
+    bool createdWaitCbMutex = false;
+    bool createdCallbackSemaphore = false;
+    BTStatus_t status = eBTStatusSuccess;
+
+    if( IotMutex_Create( &_BTInterface.threadSafetyMutex, false ) == true )
+    {
+        createdThreadSafetyMutex = true;
+    }
+    else
+    {
+        status = eBTStatusNoMem;
+        IotLogError( "Cannot create thread safety mutex." );
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        if( IotMutex_Create( &_BTInterface.waitCbMutex, false ) == true )
+        {
+            createdWaitCbMutex = true;
+        }
+        else
+        {
+            status = eBTStatusNoMem;
+            IotLogError( "Cannot create waitCbMutex mutex." );
+        }
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        if( IotSemaphore_Create( &_BTInterface.callbackSemaphore, 0, 1 ) == true )
+        {
+            createdCallbackSemaphore = true;
+        }
+        else
+        {
+            status = eBTStatusNoMem;
+            IotLogError( "Cannot create semaphore." );
+        }
+    }
+
     if( status != eBTStatusSuccess )
     {
+        /* Clean up memory. */
         if( createdThreadSafetyMutex == true )
         {
             IotMutex_Destroy( &_BTInterface.threadSafetyMutex );
@@ -736,6 +833,61 @@ BTStatus_t IotBle_Init( void )
         if( createdCallbackSemaphore == true )
         {
             IotSemaphore_Destroy( &_BTInterface.callbackSemaphore );
+        }
+    }
+
+    return status;
+}
+
+void _initializeLists( void )
+{
+    size_t index;
+
+    /* Initialize lists. */
+    IotListDouble_Create( &_BTInterface.serviceListHead );
+    IotListDouble_Create( &_BTInterface.connectionListHead );
+
+    /* Initialize the event list. */
+    for( index = 0; index < eNbEvents; index++ )
+    {
+        IotListDouble_Create( &_BTInterface.subscrEventListHead[ index ] );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+BTStatus_t IotBle_Init( void )
+{
+    BTStatus_t status = eBTStatusSuccess;
+
+    _initializeLists();
+
+    status = _createSyncrhonizationObjects();
+
+    if( status == eBTStatusSuccess )
+    {
+        _BTInterface.pBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
+        if( _BTInterface.pBTInterface == NULL )
+        {
+            status = eBTStatusFail;
+        }
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        _BTInterface.pBTLeAdapterInterface = ( BTBleAdapter_t * ) _BTInterface.pBTInterface->pxGetLeAdapter();
+        if( _BTInterface.pBTLeAdapterInterface == NULL )
+        {
+            status = eBTStatusFail;
+        }
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        _BTInterface.pGattServerInterface = ( BTGattServerInterface_t * ) _BTInterface.pBTLeAdapterInterface->ppvGetGattServerInterface();
+        if(  _BTInterface.pGattServerInterface == NULL )
+        {
+            status = eBTStatusFail;
         }
     }
 

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -396,20 +396,19 @@ BTStatus_t _startGATTServices()
 
 BTStatus_t _stopGATTServices()
 {
-
     BTStatus_t ret = eBTStatusSuccess;
     bool status = true;
 
-#if ( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
-    status = IotBleDeviceInfo_Cleanup();
-#endif
+    #if ( IOT_BLE_ENABLE_DEVICE_INFO_SERVICE == 1 )
+        status = IotBleDeviceInfo_Cleanup();
+    #endif
 
-#if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
-    if( status == true )
-    {
-        status = IotBleDataTransfer_Cleanup();
-    }
-#endif
+    #if ( IOT_BLE_ENABLE_DATA_TRANSFER_SERVICE == 1 )
+        if( status == true )
+        {
+            status = IotBleDataTransfer_Cleanup();
+        }
+    #endif
 
     if( status == false )
     {
@@ -519,6 +518,7 @@ BTStatus_t IotBle_On( void )
     if( status == eBTStatusSuccess )
     {
         status = _BTInterface.pBTInterface->pxEnable( 0 );
+
         if( status == eBTStatusSuccess )
         {
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -590,15 +590,15 @@ BTStatus_t IotBle_On( void )
     /* Start GATT services. */
     if( status == eBTStatusSuccess )
     {
-       status = _startGATTServices();
+        status = _startGATTServices();
     }
 
     /* Initialize advertisement and scan response. */
     if( status == eBTStatusSuccess )
     {
-#if ( IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG == 1 )
-        IotBle_SetCustomAdvCb( &_advParams, &_scanRespParams );
-#endif
+        #if ( IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG == 1 )
+            IotBle_SetCustomAdvCb( &_advParams, &_scanRespParams );
+        #endif
 
         status = _setAdvData( &_advParams );
         IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -614,6 +614,7 @@ BTStatus_t IotBle_On( void )
     if( status == eBTStatusSuccess )
     {
         status = IotBle_StartAdv( &_bleStartAdvCb );
+
         if( status == eBTStatusSuccess )
         {
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -631,8 +632,8 @@ static void _disconnectCallback( BTStatus_t status,
 {
     if( !isConnected )
     {
-         _BTInterface.cbStatus = status;
-         IotSemaphore_Post( &_BTInterface.callbackSemaphore );
+        _BTInterface.cbStatus = status;
+        IotSemaphore_Post( &_BTInterface.callbackSemaphore );
     }
 }
 
@@ -644,13 +645,14 @@ BTStatus_t _disconnectAllConnections( void )
     IotLink_t * pConnection;
     BTBdaddr_t bdAddr;
     uint16_t connId;
-    BTStatus_t status = eBTStatusSuccess ;
+    BTStatus_t status = eBTStatusSuccess;
     IotBleEventsCallbacks_t eventCallback;
     bool registered = false;
 
     eventCallback.pConnectionCb = _disconnectCallback;
 
     status = IotBle_RegisterEventCb( eBLEConnection, eventCallback );
+
     if( status == eBTStatusSuccess )
     {
         registered = true;
@@ -666,9 +668,8 @@ BTStatus_t _disconnectAllConnections( void )
         IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
 
         status = _BTInterface.pBTLeAdapterInterface->pxDisconnect( _BTInterface.adapterIf,
-                                    &bdAddr,
-                                    connId );
-
+                                                                   &bdAddr,
+                                                                   connId );
 
         if( status == eBTStatusSuccess )
         {
@@ -677,17 +678,16 @@ BTStatus_t _disconnectAllConnections( void )
         }
         else
         {
-            IotLogError("Failed to disconnect BLE connection, status = %d", status );
+            IotLogError( "Failed to disconnect BLE connection, status = %d", status );
         }
     }
 
     if( registered )
     {
-         IotBle_UnRegisterEventCb( eBLEConnection, eventCallback );
+        IotBle_UnRegisterEventCb( eBLEConnection, eventCallback );
     }
 
     return status;
-
 }
 
 BTStatus_t IotBle_Off( void )
@@ -720,6 +720,7 @@ BTStatus_t IotBle_Off( void )
     if( status == eBTStatusSuccess )
     {
         status = _BTInterface.pGattServerInterface->pxUnregisterServer( _BTInterface.serverIf );
+
         if( status == eBTStatusSuccess )
         {
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -735,6 +736,7 @@ BTStatus_t IotBle_Off( void )
     if( status == eBTStatusSuccess )
     {
         status = _BTInterface.pBTInterface->pxDisable();
+
         if( status == eBTStatusSuccess )
         {
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
@@ -843,6 +845,7 @@ BTStatus_t IotBle_Init( void )
     if( status == eBTStatusSuccess )
     {
         _BTInterface.pBTInterface = ( BTInterface_t * ) BTGetBluetoothInterface();
+
         if( _BTInterface.pBTInterface == NULL )
         {
             status = eBTStatusFail;
@@ -852,6 +855,7 @@ BTStatus_t IotBle_Init( void )
     if( status == eBTStatusSuccess )
     {
         _BTInterface.pBTLeAdapterInterface = ( BTBleAdapter_t * ) _BTInterface.pBTInterface->pxGetLeAdapter();
+
         if( _BTInterface.pBTLeAdapterInterface == NULL )
         {
             status = eBTStatusFail;
@@ -861,7 +865,8 @@ BTStatus_t IotBle_Init( void )
     if( status == eBTStatusSuccess )
     {
         _BTInterface.pGattServerInterface = ( BTGattServerInterface_t * ) _BTInterface.pBTLeAdapterInterface->ppvGetGattServerInterface();
-        if(  _BTInterface.pGattServerInterface == NULL )
+
+        if( _BTInterface.pGattServerInterface == NULL )
         {
             status = eBTStatusFail;
         }

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
@@ -751,7 +751,7 @@ BTStatus_t IotBle_CreateService( BTService_t * pService,
     /* Create all attributes. */
     if( pService != NULL )
     {
-        memset( pService->pusHandlesBuffer, 0, pService->xNumberOfAttributes * sizeof( pService->pusHandlesBuffer[0] ) );
+        memset( pService->pusHandlesBuffer, 0, pService->xNumberOfAttributes * sizeof( pService->pusHandlesBuffer[ 0 ] ) );
         status = _addServiceToList( pService, pEventsCallbacks );
     }
 

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
@@ -751,7 +751,7 @@ BTStatus_t IotBle_CreateService( BTService_t * pService,
     /* Create all attributes. */
     if( pService != NULL )
     {
-        memset( pService->pusHandlesBuffer, 0, pService->xNumberOfAttributes );
+        memset( pService->pusHandlesBuffer, 0, pService->xNumberOfAttributes * sizeof( pService->pusHandlesBuffer[0] ) );
         status = _addServiceToList( pService, pEventsCallbacks );
     }
 
@@ -779,7 +779,7 @@ BTStatus_t IotBle_CreateService( BTService_t * pService,
             }
         }
     }
-    else
+    else if( status == eBTStatusSuccess )
     {
         pServiceElem = _getLastAddedServiceElem();
 

--- a/libraries/c_sdk/standard/ble/src/services/device_information/iot_ble_device_information.c
+++ b/libraries/c_sdk/standard/ble/src/services/device_information/iot_ble_device_information.c
@@ -95,8 +95,8 @@ static IotBleDeviceInfoService_t _service =
 typedef enum
 {
     _ATTR_SERVICE,
-    _ATTR_CHAR_CLOUD_END_POINT,
     _ATTR_CHAR_VERSION,
+    _ATTR_CHAR_CLOUD_END_POINT,
     _ATTR_CHAR_MTU,
     _ATTR_CHAR_DESCR_MTU,
     _ATTR_CHAR_PLATFROM_NAME,
@@ -382,8 +382,6 @@ void _deviceInfoVersionCharCallback( IotBleAttributeEvent_t * pEventParam )
 
 void _deviceInfoMTUCharCallback( IotBleAttributeEvent_t * pEventParam )
 {
-    IotBleAttributeData_t attrData = { 0 };
-    IotBleEventResponse_t resp;
     char mtuStr[ MAX_INTEGER_BUFFER_WIDTH ] = { 0 };
     size_t length;
 
@@ -494,4 +492,32 @@ bool IotBleDeviceInfo_Init( void )
     }
 
     return error;
+}
+
+bool IotBleDeviceInfo_Cleanup( void )
+{
+    BTStatus_t status = eBTStatusFail;
+    IotBleEventsCallbacks_t callback;
+    bool ret = true;
+
+    callback.pConnectionCb = _connectionCallback;
+    status = IotBle_UnRegisterEventCb( eBLEConnection, callback );
+
+    if( status == eBTStatusSuccess )
+    {
+        callback.pMtuChangedCb = _MTUChangedCallback;
+        status = IotBle_UnRegisterEventCb( eBLEMtuChanged, callback );
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        status = IotBle_DeleteService( ( BTService_t * ) &_deviceInformationService );
+    }
+
+    if( status != eBTStatusSuccess )
+    {
+        ret = false;
+    }
+
+    return ret;
 }

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -964,7 +964,7 @@ static bool _initializeChannel( IotBleDataTransferChannel_t * pChannel )
     return ret;
 }
 
-static void  _cleanupChannel( IotBleDataTransferChannel_t * pChannel )
+static void _cleanupChannel( IotBleDataTransferChannel_t * pChannel )
 {
     IotBleDataTransfer_Close( pChannel );
     IotBleDataTransfer_Reset( pChannel );
@@ -977,7 +977,7 @@ static bool _cleanupService( IotBleDataTransferService_t * pService )
     bool ret = true;
 
     pService->isReady = false;
-    status = IotBle_DeleteService( &pService->gattService);
+    status = IotBle_DeleteService( &pService->gattService );
 
     if( status != eBTStatusSuccess )
     {
@@ -1038,14 +1038,14 @@ bool IotBleDataTransfer_Cleanup( void )
         for( index = 0; index < _numDataTransferServices; index++ )
         {
             _cleanupChannel( &_services[ index ].channel );
-            status = _cleanupService( &_services[index] );
+            status = _cleanupService( &_services[ index ] );
+
             if( status == false )
             {
                 break;
             }
         }
     }
-
 
     return status;
 }

--- a/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
@@ -75,7 +75,13 @@ static bool bleInit()
 
     if( bleInitialized && !iotBleInitialized )
     {
-        iotBleInitialized = ( eBTStatusSuccess == IotBle_Init() );
+        if( IotBle_Init() == eBTStatusSuccess )
+        {
+            if( IotBle_On() == eBTStatusSuccess )
+            {
+                iotBleInitialized = true;
+            }
+        }
     }
 
     return iotBleInitialized;
@@ -103,6 +109,7 @@ TEST_TEAR_DOWN( Full_WiFi_Provisioning )
     {
         IotBleWifiProv_Deinit();
         prvRemoveSavedNetworks();
+        iotBleWifiProvisioningInitialized = false;
     }
 }
 

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -161,14 +161,6 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 
         if( ret == true )
         {
-            if( IotBle_StopAdv( NULL ) != eBTStatusSuccess )
-            {
-                ret = false;
-            }
-        }
-
-        if( ret == true )
-        {
             if( IotBle_Off() != eBTStatusSuccess )
             {
                 ret = false;

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -104,7 +104,7 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
         IotBleEventsCallbacks_t xEventCb;
         BaseType_t xRet = pdTRUE;
         static bool bInitBLE = false;
-        BTStatus_t xStatus;
+        BTStatus_t xStatus = eBTStatusSuccess;
 
         if( bInitBLE == false )
         {
@@ -121,8 +121,10 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
                 }
             }
         }
-        else
+
+        if( xStatus == eBTStatusSuccess )
         {
+            configPRINTF(("Setting Iot BLe to On\r\n"));
             xStatus = IotBle_On();
         }
 

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -124,7 +124,6 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 
         if( xStatus == eBTStatusSuccess )
         {
-            configPRINTF( ( "Setting Iot BLe to On\r\n" ) );
             xStatus = IotBle_On();
         }
 

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -124,7 +124,7 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 
         if( xStatus == eBTStatusSuccess )
         {
-            configPRINTF(("Setting Iot BLe to On\r\n"));
+            configPRINTF( ( "Setting Iot BLe to On\r\n" ) );
             xStatus = IotBle_On();
         }
 

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -119,6 +119,8 @@ int app_main( void )
 
         #if BLE_ENABLED
             /* Initialize BLE. */
+            ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_CLASSIC_BT ) );
+
             if( prvBLEStackInit() != ESP_OK )
             {
                 configPRINTF( ( "Failed to initialize the bluetooth stack\n " ) );

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -92,6 +92,9 @@ BTStatus_t prvBTConfigClear();
 BTStatus_t prvBTReadRssi( const BTBdaddr_t * pxBdAddr );
 BTStatus_t prvBTGetTxpower( const BTBdaddr_t * pxBdAddr,
                             BTTransport_t xTransport );
+
+extern void vESPBTGATTServerCleanup( void );
+
 const void * prvGetClassicAdapter();
 const void * prvGetLeAdapter();
 
@@ -571,6 +574,8 @@ BTStatus_t prvBtManagerCleanup()
 {
     esp_err_t xRet;
     BTStatus_t xStatus = eBTStatusSuccess;
+
+    vESPBTGATTServerCleanup();
 
     xRet = esp_nimble_hci_and_controller_deinit();
 

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -396,8 +396,10 @@ BTStatus_t prvBTDisconnect( uint8_t ucAdapterIf,
                             uint16_t usConnId )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+    esp_err_t xRet = ESP_OK;
 
-    if( ble_gap_terminate( usConnId, BLE_ERR_REM_USER_CONN_TERM ) != 0 )
+    xRet = ble_gap_terminate( usConnId, BLE_ERR_REM_USER_CONN_TERM );
+    if( ( xRet != 0 )  && ( xRet != BLE_HS_EALREADY ) )
     {
         xStatus = eBTStatusFail;
     }

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -399,7 +399,8 @@ BTStatus_t prvBTDisconnect( uint8_t ucAdapterIf,
     esp_err_t xRet = ESP_OK;
 
     xRet = ble_gap_terminate( usConnId, BLE_ERR_REM_USER_CONN_TERM );
-    if( ( xRet != 0 )  && ( xRet != BLE_HS_EALREADY ) )
+
+    if( ( xRet != 0 ) && ( xRet != BLE_HS_EALREADY ) )
     {
         xStatus = eBTStatusFail;
     }

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -488,6 +488,7 @@ BTStatus_t prvBTGattServerInit( const BTGattServerCallbacks_t * pxCallbacks )
     }
 
     xSem = xSemaphoreCreateBinary();
+
     if( xSem != NULL )
     {
         semInited = true;
@@ -503,13 +504,16 @@ BTStatus_t prvBTGattServerInit( const BTGattServerCallbacks_t * pxCallbacks )
 void vESPBTGATTServerCleanup( void )
 {
     size_t index;
+
     if( serviceCnt > 0 )
     {
         ble_gatts_stop();
+
         for( index = 0; index < serviceCnt; index++ )
         {
             prvCleanupService( &espServices[ index ] );
         }
+
         serviceCnt = 0;
 
         memset( espServices, 0, sizeof( struct ble_gatt_svc_def ) * ( MAX_SERVICES + 1 ) );
@@ -521,7 +525,6 @@ void vESPBTGATTServerCleanup( void )
         vSemaphoreDelete( xSem );
         semInited = false;
     }
-
 }
 
 /*-----------------------------------------------------------*/
@@ -765,9 +768,8 @@ static uint16_t prvCountDescriptor( BTService_t * pxService,
  */
 static void prvCleanupService( struct ble_gatt_svc_def * pSvc )
 {
-
-    const struct ble_gatt_dsc_def *pDescriptor;
-    const struct ble_gatt_chr_def *pCharacteristic;
+    const struct ble_gatt_dsc_def * pDescriptor;
+    const struct ble_gatt_chr_def * pCharacteristic;
     size_t cIndex, dIndex;
 
     if( pSvc->uuid != NULL )
@@ -791,7 +793,6 @@ static void prvCleanupService( struct ble_gatt_svc_def * pSvc )
                 }
 
                 vPortFree( ( void * ) pCharacteristic->descriptors );
-
             }
         }
 
@@ -799,7 +800,6 @@ static void prvCleanupService( struct ble_gatt_svc_def * pSvc )
     }
 
     memset( pSvc, 0x00, sizeof( struct ble_gatt_svc_def ) );
-
 }
 
 /* @brief Simple function that creates a full service in one go.

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/application_code/main.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/application_code/main.c
@@ -324,7 +324,6 @@ static void prvTimersInit( void )
 
 static void prvMiscInitialization( void )
 {
-    nrf_sdh_enable_request();
     /* Initialize modules.*/
     xUARTTxComplete = xSemaphoreCreateBinary();
     prvUartInit();

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/application_code/main.c
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/application_code/main.c
@@ -327,7 +327,6 @@ static void prvTimersInit( void )
 
 static void prvMiscInitialization( void )
 {
-    nrf_sdh_enable_request();
     /* Initialize modules.*/
     xUARTTxComplete = xSemaphoreCreateBinary();
     prvUartInit();

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
@@ -361,6 +361,11 @@ void prvGAPeventHandler( ble_evt_t const * p_ble_evt,
                 xGattServerCb.pxConnectionCb( p_ble_evt->evt.gap_evt.conn_handle, ulGattServerIFhandle, false, &xConnectionRemoteAddress );
             }
 
+            if( usGattConnHandle == p_ble_evt->evt.gap_evt.conn_handle )
+            {
+                usGattConnHandle = BLE_CONN_HANDLE_INVALID;
+            }
+
             break;
 
         case BLE_GATTS_EVT_RW_AUTHORIZE_REQUEST:

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
@@ -740,6 +740,19 @@ BTStatus_t prvBtManagerCleanup()
 BTStatus_t prvBTEnable( uint8_t ucGuestMode )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+    ret_code_t xErrCode = NRF_SUCCESS;
+
+    xErrCode = nrf_sdh_enable_request();
+
+    if( xErrCode == NRF_SUCCESS )
+    {
+        if( !nrf_sdh_is_enabled() )
+        {
+            xErrCode = NRF_ERROR_SOFTDEVICE_NOT_ENABLED;
+        }
+    }
+
+    xStatus = BTNRFError( xErrCode );
 
     /** If status is ok and callback is set, trigger the callback.
      *  If status is fail, not need to trig a callback as original call failed.

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
@@ -76,7 +76,6 @@ bool prvAdvRestart = false;
 
 NRF_SDH_BLE_OBSERVER( m_ble_observer, aws_ble_gap_configAPP_BLE_OBSERVER_PRIO, prvGAPeventHandler, NULL );
 
-static bool prvAdvertisingInitialized = false;
 uint8_t ucBaseUUIDindex = 0;
 BTUuid_t xAppUuid =
 {
@@ -230,6 +229,10 @@ static void prvOnAdvErr( uint32_t nrf_error );
 /** @brief Initialization of the Peer Manager module. */
 static ret_code_t prvPeerManagerInit( void );
 
+/** @brief Initialization of the advertisement parameters. */
+static void prvAdvertisementDataInit( void );
+
+
 /** @breef Frees all memory occupied with ble_advdata_t structure */
 static void prvBTFreeAdvData( ble_advdata_t * xAdvData );
 
@@ -317,6 +320,11 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
         BT_NRF_PRINT_ERROR( prvConnectionParamsInit, xErrCode );
     }
 
+    if( xErrCode == NRF_SUCCESS )
+    {
+        prvAdvertisementDataInit();
+    }
+
     xStatus = BTNRFError( xErrCode );
 
     error = nrf_strerror_get(xErrCode);
@@ -366,6 +374,23 @@ ret_code_t prvPeerManagerInit( void )
     }
 
     return xErrCode;
+}
+
+static void prvAdvertisementDataInit( void )
+{
+
+   /* Clear the advertisement handle with the stack. */
+   memset( &xAdvertisingHandle, 0x00, sizeof(xAdvertisingHandle) );
+
+   /* Clear the global variables used by the porting layer. */
+   prvAdvRestart = false;
+   memset( &prvAdvData, 0x00, sizeof( ble_advdata_t ) );
+   memset( &prvScanResponseData, 0x00, sizeof( ble_advdata_t ) );
+
+   /* Clear the advertisment and scan response cache. Reset the index to 0. */
+   memset( prvAdvBinData, 0x00, sizeof( prvAdvBinData ) );
+   memset( prvSrBinData, 0x00, sizeof( prvSrBinData ) );
+   prvCurrentAdvBuf = 0;
 }
 
 /*-----------------------------------------------------------*/

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
@@ -321,8 +321,6 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
 
     error = nrf_strerror_get(xErrCode);
 
-    configPRINTF(("Error = %s\n", error));
-
     /* TODO: Add initial security */
     if( pxCallbacks != NULL )
     {
@@ -515,22 +513,10 @@ BTStatus_t prvBTDisconnect( uint8_t ucAdapterIf,
 {
 
     
-    ret_code_t xErrCode = NRF_SUCCESS;
-    
-    if( usGattConnHandle != BLE_CONN_HANDLE_INVALID )
-    {
-        xErrCode = sd_ble_gap_disconnect( usGattConnHandle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION );
-
-        if( xErrCode == NRF_SUCCESS )
-        {
-            usGattConnHandle = BLE_CONN_HANDLE_INVALID;
-            xLatestDesiredConnectionParams.pxBdAddr = NULL;
-        }
-        
-        BT_NRF_PRINT_ERROR( sd_ble_gap_disconnect, xErrCode );
-     }
-     
-     return BTNRFError( xErrCode );
+    ret_code_t xErrCode;
+    xErrCode = sd_ble_gap_disconnect( usConnId, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION );
+    BT_NRF_PRINT_ERROR( sd_ble_gap_disconnect, xErrCode );
+    return BTNRFError( xErrCode );
 }
 
 /*-----------------------------------------------------------*/
@@ -1292,10 +1278,6 @@ static void prvOnConnParamsEvt( ble_conn_params_evt_t * pxEvt )
     if( pxEvt->evt_type == BLE_CONN_PARAMS_EVT_FAILED )
     {
         xErrCode = sd_ble_gap_disconnect( usGattConnHandle, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE );
-        if( xErrCode == NRF_SUCCESS )
-        {
-            usGattConnHandle = BLE_CONN_HANDLE_INVALID;
-        }
         BT_NRF_PRINT_ERROR( sd_ble_gap_disconnect, xErrCode );
     }
 }

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
@@ -288,7 +288,7 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
 {
     ret_code_t xErrCode = NRF_SUCCESS;
     BTStatus_t xStatus = eBTStatusSuccess;
-    const char *error;
+    const char * error;
 
 
     memset( &prvAdvData, 0, sizeof( prvAdvData ) );
@@ -327,7 +327,7 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
 
     xStatus = BTNRFError( xErrCode );
 
-    error = nrf_strerror_get(xErrCode);
+    error = nrf_strerror_get( xErrCode );
 
     /* TODO: Add initial security */
     if( pxCallbacks != NULL )
@@ -378,19 +378,18 @@ ret_code_t prvPeerManagerInit( void )
 
 static void prvAdvertisementDataInit( void )
 {
+    /* Clear the advertisement handle with the stack. */
+    memset( &xAdvertisingHandle, 0x00, sizeof( xAdvertisingHandle ) );
 
-   /* Clear the advertisement handle with the stack. */
-   memset( &xAdvertisingHandle, 0x00, sizeof(xAdvertisingHandle) );
+    /* Clear the global variables used by the porting layer. */
+    prvAdvRestart = false;
+    memset( &prvAdvData, 0x00, sizeof( ble_advdata_t ) );
+    memset( &prvScanResponseData, 0x00, sizeof( ble_advdata_t ) );
 
-   /* Clear the global variables used by the porting layer. */
-   prvAdvRestart = false;
-   memset( &prvAdvData, 0x00, sizeof( ble_advdata_t ) );
-   memset( &prvScanResponseData, 0x00, sizeof( ble_advdata_t ) );
-
-   /* Clear the advertisment and scan response cache. Reset the index to 0. */
-   memset( prvAdvBinData, 0x00, sizeof( prvAdvBinData ) );
-   memset( prvSrBinData, 0x00, sizeof( prvSrBinData ) );
-   prvCurrentAdvBuf = 0;
+    /* Clear the advertisment and scan response cache. Reset the index to 0. */
+    memset( prvAdvBinData, 0x00, sizeof( prvAdvBinData ) );
+    memset( prvSrBinData, 0x00, sizeof( prvSrBinData ) );
+    prvCurrentAdvBuf = 0;
 }
 
 /*-----------------------------------------------------------*/
@@ -536,9 +535,8 @@ BTStatus_t prvBTDisconnect( uint8_t ucAdapterIf,
                             const BTBdaddr_t * pxBdAddr,
                             uint16_t usConnId )
 {
-
-    
     ret_code_t xErrCode;
+
     xErrCode = sd_ble_gap_disconnect( usConnId, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION );
     BT_NRF_PRINT_ERROR( sd_ble_gap_disconnect, xErrCode );
     return BTNRFError( xErrCode );

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gatt_server.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gatt_server.c
@@ -242,6 +242,7 @@ static BTStatus_t prvAddServiceBlob( uint8_t ucServerIf,
 static BTStatus_t prvBTConfigureMtu( uint8_t ucServerIf,
                                      uint16_t usMtu );
 
+
 static BTGattServerInterface_t xGATTserverInterface =
 {
     .pxRegisterServer     = prvBTRegisterServer,
@@ -301,6 +302,8 @@ BTStatus_t prvBTGattServerInit( const BTGattServerCallbacks_t * pxCallbacks )
 
     if( xErrCode == NRF_SUCCESS )
     {
+        xGattTableSize = 0;
+        xGattMappingTablesSize = 0;
         bGattInitialized = true;
     }
 


### PR DESCRIPTION
Fix enable/disable sequence in BLE to support disabling and re-enabling stack at runtime.

Description
-----------
* Refactor IotBle_On() and IotBle_Off() functions to be symmetrical - enable/teardown GATT services and BLE stack.
* Example usage in demo runner to disable non-used networks for demo . (Disable BLE stack to save power and reclaim RAM after WiFi provisioning when WiFi is connected).
* Tested on ESP32 and Nordic.

PR also fixes #1576

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.