### PR TITLE
Fix several issues in I2C tests after testing on TI board

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -619,10 +619,6 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailReadTwice )
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &uctestIotI2CSlaveAddr );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-        /* Set i2c configuration */
-        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSendNoStopFlag, NULL );
-        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
-
         /* read from i2c device */
         lRetVal = iot_i2c_read_async( xI2CHandle, ucBuffer, sizeof( ucBuffer ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
@@ -693,9 +689,6 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
 
     if( TEST_PROTECT() )
     {
-        /* Set completion callback */
-        iot_i2c_set_callback( xI2CHandle, prvI2CCallback, NULL );
-
         /* Set i2c configuration. */
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetMasterConfig, &xI2CConfig );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
@@ -711,6 +704,9 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
         /* write the device register address. */
         lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
+
+        /* Set completion callback */
+        iot_i2c_set_callback( xI2CHandle, prvI2CCallback, NULL );
 
         /* Set i2c slave address */
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &uctestIotI2CSlaveAddr );
@@ -806,7 +802,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
     uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
-    uint8_t writeVal2[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
+    uint8_t writeVal2[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
 
     uint16_t writeBytes;
 
@@ -871,7 +867,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailIoctl )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t writeVal[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
     IotI2CConfig_t xI2CConfig =
     {
@@ -921,7 +917,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailWriteTwice )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t writeVal[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
     IotI2CConfig_t xI2CConfig =
     {
@@ -1072,7 +1068,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncSuccess )
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
     uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
-    uint8_t writeVal2[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
+    uint8_t writeVal2[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
     uint16_t writeBytes;
 

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -41,6 +41,11 @@
 /* Common IO config includes. */
 #include "test_iot_config.h"
 
+/* Max allowed length of data to write. */
+#ifndef IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH
+    #define IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH    ( 10 )
+#endif
+
 /*-----------------------------------------------------------*/
 #define testIotI2C_BAUDRATE               IOT_I2C_FAST_MODE_BPS
 #define testIotI2C_BAUDRATE_LOW_SPEED     IOT_I2C_STANDARD_MODE_BPS


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- remove unnecessary NO_STOP in test AFQP_IotI2CReadAsyncFailReadTwice
- move iot_i2c_set_callback after iot_i2c_write_sync in test AFQP_IotI2CCancelReadSuccess
- add configurable IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH to limit the length of write buffer; this causes fault on TI
    - provide a default value for IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH 
    - vendor can override it in "test_iot_config"

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.