### PR TITLE
CMake bugfix when Secure Boot is enable

### DIFF
--- a/vendors/espressif/esp-idf/components/bootloader_support/CMakeLists.txt
+++ b/vendors/espressif/esp-idf/components/bootloader_support/CMakeLists.txt
@@ -18,44 +18,45 @@ if(${BOOTLOADER_BUILD})
     set(COMPONENT_PRIV_REQUIRES spi_flash micro-ecc efuse)
     list(APPEND COMPONENT_SRCS "src/bootloader_init.c")
 
-    if(CONFIG_SECURE_SIGNED_APPS)
-        get_filename_component(secure_boot_verification_key
-            "signature_verification_key.bin"
-            ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
-        if(CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES)
-            add_custom_command(OUTPUT "${secure_boot_verification_key}"
-                COMMAND ${ESPSECUREPY}
-                    extract_public_key --keyfile "${secure_boot_signing_key}"
-                    "${secure_boot_verification_key}"
-                DEPENDS gen_secure_boot_signing_key
-                VERBATIM)
-        else()
-            get_filename_component(orig_secure_boot_verification_key
-                "${CONFIG_SECURE_BOOT_VERIFICATION_KEY}"
-                ABSOLUTE BASE_DIR "${main_project_path}")
-            if(NOT EXISTS ${orig_secure_boot_verification_key})
-                message(FATAL_ERROR
-                    "Secure Boot Verification Public Key ${CONFIG_SECURE_BOOT_VERIFICATION_KEY} does not exist."
-                    "\nThis can be extracted from the private signing key."
-                    "\nSee docs/security/secure-boot.rst for details.")
-            endif()
-
-            add_custom_command(OUTPUT "${secure_boot_verification_key}"
-                COMMAND ${CMAKE_COMMAND} -E copy "${orig_secure_boot_verification_key}"
-                    "${secure_boot_verification_key}"
-                DEPENDS "${orig_secure_boot_verification_key}"
-                VERBATIM)
-        endif()
-        set(COMPONENT_EMBED_FILES "${secure_boot_verification_key}")
-        set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-            APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-            "${secure_boot_verification_key}")
-    endif()
 else()
     set(COMPONENT_ADD_INCLUDEDIRS "include")
     set(COMPONENT_PRIV_INCLUDEDIRS "include_bootloader")
     set(COMPONENT_REQUIRES)
     set(COMPONENT_PRIV_REQUIRES spi_flash mbedtls micro-ecc efuse)
+endif()
+
+if(CONFIG_SECURE_SIGNED_APPS)
+    get_filename_component(secure_boot_verification_key
+        "signature_verification_key.bin"
+        ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
+    if(CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES)
+        add_custom_command(OUTPUT "${secure_boot_verification_key}"
+            COMMAND ${ESPSECUREPY}
+                extract_public_key --keyfile "${secure_boot_signing_key}"
+                "${secure_boot_verification_key}"
+            DEPENDS gen_secure_boot_signing_key
+            VERBATIM)
+    else()
+        get_filename_component(orig_secure_boot_verification_key
+            "${CONFIG_SECURE_BOOT_VERIFICATION_KEY}"
+            ABSOLUTE BASE_DIR "${main_project_path}")
+        if(NOT EXISTS ${orig_secure_boot_verification_key})
+            message(FATAL_ERROR
+                "Secure Boot Verification Public Key ${CONFIG_SECURE_BOOT_VERIFICATION_KEY} does not exist."
+                "\nThis can be extracted from the private signing key."
+                "\nSee docs/security/secure-boot.rst for details.")
+        endif()
+
+        add_custom_command(OUTPUT "${secure_boot_verification_key}"
+            COMMAND ${CMAKE_COMMAND} -E copy "${orig_secure_boot_verification_key}"
+                "${secure_boot_verification_key}"
+            DEPENDS "${orig_secure_boot_verification_key}"
+            VERBATIM)
+    endif()
+    set(COMPONENT_EMBED_FILES "${secure_boot_verification_key}")
+    set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+        "${secure_boot_verification_key}")
 endif()
 
 register_component()


### PR DESCRIPTION
<!--- Title -->
Fix bug where verification key was not embedded in app when Secure Boot is enable

Description
-----------
<!--- Describe your changes in detail -->
While building app with CMake, when secured boot is enabled, verification key is not embedded in the app. This leads to build failure.

This PR fixes the issue https://github.com/espressif/esp-idf/issues/4419

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.