### PR TITLE
test: Expand on how we enable/disable peripheral tests

### DIFF
--- a/libraries/abstractions/common_io/test/iot_test_common_io.c
+++ b/libraries/abstractions/common_io/test/iot_test_common_io.c
@@ -57,7 +57,7 @@ TEST_GROUP_RUNNER( Common_IO )
     size_t i = 0;
 
     #if ( IOT_TEST_COMMON_IO_UART_SUPPORTED == 1 )
-        for( i = 0; i < UART_TEST_SET; i++ )
+        for( i = 0; i < IOT_TEST_COMMON_IO_UART_SUPPORTED; i++ )
         {
             SET_TEST_IOT_UART_CONFIG( i );
             RUN_TEST_GROUP( TEST_IOT_UART );
@@ -65,7 +65,7 @@ TEST_GROUP_RUNNER( Common_IO )
     #endif
 
     #if ( IOT_TEST_COMMON_IO_I2C_SUPPORTED == 1 )
-        for( i = 0; i < I2C_TEST_SET; i++ )
+        for( i = 0; i < IOT_TEST_COMMON_IO_I2C_SUPPORTED; i++ )
         {
             SET_TEST_IOT_I2C_CONFIG( i );
             RUN_TEST_GROUP( TEST_IOT_I2C );
@@ -73,7 +73,7 @@ TEST_GROUP_RUNNER( Common_IO )
     #endif
 
     #if ( IOT_TEST_COMMON_IO_SPI_SUPPORTED == 1 )
-        for( i = 0; i < SPI_TEST_SET; i++ )
+        for( i = 0; i < IOT_TEST_COMMON_IO_SPI_SUPPORTED; i++ )
         {
             SET_TEST_IOT_SPI_CONFIG( i );
             RUN_TEST_GROUP( TEST_IOT_SPI );

--- a/libraries/abstractions/common_io/test/iot_test_common_io.c
+++ b/libraries/abstractions/common_io/test/iot_test_common_io.c
@@ -56,7 +56,7 @@ TEST_GROUP_RUNNER( Common_IO )
 {
     size_t i = 0;
 
-    #if ( IOT_TEST_COMMON_IO_UART_SUPPORTED == 1 )
+    #ifdef IOT_TEST_COMMON_IO_UART_SUPPORTED
         for( i = 0; i < IOT_TEST_COMMON_IO_UART_SUPPORTED; i++ )
         {
             SET_TEST_IOT_UART_CONFIG( i );
@@ -64,7 +64,7 @@ TEST_GROUP_RUNNER( Common_IO )
         }
     #endif
 
-    #if ( IOT_TEST_COMMON_IO_I2C_SUPPORTED == 1 )
+    #ifdef IOT_TEST_COMMON_IO_I2C_SUPPORTED
         for( i = 0; i < IOT_TEST_COMMON_IO_I2C_SUPPORTED; i++ )
         {
             SET_TEST_IOT_I2C_CONFIG( i );
@@ -72,7 +72,7 @@ TEST_GROUP_RUNNER( Common_IO )
         }
     #endif
 
-    #if ( IOT_TEST_COMMON_IO_SPI_SUPPORTED == 1 )
+    #ifdef IOT_TEST_COMMON_IO_SPI_SUPPORTED
         for( i = 0; i < IOT_TEST_COMMON_IO_SPI_SUPPORTED; i++ )
         {
             SET_TEST_IOT_SPI_CONFIG( i );

--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -59,7 +59,7 @@ uint8_t uctestIotAdcChListLen = 1;
 /* ADC Channel list used for testing, the list is defined by board specific test code */
 uint8_t * puctestIotAdcChList = NULL;
 /* ADC module instance for assisted test, need to be configured to the channel with external access */
-uint8_t assistedTestIotAdcChannel = 0;
+uint8_t ucAssistedTestIotAdcChannel = 0;
 
 /* ADC Channel Scan Wait time in ms */
 uint32_t ltestIotAdcTestChWaitTime = 1000;
@@ -224,6 +224,12 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcGetChStatus )
     lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 
+    /* consume all semaphores given due to Async read callbacks which the test didn't care about */
+    while( pdTRUE == xSemaphoreTake( xtestIotAdcTestSemaphore, 0 ) )
+    {
+        ;
+    }
+
     /* query channel state for channel x */
     xAdcChStatus.ucAdcChannel = ucChX;
     lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
@@ -283,7 +289,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcPrintReadSample )
     TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
     /* read sample from ADC channels */
-    lRetVal = iot_adc_read_sample( xAdcHandle, assistedTestIotAdcChannel, &usSample );
+    lRetVal = iot_adc_read_sample( xAdcHandle, ucAssistedTestIotAdcChannel, &usSample );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 
     lRetVal = iot_adc_close( xAdcHandle );
@@ -602,7 +608,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChainFuzzy )
 }
 
 /*-----------------------------------------------------------*/
-void xAdcCallbackTmp( uint16_t * pusConvertedData,
+void static xAdcCallbackTmp( uint16_t * pusConvertedData,
                       void * pvUserContext )
 {
 }

--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -608,7 +608,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChainFuzzy )
 }
 
 /*-----------------------------------------------------------*/
-void static xAdcCallbackTmp( uint16_t * pusConvertedData,
+static void xAdcCallbackTmp( uint16_t * pusConvertedData,
                       void * pvUserContext )
 {
 }

--- a/libraries/abstractions/common_io/test/test_iot_efuse.c
+++ b/libraries/abstractions/common_io/test/test_iot_efuse.c
@@ -46,12 +46,12 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint32_t uctestIotEfuse16BitWordValidIdx = 151;              /**< A valid 16-bit word fuse index. */
-uint32_t uctestIotEfuse16BitWordInvalidIdx = 159;            /**< An invalid 16-bit word fuse index. */
-uint16_t uctestIotEfuse16BitWordWriteVal = 0x5a5a;           /**< test value to write into a 16-bit efuse word */
-uint32_t uctestIotEfuse32BitWordValidIdx = 159;              /**< A valid 32-bit word fuse index. */
-uint32_t uctestIotEfuse32BitWordInvalidIdx = 151;            /**< An invalid 32-bit word fuse index. */
-uint32_t uctestIotEfuse32BitWordWriteVal = 0x5a5a5a5a;       /**< test value to write into a 32-bit efuse word */
+uint32_t ultestIotEfuse16BitWordValidIdx = 151;              /**< A valid 16-bit word fuse index. */
+uint32_t ultestIotEfuse16BitWordInvalidIdx = 159;            /**< An invalid 16-bit word fuse index. */
+uint16_t ustestIotEfuse16BitWordWriteVal = 0x5a5a;           /**< test value to write into a 16-bit efuse word */
+uint32_t ultestIotEfuse32BitWordValidIdx = 159;              /**< A valid 32-bit word fuse index. */
+uint32_t ultestIotEfuse32BitWordInvalidIdx = 151;            /**< An invalid 32-bit word fuse index. */
+uint32_t ultestIotEfuse32BitWordWriteVal = 0x5a5a5a5a;       /**< test value to write into a 32-bit efuse word */
 
 
 /*-----------------------------------------------------------*/
@@ -132,9 +132,9 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead32BitWord )
 {
     IotEfuseHandle_t xEfuseHandle = NULL;
     int32_t lRetVal;
-    uint32_t ulInvalidIndex = uctestIotEfuse32BitWordInvalidIdx;
-    uint32_t ulValidIndex = uctestIotEfuse32BitWordValidIdx;
-    uint32_t ulWriteVal = uctestIotEfuse32BitWordWriteVal;
+    uint32_t ulInvalidIndex = ultestIotEfuse32BitWordInvalidIdx;
+    uint32_t ulValidIndex = ultestIotEfuse32BitWordValidIdx;
+    uint32_t ulWriteVal = ultestIotEfuse32BitWordWriteVal;
     uint32_t ulReadVal;
 
     /* Write to 32-bit wide efuse word using a NULL handle */
@@ -205,13 +205,13 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead16BitWord )
 {
     IotEfuseHandle_t xEfuseHandle = NULL;
     int32_t lRetVal;
-    uint32_t ulInvalidIndex = uctestIotEfuse16BitWordInvalidIdx;
-    uint32_t ulValidIndex = uctestIotEfuse16BitWordValidIdx;
-    uint16_t ulWriteVal = uctestIotEfuse16BitWordWriteVal;
+    uint32_t ulInvalidIndex = ultestIotEfuse16BitWordInvalidIdx;
+    uint32_t ulValidIndex = ultestIotEfuse16BitWordValidIdx;
+    uint16_t usWriteVal = ustestIotEfuse16BitWordWriteVal;
     uint16_t ulReadVal;
 
     /* Write to 16-bit wide efuse word using a NULL handle*/
-    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulValidIndex, ulWriteVal);
+    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulValidIndex, usWriteVal);
     if(lRetVal != IOT_EFUSE_FUNCTION_NOT_SUPPORTED)
     {
         TEST_ASSERT_EQUAL( IOT_EFUSE_INVALID_VALUE, lRetVal );
@@ -229,7 +229,7 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead16BitWord )
     TEST_ASSERT_NOT_EQUAL( NULL, xEfuseHandle );
 
     /* Write to 16-bit wide efuse word using an invalid index */
-    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulInvalidIndex, ulWriteVal);
+    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulInvalidIndex, usWriteVal);
     if(lRetVal != IOT_EFUSE_FUNCTION_NOT_SUPPORTED)
     {
         TEST_ASSERT_EQUAL( IOT_EFUSE_INVALID_VALUE, lRetVal );
@@ -243,7 +243,7 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead16BitWord )
     }
 
     /* Write a 16-bit wide efuse word using a valid index */
-    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulValidIndex, ulWriteVal);
+    lRetVal = iot_efuse_write_16bit_word( xEfuseHandle, ulValidIndex, usWriteVal);
     if(lRetVal != IOT_EFUSE_FUNCTION_NOT_SUPPORTED)
     {
         TEST_ASSERT_EQUAL( IOT_EFUSE_SUCCESS, lRetVal );
@@ -254,7 +254,7 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseWriteRead16BitWord )
     if(lRetVal != IOT_EFUSE_FUNCTION_NOT_SUPPORTED)
     {
         TEST_ASSERT_EQUAL( IOT_EFUSE_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( ulWriteVal, ulReadVal );
+        TEST_ASSERT_EQUAL( usWriteVal, ulReadVal );
     }
 
     /* Read a 16-bit wide efuse word using a NULL receive buffer */

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -69,7 +69,7 @@ typedef struct CallbackParam
 
 uint8_t uctestIotI2CSlaveAddr = 0;           /**< The slave address to be set for the I2C port. */
 uint8_t uctestIotI2CInvalidSlaveAddr = 0xFF; /**< The slave address to be set for the I2C port. */
-uint8_t xtestIotI2CDeviceRegister = 0;       /**< The device register to be set for the I2C port. */
+uint8_t uctestIotI2CDeviceRegister = 0;       /**< The device register to be set for the I2C port. */
 uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to device. */
 uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
 uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
@@ -413,7 +413,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadAsyncSuccess )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address to read from the device register. */
@@ -435,7 +435,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadAsyncSuccess )
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CGetTxNoOfbytes, &writeBytes );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
         /* Assert the number of bytes being written is 1. */
-        TEST_ASSERT_EQUAL( sizeof( xtestIotI2CDeviceRegister ), writeBytes );
+        TEST_ASSERT_EQUAL( sizeof( uctestIotI2CDeviceRegister ), writeBytes );
     }
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -490,7 +490,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadChainSuccess )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_async( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_async( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         lRetVal = xSemaphoreTake( xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT );
@@ -504,7 +504,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadChainSuccess )
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CGetTxNoOfbytes, &writeBytes );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
         /* Assert the number of bytes being written is 1. */
-        TEST_ASSERT_EQUAL( sizeof( xtestIotI2CDeviceRegister ), writeBytes );
+        TEST_ASSERT_EQUAL( sizeof( uctestIotI2CDeviceRegister ), writeBytes );
     }
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -550,7 +550,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailIoctl )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
@@ -612,7 +612,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailReadTwice )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
@@ -709,7 +709,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
@@ -732,7 +732,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
         lRetVal = xSemaphoreTake( xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT );
         TEST_ASSERT_EQUAL( pdFALSE, lRetVal );
 
-        uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
+        uint8_t writeVal1[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
         /* Write after cancel should also succeed. */
         lRetVal = iot_i2c_write_sync( xI2CHandle, writeVal1, sizeof( writeVal1 ) );
@@ -805,8 +805,8 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
-    uint8_t writeVal2[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
+    uint8_t writeVal1[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal };
+    uint8_t writeVal2[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
 
     uint16_t writeBytes;
 
@@ -871,7 +871,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailIoctl )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t writeVal[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
     IotI2CConfig_t xI2CConfig =
     {
@@ -921,7 +921,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailWriteTwice )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t writeVal[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
     IotI2CConfig_t xI2CConfig =
     {
@@ -1001,7 +1001,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadSyncSuccess )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* repeated start to read */
@@ -1015,7 +1015,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadSyncSuccess )
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CGetTxNoOfbytes, &writeBytes );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
         /* Assert the number of bytes being written is 1. */
-        TEST_ASSERT_EQUAL( sizeof( xtestIotI2CDeviceRegister ), writeBytes );
+        TEST_ASSERT_EQUAL( sizeof( uctestIotI2CDeviceRegister ), writeBytes );
 
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CGetRxNoOfbytes, &readBytes );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
@@ -1071,8 +1071,8 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncSuccess )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
-    uint8_t writeVal2[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
+    uint8_t writeVal1[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal };
+    uint8_t writeVal2[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
 
     uint16_t writeBytes;
 
@@ -1128,7 +1128,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncFail )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
+    uint8_t writeVal[] = { uctestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
     IotI2CConfig_t xI2CConfig =
     {
@@ -1196,7 +1196,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CGetBusStateSuccess )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* write the device register address. */
-        lRetVal = iot_i2c_write_sync( xI2CHandle, &xtestIotI2CDeviceRegister, sizeof( xtestIotI2CDeviceRegister ) );
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Assert bus is idle before calling async read. */

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -33,6 +33,190 @@
 
 #pragma once
 
+
+/*
+ * Test iteration count macros that platforms should set
+ * in their repective "test_iot_config.h" file. If not set
+ * there, the default value of 1 is set here.
+ */
+
+#ifndef IOT_TEST_COMMON_IO_UART_SUPPORTED
+ #define IOT_TEST_COMMON_IO_UART_SUPPORTED  1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_FLASH_SUPPORTED
+ #define IOT_TEST_COMMON_IO_FLASH_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED
+ #define IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_GPIO_SUPPORTED
+ #define IOT_TEST_COMMON_IO_GPIO_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_RTC_SUPPORTED
+ #define IOT_TEST_COMMON_IO_RTC_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_TIMER_SUPPORTED
+ #define IOT_TEST_COMMON_IO_TIMER_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_ADC_SUPPORTED
+ #define IOT_TEST_COMMON_IO_ADC_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_RESET_SUPPORTED
+ #define IOT_TEST_COMMON_IO_RESET_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
+ #define IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_PWM_SUPPORTED
+ #define IOT_TEST_COMMON_IO_PWM_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_I2C_SUPPORTED
+ #define IOT_TEST_COMMON_IO_I2C_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED
+ #define IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_POWER_SUPPORTED
+ #define IOT_TEST_COMMON_IO_POWER_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_BATTERY_SUPPORTED
+ #define IOT_TEST_COMMON_IO_BATTERY_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_EFUSE_SUPPORTED
+ #define IOT_TEST_COMMON_IO_EFUSE_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_SPI_SUPPORTED
+ #define IOT_TEST_COMMON_IO_SPI_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED
+ #define IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_USB_HOST_SUPPORTED
+ #define IOT_TEST_COMMON_IO_USB_HOST_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_SDIO_SUPPORTED
+ #define IOT_TEST_COMMON_IO_SDIO_SUPPORTED 1
+#endif
+
+#ifndef IOT_TEST_COMMON_IO_I2S_SUPPORTED
+ #define IOT_TEST_COMMON_IO_I2S_SUPPORTED 1
+#endif
+
+
+/*
+ * The variables below are used in the tests. Generally. they should be
+ * set in SET_TEST_IOT_RESET_CONFIG() defined in the respective platform
+ * directory. If not set, the default value set at the variable
+ * definition is used.
+ */
+
+/* Uart */
+extern uint8_t ustestIotUartPort;                       /* the index of the UART that will be tested */
+
+/* Flash */
+extern uint32_t ultestIotFlashStartOffset;              /* the Flash offset at which the flash operations in the test will take place */
+
+/* GPIO */
+extern int32_t ltestIotGpioPortA;                       /* The 1st GPIO port used in the loop back test */
+extern int32_t ltestIotGpioPortB;                       /* The 2nd GPIO port used in the loop back test */
+extern uint16_t ustestIotGpioConfig;                    /* ustestIotGpioConfig is used for configuring GPIO test
+                                                         * user must set this variable for testing different GPIOs
+                                                         *
+                                                         * default ustestIotGpioConfig = 0 means reading logic GPIO# 0
+                                                         *
+                                                         * bit[7:0] for port
+                                                         * bit[8] for direction (Read:0, Write: 1)
+                                                         * bit[9] for IRQ (disable: 0, enable: 1)
+                                                         * bit[10] for write value (0 or 1)
+                                                         */
+extern uint32_t ultestIotGpioWaitTime;                  /* Wait time for GPIO port A to receive GPIO interrupt from port B during the test
+                                                         * This is needed to avoid indefinite wait during the test */
+extern uint32_t ultestIotGpioSlowSpeed;                 /* Based on the underlying HW, set the slow speed setting of GPIO */
+extern uint32_t ultestIotGpioFastSpeed;                 /* Based on the underlying HW, set the high speed setting of GPIO */
+extern uint32_t ultestIotGpioFunction;                  /* Alt Function for GPIO for the pin */
+
+
+/* Timer */
+extern int32_t ltestIotTimerInstance;                   /* HW timer instance to use */
+
+/* SPI */
+extern uint32_t ultestIotSpiInstance;                   /* SPI instance that we plan to test */
+extern uint32_t ulAssistedTestIotSpiInstance;           /* SPI assisted tests */
+extern uint32_t ultestIotSpiSlave;                      /* SPI assisted tests */
+extern uint32_t ulAssistedTestIotSpiSlave;              /* SPI assisted tests */
+
+/* ADC */
+extern uint8_t uctestIotAdcChListLen;                   /* Length of ADC chains used in the test. The chains are ADC channels
+                                                         * that would be sampled with a single trigger */
+extern uint8_t * puctestIotAdcChList;                   /* The ADC chains used in the tests */
+extern uint8_t assistedTestIotAdcChannel;               /* Assisted Tests: ADC Channel list */
+
+/* PWM */
+extern uint32_t ultestIotPwmGpioInputPin;               /* GPIO used to measure PWM accuracy */
+extern uint32_t ultestIotPwmInstance;                   /* PWM instance */
+extern uint32_t ultestIotPwmFrequency;                  /* PWM freq */
+extern uint32_t ultestIotPwmDutyCycle;                  /* PWM duty cycle */
+extern int32_t ultestIotPwmChannel;                     /* PWM Channel */
+extern uint32_t assistedTestIotPwmGpioInputPin;         /* PWM assisted tests only */
+
+/* I2C */
+extern uint8_t uctestIotI2CSlaveAddr;                   /* Address of Slave I2C (7-bit address) connected to the bus */
+extern uint8_t xtestIotI2CDeviceRegister;               /* Slave I2C register address used in read/write tests */
+extern uint8_t uctestIotI2CWriteVal;                    /* Write value that will be used in the register write test */
+extern uint8_t uctestIotI2CInstanceIdx;                 /* I2C instance used in the test */
+extern uint8_t uctestIotI2CInstanceNum;                 /* The total number of I2C instances on the device */
+
+/* I2S */
+extern int32_t ltestIotI2sInputInstance;                /* used in assisted tests */
+extern int32_t ltestIotI2sOutputInstance;               /* used in assisted tests */
+extern int32_t ltestIotI2SReadSize;                     /* used in assisted tests */
+
+/* EFUSE */
+extern uint32_t uctestIotEfuse16BitWordValidIdx;        /* Efuse index for valid 16-bit R/W operations */
+extern uint32_t uctestIotEfuse16BitWordInvalidIdx;      /* Efuse index that is not valid for 16-bit R/W operations */
+extern uint32_t uctestIotEfuse16BitWordWriteVal;        /* 16-bit value to write to eFuse at index uctestIotEfuse16BitWordValidIdx */
+extern uint32_t uctestIotEfuse32BitWordValidIdx;        /* Efuse index for valid 32-bit R/W operations */
+extern uint32_t uctestIotEfuse32BitWordInvalidIdx;      /* Efuse index that is not valid for 32-bit R/W operations */
+extern uint32_t uctestIotEfuse32BitWordWriteVal;        /* 32-bit value to write to eFuse at index uctestIotEfuse32BitWordValidIdx */
+
+/* TSensor */
+extern uint8_t uctestIotTsensorInstance;                /* I2C instance used in the test */
+
+/* Power */
+extern uint32_t ultestIotPowerDelay;                    /* Delay used to wait for the DUT enter idle */
+
+extern uint32_t ultestIotPowerPcWakeThreshold;          /* Threshold (minimum idle Time required to enter PC Idle Mode */
+extern uint32_t ultestIotPowerClkSrcOffThreshold;       /* Threshold (minimum idle Time required to enter ClkSrc Off Idle Mode */
+extern uint32_t ultestIotPowerVddOffThreshold;          /* Threshold (minimum idle Time required to enter Vdd Off Idle Mode */
+
+extern uint32_t ultestIotPowerInterruptConfig1;         /* ARM-only: NVIC interrupt mask to disable, for interrupts 0-31 */
+extern uint32_t ultestIotPowerInterruptConfig2;         /* ARM-only: NVIC interrupt mask to disable, for interrupts 32-63 */
+
+extern uint16_t ustestIotPowerWakeupSourcesLength;      /* Number of wakeup source listed in puctestIotPowerWakeupSources */
+extern uint8_t * puctestIotPowerWakeupSources;          /* Array of wakeup sources, HW-dependent */
+
+/* USB Device */
+extern uint8_t uctestIotUsbDeviceControllerId;          /* USB Device controller ID used */
+
+
 /**
  * Board specific UART config set
  *
@@ -154,9 +338,25 @@ void SET_TEST_IOT_SDIO_CONFIG( int testSet );
 void SET_TEST_IOT_TEMP_SENSOR_CONFIG( int testSet );
 
 /**
+ * Board specific efuse config set
+ *
+ * @param: testSet: number of config set to be test
+ * @return None
+ */
+void SET_TEST_IOT_EFUSE_CONFIG(int testSet);
+
+/**
  * Board specific I2S config set
  *
  * @param: testSet: number of config set to be test
  * @return None
  */
 void SET_TEST_IOT_I2S_CONFIG( int testSet );
+
+/**
+ * Board specific USB Device config set
+ *
+ * @param: testSet: number of config set to be test
+ * @return None
+ */
+void SET_TEST_IOT_USB_DEVICE_CONFIG(int testSet);

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -129,10 +129,10 @@
  */
 
 /* Uart */
-extern uint8_t uctestIotUartPort;                       /* the index of the UART that will be tested */
+extern uint8_t uctestIotUartPort;                       /* The index of the UART that will be tested */
 
 /* Flash */
-extern uint32_t ultestIotFlashStartOffset;              /* the Flash offset at which the flash operations in the test will take place */
+extern uint32_t ultestIotFlashStartOffset;              /* The Flash offset at which the flash operations in the test will take place */
 
 /* GPIO */
 extern int32_t ltestIotGpioPortA;                       /* The 1st GPIO port used in the loop back test */

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -129,7 +129,7 @@
  */
 
 /* Uart */
-extern uint8_t ustestIotUartPort;                       /* the index of the UART that will be tested */
+extern uint8_t uctestIotUartPort;                       /* the index of the UART that will be tested */
 
 /* Flash */
 extern uint32_t ultestIotFlashStartOffset;              /* the Flash offset at which the flash operations in the test will take place */
@@ -137,16 +137,8 @@ extern uint32_t ultestIotFlashStartOffset;              /* the Flash offset at w
 /* GPIO */
 extern int32_t ltestIotGpioPortA;                       /* The 1st GPIO port used in the loop back test */
 extern int32_t ltestIotGpioPortB;                       /* The 2nd GPIO port used in the loop back test */
-extern uint16_t ustestIotGpioConfig;                    /* ustestIotGpioConfig is used for configuring GPIO test
-                                                         * user must set this variable for testing different GPIOs
-                                                         *
-                                                         * default ustestIotGpioConfig = 0 means reading logic GPIO# 0
-                                                         *
-                                                         * bit[7:0] for port
-                                                         * bit[8] for direction (Read:0, Write: 1)
-                                                         * bit[9] for IRQ (disable: 0, enable: 1)
-                                                         * bit[10] for write value (0 or 1)
-                                                         */
+extern uint16_t ustestIotGpioConfig;                    /* The configuration of GPIO in the test (port, direction, irq, write value)
+                                                         * Check test_iot_gpio.c for its bit assignment */
 extern uint32_t ultestIotGpioWaitTime;                  /* Wait time for GPIO port A to receive GPIO interrupt from port B during the test
                                                          * This is needed to avoid indefinite wait during the test */
 extern uint32_t ultestIotGpioSlowSpeed;                 /* Based on the underlying HW, set the slow speed setting of GPIO */
@@ -167,19 +159,19 @@ extern uint32_t ulAssistedTestIotSpiSlave;              /* SPI assisted tests */
 extern uint8_t uctestIotAdcChListLen;                   /* Length of ADC chains used in the test. The chains are ADC channels
                                                          * that would be sampled with a single trigger */
 extern uint8_t * puctestIotAdcChList;                   /* The ADC chains used in the tests */
-extern uint8_t assistedTestIotAdcChannel;               /* Assisted Tests: ADC Channel list */
+extern uint8_t ucAssistedTestIotAdcChannel;             /* Assisted Tests: ADC Channel list */
 
 /* PWM */
 extern uint32_t ultestIotPwmGpioInputPin;               /* GPIO used to measure PWM accuracy */
 extern uint32_t ultestIotPwmInstance;                   /* PWM instance */
 extern uint32_t ultestIotPwmFrequency;                  /* PWM freq */
 extern uint32_t ultestIotPwmDutyCycle;                  /* PWM duty cycle */
-extern int32_t ultestIotPwmChannel;                     /* PWM Channel */
-extern uint32_t assistedTestIotPwmGpioInputPin;         /* PWM assisted tests only */
+extern uint32_t ultestIotPwmChannel;                    /* PWM Channel */
+extern uint32_t ulAssistedTestIotPwmGpioInputPin;       /* PWM assisted tests only */
 
 /* I2C */
 extern uint8_t uctestIotI2CSlaveAddr;                   /* Address of Slave I2C (7-bit address) connected to the bus */
-extern uint8_t xtestIotI2CDeviceRegister;               /* Slave I2C register address used in read/write tests */
+extern uint8_t uctestIotI2CDeviceRegister;              /* Slave I2C register address used in read/write tests */
 extern uint8_t uctestIotI2CWriteVal;                    /* Write value that will be used in the register write test */
 extern uint8_t uctestIotI2CInstanceIdx;                 /* I2C instance used in the test */
 extern uint8_t uctestIotI2CInstanceNum;                 /* The total number of I2C instances on the device */
@@ -190,12 +182,12 @@ extern int32_t ltestIotI2sOutputInstance;               /* used in assisted test
 extern int32_t ltestIotI2SReadSize;                     /* used in assisted tests */
 
 /* EFUSE */
-extern uint32_t uctestIotEfuse16BitWordValidIdx;        /* Efuse index for valid 16-bit R/W operations */
-extern uint32_t uctestIotEfuse16BitWordInvalidIdx;      /* Efuse index that is not valid for 16-bit R/W operations */
-extern uint32_t uctestIotEfuse16BitWordWriteVal;        /* 16-bit value to write to eFuse at index uctestIotEfuse16BitWordValidIdx */
-extern uint32_t uctestIotEfuse32BitWordValidIdx;        /* Efuse index for valid 32-bit R/W operations */
-extern uint32_t uctestIotEfuse32BitWordInvalidIdx;      /* Efuse index that is not valid for 32-bit R/W operations */
-extern uint32_t uctestIotEfuse32BitWordWriteVal;        /* 32-bit value to write to eFuse at index uctestIotEfuse32BitWordValidIdx */
+extern uint32_t ultestIotEfuse16BitWordValidIdx;        /* Efuse index for valid 16-bit R/W operations */
+extern uint32_t ultestIotEfuse16BitWordInvalidIdx;      /* Efuse index that is not valid for 16-bit R/W operations */
+extern uint32_t ustestIotEfuse16BitWordWriteVal;        /* 16-bit value to write to eFuse at index uctestIotEfuse16BitWordValidIdx */
+extern uint32_t ultestIotEfuse32BitWordValidIdx;        /* Efuse index for valid 32-bit R/W operations */
+extern uint32_t ultestIotEfuse32BitWordInvalidIdx;      /* Efuse index that is not valid for 32-bit R/W operations */
+extern uint32_t ultestIotEfuse32BitWordWriteVal;        /* 32-bit value to write to eFuse at index uctestIotEfuse32BitWordValidIdx */
 
 /* TSensor */
 extern uint8_t uctestIotTsensorInstance;                /* I2C instance used in the test */

--- a/libraries/abstractions/common_io/test/test_iot_pwm.c
+++ b/libraries/abstractions/common_io/test/test_iot_pwm.c
@@ -53,7 +53,7 @@
 uint32_t ultestIotPwmGpioOutputPin = 14;
 uint32_t ultestIotPwmGpioInputPin = 18;
 uint32_t ultestIotPwmGpioFunction = 0x4U; //IOPCTL_PIO_FUNC4;
-uint32_t assistedTestIotPwmGpioInputPin = 17;
+uint32_t ulAssistedTestIotPwmGpioInputPin = 17;
 
 uint32_t ultestIotPwmInstance = 2;          /* Use PWM instance 2 */
 uint32_t ultestIotPwmFrequency = 2000UL;    /* 2KHz frequency */
@@ -484,7 +484,7 @@ TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracyAssisted )
     IotGpioInterrupt_t    xGpioInterruptB      = eGpioInterruptRising;
 
     /* set up port B for interrupt */
-    xtestIotGpioHandleB = iot_gpio_open( assistedTestIotPwmGpioInputPin );
+    xtestIotGpioHandleB = iot_gpio_open( ulAssistedTestIotPwmGpioInputPin );
     TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioHandleB );
 
     lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioDirection, &xGpioDirectionB);

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -63,7 +63,7 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint8_t ustestIotUartPort = 0; /** Default UART port for testing */
+uint8_t uctestIotUartPort = 0; /** Default UART port for testing */
 uint32_t ultestIotUartFlowControl = 0;
 uint32_t ultestIotUartParity = 0;
 uint32_t ultestIotUartWordLength = 0;
@@ -172,7 +172,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteReadSync )
     IotUARTHandle_t xUartHandle;
     int32_t lRead, lWrite, lClose;
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -201,7 +201,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
     int32_t lIoctl, lClose, lTransferAmount;
     IotUARTConfig_t xgetConfigBuffer, xConfigBuffer, xOriginalConfig;
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -291,7 +291,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTBaudChange )
 
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_STRING, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -376,7 +376,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -425,7 +425,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
 
     cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE - 1 ] = '\n';
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -470,7 +470,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     int32_t lRead, lWrite, lClose;
     BaseType_t xCallbackReturn;
-    uint8_t ucPort = ustestIotUartPort;
+    uint8_t ucPort = uctestIotUartPort;
     volatile IotUARTOperationStatus_t xCallbackStatus = eUartLastWriteFailed;
 
     xUartHandle = iot_uart_open( ucPort );
@@ -523,7 +523,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -574,7 +574,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncFuzzing )
     lWrite = iot_uart_write_async( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -608,7 +608,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteSyncFuzzing )
     lWrite = iot_uart_write_sync( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -638,7 +638,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadAsyncFuzzing )
     lRead = iot_uart_read_async( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -670,7 +670,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadSyncFuzzing )
     lRead = iot_uart_read_sync( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -701,7 +701,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlFuzzing )
     lIoctl = iot_uart_ioctl( NULL, eUartSetConfig, &xUartConfigTest );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -747,7 +747,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     IotUARTConfig_t xUartConfig = { .ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT };
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -778,10 +778,10 @@ TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
     lClose = iot_uart_close( NULL );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lClose );
 
-    xUartHandle_2 = iot_uart_open( ustestIotUartPort );
+    xUartHandle_2 = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle_2 );
 
-    xUartHandle_3 = iot_uart_open( ustestIotUartPort );
+    xUartHandle_3 = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
 
     lCancel = iot_uart_cancel( NULL );


### PR DESCRIPTION
This change provide:
1- Using macros to enable/diable running tests for peripherals
2- Default the macros to "enable", to avoid forgetting about setting it
for a test
3- Unify the macro used to enable the test or not with the old macro
that would set the number of tests to run.
3- Collect all variables that can be changed by the peripheral
configuration function into one header.

Why:
- Simplifying the header exposed to the vendors
- Reduce macros needed for each peripheral

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.