### PR TITLE
Fix: SOCKETS_Send is not checking if the socket is already connected …

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -464,6 +464,11 @@ int32_t SOCKETS_Send( Socket_t xSocket,
         return SOCKETS_EINVAL;
     }
 
+    if( ( ctx->status & SS_STATUS_CONNECTED ) != SS_STATUS_CONNECTED )
+    {
+        return SOCKETS_ENOTCONN;
+    }
+
     ctx = ( ss_ctx_t * ) xSocket;
     ctx->send_flag = ulFlags;
 


### PR DESCRIPTION
…before attempting to send

 Author:    Alfred Gedeon <alfred2g@hotmail.com>

SOCKETS_Send is not checking whether there is an active connection

Description
-----------
SOCKETS_Send is not acting like SOCKETS_Recv by checking for an active connection before attempting to send/receive

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.