### PR TITLE
Fix: check whether socket is connected before attempting to send

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -465,12 +465,18 @@ int32_t SOCKETS_Send( Socket_t xSocket,
     }
 
     ctx = ( ss_ctx_t * ) xSocket;
-    ctx->send_flag = ulFlags;
+
+    if( ( ctx->status & SS_STATUS_CONNECTED ) != SS_STATUS_CONNECTED )
+    {
+        return SOCKETS_ENOTCONN;
+    }
 
     if( 0 > ctx->ip_socket )
     {
         return SOCKETS_SOCKET_ERROR;
     }
+
+    ctx->send_flag = ulFlags;
 
     if( ctx->enforce_tls )
     {


### PR DESCRIPTION
check whether socket is connected before attempting to send

Description
-----------
Perform a check similar to the read one to make sure the socket is connected before calling lwip_send

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.