### PR TITLE
Fix: Potential Segfault - Validate socket handle before dereferencing

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -412,11 +412,6 @@ int32_t SOCKETS_Recv( Socket_t xSocket,
 {
     ss_ctx_t * ctx = ( ss_ctx_t * ) xSocket;
 
-    if( ( ctx->status & SS_STATUS_CONNECTED ) != SS_STATUS_CONNECTED )
-    {
-        return SOCKETS_ENOTCONN;
-    }
-
     if( SOCKETS_INVALID_SOCKET == xSocket )
     {
         return SOCKETS_SOCKET_ERROR;
@@ -425,6 +420,11 @@ int32_t SOCKETS_Recv( Socket_t xSocket,
     if( ( NULL == pvBuffer ) || ( 0 == xBufferLength ) )
     {
         return SOCKETS_EINVAL;
+    }
+
+    if( ( ctx->status & SS_STATUS_CONNECTED ) != SS_STATUS_CONNECTED )
+    {
+        return SOCKETS_ENOTCONN;
     }
 
     ctx->recv_flag = ulFlags;


### PR DESCRIPTION
Potential Segfault - Validate socket handle before dereferencing

Description
-----------
Validating the socket before dereferencing it

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.