### PR TITLE
Fix PKCS #11 object lookup logic.

### DIFF
--- a/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
+++ b/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
@@ -327,14 +327,14 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
                                                  &ulCount );
     }
 
-    if( ( CKR_OK == xResult ) && ( CK_TRUE == xFindInit ) )
+    if( CK_TRUE == xFindInit )
     {
         /* Indicate to the module that the we're done looking for the indicated
          * type of object. */
         xResult = pxFunctionList->C_FindObjectsFinal( xSession );
     }
 
-    if( ( CKR_ARGUMENTS_BAD != xResult ) && ( ulCount == 0 ) )
+    if( ulCount == 0 )
     {
         *pxHandle = CK_INVALID_HANDLE;
     }


### PR DESCRIPTION
- Always call C_FindObjectsFinal() after C_FindObjects()
- Invalidate object handle if object not found

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

PR #1498 introduced a regression in which PKCS #11 object lookups are not terminated according
to the [specification](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959743), and object handles are not invalidated as required by [`iot_tls.c:prvInitializeClientCredential()`](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/standard/tls/src/iot_tls.c#L628).  This PR reverts these changes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.