### PR TITLE
Add board dir for cypress in CMake

### DIFF
--- a/vendors/cypress/manifest.cmake
+++ b/vendors/cypress/manifest.cmake
@@ -5,3 +5,5 @@ set(
 )
 
 set(AFR_MANIFEST_BOARD_DIR "boards")
+set(AFR_MANIFEST_BOARD_DIR_cypress43 "boards/CYW943907AEVAL1F")
+set(AFR_MANIFEST_BOARD_DIR_cypress54 "boards/CYW954907AEVAL1F")


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Add board directory mapping to cypress. We can remove the hard coding from test infra with this fix.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.