### PR TITLE
Fix potential segfault: freeing memory that failed to be allocated, since it is not set to null

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -761,8 +761,9 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
             }
             else
             {
-                ctx->ppcAlpnProtocols[
-                    ctx->ulAlpnProtocolsCount - 1 ] = NULL;
+                memset( ctx->ppcAlpnProtocols,
+                        0x00,
+                        ctx->ulAlpnProtocolsCount * sizeof( char * ) );
             }
 
             /* Copy each protocol string. */


### PR DESCRIPTION
freeing memory that failed to be allocated, since it is not set to null

Description
-----------
SOCKETS_SetSockOpt option SOCKETS_SO_ALPN_PROTOCOLS
if the second malloc fails, all the remaining memory after the corresponding memory is not set to NULL.
When SOCKETS_Close is called, it is freeing the memory after the failed one, which results in a segmentation violation

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.