### PR TITLE
Address comments of Common IO in PR 1682

### DIFF
--- a/libraries/abstractions/common_io/include/iot_uart.h
+++ b/libraries/abstractions/common_io/include/iot_uart.h
@@ -60,10 +60,10 @@
  */
 typedef enum
 {
-    eUartWriteCompleted,        /*!< UART operation write completed successfully. */
-    eUartReadCompleted,         /*!< UART operation read completed successfully. */
-    eUartLastWriteFailed,       /*!< UART driver returns error when performing write operation. */
-    eUartLastReadFailed,        /*!< UART driver returns error when performing read operation. */
+    eUartWriteCompleted,  /*!< UART operation write completed successfully. */
+    eUartReadCompleted,   /*!< UART operation read completed successfully. */
+    eUartLastWriteFailed, /*!< UART driver returns error when performing write operation. */
+    eUartLastReadFailed,  /*!< UART driver returns error when performing read operation. */
 } IotUARTOperationStatus_t;
 
 /**
@@ -81,8 +81,8 @@ typedef enum
  */
 typedef enum
 {
-    eUartStopBitsOne, /*!< UART stop bits is 1 bit per frame. */
-    eUartStopBitsTwo, /*!< UART stop bits is 2 bit per frame. */
+    eUartStopBitsOne, /*!< UART character stop is one bit. */
+    eUartStopBitsTwo, /*!< UART character stop is two bits. */
 } IotUARTStopBits_t;
 
 /**

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -807,7 +807,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
     uint8_t writeVal1[] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
-    uint8_t writeVal2[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal, uctestIotI2CWriteVal };
+    uint8_t writeVal2[ IOT_TEST_COMMON_IO_I2C_MAX_WRITE_LENGTH ] = { xtestIotI2CDeviceRegister, uctestIotI2CWriteVal };
 
     uint16_t writeBytes;
 
@@ -855,7 +855,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
 
         lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CGetTxNoOfbytes, &writeBytes );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
-        /* Assert the number of bytes being written is 4. */
+        /* Assert the number of written bytes. */
         TEST_ASSERT_EQUAL( sizeof( writeVal2 ), writeBytes );
     }
 

--- a/libraries/abstractions/common_io/test/test_iot_spi.c
+++ b/libraries/abstractions/common_io/test/test_iot_spi.c
@@ -46,6 +46,7 @@
 
 #define SPI_BUFFER_SIZE                       ( 32 )
 #define testIotSPI_DEFAULT_SEMAPHORE_DELAY    ( 3000U )
+#define _MESSAGE_LENGTH                       ( 50 )
 
 /*-----------------------------------------------------------*/
 
@@ -65,6 +66,15 @@ uint32_t ultestIotSpiSlave = 0;
 
 
 /*-----------------------------------------------------------*/
+/* The message string output by assisted test. */
+static char _cMsg[ _MESSAGE_LENGTH ] = { 0 };
+
+/* Append bytes in the buffer to _cMsg, starting at given offset. */
+static void prvAppendToMessage( size_t * pOffset,
+                                uint8_t * pBuffer,
+                                size_t bufferLen );
+/* Output message _cMsg. */
+static void prvOutputMessage();
 
 /**
  * @brief Application/POSIX defined callback for asynchronous operations
@@ -92,6 +102,8 @@ TEST_SETUP( TEST_IOT_SPI )
 {
     xtestIotSPISemaphore = xSemaphoreCreateBinaryStatic( &xtestIotSPICompleted );
     TEST_ASSERT_NOT_EQUAL( NULL, xtestIotSPISemaphore );
+
+    memset( _cMsg, 0, _MESSAGE_LENGTH );
 }
 /*-----------------------------------------------------------*/
 
@@ -146,11 +158,9 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_OpenClose )
     IotSPIHandle_t xSPIHandle;
     int32_t lRetVal;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -167,7 +177,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_Init )
     IotSPIMasterConfig_t xNewConfig, xOrigConfig, xConfirmConfig;
     int32_t lRetVal;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -193,7 +202,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_Init )
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
     }
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -212,11 +220,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSync )
     uint8_t ucRxBuf[ 4 ] = { 0xff, 0xff, 0xff, 0xff };
     size_t xBytesRx;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -245,11 +252,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSync )
         }
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -266,9 +273,8 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncAssisted )
     int32_t lRetVal;
     int32_t lLoop = 0;
     uint8_t ucRxBuf[ 16 ] = { 0 };
-    char cMsg[ 50 ] = { 0 };
     size_t xBytesRx;
-    int i = 0, j = 0, len = 0;
+    size_t msgOffset = 0;
 
     /* If unit test and assisted test have different spi slave, make sure select slave function in
      * ll hal is defined and select the slave for assisted slave. */
@@ -282,11 +288,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncAssisted )
         #endif
     }
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -309,33 +314,25 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncAssisted )
         TEST_ASSERT_EQUAL( xBytesRx, 4 );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* restore slave select */
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
     if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
     {
         #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
             TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
         #endif
     }
 
-    /* Create a string with read bytes and print it to console. */
-    for( i = 0, j = 0, len = sizeof( ucRxBuf ); i < len; i++ )
-    {
-        cMsg[ j++ ] = ',';
-        uint8_t upp = ucRxBuf[ i ] >> 4, low = ucRxBuf[ i ] & 0xF;
-        cMsg[ j++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ j++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
-    }
-
-    TEST_IGNORE_MESSAGE( cMsg );
+    prvAppendToMessage( &msgOffset, ucRxBuf, sizeof( ucRxBuf ) );
+    prvOutputMessage();
 }
 
 /**
@@ -351,11 +348,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsync )
     size_t xBytesRx;
     int32_t lLoop = 0;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -392,11 +388,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsync )
         }
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -412,10 +408,9 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncAssisted )
     IotSPIMasterConfig_t xOrigConfig, xTestConfig;
     int32_t lRetVal;
     uint8_t ucRxBuf[ 16 ] = { 0 };
-    char cMsg[ 50 ] = { 0 };
     size_t xBytesRx;
     int32_t lLoop = 0;
-    int i = 0, j = 0, len = 0;
+    size_t msgOffset = 0;
 
     /* If unit test and assisted test have different spi slave, make sure select slave function in
      * ll hal is defined and select the slave for assisted slave. */
@@ -429,11 +424,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncAssisted )
         #endif
     }
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -464,35 +458,26 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncAssisted )
         TEST_ASSERT_EQUAL( xBytesRx, 4 );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* restore slave select */
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
     if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
     {
         #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
             TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
         #endif
     }
 
-    /* Create a string with read bytes and print it to console. */
-    for( i = 0, j = 0, len = sizeof( ucRxBuf ); i < len; i++ )
-    {
-        cMsg[ j++ ] = ',';
-        uint8_t upp = ucRxBuf[ i ] >> 4, low = ucRxBuf[ i ] & 0xF;
-        cMsg[ j++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ j++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
-    }
-
-    TEST_IGNORE_MESSAGE( cMsg );
+    prvAppendToMessage( &msgOffset, ucRxBuf, sizeof( ucRxBuf ) );
+    prvOutputMessage();
 }
-/*-----------------------------------------------------------*/
 
 /**
  * @brief Test Function to test spi write sync
@@ -506,11 +491,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSync )
     uint8_t ucTxBuf[ 4 ] = { 0, 2, 4, 6 };
     size_t xBytesTx;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -533,11 +517,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSync )
         TEST_ASSERT_EQUAL( xBytesTx, 4 );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -552,21 +536,19 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncAssisted )
     IotSPIMasterConfig_t xOrigConfig, xTestConfig;
     int32_t lRetVal;
     uint8_t ucTxBuf[ 16 ] = { 0 };
-    char cMsg[ 50 ] = { 0 };
     size_t xBytesTx;
-    int i = 0, j = 0, len = 0;
+    size_t i = 0;
+    size_t msgOffset = 0;
 
     srand( xTaskGetTickCount() );
 
-    /* Generate random tx bytes and load them to a string to print later. */
-    for( i = 0, j = 0, len = sizeof( ucTxBuf ); i < len; i++ )
+    /* Generate random tx bytes. */
+    for( ; i < sizeof( ucTxBuf ); i++ )
     {
         ucTxBuf[ i ] = ( uint8_t ) rand();
-        cMsg[ j++ ] = ',';
-        uint8_t upp = ucTxBuf[ i ] >> 4, low = ucTxBuf[ i ] & 0xF;
-        cMsg[ j++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ j++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
     }
+
+    prvAppendToMessage( &msgOffset, ucTxBuf, sizeof( ucTxBuf ) );
 
     /* If unit test and assisted test have different spi slave, make sure select slave function in
      * ll hal is defined and select the slave for assisted slave. */
@@ -580,11 +562,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncAssisted )
         #endif
     }
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -606,24 +587,24 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncAssisted )
         TEST_ASSERT_EQUAL( xBytesTx, 4 );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* restore slave select */
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
     if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
     {
         #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
             TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
         #endif
     }
 
-    TEST_IGNORE_MESSAGE( cMsg );
+    prvOutputMessage();
 }
 
 /**
@@ -638,11 +619,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsync )
     uint8_t ucTxBuf[ 4 ] = { 0, 2, 4, 6 };
     size_t xBytesTx;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -673,107 +653,16 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsync )
         TEST_ASSERT_EQUAL( xBytesTx, 4 );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
 
-/**
- * @brief Assisted Test Function to test spi write async
- *
- */
-TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsyncAssisted )
-{
-    IotSPIHandle_t xSPIHandle;
-    IotSPIMasterConfig_t xOrigConfig, xTestConfig;
-    int32_t lRetVal;
-    uint8_t ucTxBuf[ 16 ] = { 0 };
-    char cMsg[ 50 ] = { 0 };
-    size_t xBytesTx;
-    int i = 0, j = 0, len = 0;
 
-    srand( xTaskGetTickCount() );
-
-    /* Generate random tx bytes and load them to a string to print later. */
-    for( i = 0, j = 0, len = sizeof( ucTxBuf ); i < len; i++ )
-    {
-        ucTxBuf[ i ] = ( uint8_t ) rand();
-        cMsg[ j++ ] = ',';
-        uint8_t upp = ucTxBuf[ i ] >> 4, low = ucTxBuf[ i ] & 0xF;
-        cMsg[ j++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ j++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
-    }
-
-    /* If unit test and assisted test have different spi slave, make sure select slave function in
-     * ll hal is defined and select the slave for assisted slave. */
-    if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
-    {
-        #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
-            TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        #else
-            TEST_ASSERT_MESSAGE( 0, "Assisted test has a different salve, but slave select is not supported." );
-        #endif
-    }
-
-    /* Open SPI handle */
-    xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
-
-    /* save original configuration */
-    lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-
-    if( TEST_PROTECT() )
-    {
-        /* configure bus */
-        xTestConfig.ulFreq = ultestIotSPIFrequency;
-        xTestConfig.eMode = xtestIotSPIDefaultConfigMode;
-        xTestConfig.eSetBitOrder = xtestIotSPIDefaultconfigBitOrder;
-        xTestConfig.ucDummyValue = ultestIotSPIDummyValue;
-
-        lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xTestConfig );
-        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-
-        /* Set a callback for async call */
-        iot_spi_set_callback( xSPIHandle, prvSpiAsyncCallback, NULL );
-
-        /* Make async write call */
-        lRetVal = iot_spi_write_async( xSPIHandle, ucTxBuf, sizeof( ucTxBuf ) );
-        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-
-        /*Wait for the callback. */
-        lRetVal = xSemaphoreTake( xtestIotSPISemaphore, testIotSPI_DEFAULT_SEMAPHORE_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-
-        lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetTxNoOfbytes, &xBytesTx );
-        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( xBytesTx, 4 );
-    }
-
-    /* restore original configuration */
-    lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
-    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-
-    /* Close SPI handle */
-    lRetVal = iot_spi_close( xSPIHandle );
-    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-
-    /* restore slave select */
-    if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
-    {
-        #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
-            TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        #endif
-    }
-
-    TEST_IGNORE_MESSAGE( cMsg );
-}
 /*-----------------------------------------------------------*/
 
 /**
@@ -790,11 +679,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSync )
     int32_t lLoop = 0;
     size_t xBytesTx, xBytesRx;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -827,11 +715,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSync )
         }
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -851,19 +739,18 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncAssisted )
     char cMsg[ 50 ] = { 0 };
     int32_t lLoop = 0;
     size_t xBytesTx, xBytesRx;
-    int i = 0, len = 0;
+    size_t i = 0;
+    size_t msgOffset = 0;
 
     srand( xTaskGetTickCount() );
 
-    /* Generate random tx bytes and load them to a string to print later. */
-    for( i = 0, len = sizeof( ucTxBuf ); i < len; i++ )
+    /* Generate random tx bytes. */
+    for( ; i < sizeof( ucTxBuf ); i++ )
     {
         ucTxBuf[ i ] = ( uint8_t ) rand();
-        cMsg[ lLoop++ ] = ',';
-        uint8_t upp = ucTxBuf[ i ] >> 4, low = ucTxBuf[ i ] & 0xF;
-        cMsg[ lLoop++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ lLoop++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
     }
+
+    prvAppendToMessage( &msgOffset, ucTxBuf, sizeof( ucTxBuf ) );
 
     /* If unit test and assisted test have different spi slave, make sure select slave function in
      * ll hal is defined and select the slave for assisted slave. */
@@ -877,11 +764,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncAssisted )
         #endif
     }
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -908,34 +794,27 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncAssisted )
         TEST_ASSERT_EQUAL( 4, xBytesTx );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* restore slave select */
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
     if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
     {
         #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
-            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
             TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
         #endif
     }
 
-    /* Append read bytes to string. */
-    for( i = 0, len = sizeof( ucRxBuf ); i < len; i++ )
-    {
-        cMsg[ lLoop++ ] = ',';
-        uint8_t upp = ucRxBuf[ i ] >> 4, low = ucRxBuf[ i ] & 0xF;
-        cMsg[ lLoop++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ lLoop++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
-    }
-
-    TEST_IGNORE_MESSAGE( cMsg );
+    prvAppendToMessage( &msgOffset, ucRxBuf, sizeof( ucRxBuf ) );
+    prvOutputMessage();
 }
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -951,11 +830,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsync )
     uint8_t ucTxBuf[ 4 ] = { 0x00, 0x02, 0x04, 0x06 };
     int32_t lLoop = 0;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -988,11 +866,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsync )
         }
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1011,19 +889,18 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncAssisted )
     uint8_t ucTxBuf[ 8 ] = { 0 };
     char cMsg[ 50 ] = { 0 };
     int32_t lLoop = 0;
-    int i = 0, len = 0;
+    size_t i = 0;
+    size_t msgOffset = 0;
 
     srand( xTaskGetTickCount() );
 
-    /* Generate random tx bytes and load them to a string to print later. */
-    for( i = 0, len = sizeof( ucTxBuf ); i < len; i++ )
+    /* Generate random tx bytes. */
+    for( ; i < sizeof( ucTxBuf ); i++ )
     {
         ucTxBuf[ i ] = ( uint8_t ) rand();
-        cMsg[ lLoop++ ] = ',';
-        uint8_t upp = ucTxBuf[ i ] >> 4, low = ucTxBuf[ i ] & 0xF;
-        cMsg[ lLoop++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ lLoop++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
     }
+
+    prvAppendToMessage( &msgOffset, ucTxBuf, sizeof( ucTxBuf ) );
 
     /* If unit test and assisted test have different spi slave, make sure select slave function in
      * ll hal is defined and select the slave for assisted slave. */
@@ -1037,11 +914,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncAssisted )
         #endif
     }
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /* Save the original configuration for later restore. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -1068,35 +944,117 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncAssisted )
         TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* restore slave select */
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
+    if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
+    {
+        #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
+            TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+        #endif
+    }
+
+    prvAppendToMessage( &msgOffset, ucRxBuf, sizeof( ucRxBuf ) );
+    prvOutputMessage();
+}
+
+/**
+ * @brief Assisted Test Function to test spi write async
+ *
+ */
+TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsyncAssisted )
+{
+    IotSPIHandle_t xSPIHandle;
+    IotSPIMasterConfig_t xOrigConfig, xTestConfig;
+    int32_t lRetVal;
+    uint8_t ucTxBuf[ 16 ] = { 0 };
+    char cMsg[ 50 ] = { 0 };
+    size_t xBytesTx;
+    size_t i = 0;
+    size_t msgOffset = 0;
+
+    srand( xTaskGetTickCount() );
+
+    /* Generate random tx bytes. */
+    for( ; i < sizeof( ucTxBuf ); i++ )
+    {
+        ucTxBuf[ i ] = ( uint8_t ) rand();
+    }
+
+    prvAppendToMessage( &msgOffset, ucTxBuf, sizeof( ucTxBuf ) );
+
+    /* If unit test and assisted test have different spi slave, make sure select slave function in
+     * ll hal is defined and select the slave for assisted slave. */
     if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
     {
         #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
             lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ulAssistedTestIotSpiSlave );
             TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+        #else
+            TEST_ASSERT_MESSAGE( 0, "Assisted test has a different salve, but slave select is not supported." );
         #endif
     }
 
-    /* Append read bytes to string. */
-    for( i = 0, len = sizeof( ucRxBuf ); i < len; i++ )
+    xSPIHandle = iot_spi_open( ulAssistedTestIotSpiInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
+
+    /* Save the original configuration for later restore. */
+    lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
+    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+
+    if( TEST_PROTECT() )
     {
-        cMsg[ lLoop++ ] = ',';
-        uint8_t upp = ucRxBuf[ i ] >> 4, low = ucRxBuf[ i ] & 0xF;
-        cMsg[ lLoop++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
-        cMsg[ lLoop++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
+        /* configure bus */
+        xTestConfig.ulFreq = ultestIotSPIFrequency;
+        xTestConfig.eMode = xtestIotSPIDefaultConfigMode;
+        xTestConfig.eSetBitOrder = xtestIotSPIDefaultconfigBitOrder;
+        xTestConfig.ucDummyValue = ultestIotSPIDummyValue;
+
+        lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xTestConfig );
+        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+
+        /* Set a callback for async call */
+        iot_spi_set_callback( xSPIHandle, prvSpiAsyncCallback, NULL );
+
+        /* Make async write call */
+        lRetVal = iot_spi_write_async( xSPIHandle, ucTxBuf, sizeof( ucTxBuf ) );
+        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+
+        /*Wait for the callback. */
+        lRetVal = xSemaphoreTake( xtestIotSPISemaphore, testIotSPI_DEFAULT_SEMAPHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+        lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetTxNoOfbytes, &xBytesTx );
+        TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( xBytesTx, 4 );
     }
 
-    TEST_IGNORE_MESSAGE( cMsg );
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
+    lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
+    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+
+    lRetVal = iot_spi_close( xSPIHandle );
+    TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+
+    /* Restore the original selected slave device, in order to reset to the original state before this test. */
+    if( ulAssistedTestIotSpiSlave != ultestIotSpiSlave )
+    {
+        #ifdef IOT_TEST_COMMON_IO_SPI_SLAVE_SELECT_SUPPORTED
+            lRetVal = iot_spi_select_slave( ulAssistedTestIotSpiInstance, ultestIotSpiSlave );
+            TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
+        #endif
+    }
+
+    prvOutputMessage();
 }
-/*-----------------------------------------------------------*/
 
 /**
  * @brief Test Function to test spi cancel with nothing to cancel
@@ -1107,7 +1065,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelFail )
     IotSPIHandle_t xSPIHandle;
     int32_t lRetVal;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1121,7 +1078,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelFail )
         }
     }
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1140,11 +1096,10 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelSuccess )
     uint8_t ucTxBuf[ 4 ] = { 0x00, 0x02, 0x04, 0x06 };
     BaseType_t xCallbackReturn;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
-    /* save original configuration */
+    /** Save the original configuration for later restore. * / */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
@@ -1175,11 +1130,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelSuccess )
         TEST_ASSERT_EQUAL( pdFALSE, xCallbackReturn );
     }
 
-    /* restore original configuration */
+    /* Restore the original configuration saved in the beginning of this test,
+     * in order to reset to the original state before this test. */
     lRetVal = iot_spi_ioctl( xSPIHandle, eSPISetMasterConfig, &xOrigConfig );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1219,11 +1174,9 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CloseFuzzing )
     IotSPIHandle_t xSPIHandle;
     int32_t lRetVal;
 
-    /* Close with NULL handle */
     lRetVal = iot_spi_close( NULL );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1250,7 +1203,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_IoctlFuzzing )
     IotSPIIoctlRequest_t xRequest;
     int32_t lRetVal;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1299,7 +1251,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_IoctlFuzzing )
         TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
     }
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1315,7 +1266,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncFuzzing )
     int32_t lRetVal;
     uint8_t ucBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1328,7 +1278,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncFuzzing )
     lRetVal = iot_spi_read_sync( xSPIHandle, ucBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1344,7 +1293,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncFuzzing )
     int32_t lRetVal;
     uint8_t ucBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1357,7 +1305,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncFuzzing )
     lRetVal = iot_spi_read_async( xSPIHandle, ucBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1373,7 +1320,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncFuzzing )
     int32_t lRetVal;
     uint8_t ucBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1386,7 +1332,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncFuzzing )
     lRetVal = iot_spi_write_sync( xSPIHandle, ucBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1402,7 +1347,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsyncFuzzing )
     int32_t lRetVal;
     uint8_t ucBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1415,7 +1359,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsyncFuzzing )
     lRetVal = iot_spi_write_async( xSPIHandle, ucBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1432,7 +1375,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncFuzzing )
     uint8_t ucRxBuffer[ SPI_BUFFER_SIZE ];
     uint8_t ucTxBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1448,7 +1390,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncFuzzing )
     lRetVal = iot_spi_transfer_sync( xSPIHandle, ucRxBuffer, ucTxBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1465,7 +1406,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncFuzzing )
     uint8_t ucRxBuffer[ SPI_BUFFER_SIZE ];
     uint8_t ucTxBuffer[ SPI_BUFFER_SIZE ];
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1481,7 +1421,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferAsyncFuzzing )
     lRetVal = iot_spi_transfer_async( xSPIHandle, ucRxBuffer, ucTxBuffer, 0 );
     TEST_ASSERT_EQUAL( IOT_SPI_INVALID_VALUE, lRetVal );
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
@@ -1496,7 +1435,6 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelFuzzing )
     IotSPIHandle_t xSPIHandle;
     int32_t lRetVal;
 
-    /* Open SPI handle */
     xSPIHandle = iot_spi_open( ultestIotSpiInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xSPIHandle );
 
@@ -1515,8 +1453,34 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_CancelFuzzing )
         TEST_ASSERT_EQUAL( IOT_SPI_NOTHING_TO_CANCEL, lRetVal );
     }
 
-    /* Close SPI handle */
     lRetVal = iot_spi_close( xSPIHandle );
     TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
 }
 /*-----------------------------------------------------------*/
+
+
+
+/*-----------------------------------------------------------*/
+
+static void prvAppendToMessage( size_t * pOffset,
+                                uint8_t * pBuffer,
+                                size_t bufferLen )
+{
+    size_t i = 0;
+    size_t offset = *pOffset;
+
+    for( ; i < bufferLen && offset + 2 < _MESSAGE_LENGTH; i++ )
+    {
+        _cMsg[ offset++ ] = ',';
+        uint8_t upp = pBuffer[ i ] >> 4, low = pBuffer[ i ] & 0xF;
+        _cMsg[ offset++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
+        _cMsg[ offset++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
+    }
+
+    *pOffset = offset;
+}
+
+static void prvOutputMessage()
+{
+    TEST_IGNORE_MESSAGE( _cMsg );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Address comments in this PR: https://github.com/aws/amazon-freertos/pull/1682
- refactored SPI tests code by putting the code of constructing assisted test message into one helper function
- minor update of UART data type in the comment
- formatting the iot_uart.h

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.