### PR TITLE
Cover different types of carriage return and modify the method to get…

### DIFF
--- a/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_adc_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/adc/test_iot_adc_test.py
@@ -24,18 +24,18 @@
 # http://www.FreeRTOS.org
 
 
-
-
 import serial
 import csv
 from time import sleep
 import argparse
 import os, sys
-scriptdir = os.path.abspath(sys.path[0])
+
+scriptdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(scriptdir)
-print("Script Dir: %s" % scriptdir)
-print("Parent Dir: %s" % parentdir)
-sys.path.insert(0, parentdir)
+if parentdir not in sys.path:
+    print("Script Dir: %s" % scriptdir)
+    print("Parent Dir: %s" % parentdir)
+    sys.path.append(parentdir)
 from test_iot_test_template import test_template
 
 
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     rpi_login = args.login_name[0]
     rpi_pwd = args.password[0]
 
-    with open('test_result.csv', 'w', newline='') as csvfile:
+    with open(scriptdir + '/test_result.csv', 'w', newline='') as csvfile:
         field_name = ['test name', 'test result']
         writer = csv.DictWriter(csvfile, fieldnames=field_name)
         writer.writeheader()

--- a/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_runonPI_gpio.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/gpio/test_iot_runonPI_gpio.sh
@@ -1,23 +1,24 @@
 #! /bin/bash
-# Amazon FreeRTOS V1.2.3
+
+# Amazon FreeRTOS Common IO V0.1.0
 # Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 # http://aws.amazon.com/freertos
 # http://www.FreeRTOS.org
@@ -42,7 +43,7 @@ elif [ "$1" == "-w" ]; then
     sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "python /home/pi/Tests/test_iot_gpio_rp3.py -i $2 > /home/pi/Tests/gpio_rpi_res.txt"
 
     #Copy the GPIO pin status to host for validation
-    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/gpio_rpi_res.txt .
+    sshpass -p ${PASSWD} scp ${LOGINID}@${IP}:/home/pi/Tests/gpio_rpi_res.txt ${DIR}
 
 elif [ "$1" == "-r" ]; then
     #Open a SSH connection to RP3 and run the test_iot_gpio_rp3.py to set the GPIO pin output

--- a/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_pwm_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/pwm/test_iot_pwm_test.py
@@ -24,7 +24,6 @@
 # http://www.FreeRTOS.org
 
 
-
 import serial
 import csv
 import threading
@@ -33,12 +32,14 @@ import sys
 import math
 import os
 import argparse
+import re
 
-scriptdir = os.path.abspath(sys.path[0])
+scriptdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(scriptdir)
-print("Script Dir: %s" % scriptdir)
-print("Parent Dir: %s" % parentdir)
-sys.path.insert(0, parentdir)
+if parentdir not in sys.path:
+    print("Script Dir: %s" % scriptdir)
+    print("Parent Dir: %s" % parentdir)
+    sys.path.append(parentdir)
 from test_iot_test_template import test_template
 import socket
 
@@ -103,9 +104,9 @@ class TestPwmAssisted(test_template):
         # wait the script on rpi to finish.
         t_shell.join()
         s.close()
-        res = str(self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored \n\r'])))
+        res = self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored '])).decode('utf-8')
 
-        if res.find('PASS\\n') == -1:
+        if re.sub('\r', '', res).find('PASS\n') == -1:
             print(sys._getframe().f_code.co_name, ": device under test pwm capture failed")
             return 'Fail'
 
@@ -150,7 +151,7 @@ if __name__ == "__main__":
     rpi_login = args.login_name[0]
     rpi_pwd = args.password[0]
 
-    with open('test_result.csv', 'w', newline='') as csvfile:
+    with open(scriptdir + '/test_result.csv', 'w', newline='') as csvfile:
         field_name = ['test name', 'test result']
         writer = csv.DictWriter(csvfile, fieldnames=field_name)
         writer.writeheader()

--- a/libraries/abstractions/common_io/test/test_scripts/test_iot_assisted_tests.py
+++ b/libraries/abstractions/common_io/test/test_scripts/test_iot_assisted_tests.py
@@ -34,14 +34,17 @@ from adc.test_iot_adc_test import TestAdcAssisted
 from tsensor.test_iot_tsensor_test import TestTsensorAssisted
 from uart.test_iot_uart_test import TestUartAssisted
 from spi_master.test_iot_spi_master_test import TestSPIMasterAssisted
-import os
+import os, sys
 
-test_class_list = [(TestGpioAssisted, "./gpio"),
-                   (TestPwmAssisted, "./pwm"),
-                   (TestAdcAssisted, "./adc"),
-                   (TestTsensorAssisted, "./tsensor"),
-                   (TestUartAssisted, "./uart"),
-                   (TestSPIMasterAssisted, "./spi_master")
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+parentdir = os.path.dirname(scriptdir)
+
+test_class_list = [(TestGpioAssisted, "gpio"),
+                   (TestPwmAssisted, "pwm"),
+                   (TestAdcAssisted, "adc"),
+                   (TestTsensorAssisted, "tsensor"),
+                   (TestUartAssisted, "uart"),
+                   (TestSPIMasterAssisted, "spi_master")
 ]
 
 if __name__ == "__main__":
@@ -64,14 +67,15 @@ if __name__ == "__main__":
     rpi_login = args.login_name[0]
     rpi_pwd = args.password[0]
 
-    with open('test_result.csv', 'w', newline='') as csvfile:
+    with open(scriptdir+'/test_result.csv', 'w', newline='') as csvfile:
         field_name = ['test name', 'test result']
         writer = csv.DictWriter(csvfile, fieldnames=field_name)
         writer.writeheader()
-        root_dir = os.getcwd()
+        root_dir = scriptdir
+        print(scriptdir)
         for i in range(0, len(test_class_list)):
             print(test_class_list[i][0].__name__)
-            os.chdir(test_class_list[i][1])
+            os.chdir(scriptdir+'/'+test_class_list[i][1])
             test_obj = test_class_list[i][0](serial_port, rpi_ip, rpi_login, rpi_pwd, writer)
             test_obj.auto_run()
             os.chdir(root_dir)

--- a/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_tsensor_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/tsensor/test_iot_tsensor_test.py
@@ -28,11 +28,12 @@ import csv
 import os, sys
 import argparse
 
-scriptdir = os.path.abspath(sys.path[0])
+scriptdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(scriptdir)
-print("Script Dir: %s" % scriptdir)
-print("Parent Dir: %s" % parentdir)
-sys.path.insert(0, parentdir)
+if parentdir not in sys.path:
+    print("Script Dir: %s" % scriptdir)
+    print("Parent Dir: %s" % parentdir)
+    sys.path.append(parentdir)
 from test_iot_test_template import test_template
 
 
@@ -72,11 +73,11 @@ class TestTsensorAssisted(test_template):
 
             self._serial.write('\r\n'.encode('utf-8'))
 
-            res = str(self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored \n\r'])))
+            res = self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored '])).decode('utf-8')
             # print(res)
             temp = []
             # Extract temperature readings from all of on board sensors.
-            for x in res.split('\\n\\r'):
+            for x in res.split('\n'):
                 # Look for the line with ADC reading.
                 if x.find('TEST(TEST_IOT_TSENSOR, AFQP_IotTsensorTemp)') != -1:
                     for s in x.split():
@@ -138,7 +139,7 @@ if __name__ == "__main__":
     rpi_login = args.login_name[0]
     rpi_pwd = args.password[0]
 
-    with open('test_result.csv', 'w', newline='') as csvfile:
+    with open(scriptdir + '/test_result.csv', 'w', newline='') as csvfile:
         field_name = ['test name', 'test result']
         writer = csv.DictWriter(csvfile, fieldnames=field_name)
         writer.writeheader()


### PR DESCRIPTION
… absolute path



<!--- Title -->

Description
-----------
[Problem]
The carriage return style ('\r\n') some vendor used confuses current scripts. The keywords used as criteria could be parsed correctly.
The way to get absolute path can not work with the top script test_iot_assisted_tests.py.

[Solution]
Remove '\r' from the string read from serial. And take away '\r' as part of parsing keyword.
Use os.path.dirname(os.path.realpath(__file__)) instead of os.path.abspath(sys.path[0]) to get abolute path. Because sys.path[0] may not be the path of current script if the file is imported.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.