### PR TITLE
Fix SegFault: ss_ctx_t context is shared and sent to a user callback,…

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -116,13 +116,16 @@ static int8_t sockets_allocated = socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS;
 #define TICK_TO_US( _t_ )    ( ( _t_ ) * 1000 / configTICK_RATE_HZ * 1000 )
 
 /*-----------------------------------------------------------*/
+
 /*
  * @brief Sockets close
  */
-static void prvSocketsClose( ss_ctx_t *ctx )
+static void prvSocketsClose( ss_ctx_t * ctx )
 {
     uint32_t ulProtocol;
+
     sockets_allocated++;
+
     /* Clean-up application protocol array. */
     if( NULL != ctx->ppcAlpnProtocols )
     {
@@ -161,16 +164,18 @@ static void prvSocketsClose( ss_ctx_t *ctx )
  * @brief Decrement ctx refcount and call release function if the count is 1 (
  *        last user of the ctx)
  */
-static void prvDecrementRefCount( ss_ctx_t *ctx )
+static void prvDecrementRefCount( ss_ctx_t * ctx )
 {
-    if( Atomic_Decrement_u32( &ctx->ulRefcount) == 1 )
+    if( Atomic_Decrement_u32( &ctx->ulRefcount ) == 1 )
+    {
         prvSocketsClose( ctx );
+    }
 }
 
 /*
  * @brief Increment ctx refcount
  */
-static void prvIncrementRefCount( ss_ctx_t *ctx )
+static void prvIncrementRefCount( ss_ctx_t * ctx )
 {
     Atomic_Increment_u32( &ctx->ulRefcount );
 }
@@ -291,6 +296,7 @@ static void vTaskRxSelect( void * param )
             /*vTaskDelay( 10 ); // delay a little bit to yield time for RX */
         }
     }
+
     prvDecrementRefCount( ctx );
     vTaskDelete( NULL );
 }

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -43,6 +43,8 @@
 
 #include "iot_tls.h"
 
+#include "iot_atomic.h"
+
 #include "FreeRTOSConfig.h"
 
 #include "task.h"
@@ -88,6 +90,7 @@ typedef struct _ss_ctx_t
 
     char ** ppcAlpnProtocols;
     uint32_t ulAlpnProtocolsCount;
+    uint32_t ulRefcount;
 } ss_ctx_t;
 
 /*-----------------------------------------------------------*/
@@ -113,6 +116,64 @@ static int8_t sockets_allocated = socketsconfigDEFAULT_MAX_NUM_SECURE_SOCKETS;
 #define TICK_TO_US( _t_ )    ( ( _t_ ) * 1000 / configTICK_RATE_HZ * 1000 )
 
 /*-----------------------------------------------------------*/
+/*
+ * @brief Sockets close
+ */
+static void prvSocketsClose( ss_ctx_t *ctx )
+{
+    uint32_t ulProtocol;
+    sockets_allocated++;
+    /* Clean-up application protocol array. */
+    if( NULL != ctx->ppcAlpnProtocols )
+    {
+        for( ulProtocol = 0;
+             ulProtocol < ctx->ulAlpnProtocolsCount;
+             ulProtocol++ )
+        {
+            if( NULL != ctx->ppcAlpnProtocols[ ulProtocol ] )
+            {
+                vPortFree( ctx->ppcAlpnProtocols[ ulProtocol ] );
+            }
+        }
+
+        vPortFree( ctx->ppcAlpnProtocols );
+    }
+
+    if( true == ctx->enforce_tls )
+    {
+        TLS_Cleanup( ctx->tls_ctx );
+    }
+
+    if( ctx->server_cert )
+    {
+        vPortFree( ctx->server_cert );
+    }
+
+    if( ctx->destination )
+    {
+        vPortFree( ctx->destination );
+    }
+
+    vPortFree( ctx );
+}
+
+/*
+ * @brief Decrement ctx refcount and call release function if the count is 1(
+ *        last user of the ctx)
+ */
+static void prvDecrementRefCount( ss_ctx_t *ctx )
+{
+    if( Atomic_Decrement_u32( &ctx->ulRefcount) == 1 )
+        prvSocketsClose( ctx );
+}
+
+/*
+ * @brief Increment ctx refcount
+ */
+static void prvIncrementRefCount( ss_ctx_t *ctx )
+{
+    Atomic_Increment_u32( &ctx->ulRefcount );
+}
 
 /*
  * @brief Network send callback.
@@ -209,7 +270,7 @@ static void vTaskRxSelect( void * param )
         if( ctx->state == SST_RX_CLOSING )
         {
             ctx->state = SST_RX_CLOSED;
-            vTaskDelete( NULL );
+            break;
         }
 
         if( lwip_select( s + 1, &read_fds, &write_fds, &err_fds, NULL ) == -1 )
@@ -220,7 +281,7 @@ static void vTaskRxSelect( void * param )
             /*ctx->rx_callback = NULL; */
 
             /*vTaskDelete( rx_handle ); */
-            vTaskDelete( NULL );
+            break;
         }
 
         if( FD_ISSET( s, &read_fds ) )
@@ -230,6 +291,8 @@ static void vTaskRxSelect( void * param )
             /*vTaskDelay( 10 ); // delay a little bit to yield time for RX */
         }
     }
+    prvDecrementRefCount( ctx );
+    vTaskDelete( NULL );
 }
 
 /*-----------------------------------------------------------*/
@@ -243,6 +306,7 @@ static void prvRxSelectSet( ss_ctx_t * ctx,
 
     ctx->rx_callback = ( void ( * )( Socket_t ) )pvOptionValue;
 
+    prvIncrementRefCount( ctx );
     xReturned = xTaskCreate( vTaskRxSelect, /* pvTaskCode */
                              "rxs",         /* pcName */
                              xStackDepth,   /* usStackDepth */
@@ -294,6 +358,7 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
 
         if( ctx->ip_socket >= 0 )
         {
+            ctx->ulRefcount = 1;
             sockets_allocated--;
             return ( Socket_t ) ctx;
         }
@@ -525,7 +590,6 @@ int32_t SOCKETS_Close( Socket_t xSocket )
 {
     ss_ctx_t * ctx;
 
-    uint32_t ulProtocol;
 
     if( SOCKETS_INVALID_SOCKET == xSocket )
     {
@@ -533,58 +597,15 @@ int32_t SOCKETS_Close( Socket_t xSocket )
     }
 
     ctx = ( ss_ctx_t * ) xSocket;
+    ctx->state = SST_RX_CLOSING;
 
-    /* Clean-up application protocol array. */
-    if( NULL != ctx->ppcAlpnProtocols )
-    {
-        for( ulProtocol = 0;
-             ulProtocol < ctx->ulAlpnProtocolsCount;
-             ulProtocol++ )
-        {
-            if( NULL != ctx->ppcAlpnProtocols[ ulProtocol ] )
-            {
-                vPortFree( ctx->ppcAlpnProtocols[ ulProtocol ] );
-            }
-        }
+    lwip_close( ctx->ip_socket );
 
-        vPortFree( ctx->ppcAlpnProtocols );
-    }
-
-    if( true == ctx->enforce_tls )
-    {
-        TLS_Cleanup( ctx->tls_ctx );
-    }
-
-    if( 0 <= ctx->ip_socket )
-    {
-        int cnt = 0;
-        ctx->state = SST_RX_CLOSING;
-
-        while( ( ctx->state != SST_RX_CLOSED ) && ( cnt < 30 ) )
-        {
-            cnt++;
-            vTaskDelay( 10 );
-        }
-
-        lwip_close( ctx->ip_socket );
-
-        sockets_allocated++;
-    }
-
-    if( ctx->server_cert )
-    {
-        vPortFree( ctx->server_cert );
-    }
-
-    if( ctx->destination )
-    {
-        vPortFree( ctx->destination );
-    }
-
-    vPortFree( ctx );
+    prvDecrementRefCount( ctx );
 
     return SOCKETS_ERROR_NONE;
 }
+
 
 /*-----------------------------------------------------------*/
 

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -280,12 +280,6 @@ static void vTaskRxSelect( void * param )
 
         if( lwip_select( s + 1, &read_fds, &write_fds, &err_fds, NULL ) == -1 )
         {
-            /*TaskHandle_t rx_handle = ctx->rx_handle; */
-
-            /*ctx->rx_handle   = NULL; */
-            /*ctx->rx_callback = NULL; */
-
-            /*vTaskDelete( rx_handle ); */
             break;
         }
 
@@ -293,7 +287,6 @@ static void vTaskRxSelect( void * param )
         {
             configASSERT( ctx->rx_callback );
             ctx->rx_callback( ( Socket_t ) ctx );
-            /*vTaskDelay( 10 ); // delay a little bit to yield time for RX */
         }
     }
 

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -158,7 +158,7 @@ static void prvSocketsClose( ss_ctx_t *ctx )
 }
 
 /*
- * @brief Decrement ctx refcount and call release function if the count is 1(
+ * @brief Decrement ctx refcount and call release function if the count is 1 (
  *        last user of the ctx)
  */
 static void prvDecrementRefCount( ss_ctx_t *ctx )


### PR DESCRIPTION
… in the meantime if the socket is closed and subsequently freed, the callback task still holds a reference that was previously deleted

Description
-----------
The changes consists of adding a reference count to the number of users of the context, and is only freed once the count reaches zero

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.