### PR TITLE
Fix advertising slave connection interval in Nordic

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
@@ -870,6 +870,10 @@ ret_code_t prvBTAdvDataConvert( ble_advdata_t * xAdvData,
             IotLogError( "Invalid params in advertisement/scan response: either min connection interval or max connection interval is zero" );
             xErrCode = NRF_ERROR_INVALID_PARAM;
         }
+        else
+        {
+            /* Do nothing. User have set min interval and max interval to 0 to not include this in advertisment. */
+        }
 
         /* Set manufacturer specific data only when its length is atleast equal to iot_ble_hal_gapADVERTISING_COMPANY_ID_SIZE */
         if( ( pcManufacturerData != NULL ) && ( usManufacturerLen >= iot_ble_hal_gapADVERTISING_COMPANY_ID_SIZE ) )

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gap.c
@@ -850,8 +850,26 @@ ret_code_t prvBTAdvDataConvert( ble_advdata_t * xAdvData,
     {
         /* The first two UUID go to the initial advertisement packet */
         xAdvData->uuids_complete = xCompleteUUIDS;
-        xAdvData->p_slave_conn_int->max_conn_interval = pxParams->ulMaxInterval;
-        xAdvData->p_slave_conn_int->min_conn_interval = pxParams->ulMinInterval;
+
+        if( ( pxParams->ulMaxInterval != 0 ) && ( pxParams->ulMinInterval != 0 ) )
+        {
+            xAdvData->p_slave_conn_int = IotBle_Malloc( sizeof( ble_advdata_conn_int_t ) );
+
+            if( xAdvData->p_slave_conn_int != NULL )
+            {
+                xAdvData->p_slave_conn_int->max_conn_interval = pxParams->ulMaxInterval;
+                xAdvData->p_slave_conn_int->min_conn_interval = pxParams->ulMinInterval;
+            }
+            else
+            {
+                xErrCode = NRF_ERROR_NO_MEM;
+            }
+        }
+        else if( ( pxParams->ulMinInterval != 0 ) || ( pxParams->ulMaxInterval != 0 ) )
+        {
+            IotLogError( "Invalid params in advertisement/scan response: either min connection interval or max connection interval is zero" );
+            xErrCode = NRF_ERROR_INVALID_PARAM;
+        }
 
         /* Set manufacturer specific data only when its length is atleast equal to iot_ble_hal_gapADVERTISING_COMPANY_ID_SIZE */
         if( ( pcManufacturerData != NULL ) && ( usManufacturerLen >= iot_ble_hal_gapADVERTISING_COMPANY_ID_SIZE ) )


### PR DESCRIPTION
Fix advertising slave connection interval in Nordic

Description
-----------
Nordic port was not including slave connection interval range in advertisement.
PR fixes this.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.