### PR TITLE
CBMC QueuePeek harness clean up.

### DIFF
--- a/tools/cbmc/proofs/CBMCStubLibrary/tasksStubs.c
+++ b/tools/cbmc/proofs/CBMCStubLibrary/tasksStubs.c
@@ -34,14 +34,18 @@ void vInitTaskCheckForTimeOut(BaseType_t maxCounter, BaseType_t maxCounter_limit
 /* This is mostly called in a loop. For CBMC, we have to bound the loop
    to a max limits of calls. Therefore this Stub models a nondet timeout in
    max TASK_STUB_COUNTER_LIMIT iterations.*/
+uint8_t time;
+
 BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) {
-	++xCounter;
-	if(xCounter == xCounterLimit)
-	{
-		return pdTRUE;
-	}
-	else
-	{
-		return nondet_basetype();
-	}
+	
+	(void *) pxTimeOut;
+	(void *) pxTicksToWait;
+
+	uint8_t increment;
+
+	__CPROVER_assume(increment > 0 && increment < 10);
+
+	time += increment;
+
+	return time > 2 ? pdTRUE : pdFALSE;
 }

--- a/tools/cbmc/proofs/Queue/QueuePeek/QueuePeek_harness.c
+++ b/tools/cbmc/proofs/Queue/QueuePeek/QueuePeek_harness.c
@@ -43,7 +43,6 @@
 
 QueueHandle_t xQueue;
 
-
 /* This method is called to initialize pxTimeOut.
    Setting up the data structure is not interesting for the proof,
    but the harness uses it to model a release
@@ -54,26 +53,17 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ){
 
 void harness(){
 	xQueue = xUnconstrainedQueueBoundedItemSize(10);
+	__CPROVER_assume( xQueue );
 
-	//Initialise the tasksStubs
-	vInitTaskCheckForTimeOut(0, QUEUE_PEEK_BOUND - 1);
+	void *pvItemToQueue = pvPortMalloc( xQueue->uxItemSize );
+	__CPROVER_assume( pvItemToQueue || xQueue->uxItemSize == 0 );
 
 	TickType_t xTicksToWait;
-	if(xState == taskSCHEDULER_SUSPENDED){
-		xTicksToWait = 0;
-	}
+	__CPROVER_assume( xState != taskSCHEDULER_SUSPENDED || xTicksToWait == 0 );
+	
+	/* This is for loop unwinding. */
+	__CPROVER_assume( xQueue->cTxLock < LOCK_BOUND - 1 );
+	__CPROVER_assume( xQueue->cRxLock < LOCK_BOUND - 1 );
 
-	if(xQueue){
-		__CPROVER_assume(xQueue->cTxLock < LOCK_BOUND - 1);
-		__CPROVER_assume(xQueue->cRxLock < LOCK_BOUND - 1);
-
-		void *pvItemToQueue = pvPortMalloc(xQueue->uxItemSize);
-
-		/* In case malloc fails as this is otherwise an invariant violation. */
-		if(!pvItemToQueue){
-			xQueue->uxItemSize = 0;
-		}
-
-		xQueuePeek( xQueue, pvItemToQueue, xTicksToWait );
-	}
+	xQueuePeek( xQueue, pvItemToQueue, xTicksToWait );
 }


### PR DESCRIPTION
Post CBMC workshop

Description
-----------
Clean up from CBMC as-is. 
- Cleaning up QueuePeek harness.
- Cleaning up xTaskCheckForTimeOut stub.

Queue initialization stub is not in this PR, since that one impacts more than one harness. Makefile template change is also not in this PR. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.