### PR TITLE
Update efuse test to make sure iot_efuse_open() only allow 1 handle p…

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_efuse.c
+++ b/libraries/abstractions/common_io/test/test_iot_efuse.c
@@ -110,16 +110,16 @@ TEST( TEST_IOT_EFUSE, AFQP_IotEfuseOpenClose )
     xEfuseHandle = iot_efuse_open();
     TEST_ASSERT_NOT_EQUAL( NULL, xEfuseHandle );
 
-    /* Open again should get the same handle. */
+    /* Open again should get NULL. */
     xEfuseHandle2 = iot_efuse_open();
-    TEST_ASSERT_EQUAL( xEfuseHandle, xEfuseHandle2 );
+    TEST_ASSERT_EQUAL( NULL, xEfuseHandle2 );
 
     /* Close efuse to deinit hardware. */
     lRetVal = iot_efuse_close( xEfuseHandle );
     TEST_ASSERT_EQUAL( IOT_EFUSE_SUCCESS, lRetVal);
 
     /* Close again should get IOT_EFUSE_INVALID_VALUE */
-    lRetVal = iot_efuse_close( xEfuseHandle2 );
+    lRetVal = iot_efuse_close( xEfuseHandle );
     TEST_ASSERT_EQUAL( IOT_EFUSE_INVALID_VALUE, lRetVal);
 }
 


### PR DESCRIPTION
…er HW instance at any given time.

<!--- Title -->
Update efuse test to make sure iot_efuse_open() only allow 1 handle per HW instance at any given time.

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.