### PR TITLE
Synopsys ARC port. Add basic support to Synopsys ARC processors and boards

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/ReadMe.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/ReadMe.txt
@@ -1,0 +1,3 @@
+Update pack_struct_start.h and pack_struct_end.h for your architecure.
+These files define the specifiers needed by your compiler to properly pack struct data 
+need by FreeRTOS+TCP.

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/pack_struct_end.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/pack_struct_end.h
@@ -1,0 +1,32 @@
+/*
+FreeRTOS+TCP V2.0.11
+Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ http://aws.amazon.com/freertos
+ http://www.FreeRTOS.org
+*/
+
+/*****************************************************************************
+ *
+ * See the following URL for an explanation of this file:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+ *
+ *****************************************************************************/
+__attribute__( (packed) );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/pack_struct_start.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare/pack_struct_start.h
@@ -1,0 +1,33 @@
+/*
+FreeRTOS+TCP V2.0.11
+Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ http://aws.amazon.com/freertos
+ http://www.FreeRTOS.org
+*/
+
+/*****************************************************************************
+ *
+ * See the following URL for an explanation of this file:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+ *
+ *****************************************************************************/
+
+/* Nothing to do here. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/embARC/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/embARC/NetworkInterface.c
@@ -1,0 +1,63 @@
+/*
+FreeRTOS+TCP V2.0.11
+Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ http://aws.amazon.com/freertos
+ http://www.FreeRTOS.org
+*/
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
+driver will filter incoming packets and only pass the stack those packets it
+considers need processing. */
+#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+#else
+#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+#endif
+
+BaseType_t xNetworkInterfaceInitialise( void )
+{
+    /* FIX ME. */
+    return pdFALSE;
+}
+
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer, BaseType_t xReleaseAfterSend )
+{
+    /* FIX ME. */
+    return pdFALSE;
+}
+
+void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+{
+    /* FIX ME. */
+}
+
+BaseType_t xGetPhyLinkStatus( void )
+{
+    /* FIX ME. */
+    return pdFALSE;
+}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/embARC/ReadMe.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/embARC/ReadMe.txt
@@ -1,0 +1,1 @@
+Update NetworkInterface.c and include other files needed by FreeRTOS+TCP here.

--- a/tools/cmake/toolchains/synopsys-gcc.cmake
+++ b/tools/cmake/toolchains/synopsys-gcc.cmake
@@ -1,0 +1,26 @@
+include("${CMAKE_CURRENT_LIST_DIR}/find_compiler.cmake")
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+# Find Metaware for SYNOPSYS-ARC
+afr_find_compiler(AFR_COMPILER_CC arc-elf32-gcc)
+afr_find_compiler(AFR_COMPILER_CXX arc-elf32-g++)
+afr_find_compiler(AFR_COMPILER_ASM arc-elf32-gcc)
+#arc-elf32-gcc will call arc-elf32-as automatically
+
+# Specify the cross compiler.
+set(CMAKE_C_COMPILER ${AFR_COMPILER_CC} CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER ${AFR_COMPILER_CXX} CACHE FILEPATH "C++ compiler")
+set(CMAKE_ASM_COMPILER ${AFR_COMPILER_ASM} CACHE FILEPATH "ASM compiler")
+
+# Disable compiler checks.
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+# Add target system root to cmake find path.
+get_filename_component(AFR_COMPILER_DIR "${AFR_COMPILER_CC}" DIRECTORY)
+get_filename_component(CMAKE_FIND_ROOT_PATH "${AFR_COMPILER_DIR}" DIRECTORY)
+
+# Look for includes and libraries only in the target system prefix.
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/tools/cmake/toolchains/synopsys-mw.cmake
+++ b/tools/cmake/toolchains/synopsys-mw.cmake
@@ -1,0 +1,35 @@
+include("${CMAKE_CURRENT_LIST_DIR}/find_compiler.cmake")
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+# Find Metaware for SYNOPSYS-ARC
+afr_find_compiler(AFR_COMPILER_CC ccac)
+afr_find_compiler(AFR_COMPILER_CXX ccac)
+afr_find_compiler(AFR_COMPILER_ASM ccac)
+afr_find_compiler(AFR_COMPILER_LD ccac)
+afr_find_compiler(AFR_COMPILER_AR arac)
+afr_find_compiler(AFR_COMPILER_DMP elfdumpac)
+afr_find_compiler(AFR_COMPILER_NM nmac)
+afr_find_compiler(AFR_COMPILER_OBJCOPY elf2bin)
+
+# Specify the cross compiler.
+set(CMAKE_C_COMPILER ${AFR_COMPILER_CC} CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER ${AFR_COMPILER_CXX} CACHE FILEPATH "C++ compiler")
+set(CMAKE_ASM_COMPILER ${AFR_COMPILER_ASM} CACHE FILEPATH "ASM compiler")
+set(CMAKE_LINKER ${AFR_COMPILER_LD} CACHE FILEPATH "Linker")
+set(CMAKE_AR ${AFR_COMPILER_AR} CACHE FILEPATH "Archiver")
+set(CMAKE_OBJDUMP ${AFR_COMPILER_DMP} CACHE FILEPATH "object dump")
+set(CMAKE_NM ${AFR_COMPILER_NM} CACHE FILEPATH "nm archiver")
+set(CMAKE_OBJCOPY ${AFR_COMPILER_OBJCOPY} CACHE FILEPATH "opject copy")
+
+# Disable compiler checks.
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+# Add target system root to cmake find path.
+get_filename_component(AFR_COMPILER_DIR "${AFR_COMPILER_CC}" DIRECTORY)
+get_filename_component(CMAKE_FIND_ROOT_PATH "${AFR_COMPILER_DIR}" DIRECTORY)
+
+# Look for includes and libraries only in the target system prefix.
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/vendors/synopsys/boards/embARC/0001-arc-add-support-to-nest-exception.patch
+++ b/vendors/synopsys/boards/embARC/0001-arc-add-support-to-nest-exception.patch
@@ -1,0 +1,158 @@
+From 23721a0cf153e5a2b9e975a7586a48ad2184f4fb Mon Sep 17 00:00:00 2001
+From: Yuguo Zou <yuguo.zou@synopsys.com>
+Date: Mon, 20 Jan 2020 10:44:54 +0800
+Subject: [PATCH] arc: add support to nest exception
+
+add a nest count
+add nest check in exception asm code
+
+Signed-off-by: Yuguo Zou <yuguo.zou@synopsys.com>
+---
+ arc/arc_exc_asm.s           | 36 ++++++++++++++++++++++++++++++++++++
+ arc/arc_exception.c         |  9 +++++++++
+ include/arc/arc_exception.h | 13 +++++++++++++
+ 3 files changed, 58 insertions(+)
+
+diff --git a/arc/arc_exc_asm.s b/arc/arc_exc_asm.s
+index 3334c2e..54b4bd6 100644
+--- a/arc/arc_exc_asm.s
++++ b/arc/arc_exc_asm.s
+@@ -71,6 +71,11 @@ exc_entry_cpu:
+ 
+ 	EXCEPTION_PROLOGUE
+ 
++/* exc_nest_count +1 */
++	ld	r0, [exc_nest_count]
++	add	r0, r0, 1
++	st	r0, [exc_nest_count]
++
+ /* find the exception cause */
+ 	lr	r0, [AUX_ECR]
+ 	lsr	r0, r0, 16
+@@ -83,6 +88,11 @@ exc_entry_cpu:
+ 	jl	[r2]
+ exc_return:
+ 
++/* exc_nest_count -1 */
++	ld	r0, [exc_nest_count]
++	sub	r0, r0, 1
++	st	r0, [exc_nest_count]
++
+ 	EXCEPTION_EPILOGUE
+ 	rtie
+ 
+@@ -109,6 +119,13 @@ exc_entry_int:
+ 	INTERRUPT_PROLOGUE
+ 
+ /* critical area */
++/* exc_nest_count is designed to record the nest interrupts */
++	clri
++	ld	r0, [exc_nest_count]
++	add	r0, r0, 1
++	st	r0, [exc_nest_count]
++	seti
++
+ 	lr	r0, [AUX_IRQ_CAUSE]
+ 	mov	r1, exc_int_handler_table
+ /* r2 = _kernel_exc_tbl + irqno *4 */
+@@ -126,6 +143,14 @@ irq_hint_handled:
+ 	mov	r0, sp
+ 	jl	[r2]
+ int_return:
++/* critical area */
++/* exc_nest_count is designed to record the nest interrupts */
++	clri
++	ld	r0, [exc_nest_count]
++	sub	r0, r0, 1
++	st	r0, [exc_nest_count]
++	seti
++
+ 	INTERRUPT_EPILOGUE
+ 	rtie
+ 
+@@ -136,6 +161,11 @@ int_return:
+ exc_entry_firq:
+ 	SAVE_FIQ_EXC_REGS
+ 
++/* firq's priority is the highest */
++	ld	r0, [exc_nest_count]
++	add	r0, r0, 1
++	st	r0, [exc_nest_count]
++
+ 	lr	r0, [AUX_IRQ_CAUSE]
+ 	mov	r1, exc_int_handler_table
+ /* r2 = _kernel_exc_tbl + irqno *4 */
+@@ -153,6 +183,12 @@ firq_hint_handled:
+ 	jl	[r2]
+ 
+ firq_return:
++
++/* exc_nest_count -1 */
++	ld	r0, [exc_nest_count]
++	sub	r0, r0, 1
++	st	r0, [exc_nest_count]
++
+ 	RESTORE_FIQ_EXC_REGS
+ 	rtie
+ 
+diff --git a/arc/arc_exception.c b/arc/arc_exception.c
+index 7292b02..bb79648 100644
+--- a/arc/arc_exception.c
++++ b/arc/arc_exception.c
+@@ -361,6 +361,14 @@ EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL] = {
+ 	[NUM_EXC_CPU ... NUM_EXC_ALL - 1] = int_handler_default
+ };
+ 
++/**
++ * \var exc_nest_count
++ * \brief the counter for exc/int processing, =0 no int/exc
++ * >1 in int/exc processing
++ * @}
++ */
++uint32_t exc_nest_count;
++
+ /**
+  * @endcond
+  */
+@@ -693,6 +701,7 @@ int32_t int_level_config(const uint32_t intno, const uint32_t level)
+  * \brief Get interrupt request mode
+  *
+  * @param intno Interrupt number
++ * @param level 0-level triggered, 1-pulse triggered
+  */
+ int32_t int_level_get(const uint32_t intno)
+ {
+diff --git a/include/arc/arc_exception.h b/include/arc/arc_exception.h
+index 6ffd521..bf61c94 100644
+--- a/include/arc/arc_exception.h
++++ b/include/arc/arc_exception.h
+@@ -208,6 +208,8 @@ typedef struct {
+ #define ARC_INT_EXC_FRAME_T_SIZE      (sizeof(INT_EXC_FRAME_T) / sizeof(uint32_t))
+ #define ARC_CALLEE_FRAME_T_SIZE       (sizeof(CALLEE_FRAME_T) / sizeof(uint32_t))
+ 
++extern uint32_t exc_nest_count;
++
+ /**
+  * @fn void arc_vector_base_write(uint32_t vec_base)
+  * @brief Write exception vector base
+@@ -231,6 +233,17 @@ Inline uint32_t arc_vector_base_read(void)
+ }
+ /** @}*/
+ 
++/**
++ * \brief  sense whether in exc/interrupt processing
++ *
++ * \retval 0	not in exc/interrupt processing
++ * \retval 1	in exc/interrupt processing
++ */
++Inline uint32_t exc_sense(void)
++{
++	return (exc_nest_count > 0U);
++}
++
+ /**
+  * @addtogroup ARC_HAL_EXCEPTION_INTERRUPT
+  * @{
+-- 
+2.15.0.windows.1
+

--- a/vendors/synopsys/boards/embARC/CMakeLists.txt
+++ b/vendors/synopsys/boards/embARC/CMakeLists.txt
@@ -1,0 +1,325 @@
+# These Amazon FreeRTOS related global variables are available to use.
+# AFR_ROOT_DIR                  Amazon FreeRTOS source root.
+# AFR_KERNEL_DIR                FreeRTOS kernel root.
+# AFR_MODULES_DIR               Amazon FreeRTOS modules root.
+# AFR_MODULES_C_SDK_DIR         C-SDK libraries root.
+# AFR_MODULES_FREERTOS_PLUS_DIR FreeRTOS-Plus libraries root.
+# AFR_MODULES_ABSTRACTIONS_DIR  Abstractions layers root.
+# AFR_DEMOS_DIR                 Amazon FreeRTOS demos root.
+# AFR_TESTS_DIR                 Amazon FreeRTOS common tests and framework root.
+# AFR_VENDORS_DIR               vendors content root.
+# AFR_3RDPARTY_DIR              3rdparty libraries root.
+
+# AFR_VENDOR_NAME           Folder name for vendor.
+# AFR_BOARD_NAME            Folder name for this board.
+
+# AFR_TOOLCHAIN             Compiler chosen by the user. Should be one of
+#                           the file names under ${AFR_ROOT_DIR}/tools/cmake/toolchains
+# AFR_IS_TESTING            1 if testing enabled, otherwise, 0.
+
+# You may also use these 2 functions we defined to glob files when needed. However, we recommend
+# to specify your source files explicitly to avoid unexpected behavior unless you're 100% sure.
+# CMake reference link: https://cmake.org/cmake/help/latest/command/file.html#filesystem
+# afr_glob_files(<out_var> [RECURSE] <DIRECTORY> <directory> [<GLOBS> <glob-expressions>...])
+# afr_glob_src(<out_var> [RECURSE] <DIRECTORY> <directory> [<EXTENSIONS> <file-extensions>...])
+
+# If you don't specify GLOBS or EXTENSIONS parameters,
+# afr_glob_files: glob all files including hidden files in the specified directory.
+# afr_glob_src:   glob all files ending with either .c, .h, .s or .asm
+
+# Use RECURSE if you want to recursively search all subdirectories.
+
+# Example usage,
+# afr_glob_src(board_code DIRECTORY "${board_dir}/application_code/${vendor}_code")
+# afr_glob_src(driver_code RECURSE DIRECTORY "${driver_path}")
+# afr_glob_src(headers DIRECTORY "${some_path}" EXTENSIONS h)
+
+set(embARC_src_dir ${AFR_VENDORS_DIR}/${AFR_VENDOR_NAME}/embarc_bsp)
+# relative directory from embarc makefile to embarc folder
+set(embARC_ROOT ../../vendors/synopsys/embarc_bsp)
+set(embARC_BOARD ${AFR_BOARD_NAME})
+
+# default board version and core settings.
+if(${embARC_BOARD} STREQUAL "emsdp")
+    set(embARC_BOARD_VER rev2)
+    set(embARC_CUR_CORE em11d_dfss)
+elseif(${embARC_BOARD} STREQUAL "emsk")
+    set(embARC_BOARD_VER 22)
+    set(embARC_CUR_CORE arcem7d)
+elseif(${embARC_BOARD} STREQUAL "hsdk")
+    set(embARC_BOARD_VER 10)
+    set(embARC_CUR_CORE archs38_c0)
+elseif(${embARC_BOARD} STREQUAL "iotdk")
+    set(embARC_BOARD_VER 10)
+    set(embARC_CUR_CORE arcem9d)
+else()
+    message(FATAL_ERROR "embARC: Please select correct board")
+endif()
+
+# Include IDE specific cmake file.
+if(${AFR_TOOLCHAIN} STREQUAL "synopsys-gcc")
+    set(embARC_TOOLCHAIN gnu)
+    include("${CMAKE_CURRENT_LIST_DIR}/gcc.cmake")
+    message(WARNING "CMake support for Synopsys ARC using GNU is not complete yet.")
+elseif(${AFR_TOOLCHAIN} STREQUAL "synopsys-mw")
+    set(embARC_TOOLCHAIN mw)
+    include("${CMAKE_CURRENT_LIST_DIR}/mw.cmake")
+else()
+    message( FATAL_ERROR "The toolchain ${AFR_TOOLCHAIN} is not supported." )
+endif()
+
+# message("AFR_VENDORS_DIR is ${AFR_VENDORS_DIR}" )
+# message("embARC_src_dir is ${embARC_src_dir}" )
+include(${CMAKE_CURRENT_LIST_DIR}/embARC.cmake)
+# message("embARC_LIB_DIR is ${embARC_LIB_DIR}" )
+# message("embARC_INC_DIR is ${embARC_INC_DIR}" )
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+# Provide metadata for listing on Amazon FreeRTOS console.
+include("${CMAKE_CURRENT_LIST_DIR}/embARC_${AFR_BOARD_NAME}.cmake")
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+# If you support multiple compilers, you can use AFR_TOOLCHAIN to conditionally define the compiler
+# settings. This variable will be set to the file name of CMAKE_TOOLCHAIN_FILE. It might also be a
+# good idea to put your compiler settings to different files and just include them here, e.g.,
+# include(compilers/${AFR_TOOLCHAIN}.cmake)
+
+afr_mcu_port(compiler)
+
+# Compile definitions/macros
+target_compile_definitions(
+    AFR::compiler::mcu_port
+    INTERFACE
+    ${compiler_defined_symbols}
+)
+
+# Compiler flags
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        $<$<COMPILE_LANGUAGE:C>:${c_flags}>
+)
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        $<$<COMPILE_LANGUAGE:CXX>:${cxx_flags}>
+)
+target_compile_options(
+    AFR::compiler::mcu_port
+    INTERFACE
+        $<$<COMPILE_LANGUAGE:ASM>:${assembler_flags}>
+)
+
+# Linker flags
+target_link_options(
+    AFR::compiler::mcu_port
+    INTERFACE ${linker_flags}
+)
+
+# Libraries to link
+target_link_libraries(
+    AFR::compiler::mcu_port
+    INTERFACE
+    ${link_dependent_libs}
+)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS portable layers
+# -------------------------------------------------------------------------------------------------
+# Define portable layer targets with afr_mcu_port(<module_name>). We will create an CMake
+# INTERFACE IMPORTED target called AFR::${module_name}::mcu_port for you. You can use it with
+# standard CMake functions like target_*. To better organize your files, you can define your own
+# targets and use target_link_libraries(AFR::${module_name}::mcu_port INTERFACE <your_targets>)
+# to provide the public interface you want expose.
+
+set(vendor ${AFR_VENDOR_NAME})
+set(board ${AFR_BOARD_NAME})
+
+set(portable_dir "${CMAKE_CURRENT_LIST_DIR}/ports")
+set(board_demos_dir "${CMAKE_CURRENT_LIST_DIR}/aws_demos")
+set(board_tests_dir "${CMAKE_CURRENT_LIST_DIR}/aws_tests")
+
+if(AFR_IS_TESTING)
+    set(board_dir "${board_tests_dir}")
+    set(aws_credentials_include "${AFR_TESTS_DIR}/include")
+else()
+    set(board_dir "${board_demos_dir}")
+    set(aws_credentials_include "${AFR_DEMOS_DIR}/include")
+endif()
+
+# Kernel
+afr_mcu_port(kernel)
+target_sources(
+    AFR::kernel::mcu_port
+    INTERFACE
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/port.c"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/portmacro.h"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/arc_freertos_exceptions.c"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/arc_freertos_exceptions.h"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/freertos_tls.c"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC/arc_support.s"
+        "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
+)
+target_include_directories(
+    AFR::kernel::mcu_port
+    INTERFACE
+        # "${board_specific_include}"       # Normally ${board_dir}/application_code/${vendor}_code
+        # "${board_configs_include}"        # Normally ${board_dir}/application_code/config_files
+        # "${driver_public_include}"        # Normally in ${driver_dir}
+        ${aws_credentials_include}
+        ${embARC_INC_DIR}
+        "${board_dir}/config_files"
+        "${AFR_KERNEL_DIR}/portable/Synopsys/ARC"
+        "${AFR_MODULES_C_SDK_DIR}/standard/common/include"
+)
+target_link_libraries(
+    AFR::kernel::mcu_port
+    INTERFACE
+    ${other_targets}
+)
+
+# If you defined the driver and freertos portable target separately, you can use afr_mcu_port with
+# DEPENDS keyword, e.g.,
+# afr_mcu_port(kernel DEPENDS my_board_driver freertos_port)
+
+# POSIX
+# afr_mcu_port(posix)
+# target_include_directories(
+#     AFR::posix::mcu_port
+#     INTERFACE "${portable_dir}/posix"
+# )
+
+# WiFi
+# afr_mcu_port(wifi)
+# target_sources(
+#     AFR::wifi::mcu_port
+#     INTERFACE "${portable_dir}/wifi/iot_wifi.c"
+# )
+
+#currently the following modules are not ported
+if(AFR_IS_TESTING)
+    # PKCS11
+    afr_mcu_port(pkcs11_implementation)
+    target_sources(
+        AFR::pkcs11_implementation::mcu_port
+        INTERFACE "${portable_dir}/pkcs11/iot_pkcs11_pal.c"
+    )
+    # Link to AFR::pkcs11_mbedtls if you want to use default implementation based on mbedtls.
+    target_link_libraries(
+        AFR::pkcs11_implementation::mcu_port
+        INTERFACE AFR::pkcs11_mbedtls
+    )
+
+    # FreeRTOS Plus TCP
+    afr_mcu_port(freertos_plus_tcp)
+    target_sources(
+        AFR::freertos_plus_tcp::mcu_port
+        INTERFACE
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.c"
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/NetworkInterface/embARC/NetworkInterface.c"
+    )
+    target_include_directories(
+        AFR::freertos_plus_tcp::mcu_port
+        INTERFACE
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/source/portable/Compiler/MetaWare"
+    )
+
+    # Secure sockets
+    afr_mcu_port(secure_sockets)
+    # Link to AFR::secure_sockets_freertos_plus_tcp if you want use default implementation based on
+    # FreeRTOS-Plus-TCP.
+    target_link_libraries(
+        AFR::secure_sockets::mcu_port
+        INTERFACE AFR::secure_sockets_freertos_plus_tcp
+    )
+endif()
+# OTA
+# afr_mcu_port(ota)
+# target_sources(
+#     AFR::ota::mcu_port
+#     INTERFACE "${portable_dir}/ota/aws_ota_pal.c"
+# )
+# Choose which backend to enable. Link to AFR::ota_mqtt to enable MQTT, link to AFR:ota_http to enable HTTP.
+# target_link_libraries(
+#     AFR::ota::mcu_port
+#     INTERFACE
+#         AFR::ota_mqtt
+#         AFR::ota_http
+# )
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS demos and tests
+# -------------------------------------------------------------------------------------------------
+# We require you to define at least demos and tests executable targets. Available demos and tests
+# will be automatically enabled by us. You need to provide other project settings such as linker
+# scripts and post build commands.
+
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+
+# Do not add demos or tests if they're turned off.
+if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
+
+    if(AFR_IS_TESTING)
+        set(exe_target aws_tests)
+    else()
+        set(exe_target aws_demos)
+    endif()
+    add_executable(
+        ${exe_target}
+        "${board_dir}/application_code/main.c"
+    )
+    target_include_directories(
+        ${exe_target}
+        PUBLIC
+            ${embARC_INC_DIR}
+    )
+    target_link_libraries(
+        ${exe_target}
+        PRIVATE
+            AFR::kernel
+            # AFR::common
+            AFR::platform
+            # ${embARC_LIB_DIR}/libembarc.a
+            # AFR::wifi
+            # AFR::utils
+            # AFR::ble
+    )
+    target_compile_definitions(
+        ${exe_target}
+        PUBLIC
+            ${compiler_defined_symbols}
+    )
+
+    if(${AFR_TOOLCHAIN} STREQUAL "synopsys-gcc")
+    # TODO: add support of openocd
+    add_custom_target(run
+        COMMAND arc-elf32-gdb ${exe_target}.elf
+        DEPENDS ${exe_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    add_custom_target(debug
+        COMMAND arc-elf32-gdb ${exe_target}.elf
+        DEPENDS ${exe_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    add_custom_target(debug_mdb
+        COMMAND mdb -source_path=${embARC_src_dir}/arc/startup -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent ${exe_target}.elf
+        DEPENDS ${exe_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    elseif(${AFR_TOOLCHAIN} STREQUAL "synopsys-mw")
+    add_custom_target(run
+        COMMAND mdb -source_path=${embARC_src_dir}/arc/startup -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent -run ${exe_target}.elf
+        DEPENDS ${exe_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    add_custom_target(debug
+        COMMAND mdb -source_path=${embARC_src_dir}/arc/startup -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent -OS=FreeRTOS ${exe_target}.elf
+        DEPENDS ${exe_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    endif()
+endif()

--- a/vendors/synopsys/boards/embARC/aws_demos/application_code/main.c
+++ b/vendors/synopsys/boards/embARC/aws_demos/application_code/main.c
@@ -1,0 +1,529 @@
+/*
+ * Amazon FreeRTOS V1.4.7
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include "embARC.h"
+#include "embARC_debug.h"
+#define LED_TOGGLE_MASK     BOARD_LED_MASK
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+// #include "FreeRTOS_IP.h" /* FIX ME: Delete if you are not using the FreeRTOS-Plus-TCP library. */
+
+/* Demo includes */
+#include "aws_demo.h"
+
+/* AWS library includes. */
+// #include "iot_system_init.h"
+#include "iot_logging_task.h"
+// #include "iot_wifi.h"
+// #include "aws_clientcredential.h"
+#include "aws_application_version.h"
+// #include "aws_dev_mode_key_provisioning.h"
+
+/* Declare the firmware version structure for all to see. */
+const AppVersion32_t xAppFirmwareVersion = {
+	.u.x.ucMajor = APP_VERSION_MAJOR,
+	.u.x.ucMinor = APP_VERSION_MINOR,
+	.u.x.usBuild = APP_VERSION_BUILD,
+};
+
+/* Logging Task Defines. */
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
+#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
+
+/* The task delay for allowing the lower priority logging task to print out Wi-Fi 
+ * failure status before blocking indefinitely. */
+#define mainLOGGING_WIFI_STATUS_DELAY       pdMS_TO_TICKS( 1000 )
+
+/* Unit test defines. */
+#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
+
+/* The name of the devices for xApplicationDNSQueryHook. */
+#define mainDEVICE_NICK_NAME				"synopsys_demo" /* FIX ME.*/
+
+
+/* Static arrays for FreeRTOS-Plus-TCP stack initialization for Ethernet network 
+ * connections are declared below. If you are using an Ethernet connection on your MCU 
+ * device it is recommended to use the FreeRTOS+TCP stack. The default values are 
+ * defined in FreeRTOSConfig.h. */
+
+/* Default MAC address configuration.  The application creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition for information on how to configure
+ * the real network connection to use. */
+const uint8_t ucMACAddress[ 6 ] =
+{
+    configMAC_ADDR0,
+    configMAC_ADDR1,
+    configMAC_ADDR2,
+    configMAC_ADDR3,
+    configMAC_ADDR4,
+    configMAC_ADDR5
+};
+
+/* The default IP and MAC address used by the application.  The address configuration
+ * defined here will be used if ipconfigUSE_DHCP is 0, or if ipconfigUSE_DHCP is
+ * 1 but a DHCP server could not be contacted.  See the online documentation for
+ * more information. */
+static const uint8_t ucIPAddress[ 4 ] =
+{
+    configIP_ADDR0,
+    configIP_ADDR1,
+    configIP_ADDR2,
+    configIP_ADDR3
+};
+static const uint8_t ucNetMask[ 4 ] =
+{
+    configNET_MASK0,
+    configNET_MASK1,
+    configNET_MASK2,
+    configNET_MASK3
+};
+static const uint8_t ucGatewayAddress[ 4 ] =
+{
+    configGATEWAY_ADDR0,
+    configGATEWAY_ADDR1,
+    configGATEWAY_ADDR2,
+    configGATEWAY_ADDR3
+};
+static const uint8_t ucDNSServerAddress[ 4 ] =
+{
+    configDNS_SERVER_ADDR0,
+    configDNS_SERVER_ADDR1,
+    configDNS_SERVER_ADDR2,
+    configDNS_SERVER_ADDR3
+};
+
+/**
+ * @brief Application task startup hook for applications using Wi-Fi. If you are not 
+ * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
+ * function. If you are not using Wi-Fi, this hook can be disabled by setting 
+ * configUSE_DAEMON_TASK_STARTUP_HOOK to 0.
+ */
+void vApplicationDaemonTaskStartupHook( void );
+
+/**
+ * @brief Application IP network event hook called by the FreeRTOS+TCP stack for
+ * applications using Ethernet. If you are not using Ethernet and the FreeRTOS+TCP stack,
+ * start network dependent applications in vApplicationDaemonTaskStartupHook after the
+ * network status is up.
+ */
+// void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+
+/**
+ * @brief Connects to Wi-Fi.
+ */
+static void prvWifiConnect( void );
+
+/**
+ * @brief Initializes the board.
+ */
+static void prvMiscInitialization( void );
+
+/*-----------------------------------------------------------*/
+void blinky_task( void *pvParameters )
+{
+    uint16_t led_toggle_val = LED_TOGGLE_MASK;
+
+    while (1) {
+        led_write(led_toggle_val, LED_TOGGLE_MASK);
+        led_toggle_val = ~led_toggle_val;
+        // configPRINT_STRING( "Toggle LED!\n" );
+        board_delay_ms(1000);
+    }
+}
+
+/**
+ * @brief Application runtime entry point.
+ */
+int main( void )
+{
+    /* Perform any hardware initialization that does not require the RTOS to be
+     * running.  */
+    prvMiscInitialization();
+
+    xTaskCreate( blinky_task, "blinky", 100, NULL, tskIDLE_PRIORITY, NULL );
+    /* Create tasks that are not dependent on the Wi-Fi being initialized. */
+    xLoggingTaskInitialize( mainLOGGING_TASK_STACK_SIZE,
+                            tskIDLE_PRIORITY,
+                            mainLOGGING_MESSAGE_QUEUE_LENGTH );
+
+    /* FIX ME: If you are using Ethernet network connections and the FreeRTOS+TCP stack,
+     * uncomment the initialization function, FreeRTOS_IPInit(), below. */
+    /*FreeRTOS_IPInit( ucIPAddress,
+     *                 ucNetMask,
+     *                 ucGatewayAddress,
+     *                 ucDNSServerAddress,
+     *                 ucMACAddress );
+     */
+
+    /* Start the scheduler.  Initialization that requires the OS to be running,
+     * including the Wi-Fi initialization, is performed in the RTOS daemon task
+     * startup hook. */
+    vTaskStartScheduler();
+
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+static void prvMiscInitialization( void )
+{
+    /* FIX ME: Perform any hardware initializations, that don't require the RTOS to be 
+     * running, here.
+     */
+    configPRINT_STRING( "hello world using configPRINT_STRING\n" );
+    EMBARC_PRINTF( "%s: hello world using EMBARC_PRINTF\n", mainDEVICE_NICK_NAME );
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationDaemonTaskStartupHook( void )
+{
+    /* FIX ME: Perform any hardware initialization, that require the RTOS to be
+     * running, here. */
+    
+
+    /* FIX ME: If your MCU is using Wi-Fi, delete surrounding compiler directives to 
+     * enable the unit tests and after MQTT, Bufferpool, and Secure Sockets libraries 
+     * have been imported into the project. If you are not using Wi-Fi, see the 
+     * vApplicationIPNetworkEventHook function. */
+    #if 0
+        if( SYSTEM_Init() == pdPASS )
+        {
+            /* Connect to the Wi-Fi before running the tests. */
+            prvWifiConnect();
+
+            /* Provision the device with AWS certificate and private key. */
+            vDevModeKeyProvisioning();
+
+            /* Start the demo tasks. */
+            DEMO_RUNNER_RunDemos();
+        }
+    #endif
+}
+/*-----------------------------------------------------------*/
+#if 0
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
+{
+    /* FIX ME: If your application is using Ethernet network connections and the 
+     * FreeRTOS+TCP stack, delete the surrounding compiler directives to enable the 
+     * unit tests and after MQTT, Bufferpool, and Secure Sockets libraries have been 
+     * imported into the project. If you are not using Ethernet see the 
+     * vApplicationDaemonTaskStartupHook function. */
+    #if 0
+    static BaseType_t xTasksAlreadyCreated = pdFALSE;
+
+    /* If the network has just come up...*/
+    if( eNetworkEvent == eNetworkUp )
+    {
+        if( ( xTasksAlreadyCreated == pdFALSE ) && ( SYSTEM_Init() == pdPASS ) )
+        {
+            DEMO_RUNNER_RunDemos();
+            xTasksAlreadyCreated = pdTRUE;
+        }
+    }
+    #endif /* if 0 */
+}
+#endif
+/*-----------------------------------------------------------*/
+
+void prvWifiConnect( void )
+{
+    /* FIX ME: Delete surrounding compiler directives when the Wi-Fi library is ported. */
+    #if 0
+        WIFINetworkParams_t xNetworkParams;
+        WIFIReturnCode_t xWifiStatus;
+        uint8_t ucTempIp[4] = { 0 };
+
+        xWifiStatus = WIFI_On();
+
+        if( xWifiStatus == eWiFiSuccess )
+        {
+            
+            configPRINTF( ( "Wi-Fi module initialized. Connecting to AP...\r\n" ) );
+        }
+        else
+        {
+            configPRINTF( ( "Wi-Fi module failed to initialize.\r\n" ) );
+
+            /* Delay to allow the lower priority logging task to print the above status. 
+             * The while loop below will block the above printing. */
+            TaskDelay( mainLOGGING_WIFI_STATUS_DELAY );
+
+            while( 1 )
+            {
+            }
+        }
+
+        /* Setup parameters. */
+        xNetworkParams.pcSSID = clientcredentialWIFI_SSID;
+        xNetworkParams.ucSSIDLength = sizeof( clientcredentialWIFI_SSID );
+        xNetworkParams.pcPassword = clientcredentialWIFI_PASSWORD;
+        xNetworkParams.ucPasswordLength = sizeof( clientcredentialWIFI_PASSWORD );
+        xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
+        xNetworkParams.cChannel = 0;
+
+        xWifiStatus = WIFI_ConnectAP( &( xNetworkParams ) );
+
+        if( xWifiStatus == eWiFiSuccess )
+        {
+            configPRINTF( ( "Wi-Fi Connected to AP. Creating tasks which use network...\r\n" ) );
+
+            xWifiStatus = WIFI_GetIP( ucTempIp );
+            if ( eWiFiSuccess == xWifiStatus ) 
+            {
+                configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
+                                ucTempIp[ 0 ], ucTempIp[ 1 ], ucTempIp[ 2 ], ucTempIp[ 3 ] ) );
+            }
+        }
+        else
+        {
+            /* Connection failed, configure SoftAP. */
+            configPRINTF( ( "Wi-Fi failed to connect to AP %s.\r\n", xNetworkParams.pcSSID ) );
+
+            xNetworkParams.pcSSID = wificonfigACCESS_POINT_SSID_PREFIX;
+            xNetworkParams.pcPassword = wificonfigACCESS_POINT_PASSKEY;
+            xNetworkParams.xSecurity = wificonfigACCESS_POINT_SECURITY;
+            xNetworkParams.cChannel = wificonfigACCESS_POINT_CHANNEL;
+
+            configPRINTF( ( "Connect to SoftAP %s using password %s. \r\n",
+                            xNetworkParams.pcSSID, xNetworkParams.pcPassword ) );
+
+            while( WIFI_ConfigureAP( &xNetworkParams ) != eWiFiSuccess )
+            {
+                configPRINTF( ( "Connect to SoftAP %s using password %s and configure Wi-Fi. \r\n",
+                                xNetworkParams.pcSSID, xNetworkParams.pcPassword ) );
+            }
+
+            configPRINTF( ( "Wi-Fi configuration successful. \r\n" ) );
+        }
+    #endif /* if 0 */
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This is to provide memory that is used by the Idle task.
+ *
+ * If configUSE_STATIC_ALLOCATION is set to 1, then the application must provide an
+ * implementation of vApplicationGetIdleTaskMemory() in order to provide memory to
+ * the Idle task.
+ */
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
+{
+    /* If the buffers to be provided to the Idle task are declared inside this
+     * function then they must be declared static - otherwise they will be allocated on
+     * the stack and so not exists after this function exits. */
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Idle
+     * task's state will be stored. */
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+    /* Pass out the array that will be used as the Idle task's stack. */
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+     * Note that, as the array is necessarily of type StackType_t,
+     * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This is to provide the memory that is used by the RTOS daemon/time task.
+ *
+ * If configUSE_STATIC_ALLOCATION is set to 1, then application must provide an
+ * implementation of vApplicationGetTimerTaskMemory() in order to provide memory
+ * to the RTOS daemon/time task.
+ */
+void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                     StackType_t ** ppxTimerTaskStackBuffer,
+                                     uint32_t * pulTimerTaskStackSize )
+{
+    /* If the buffers to be provided to the Timer task are declared inside this
+     * function then they must be declared static - otherwise they will be allocated on
+     * the stack and so not exists after this function exits. */
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Idle
+     * task's state will be stored. */
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+     * Note that, as the array is necessarily of type StackType_t,
+     * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Warn user if pvPortMalloc fails.
+ *
+ * Called if a call to pvPortMalloc() fails because there is insufficient
+ * free memory available in the FreeRTOS heap.  pvPortMalloc() is called
+ * internally by FreeRTOS API functions that create tasks, queues, software
+ * timers, and semaphores.  The size of the FreeRTOS heap is set by the
+ * configTOTAL_HEAP_SIZE configuration constant in FreeRTOSConfig.h.
+ *
+ */
+void vApplicationMallocFailedHook()
+{
+    taskDISABLE_INTERRUPTS();
+    for( ;; );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Loop forever if stack overflow is detected.
+ *
+ * If configCHECK_FOR_STACK_OVERFLOW is set to 1,
+ * this hook provides a location for applications to
+ * define a response to a stack overflow.
+ *
+ * Use this hook to help identify that a stack overflow
+ * has occurred.
+ *
+ */
+void vApplicationStackOverflowHook( TaskHandle_t xTask,
+                                    char * pcTaskName )
+{
+    portDISABLE_INTERRUPTS();
+
+    /* Loop forever */
+    for( ; ; )
+    {
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined Idle task function.
+ *
+ * @note Do not make any blocking operations in this function.
+ */
+void vApplicationIdleHook( void )
+{
+    /* FIX ME. If necessary, update to application idle periodic actions. */
+    
+    static TickType_t xLastPrint = 0;
+    TickType_t xTimeNow;
+    const TickType_t xPrintFrequency = pdMS_TO_TICKS( 5000 );
+
+    xTimeNow = xTaskGetTickCount();
+
+    if( ( xTimeNow - xLastPrint ) > xPrintFrequency )
+    {
+        configPRINT( "." );
+        xLastPrint = xTimeNow;
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+* @brief User defined application hook to process names returned by the DNS server.
+*/
+#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
+    BaseType_t xApplicationDNSQueryHook( const char * pcName )
+    {
+        /* FIX ME. If necessary, update to applicable DNS name lookup actions. */
+
+        BaseType_t xReturn;
+
+        /* Determine if a name lookup is for this node.  Two names are given
+         * to this node: that returned by pcApplicationHostnameHook() and that set
+         * by mainDEVICE_NICK_NAME. */
+        if( strcmp( pcName, pcApplicationHostnameHook() ) == 0 )
+        {
+            xReturn = pdPASS;
+        }
+        else if( strcmp( pcName, mainDEVICE_NICK_NAME ) == 0 )
+        {
+            xReturn = pdPASS;
+        }
+        else
+        {
+            xReturn = pdFAIL;
+        }
+
+        return xReturn;
+    }
+	
+#endif /* if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined assertion call. This function is plugged into configASSERT.
+ * See FreeRTOSConfig.h to define configASSERT to something different.
+ */
+void vAssertCalled(const char * pcFile,
+	uint32_t ulLine)
+{
+    /* FIX ME. If necessary, update to applicable assertion routine actions. */
+
+	const uint32_t ulLongSleep = 1000UL;
+	volatile uint32_t ulBlockVariable = 0UL;
+	volatile char * pcFileName = (volatile char *)pcFile;
+	volatile uint32_t ulLineNumber = ulLine;
+
+	(void)pcFileName;
+	(void)ulLineNumber;
+
+	printf("vAssertCalled %s, %ld\n", pcFile, (long)ulLine);
+	fflush(stdout);
+
+	/* Setting ulBlockVariable to a non-zero value in the debugger will allow
+	* this function to be exited. */
+	taskDISABLE_INTERRUPTS();
+	{
+		while (ulBlockVariable == 0UL)
+		{
+			vTaskDelay( pdMS_TO_TICKS( ulLongSleep ) );
+		}
+	}
+	taskENABLE_INTERRUPTS();
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined application hook need by the FreeRTOS-Plus-TCP library.
+ */
+#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+    const char * pcApplicationHostnameHook(void)
+    {
+        /* FIX ME: If necessary, update to applicable registration name. */
+
+        /* This function will be called during the DHCP: the machine will be registered 
+         * with an IP address plus this name. */
+        return clientcredentialIOT_THING_NAME;
+    }
+
+#endif

--- a/vendors/synopsys/boards/embARC/aws_demos/application_code/synopsys_code/ReadMe.txt
+++ b/vendors/synopsys/boards/embARC/aws_demos/application_code/synopsys_code/ReadMe.txt
@@ -1,0 +1,1 @@
+Place board support specific code in this directory.

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/FreeRTOSConfig.h
@@ -1,0 +1,269 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* http://www.freertos.org/a00110.html
+*
+* The bottom of this file contains some constants specific to running the UDP
+* stack in this demo.  Constants specific to FreeRTOS+TCP itself (rather than
+* the demo) are contained in FreeRTOSIPConfig.h.
+*----------------------------------------------------------*/
+
+/* FIX ME: Uncomment and set to the specifications for your MCU. */
+#define configCPU_CLOCK_HZ                        ( ( unsigned long ) BOARD_CPU_CLOCK )
+
+#define configUSE_DAEMON_TASK_STARTUP_HOOK         1
+#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configUSE_PREEMPTION                       1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
+#define configMAX_PRIORITIES                       ( 7 )
+#define configTICK_RATE_HZ                         ( 1000 )
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 )
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
+#define configMAX_TASK_NAME_LEN                    ( 15 )
+#define configUSE_TRACE_FACILITY                   1
+#define configUSE_16_BIT_TICKS                     0
+#define configIDLE_SHOULD_YIELD                    1
+#define configUSE_CO_ROUTINES                      0
+#define configUSE_MUTEXES                          1
+#define configUSE_RECURSIVE_MUTEXES                1
+#define configQUEUE_REGISTRY_SIZE                  0
+#define configUSE_APPLICATION_TASK_TAG             0
+#define configUSE_COUNTING_SEMAPHORES              1
+#define configUSE_ALTERNATIVE_API                  0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    3      /* FreeRTOS+FAT requires 2 pointers if a CWD is supported. */
+#define configRECORD_STACK_HIGH_ADDRESS            1
+
+/* Hook function related definitions. */
+#define configUSE_TICK_HOOK                        0
+#define configUSE_IDLE_HOOK                        1
+#define configUSE_MALLOC_FAILED_HOOK               0
+#define configCHECK_FOR_STACK_OVERFLOW             0      /* use arc stack check */
+
+/* Software timer related definitions. */
+#define configUSE_TIMERS                           1
+#define configTIMER_TASK_PRIORITY                  ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                   5
+#define configTIMER_TASK_STACK_DEPTH               ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Event group related definitions. */
+#define configUSE_EVENT_GROUPS                     1
+
+/* Run time stats gathering definitions. */
+/* FIX ME: Uncomment if you plan to use Tracealyzer.
+unsigned long ulGetRunTimeCounterValue( void );
+void vConfigureTimerForRunTimeStats( void );
+#define configGENERATE_RUN_TIME_STATS    1
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+*/
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+
+/* Currently the TCP/IP stack is using dynamic allocation, and the MQTT task is
+ * using static allocation. */
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+#define configSUPPORT_STATIC_ALLOCATION         1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskCleanUpResources           0
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_uxTaskGetStackHighWaterMark     0
+#define INCLUDE_xTaskGetSchedulerState          1
+#define INCLUDE_xTimerGetTimerTaskHandle        0
+#define INCLUDE_xTaskGetIdleTaskHandle          0
+#define INCLUDE_xQueueGetMutexHolder            1
+#define INCLUDE_eTaskGetState                   1
+#define INCLUDE_xEventGroupSetBitsFromISR       1
+#define INCLUDE_xTimerPendFunctionCall          1
+#define INCLUDE_xTaskGetCurrentTaskHandle       1
+#define INCLUDE_xTaskAbortDelay                 1
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+    /* __NVIC_PRIO_BITS will be specified when CMSIS is being used. */
+    #define configPRIO_BITS    __NVIC_PRIO_BITS
+#else
+    #define configPRIO_BITS    3                                 /* 8 priority levels. */
+#endif
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations.  configUSE_STATS_FORMATTING_FUNCTIONS
+ * is set to 2 so the formatting functions are included without the stdio.h being
+ * included in tasks.c.  That is because this project defines its own sprintf()
+ * functions. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+/* Assert call defined for debug builds. */
+extern void vAssertCalled( const char * pcFile,
+                           uint32_t ulLine );
+#define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ )
+
+/* The function that implements FreeRTOS printf style output, and the macro
+ * that maps the configPRINTF() macros to that function. */
+extern void vLoggingPrintf( const char * pcFormat, ... );
+#define configPRINTF( X )    vLoggingPrintf X
+
+/* Non-format version thread-safe print */
+extern void vLoggingPrint( const char * pcMessage );
+#define configPRINT( X )     vLoggingPrint( X )
+
+/* Map the logging task's printf to the board specific output function. */
+#include <stdio.h>
+#include "embARC_debug.h"
+#define configPRINT_STRING( X )    EMBARC_PRINTF( X );
+/* Sets the length of the buffers into which logging messages are written - so
+ * also defines the maximum length of each log message. */
+#define configLOGGING_MAX_MESSAGE_LENGTH            100
+
+/* Set to 1 to prepend each log message with a message number, the task name,
+ * and a time stamp. */
+#define configLOGGING_INCLUDE_TIME_AND_TASK_NAME    1
+
+/* The priority at which the tick interrupt runs.  This should probably be kept at 1. */
+#define configKERNEL_INTERRUPT_PRIORITY             1
+
+/* The maximum interrupt priority from which FreeRTOS API functions can be called.
+ * Only API functions that end in ...FromISR() can be used within interrupts. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY        ( 1 << 5 )
+
+/* Application specific definitions follow. **********************************/
+
+/* If configINCLUDE_DEMO_DEBUG_STATS is set to one, then a few basic IP trace
+ * macros are defined to gather some UDP stack statistics that can then be viewed
+ * through the CLI interface. */
+#define configINCLUDE_DEMO_DEBUG_STATS       1
+
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
+/* Only used when running in the FreeRTOS Windows simulator.  Defines the
+ * priority of the task used to simulate Ethernet interrupts. */
+#define configMAC_ISR_SIMULATOR_PRIORITY     ( configMAX_PRIORITIES - 1 )
+
+/* This demo creates a virtual network connection by accessing the raw Ethernet
+ * or WiFi data to and from a real network connection.  Many computers have more
+ * than one real network port, and configNETWORK_INTERFACE_TO_USE is used to tell
+ * the demo which real port should be used to create the virtual port.  The ports
+ * available are displayed on the console when the application is executed.  For
+ * example, on my development laptop setting configNETWORK_INTERFACE_TO_USE to 4
+ * results in the wired network being used, while setting
+ * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
+ * used. */
+#define configNETWORK_INTERFACE_TO_USE       2L
+
+/* The address of an echo server that will be used by the two demo echo client
+ * tasks:
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Echo_Clients.html,
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/UDP_Echo_Clients.html. */
+#define configECHO_SERVER_ADDR0              192
+#define configECHO_SERVER_ADDR1              168
+#define configECHO_SERVER_ADDR2              2
+#define configECHO_SERVER_ADDR3              7
+#define configTCP_ECHO_CLIENT_PORT           7
+
+/* Default MAC address configuration.  The demo creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition above for information on how to
+ * configure the real network connection to use. */
+#define configMAC_ADDR0                      0x00
+#define configMAC_ADDR1                      0x11
+#define configMAC_ADDR2                      0x22
+#define configMAC_ADDR3                      0x33
+#define configMAC_ADDR4                      0x44
+#define configMAC_ADDR5                      0x21
+
+/* Default IP address configuration.  Used in ipconfigUSE_DHCP is set to 0, or
+ * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configIP_ADDR0                       192
+#define configIP_ADDR1                       168
+#define configIP_ADDR2                       0
+#define configIP_ADDR3                       105
+
+/* Default gateway IP address configuration.  Used in ipconfigUSE_DHCP is set to
+ * 0, or ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configGATEWAY_ADDR0                  192
+#define configGATEWAY_ADDR1                  168
+#define configGATEWAY_ADDR2                  0
+#define configGATEWAY_ADDR3                  1
+
+/* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
+ * 208.67.220.220.  Used in ipconfigUSE_DHCP is set to 0, or ipconfigUSE_DHCP is
+ * set to 1 but a DNS server cannot be contacted.*/
+#define configDNS_SERVER_ADDR0               208
+#define configDNS_SERVER_ADDR1               67
+#define configDNS_SERVER_ADDR2               222
+#define configDNS_SERVER_ADDR3               222
+
+/* Default netmask configuration.  Used in ipconfigUSE_DHCP is set to 0, or
+ * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configNET_MASK0                      255
+#define configNET_MASK1                      255
+#define configNET_MASK2                      255
+#define configNET_MASK3                      0
+
+/* The UDP port to which print messages are sent. */
+#define configPRINT_PORT                     ( 15000 )
+
+#define configPROFILING                      ( 0 )
+
+/* Pseudo random number generater used by some demo tasks. */
+extern uint32_t ulRand();
+#define configRAND32()    ulRand()
+
+/* FIX ME: The platform FreeRTOS is running on. */
+#define configPLATFORM_NAME    "Unknown"
+
+/* Header required for the tracealyzer recorder library. */
+/* #include "trcRecorder.h" */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -1,0 +1,313 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    0
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket. */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                         1
+#define ipconfigDHCP_REGISTER_HOSTNAME           1
+#define ipconfigDHCP_USES_UNICAST                1
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                    0
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD \
+    ( 120000 / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1200
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 0
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                0
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      240
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 0 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 0 )
+
+
+#define portINLINE                               __inline
+
+void vApplicationMQTTGetKeys( const char ** ppcRootCA,
+                              const char ** ppcClientCert,
+                              const char ** ppcClientPrivateKey );
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_bufferpool_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_bufferpool_config.h
@@ -1,0 +1,44 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_bufferpool_config.h
+ * @brief Buffer Pool config options.
+ */
+
+#ifndef _AWS_BUFFER_POOL_CONFIG_H_
+#define _AWS_BUFFER_POOL_CONFIG_H_
+
+/**
+ * @brief The number of buffers in the static buffer pool.
+ */
+#define bufferpoolconfigNUM_BUFFERS    ( 8 )
+
+/**
+ * @brief The size of each buffer in the static buffer pool.
+ */
+#define bufferpoolconfigBUFFER_SIZE    ( 512 )
+
+#endif /* _AWS_BUFFER_POOL_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_demo_config.h
@@ -1,0 +1,100 @@
+/*
+ * Amazon FreeRTOS V1.4.7
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef _AWS_DEMO_CONFIG_H_
+#define _AWS_DEMO_CONFIG_H_
+
+#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
+
+/* To run a particular demo you need to define one of these.
+ * Only one demo can be configured at a time
+ *
+ *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_SHADOW_DEMO_ENABLED
+ *          CONFIG_MQTT_BLE_DEMO_ENABLED
+ *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
+ *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
+ *          CONFIG_DEFENDER_DEMO_ENABLED
+ *          CONFIG_POSIX_DEMO_ENABLED
+ *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *          CONFIG_BLE_NUMERIC_COMPARISON_DEMO_ENABLED
+ *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_SYNC_UPLOAD_DEMO_ENABLED
+ *          CONFIG_HTTPS_ASYNC_UPLOAD_DEMO_ENABLED
+ *
+ *  These defines are used in iot_demo_runner.h for demo selection */
+
+#define CONFIG_MQTT_DEMO_ENABLED
+
+/* Timeout used when performing MQTT operations that do not need extra time
+ * to perform a TLS negotiation. */
+#define democonfigMQTT_TIMEOUT                               pdMS_TO_TICKS( 300 )
+
+/* Timeout used when establishing a connection, which required TLS
+ * negotiation. */
+#define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT          pdMS_TO_TICKS( 12000 )
+
+/* MQTT echo task example parameters. */
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 2 )
+#define democonfigMQTT_ECHO_TASK_PRIORITY                    ( tskIDLE_PRIORITY )
+
+/* IoT simple subscribe/publish example task parameters. */
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_SUB_PUB_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
+
+/* Greengrass discovery example task parameters. */
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE       ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY         ( tskIDLE_PRIORITY )
+
+/* Shadow demo task parameters. */
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_PRIORITY                  ( tskIDLE_PRIORITY )
+
+/* Number of shadow light switch tasks running. */
+#define democonfigSHADOW_DEMO_NUM_TASKS                      ( 2 )
+
+/* TCP Echo Client tasks single example parameters. */
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY        ( tskIDLE_PRIORITY + 1 )
+
+/* OTA Update task example parameters. */
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                 ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_TASK_PRIORITY              ( tskIDLE_PRIORITY )
+
+/* Simple TCP Echo Server task example parameters */
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_PRIORITY              ( tskIDLE_PRIORITY )
+
+/* TCP Echo Client tasks multi task example parameters. */
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY      ( tskIDLE_PRIORITY )
+
+/* Send AWS IoT MQTT traffic encrypted to destination port 443. */
+#define democonfigMQTT_AGENT_CONNECT_FLAGS                   ( mqttagentREQUIRE_TLS )
+
+#endif /* _AWS_DEMO_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_ggd_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_ggd_config.h
@@ -1,0 +1,46 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/**
+ * @file aws_ggd_config.h
+ * @brief GGD config options.
+ */
+
+#ifndef _AWS_GGD_CONFIG_H_
+#define _AWS_GGD_CONFIG_H_
+
+
+/**
+ * @brief The number of your network interface here.
+ */
+#define ggdconfigCORE_NETWORK_INTERFACE     ( 0 )
+
+/**
+ * @brief Size of the array used by jsmn to store the tokens.
+ */
+#define ggdconfigJSON_MAX_TOKENS            ( 128 )
+
+#endif /* _AWS_GGD_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_mqtt_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_mqtt_config.h
@@ -1,0 +1,66 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_mqtt_config.h
+ * @brief MQTT config options.
+ */
+
+#ifndef _AWS_MQTT_CONFIG_H_
+#define _AWS_MQTT_CONFIG_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Enable subscription management.
+ *
+ * This gives the user flexibility of registering a callback per topic.
+ */
+#define mqttconfigENABLE_SUBSCRIPTION_MANAGEMENT            ( 1 )
+
+/**
+ * @brief Maximum length of the topic which can be stored in subscription
+ * manager.
+ */
+#define mqttconfigSUBSCRIPTION_MANAGER_MAX_TOPIC_LENGTH     ( 128 )
+
+/**
+ * @brief Maximum number of subscriptions which can be stored in subscription
+ * manager.
+ */
+#define mqttconfigSUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS    ( 8 )
+
+/*
+ * Uncomment the following two lines to enable asserts.
+ */
+/* extern void vAssertCalled( const char *pcFile, uint32_t ulLine ); */
+/* #define mqttconfigASSERT( x ) if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ ) */
+
+/**
+ * @brief Set this macro to 1 for enabling debug logs.
+ */
+#define mqttconfigENABLE_DEBUG_LOGS    0
+
+#endif /* _AWS_MQTT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_ota_agent_config.h
@@ -1,0 +1,88 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_ota_agent_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef _AWS_OTA_AGENT_CONFIG_H_
+#define _AWS_OTA_AGENT_CONFIG_H_
+
+/**
+ * @brief The number of words allocated to the stack for the OTA agent.
+ */
+#define otaconfigSTACK_SIZE                     630U    /* FIX ME. */
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL    /* FIX ME. */
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA service so we will only send
+ * the request message after being idle for this amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U   /* FIX ME. */
+
+/**
+ * @brief The OTA agent task priority. Normally it runs at a low priority.
+ */
+#define otaconfigAGENT_PRIORITY                 tskIDLE_PRIORITY    /* FIX ME. */
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the broker.
+ * Likewise, the OTA agent requires the developer to construct and pass in the Thing name when
+ * initializing the OTA agent. The agent uses this size to allocate static storage for the
+ * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ *  This configuration parameter is sent with data requests and represents the maximum number of
+ *  data blocks the service will send in response. The maximum limit for this must be calculated
+ *  from the maximum data response limit (128 KB from service) divided by the block size.
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
+ *  how many data blocks response is expected for each data requests.
+ *  Please note that this must be set larger than zero.
+ *
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+
+#endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_secure_sockets_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_secure_sockets_config.h
@@ -1,0 +1,51 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_secure_sockets_config.h
+ * @brief Secure sockets configuration options.
+ */
+
+#ifndef _AWS_SECURE_SOCKETS_CONFIG_H_
+#define _AWS_SECURE_SOCKETS_CONFIG_H_
+
+/**
+ * @brief Byte order of the target MCU.
+ *
+ * Valid values are pdLITTLE_ENDIAN and pdBIG_ENDIAN.
+ */
+#define socketsconfigBYTE_ORDER              pdLITTLE_ENDIAN
+
+/**
+ * @brief Default socket send timeout.
+ */
+#define socketsconfigDEFAULT_SEND_TIMEOUT    ( 10000 )
+
+/**
+ * @brief Default socket receive timeout.
+ */
+#define socketsconfigDEFAULT_RECV_TIMEOUT    ( 10000 )
+
+#endif /* _AWS_SECURE_SOCKETS_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_shadow_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_shadow_config.h
@@ -1,0 +1,93 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_shadow_config.h
+ * @brief Configuration constants used by the Shadow library.
+ */
+
+#ifndef _AWS_SHADOW_CONFIG_H_
+#define _AWS_SHADOW_CONFIG_H_
+
+/**
+ * @brief Number of jsmn tokens to use in parsing.  Each jsmn token contains 4 ints.
+ * Ensure that the number of tokens does not overflow the calling task's stack,
+ * but is also sufficient to parse the largest expected JSON documents. */
+#define shadowconfigJSON_JSMN_TOKENS             ( 64 )
+
+/**
+ * @brief Maximum number of Shadow Clients.
+ *
+ * Up to this number of Shadow Clients may be successfully created with
+ * #SHADOW_ClientCreate. Shadow clients are allocated in the global data
+ * segment. Ensure that there is enough memory to accommodate the Shadow
+ * Clients.
+ *
+ * @note Should be less than 256.
+ */
+#define shadowconfigMAX_CLIENTS                  ( 1 )
+
+/**
+ * @brief Shadow debug message setting.
+ *
+ * Set this value to @c 0 to disable Shadow Client debug messages; or set
+ * it to @c 1 to enable debug messages. Ensure that the macro @c configPRINTF
+ * is available if debugging is enabled.
+ */
+#define shadowconfigENABLE_DEBUG_LOGS            ( 1 )
+
+/**
+ * @brief Number of unique Things for which user notify callbacks can be
+ * registered in each Shadow Client.
+ *
+ * Each Shadow Client stores the Things with user notify callbacks registered.
+ * Define how many unique Things require user notify callbacks here.
+ *
+ * @note Should be less than 256.
+ */
+#define shadowconfigMAX_THINGS_WITH_CALLBACKS    ( 1 )
+
+/**
+ * @brief Time (in milliseconds) a Shadow Client may block during cleanup @b IF
+ * a timeout occurs.
+ *
+ * Should a Shadow API call time out, the Shadow Client will stop its current
+ * operation and cleanup before returning. The time below (in milliseconds) is
+ * the amount of additional time that the Shadow Client may block to cleanup @b
+ * IF the user's given timeout is inadequate. In general, 5000 ms is sufficient
+ * for cleanup on a good connection; more time should be given if the connection
+ * is unreliable.
+ *
+ * @note If a user gives a Shadow API call @a x milliseconds of block time but
+ * @a x is insufficient time to complete the API call, then function may block
+ * for up to (@a x + #shadowCLEANUP_TIME_MS) milliseconds. However, if @a x is
+ * sufficient time for the API call, then block time will be at most @a x
+ * milliseconds.
+ * @warning If cleanup doesn't fully complete, users may be billed for MQTT
+ * messages on topics that weren't properly cleaned up!
+ */
+#define shadowconfigCLEANUP_TIME_MS              ( 5000UL )
+
+#endif /* _AWS_SHADOW_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/aws_wifi_config.h
@@ -1,0 +1,97 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_wifi_config.h
+ * @brief WiFi module configuration parameters.
+ */
+
+#ifndef _AWS_WIFI_CONFIG_H_
+#define _AWS_WIFI_CONFIG_H_
+
+/**
+ * @brief Maximum number of sockets that can be created simultaneously.
+ */
+#define wificonfigMAX_SOCKETS                 ( 4 )
+
+/**
+ * @brief Maximum number of connection retries.
+ */
+#define wificonfigNUM_CONNECTION_RETRY        ( 3 )
+
+/**
+ * @brief Maximum number of connected station in Access Point mode.
+ */
+#define wificonfigMAX_CONNECTED_STATIONS      ( 4 )
+
+/**
+ * @brief Max number of network profiles stored in Non Volatile memory,
+ * set to zero if not supported.
+ */
+#define wificonfigMAX_NETWORK_PROFILES        ( 0 )
+
+/**
+ * @brief Max SSID length
+ */
+#define wificonfigMAX_SSID_LEN                ( 32 )
+
+/**
+ * @brief Max BSSID length
+ */
+#define wificonfigMAX_BSSID_LEN               ( 6 )
+
+/**
+ * @brief Max passphrase length
+ */
+#define wificonfigMAX_PASSPHRASE_LEN          ( 32 )
+
+/**
+ * @brief Soft Access point SSID
+ */
+#define wificonfigACCESS_POINT_SSID_PREFIX    ( "Enter SSID for Soft AP" )
+
+/**
+ * @brief Soft Access point Passkey
+ */
+#define wificonfigACCESS_POINT_PASSKEY        ( "Enter Password for Soft AP" )
+
+/**
+ * @brief Soft Access point Channel
+ */
+#define wificonfigACCESS_POINT_CHANNEL        ( 11 )
+
+/**
+ * @brief WiFi semaphore timeout
+ */
+#define wificonfigMAX_SEMAPHORE_WAIT_TIME_MS  ( 60000 )
+
+/**
+ * @brief Soft Access point security
+ * WPA2 Security, see WIFISecurity_t
+ * other values are - eWiFiSecurityOpen, eWiFiSecurityWEP, eWiFiSecurityWPA
+ */
+#define wificonfigACCESS_POINT_SECURITY       ( eWiFiSecurityWPA2 )
+
+#endif /* _AWS_WIFI_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_config.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* This file contains configuration settings for the demos. */
+
+#ifndef IOT_CONFIG_H_
+#define IOT_CONFIG_H_
+
+/* MQTT demo configuration. */
+#define IOT_DEMO_MQTT_PUBLISH_BURST_COUNT       ( 10 )
+#define IOT_DEMO_MQTT_PUBLISH_BURST_SIZE        ( 2 )
+
+/* Shadow demo configuration. The demo publishes periodic Shadow updates and responds
+ * to changing Shadows. */
+#define AWS_IOT_DEMO_SHADOW_UPDATE_COUNT        ( 20 )   /* Number of updates to publish. */
+#define AWS_IOT_DEMO_SHADOW_UPDATE_PERIOD_MS    ( 3000 ) /* Period of Shadow updates. */
+
+/* Library logging configuration. IOT_LOG_LEVEL_GLOBAL provides a global log
+ * level for all libraries; the library-specific settings override the global
+ * setting. If both the library-specific and global settings are undefined,
+ * no logs will be printed. */
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_INFO
+#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_INFO
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_INFO
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_INFO
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_INFO
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_INFO
+
+/* Platform thread priority. */
+#define IOT_THREAD_DEFAULT_PRIORITY             5
+
+#define WIFI_SUPPORTED 							(0)
+
+/* Include the common configuration file for FreeRTOS. */
+#include "iot_config_common.h"
+
+#endif /* ifndef IOT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_mqtt_agent_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_mqtt_agent_config.h
@@ -1,0 +1,105 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_mqtt_agent_config.h
+ * @brief MQTT agent config options.
+ */
+
+#ifndef _AWS_MQTT_AGENT_CONFIG_H_
+#define _AWS_MQTT_AGENT_CONFIG_H_
+
+#include "FreeRTOS.h"
+
+/**
+ * @brief Controls whether or not to report usage metrics to the
+ * AWS IoT broker.
+ *
+ * If mqttconfigENABLE_METRICS is set to 1, a string containing
+ * metric information will be included in the "username" field of
+ * the MQTT connect messages.
+ */
+#define mqttconfigENABLE_METRICS                      ( 1 )
+
+/**
+ * @brief The maximum time interval in seconds allowed to elapse between 2 consecutive
+ * control packets.
+ */
+#define mqttconfigKEEP_ALIVE_INTERVAL_SECONDS         ( 1200 )
+
+/**
+ * @brief Defines the frequency at which the client should send Keep Alive messages.
+ *
+ * Even though the maximum time allowed between 2 consecutive control packets
+ * is defined by the mqttconfigKEEP_ALIVE_INTERVAL_SECONDS macro, the user
+ * can and should send Keep Alive messages at a slightly faster rate to ensure
+ * that the connection is not closed by the server because of network delays.
+ * This macro defines the interval of inactivity after which a keep alive messages
+ * is sent.
+ */
+#define mqttconfigKEEP_ALIVE_ACTUAL_INTERVAL_TICKS    ( pdMS_TO_TICKS( 300000 ) )
+
+/**
+ * @brief The maximum interval in ticks to wait for PINGRESP.
+ *
+ * If PINGRESP is not received within this much time after sending PINGREQ,
+ * the client assumes that the PINGREQ timed out.
+ */
+#define mqttconfigKEEP_ALIVE_TIMEOUT_TICKS            ( 1000 )
+
+/**
+ * @defgroup MQTTTask MQTT task configuration parameters.
+ */
+/** @{ */
+#define mqttconfigMQTT_TASK_STACK_DEPTH    ( configMINIMAL_STACK_SIZE * 4 )
+#define mqttconfigMQTT_TASK_PRIORITY       ( configMAX_PRIORITIES - 3 )
+/** @} */
+
+/**
+ * @brief Maximum number of MQTT clients that can exist simultaneously.
+ */
+#define mqttconfigMAX_BROKERS                  ( 4 )
+
+/**
+ * @brief Maximum number of parallel operations per client.
+ */
+#define mqttconfigMAX_PARALLEL_OPS             ( 5 )
+
+/**
+ * @brief Time in milliseconds after which the TCP send operation should timeout.
+ */
+#define mqttconfigTCP_SEND_TIMEOUT_MS          ( 2000 )
+
+/**
+ * @brief Length of the buffer used to receive data.
+ */
+#define mqttconfigRX_BUFFER_SIZE               ( 128 )
+
+/**
+ * @brief The maximum time in ticks for which the MQTT task is permitted to block.
+ */
+#define mqttconfigMQTT_TASK_MAX_BLOCK_TICKS    ( 100 )
+
+#endif /* _AWS_MQTT_AGENT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/iot_pkcs11_config.h
@@ -1,0 +1,131 @@
+/*
+ * Amazon FreeRTOS V1.4.8
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_pkcs11_config.h
+ * @brief PCKS#11 config options.
+ */
+
+
+#ifndef _AWS_PKCS11_CONFIG_H_
+#define _AWS_PKCS11_CONFIG_H_
+
+/* A non-standard version of C_INITIALIZE should be used by this port. */
+/* #define pkcs11configC_INITIALIZE_ALT */
+
+/**
+ * @brief PKCS #11 default user PIN.
+ *
+ * The PKCS #11 standard specifies the presence of a user PIN. That feature is
+ * sensible for applications that have an interactive user interface and memory
+ * protections. However, since typical microcontroller applications lack one or
+ * both of those, the user PIN is assumed to be used herein for interoperability
+ * purposes only, and not as a security feature.
+ */
+#define configPKCS11_DEFAULT_USER_PIN    "0000"
+
+/**
+ * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
+ * attribute.
+ */
+#define pkcs11configMAX_LABEL_LENGTH     32
+
+/**
+ * @brief Maximum number of token objects that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_NUM_OBJECTS      6
+
+/**
+ * @brief Set to 1 if a PAL destroy object is implemented.
+ *
+ * If set to 0, no PAL destroy object is implemented, and this functionality
+ * is implemented in the common PKCS #11 layer.
+ */
+#define pkcs11configPAL_DESTROY_SUPPORTED                  0
+
+/**
+ * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
+ *
+ * If set to 0, OTA code signing certificate is built in via
+ * aws_ota_codesigner_certificate.h.
+ */
+#define pkcs11configOTA_SUPPORTED                          0
+
+/**
+ * @brief Set to 1 if PAL supports storage for JITP certificate,
+ * code verify certificate, and trusted server root certificate.
+ *
+ * If set to 0, PAL does not support storage mechanism for these, and
+ * they are accessed via headers compiled into the code.
+ */
+#define pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED    0
+
+/**
+ * @brief The PKCS #11 label for device private key.
+ *
+ * Private key for connection to AWS IoT endpoint.  The corresponding
+ * public key should be registered with the AWS IoT endpoint.
+ */
+#define pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "Device Priv TLS Key"
+
+/**
+ * @brief The PKCS #11 label for device public key.
+ *
+ * The public key corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "Device Pub TLS Key"
+
+/**
+ * @brief The PKCS #11 label for the device certificate.
+ *
+ * Device certificate corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
+
+/**
+ * @brief The PKCS #11 label for the object to be used for code verification.
+ *
+ * Used by over-the-air update code to verify an incoming signed image.
+ */
+#define pkcs11configLABEL_CODE_VERIFICATION_KEY            "Code Verify Key"
+
+/**
+ * @brief The PKCS #11 label for Just-In-Time-Provisioning.
+ *
+ * The certificate corresponding to the issuer of the device certificate
+ * (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
+ * JITP flow.
+ */
+#define pkcs11configLABEL_JITP_CERTIFICATE                 "JITP Cert"
+
+/**
+ * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
+ *
+ * @see aws_default_root_certificates.h
+ */
+#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
+
+#endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/trcConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/trcConfig.h
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Trace Recorder Library for Tracealyzer v3.1.2
+ * Percepio AB, www.percepio.com
+ *
+ * trcConfig.h
+ *
+ * Main configuration parameters for the trace recorder library.
+ * More settings can be found in trcStreamingConfig.h and trcSnapshotConfig.h.
+ *
+ * Read more at http://percepio.com/2016/10/05/rtos-tracing/
+ *
+ * Terms of Use
+ * This file is part of the trace recorder library (RECORDER), which is the
+ * intellectual property of Percepio AB (PERCEPIO) and provided under a
+ * license as follows.
+ * The RECORDER may be used free of charge for the purpose of recording data
+ * intended for analysis in PERCEPIO products. It may not be used or modified
+ * for other purposes without explicit permission from PERCEPIO.
+ * You may distribute the RECORDER in its original source code form, assuming
+ * this text (terms of use, disclaimer, copyright notice) is unchanged. You are
+ * allowed to distribute the RECORDER with minor modifications intended for
+ * configuration or porting of the RECORDER, e.g., to allow using it on a
+ * specific processor, processor family or with a specific communication
+ * interface. Any such modifications should be documented directly below
+ * this comment block.
+ *
+ * Disclaimer
+ * The RECORDER is being delivered to you AS IS and PERCEPIO makes no warranty
+ * as to its use or performance. PERCEPIO does not and cannot warrant the
+ * performance or results you may obtain by using the RECORDER or documentation.
+ * PERCEPIO make no warranties, express or implied, as to noninfringement of
+ * third party rights, merchantability, or fitness for any particular purpose.
+ * In no event will PERCEPIO, its technology partners, or distributors be liable
+ * to you for any consequential, incidental or special damages, including any
+ * lost profits or lost savings, even if a representative of PERCEPIO has been
+ * advised of the possibility of such damages, or for any claim by any third
+ * party. Some jurisdictions do not allow the exclusion or limitation of
+ * incidental, consequential or special damages, or the exclusion of implied
+ * warranties or limitations on how long an implied warranty may last, so the
+ * above limitations may not apply to you.
+ *
+ * Tabs are used for indent in this file (1 tab = 4 spaces)
+ *
+ * Copyright Percepio AB, 2016.
+ * www.percepio.com
+ ******************************************************************************/
+
+#ifndef TRC_CONFIG_H
+#define TRC_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "trcPortDefines.h"
+
+/******************************************************************************
+ * Include of processor header file
+ *
+ * Here you may need to include the header file for your processor. This is
+ * required at least for the ARM Cortex-M port, that uses the ARM CMSIS API.
+ * Try that in case of build problems. Otherwise, remove the #error line below.
+ *****************************************************************************/
+//#error "Trace Recorder: Please include your processor's header file here and remove this line."
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_HARDWARE_PORT
+ *
+ * Specify what hardware port to use (i.e., the "timestamping driver").
+ *
+ * All ARM Cortex-M MCUs are supported by "TRC_HARDWARE_PORT_ARM_Cortex_M".
+ * This port uses the DWT cycle counter for Cortex-M3/M4/M7 devices, which is
+ * available on most such devices. In case your device don't have DWT support,
+ * you will get an error message opening the trace. In that case, you may
+ * force the recorder to use SysTick timestamping instead, using this define:
+ *
+ * #define TRC_CFG_ARM_CM_USE_SYSTICK
+ *
+ * For ARM Cortex-M0/M0+ devices, SysTick mode is used automatically.
+ *
+ * See trcHardwarePort.h for available ports and information on how to
+ * define your own port, if not already present.
+ ******************************************************************************/
+#define TRC_CFG_HARDWARE_PORT TRC_HARDWARE_PORT_Win32
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_RECORDER_MODE
+ *
+ * Specify what recording mode to use. Snapshot means that the data is saved in
+ * an internal RAM buffer, for later upload. Streaming means that the data is
+ * transferred continuously to the host PC.
+ *
+ * For more information, see http://percepio.com/2016/10/05/rtos-tracing/
+ * and the Tracealyzer User Manual.
+ *
+ * Values:
+ * TRC_RECORDER_MODE_SNAPSHOT
+ * TRC_RECORDER_MODE_STREAMING
+ ******************************************************************************/
+#define TRC_CFG_RECORDER_MODE TRC_RECORDER_MODE_SNAPSHOT
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_RECORDER_BUFFER_ALLOCATION
+ *
+ * Specifies how the recorder buffer is allocated (also in case of streaming, in
+ * port using the recorder's internal temporary buffer)
+ *
+ * Values:
+ * TRC_RECORDER_BUFFER_ALLOCATION_STATIC  - Static allocation (internal)
+ * TRC_RECORDER_BUFFER_ALLOCATION_DYNAMIC - Malloc in vTraceEnable
+ * TRC_RECORDER_BUFFER_ALLOCATION_CUSTOM  - Use vTraceSetRecorderDataBuffer
+ *
+ * Static and dynamic mode does the allocation for you, either in compile time
+ * (static) or in runtime (malloc).
+ * The custom mode allows you to control how and where the allocation is made,
+ * for details see TRC_ALLOC_CUSTOM_BUFFER and vTraceSetRecorderDataBuffer().
+ ******************************************************************************/
+#define TRC_CFG_RECORDER_BUFFER_ALLOCATION TRC_RECORDER_BUFFER_ALLOCATION_STATIC
+
+/******************************************************************************
+ * TRC_CFG_FREERTOS_VERSION
+ *
+ * Specify what version of FreeRTOS that is used (don't change unless using the
+ * trace recorder library with an older version of FreeRTOS).
+ *
+ * TRC_FREERTOS_VERSION_7_3_OR_7_4				If using FreeRTOS v7.3.0 - v7.4.2
+ * TRC_FREERTOS_VERSION_7_5_OR_7_6				If using FreeRTOS v7.5.0 - v7.6.0
+ * TRC_FREERTOS_VERSION_8_X						If using FreeRTOS v8.X.X
+ * TRC_FREERTOS_VERSION_9_X						If using FreeRTOS v9.X.X
+ *****************************************************************************/
+#define TRC_CFG_FREERTOS_VERSION	TRC_FREERTOS_VERSION_9_X
+
+/******************************************************************************
+ * TRC_CFG_MAX_ISR_NESTING
+ *
+ * Defines how many levels of interrupt nesting the recorder can handle, in
+ * case multiple ISRs are traced and ISR nesting is possible. If this
+ * is exceeded, the particular ISR will not be traced and the recorder then
+ * logs an error message. This setting is used to allocate an internal stack
+ * for keeping track of the previous execution context (4 byte per entry).
+ *
+ * This value must be a non-zero positive constant, at least 1.
+ *
+ * Default value: 8
+ *****************************************************************************/
+#define TRC_CFG_MAX_ISR_NESTING 8
+
+/* Specific configuration, depending on Streaming/Snapshot mode */
+#if (TRC_CFG_RECORDER_MODE == TRC_RECORDER_MODE_SNAPSHOT)
+#include "trcSnapshotConfig.h"
+#elif (TRC_CFG_RECORDER_MODE == TRC_RECORDER_MODE_STREAMING)
+#include "trcStreamingConfig.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TRC_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_demos/config_files/trcSnapshotConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_demos/config_files/trcSnapshotConfig.h
@@ -1,0 +1,472 @@
+/*******************************************************************************
+ * Trace Recorder Library for Tracealyzer v3.1.2
+ * Percepio AB, www.percepio.com
+ *
+ * trcSnapshotConfig.h
+ *
+ * Configuration parameters for trace recorder library in snapshot mode.
+ * Read more at http://percepio.com/2016/10/05/rtos-tracing/
+ *
+ * Terms of Use
+ * This file is part of the trace recorder library (RECORDER), which is the
+ * intellectual property of Percepio AB (PERCEPIO) and provided under a
+ * license as follows.
+ * The RECORDER may be used free of charge for the purpose of recording data
+ * intended for analysis in PERCEPIO products. It may not be used or modified
+ * for other purposes without explicit permission from PERCEPIO.
+ * You may distribute the RECORDER in its original source code form, assuming
+ * this text (terms of use, disclaimer, copyright notice) is unchanged. You are
+ * allowed to distribute the RECORDER with minor modifications intended for
+ * configuration or porting of the RECORDER, e.g., to allow using it on a
+ * specific processor, processor family or with a specific communication
+ * interface. Any such modifications should be documented directly below
+ * this comment block.
+ *
+ * Disclaimer
+ * The RECORDER is being delivered to you AS IS and PERCEPIO makes no warranty
+ * as to its use or performance. PERCEPIO does not and cannot warrant the
+ * performance or results you may obtain by using the RECORDER or documentation.
+ * PERCEPIO make no warranties, express or implied, as to noninfringement of
+ * third party rights, merchantability, or fitness for any particular purpose.
+ * In no event will PERCEPIO, its technology partners, or distributors be liable
+ * to you for any consequential, incidental or special damages, including any
+ * lost profits or lost savings, even if a representative of PERCEPIO has been
+ * advised of the possibility of such damages, or for any claim by any third
+ * party. Some jurisdictions do not allow the exclusion or limitation of
+ * incidental, consequential or special damages, or the exclusion of implied
+ * warranties or limitations on how long an implied warranty may last, so the
+ * above limitations may not apply to you.
+ *
+ * Tabs are used for indent in this file (1 tab = 4 spaces)
+ *
+ * Copyright Percepio AB, 2017.
+ * www.percepio.com
+ ******************************************************************************/
+
+#ifndef TRC_SNAPSHOT_CONFIG_H
+#define TRC_SNAPSHOT_CONFIG_H
+
+#define TRC_SNAPSHOT_MODE_RING_BUFFER       ( 0x01 )
+#define TRC_SNAPSHOT_MODE_STOP_WHEN_FULL    ( 0x02 )
+
+/******************************************************************************
+ * TRC_CFG_SNAPSHOT_MODE
+ *
+ * Macro which should be defined as one of:
+ * - TRC_SNAPSHOT_MODE_RING_BUFFER
+ * - TRC_SNAPSHOT_MODE_STOP_WHEN_FULL
+ * Default is TRC_SNAPSHOT_MODE_RING_BUFFER.
+ *
+ * With TRC_CFG_SNAPSHOT_MODE set to TRC_SNAPSHOT_MODE_RING_BUFFER, the
+ * events are stored in a ring buffer, i.e., where the oldest events are
+ * overwritten when the buffer becomes full. This allows you to get the last
+ * events leading up to an interesting state, e.g., an error, without having
+ * to store the whole run since startup.
+ *
+ * When TRC_CFG_SNAPSHOT_MODE is TRC_SNAPSHOT_MODE_STOP_WHEN_FULL, the
+ * recording is stopped when the buffer becomes full. This is useful for
+ * recording events following a specific state, e.g., the startup sequence.
+ *****************************************************************************/
+#define TRC_CFG_SNAPSHOT_MODE               TRC_SNAPSHOT_MODE_RING_BUFFER
+
+/*******************************************************************************
+ * TRC_CFG_SCHEDULING_ONLY
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * If this setting is enabled (= 1), only scheduling events are recorded.
+ * If disabled (= 0), all events are recorded.
+ *
+ * For users of Tracealyzer Free Edition, that only displays scheduling events, this
+ * option can be used to avoid storing other events.
+ *
+ * Default value is 0 (store all enabled events).
+ *
+ ******************************************************************************/
+#define TRC_CFG_SCHEDULING_ONLY             0
+
+/*******************************************************************************
+ * TRC_CFG_EVENT_BUFFER_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the event buffer, i.e., the number of records
+ * it may store. Most events use one record (4 byte), although some events
+ * require multiple 4-byte records. You should adjust this to the amount of RAM
+ * available in the target system.
+ *
+ * Default value is 1000, which means that 4000 bytes is allocated for the
+ * event buffer.
+ ******************************************************************************/
+#define TRC_CFG_EVENT_BUFFER_SIZE           15000
+
+/*******************************************************************************
+ * TRC_CFG_NTASK, TRC_CFG_NISR, TRC_CFG_NQUEUE, TRC_CFG_NSEMAPHORE...
+ *
+ * A group of macros which should be defined as integer values, zero or larger.
+ *
+ * These define the capacity of the Object Property Table, i.e., the maximum
+ * number of objects active at any given point, within each object class (e.g.,
+ * task, queue, semaphore, ...).
+ *
+ * If tasks or other objects are deleted in your system, this
+ * setting does not limit the total amount of objects created, only the number
+ * of objects that have been successfully created but not yet deleted.
+ *
+ * Using too small values will cause vTraceError to be called, which stores an
+ * error message in the trace that is shown when opening the trace file. The
+ * error message can also be retrieved using xTraceGetLastError.
+ *
+ * It can be wise to start with large values for these constants,
+ * unless you are very confident on these numbers. Then do a recording and
+ * check the actual usage by selecting View menu -> Trace Details ->
+ * Resource Usage -> Object Table.
+ ******************************************************************************/
+#define TRC_CFG_NTASK                       150
+#define TRC_CFG_NISR                        90
+#define TRC_CFG_NQUEUE                      90
+#define TRC_CFG_NSEMAPHORE                  90
+#define TRC_CFG_NMUTEX                      90
+#define TRC_CFG_NTIMER                      250
+#define TRC_CFG_NEVENTGROUP                 90
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_MEMMANG_EVENTS
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * This controls if malloc and free calls should be traced. Set this to zero (0)
+ * to exclude malloc/free calls, or one (1) to include such events in the trace.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_MEMMANG_EVENTS      1
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_USER_EVENTS
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If this is zero (0) the code for creating User Events is excluded to
+ * reduce code size. User Events are application-generated events, like
+ * "printf" but for the trace log and the formatting is done offline, by the
+ * Tracealyzer visualization tool. User Events are much faster than a printf
+ * and can therefore be used in timing critical code.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_USER_EVENTS         1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_ISR_TRACING
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If this is zero (0), the code for recording Interrupt Service Routines is
+* excluded, in order to reduce code size.
+*
+* Default value is 1.
+*
+* Note: tracing ISRs requires that you insert calls to vTraceStoreISRBegin
+* and vTraceStoreISREnd in your interrupt handlers.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_ISR_TRACING         1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_READY_EVENTS
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If one (1), events are recorded when tasks enter scheduling state "ready".
+* This allows Tracealyzer to show the initial pending time before tasks enter
+* the execution state, and present accurate response times.
+* If zero (0), "ready events" are not created, which allows for recording
+* longer traces in the same amount of RAM.
+*
+* Default value is 1.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_READY_EVENTS        1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_OSTICK_EVENTS
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If this is one (1), events will be generated whenever the OS clock is
+* increased. If zero (0), OS tick events are not generated, which allows for
+* recording longer traces in the same amount of RAM.
+*
+* Default value is 0.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_OSTICK_EVENTS       1
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_FLOAT_SUPPORT
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If this is zero (0), the support for logging floating point values in
+ * vTracePrintF is stripped out, in case floating point values are not used or
+ * supported by the platform used.
+ *
+ * Floating point values are only used in vTracePrintF and its subroutines, to
+ * allow for storing float (%f) or double (%lf) arguments.
+ *
+ * vTracePrintF can be used with integer and string arguments in either case.
+ *
+ * Default value is 0.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_FLOAT_SUPPORT       0
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_OBJECT_DELETE
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * This must be enabled (1) if tasks, queues or other
+ * traced kernel objects are deleted at runtime. If no deletes are made, this
+ * can be set to 0 in order to exclude the delete-handling code.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_OBJECT_DELETE       1
+
+/*******************************************************************************
+ * TRC_CFG_SYMBOL_TABLE_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the symbol table, in bytes. This symbol table
+ * stores User Events labels and names of deleted tasks, queues, or other kernel
+ * objects. If you don't use User Events or delete any kernel
+ * objects you set this to a very low value. The minimum recommended value is 4.
+ * A size of zero (0) is not allowed since a zero-sized array may result in a
+ * 32-bit pointer, i.e., using 4 bytes rather than 0.
+ *
+ * Default value is 800.
+ ******************************************************************************/
+#define TRC_CFG_SYMBOL_TABLE_SIZE           5000
+
+#if ( TRC_CFG_SYMBOL_TABLE_SIZE == 0 )
+    #error "TRC_CFG_SYMBOL_TABLE_SIZE may not be zero!"
+#endif
+
+/******************************************************************************
+ * TRC_CFG_NAME_LEN_TASK, TRC_CFG_NAME_LEN_QUEUE, ...
+ *
+ * Macros that specify the maximum lengths (number of characters) for names of
+ * kernel objects, such as tasks and queues. If longer names are used, they will
+ * be truncated when stored in the recorder.
+ *****************************************************************************/
+#define TRC_CFG_NAME_LEN_TASK          15
+#define TRC_CFG_NAME_LEN_ISR           15
+#define TRC_CFG_NAME_LEN_QUEUE         15
+#define TRC_CFG_NAME_LEN_SEMAPHORE     15
+#define TRC_CFG_NAME_LEN_MUTEX         15
+#define TRC_CFG_NAME_LEN_TIMER         15
+#define TRC_CFG_NAME_LEN_EVENTGROUP    15
+
+/******************************************************************************
+ *** ADVANCED SETTINGS ********************************************************
+ ******************************************************************************
+ * The remaining settings are not necessary to modify but allows for optimizing
+ * the recorder setup for your specific needs, e.g., to exclude events that you
+ * are not interested in, in order to get longer traces.
+ *****************************************************************************/
+
+/******************************************************************************
+* TRC_CFG_HEAP_SIZE_BELOW_16M
+*
+* An integer constant that can be used to reduce the buffer usage of memory
+* allocation events (malloc/free). This value should be 1 if the heap size is
+* below 16 MB (2^24 byte), and you can live with reported addresses showing the
+* lower 24 bits only. If 0, you get the full 32-bit addresses.
+*
+* Default value is 0.
+******************************************************************************/
+#define TRC_CFG_HEAP_SIZE_BELOW_16M                0
+
+/******************************************************************************
+ * TRC_CFG_USE_IMPLICIT_IFE_RULES
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ * Default is 1.
+ *
+ * Tracealyzer groups the events into "instances" based on Instance Finish
+ * Events (IFEs), produced either by default rules or calls to the recorder
+ * functions vTraceInstanceFinishedNow and vTraceInstanceFinishedNext.
+ *
+ * If TRC_CFG_USE_IMPLICIT_IFE_RULES is one (1), the default IFE rules is
+ * used, resulting in a "typical" grouping of events into instances.
+ * If these rules don't give appropriate instances in your case, you can
+ * override the default rules using vTraceInstanceFinishedNow/Next for one
+ * or several tasks. The default IFE rules are then disabled for those tasks.
+ *
+ * If TRC_CFG_USE_IMPLICIT_IFE_RULES is zero (0), the implicit IFE rules are
+ * disabled globally. You must then call vTraceInstanceFinishedNow or
+ * vTraceInstanceFinishedNext to manually group the events into instances,
+ * otherwise the tasks will appear a single long instance.
+ *
+ * The default IFE rules count the following events as "instance finished":
+ * - Task delay, delay until
+ * - Task suspend
+ * - Blocking on "input" operations, i.e., when the task is waiting for the
+ *   next a message/signal/event. But only if this event is blocking.
+ *
+ * For details, see trcSnapshotKernelPort.h and look for references to the
+ * macro trcKERNEL_HOOKS_SET_TASK_INSTANCE_FINISHED.
+ *****************************************************************************/
+#define TRC_CFG_USE_IMPLICIT_IFE_RULES             1
+
+/******************************************************************************
+ * TRC_CFG_USE_16BIT_OBJECT_HANDLES
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If set to 0 (zero), the recorder uses 8-bit handles to identify kernel
+ * objects such as tasks and queues. This limits the supported number of
+ * concurrently active objects to 255 of each type (tasks, queues, mutexes,
+ * etc.) Note: 255, not 256, since handle 0 is reserved.
+ *
+ * If set to 1 (one), the recorder uses 16-bit handles to identify kernel
+ * objects such as tasks and queues. This limits the supported number of
+ * concurrent objects to 65535 of each type (object class). However, since the
+ * object property table is limited to 64 KB, the practical limit is about
+ * 3000 objects in total.
+ *
+ * Default is 0 (8-bit handles)
+ *
+ * NOTE: An object with handle above 255 will use an extra 4-byte record in
+ * the event buffer whenever the object is referenced. Moreover, some internal
+ * tables in the recorder gets slightly larger when using 16-bit handles.
+ *****************************************************************************/
+#define TRC_CFG_USE_16BIT_OBJECT_HANDLES           0
+
+/******************************************************************************
+ * TRC_CFG_USE_TRACE_ASSERT
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ * Default is 1.
+ *
+ * If this is one (1), the TRACE_ASSERT macro (used at various locations in the
+ * trace recorder) will verify that a relevant condition is true.
+ * If the condition is false, prvTraceError() will be called, which stops the
+ * recording and stores an error message that is displayed when opening the
+ * trace in Tracealyzer.
+ *
+ * This is used on several places in the recorder code for sanity checks on
+ * parameters. Can be switched off to reduce the footprint of the tracing, but
+ * we recommend to have it enabled initially.
+ *****************************************************************************/
+#define TRC_CFG_USE_TRACE_ASSERT                   1
+
+/*******************************************************************************
+ * TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * Set TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER to 1 to enable the
+ * separate user event buffer (UB).
+ * In this mode, user events are stored separately from other events,
+ * e.g., RTOS events. Thereby you can get a much longer history of
+ * user events as they don't need to share the buffer space with more
+ * frequent events.
+ *
+ * The UB is typically used with the snapshot ring-buffer mode, so the
+ * recording can continue when the main buffer gets full. And since the
+ * main buffer then overwrites the earliest events, Tracealyzer displays
+ * "Unknown Actor" instead of task scheduling for periods with UB data only.
+ *
+ * In UB mode, user events are structured as UB channels, which contains
+ * a channel name and a default format string. Register a UB channel using
+ * xTraceRegisterUBChannel.
+ *
+ * Events and data arguments are written using vTraceUBEvent and
+ * vTraceUBData. They are designed to provide efficient logging of
+ * repeating events, using the same format string within each channel.
+ *
+ * Examples:
+ *
+ *  traceString chn1 = xTraceRegisterString("Channel 1");
+ *  traceString fmt1 = xTraceRegisterString("Event!");
+ *  traceUBChannel UBCh1 = xTraceRegisterUBChannel(chn1, fmt1);
+ *
+ *  traceString chn2 = xTraceRegisterString("Channel 2");
+ *  traceString fmt2 = xTraceRegisterString("X: %d, Y: %d");
+ *	traceUBChannel UBCh2 = xTraceRegisterUBChannel(chn2, fmt2);
+ *
+ *  // Result in "[Channel 1] Event!"
+ *	vTraceUBEvent(UBCh1);
+ *
+ *  // Result in "[Channel 2] X: 23, Y: 19"
+ *	vTraceUBData(UBCh2, 23, 19);
+ *
+ * You can also use the other user event functions, like vTracePrintF.
+ * as they are then rerouted to the UB instead of the main event buffer.
+ * vTracePrintF then looks up the correct UB channel based on the
+ * provided channel name and format string, or creates a new UB channel
+ * if no match is found. The format string should therefore not contain
+ * "random" messages but mainly format specifiers. Random strings should
+ * be stored using %s and with the string as an argument.
+ *
+ *  // Creates a new UB channel ("Channel 2", "%Z: %d")
+ *  vTracePrintF(chn2, "%Z: %d", value1);
+ *
+ *  // Finds the existing UB channel
+ *  vTracePrintF(chn2, "%Z: %d", value2);
+ *
+ ******************************************************************************/
+#define TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER     0
+
+/*******************************************************************************
+ * TRC_CFG_SEPARATE_USER_EVENT_BUFFER_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the user event buffer (UB), in number of slots.
+ * A single user event can use multiple slots, depending on the arguments.
+ *
+ * Only applicable if TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER is 1.
+ ******************************************************************************/
+#define TRC_CFG_SEPARATE_USER_EVENT_BUFFER_SIZE    200
+
+/*******************************************************************************
+ * TRC_CFG_UB_CHANNELS
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the number of User Event Buffer Channels (UB channels).
+ * These are used to structure the events when using the separate user
+ * event buffer, and contains both a User Event Channel (the name) and
+ * a default format string for the channel.
+ *
+ * Only applicable if TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER is 1.
+ ******************************************************************************/
+#define TRC_CFG_UB_CHANNELS                        32
+
+/*******************************************************************************
+ * TRC_CFG_ISR_TAILCHAINING_THRESHOLD
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * If tracing multiple ISRs, this setting allows for accurate display of the
+ * context-switching also in cases when the ISRs execute in direct sequence.
+ *
+ * vTraceStoreISREnd normally assumes that the ISR returns to the previous
+ * context, i.e., a task or a preempted ISR. But if another traced ISR
+ * executes in direct sequence, Tracealyzer may incorrectly display a minimal
+ * fragment of the previous context in between the ISRs.
+ *
+ * By using TRC_CFG_ISR_TAILCHAINING_THRESHOLD you can avoid this. This is
+ * however a threshold value that must be measured for your specific setup.
+ * See http://percepio.com/2014/03/21/isr_tailchaining_threshold/
+ *
+ * The default setting is 0, meaning "disabled" and that you may get an
+ * extra fragments of the previous context in between tail-chained ISRs.
+ *
+ * Note: This setting has separate definitions in trcSnapshotConfig.h and
+ * trcStreamingConfig.h, since it is affected by the recorder mode.
+ ******************************************************************************/
+#define TRC_CFG_ISR_TAILCHAINING_THRESHOLD         0
+
+#endif /*TRC_SNAPSHOT_CONFIG_H*/

--- a/vendors/synopsys/boards/embARC/aws_tests/application_code/main.c
+++ b/vendors/synopsys/boards/embARC/aws_tests/application_code/main.c
@@ -1,0 +1,521 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+#include "embARC.h"
+#include "embARC_debug.h"
+
+#define LED_TOGGLE_MASK     BOARD_LED_MASK
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+// #include "FreeRTOS_IP.h" /* FIX ME: Delete if you are not using the FreeRTOS-Plus-TCP library. */
+
+/* Test includes */
+#include "aws_test_runner.h"
+
+/* AWS library includes. */
+// #include "iot_system_init.h"
+#include "iot_logging_task.h"
+// #include "iot_wifi.h"
+#include "aws_clientcredential.h"
+// #include "aws_dev_mode_key_provisioning.h"
+
+/* Logging Task Defines. */
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
+#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
+
+/* Unit test defines. */
+#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
+
+/* The task delay for allowing the lower priority logging task to print out Wi-Fi 
+ * failure status before blocking indefinitely. */
+#define mainLOGGING_WIFI_STATUS_DELAY       pdMS_TO_TICKS( 1000 )
+
+/* The name of the devices for xApplicationDNSQueryHook. */
+#define mainDEVICE_NICK_NAME				"Synopsys_test" /* FIX ME.*/
+
+/* Static arrays for FreeRTOS-Plus-TCP stack initialization for Ethernet network 
+ * connections are declared below. If you are using an Ethernet connection on your MCU 
+ * device it is recommended to use the FreeRTOS+TCP stack. The default values are 
+ * defined in FreeRTOSConfig.h. */
+
+/* Default MAC address configuration.  The application creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition for information on how to configure
+ * the real network connection to use. */
+const uint8_t ucMACAddress[ 6 ] =
+{
+    configMAC_ADDR0,
+    configMAC_ADDR1,
+    configMAC_ADDR2,
+    configMAC_ADDR3,
+    configMAC_ADDR4,
+    configMAC_ADDR5
+};
+
+/* The default IP and MAC address used by the application.  The address configuration
+ * defined here will be used if ipconfigUSE_DHCP is 0, or if ipconfigUSE_DHCP is
+ * 1 but a DHCP server could not be contacted.  See the online documentation for
+ * more information. */
+static const uint8_t ucIPAddress[ 4 ] =
+{
+    configIP_ADDR0,
+    configIP_ADDR1,
+    configIP_ADDR2,
+    configIP_ADDR3
+};
+static const uint8_t ucNetMask[ 4 ] =
+{
+    configNET_MASK0,
+    configNET_MASK1,
+    configNET_MASK2,
+    configNET_MASK3
+};
+static const uint8_t ucGatewayAddress[ 4 ] =
+{
+    configGATEWAY_ADDR0,
+    configGATEWAY_ADDR1,
+    configGATEWAY_ADDR2,
+    configGATEWAY_ADDR3
+};
+static const uint8_t ucDNSServerAddress[ 4 ] =
+{
+    configDNS_SERVER_ADDR0,
+    configDNS_SERVER_ADDR1,
+    configDNS_SERVER_ADDR2,
+    configDNS_SERVER_ADDR3
+};
+
+/**
+ * @brief Application task startup hook for applications using Wi-Fi. If you are not 
+ * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
+ * function. If you are not using Wi-Fi, this hook can be disabled by setting 
+ * configUSE_DAEMON_TASK_STARTUP_HOOK to 0.
+ */
+void vApplicationDaemonTaskStartupHook( void );
+
+/**
+ * @brief Application IP network event hook called by the FreeRTOS+TCP stack for
+ * applications using Ethernet. If you are not using Ethernet and the FreeRTOS+TCP stack,
+ * start network dependent applications in vApplicationDaemonTaskStartupHook after the
+ * network status is up.
+ */
+// void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+
+/**
+ * @brief Connects to Wi-Fi.
+ */
+static void prvWifiConnect( void );
+
+/**
+ * @brief Initializes the board.
+ */
+static void prvMiscInitialization( void );
+
+/*-----------------------------------------------------------*/
+void blinky_task( void *pvParameters )
+{
+    uint16_t led_toggle_val = LED_TOGGLE_MASK;
+
+    while (1) {
+        led_write(led_toggle_val, LED_TOGGLE_MASK);
+        led_toggle_val = ~led_toggle_val;
+        // configPRINT_STRING( "Toggle LED!\n" );
+        board_delay_ms(1000);
+    }
+}
+
+/**
+ * @brief Application runtime entry point.
+ */
+int main( void )
+{
+    /* Perform any hardware initialization that does not require the RTOS to be
+     * running.  */
+    prvMiscInitialization();
+
+    xTaskCreate( blinky_task, "blinky", 100, NULL, tskIDLE_PRIORITY, NULL );
+    /* Create tasks that are not dependent on the Wi-Fi being initialized. */
+    xLoggingTaskInitialize( mainLOGGING_TASK_STACK_SIZE,
+                            tskIDLE_PRIORITY,
+                            mainLOGGING_MESSAGE_QUEUE_LENGTH );
+
+    /* FIX ME: If you are using Ethernet network connections and the FreeRTOS+TCP stack,
+     * uncomment the initialization function, FreeRTOS_IPInit(), below. */
+    /*FreeRTOS_IPInit( ucIPAddress,
+     *                 ucNetMask,
+     *                 ucGatewayAddress,
+     *                 ucDNSServerAddress,
+     *                 ucMACAddress );
+     */
+
+    /* Start the scheduler.  Initialization that requires the OS to be running,
+     * including the Wi-Fi initialization, is performed in the RTOS daemon task
+     * startup hook. */
+    vTaskStartScheduler();
+
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+static void prvMiscInitialization( void )
+{
+    /* FIX ME: Perform any hardware initializations, that don't require the RTOS to be 
+     * running, here.
+     */
+    configPRINT_STRING( "hello world using configPRINT_STRING\n" );
+    EMBARC_PRINTF( "%s: hello world using EMBARC_PRINTF\n", mainDEVICE_NICK_NAME );
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationDaemonTaskStartupHook( void )
+{
+    /* FIX ME: Perform any hardware initialization, that require the RTOS to be
+     * running, here. */
+    
+
+    /* FIX ME: If your MCU is using Wi-Fi, delete surrounding compiler directives to 
+     * enable the unit tests and after MQTT, Bufferpool, and Secure Sockets libraries 
+     * have been imported into the project. If you are not using Wi-Fi, see the 
+     * vApplicationIPNetworkEventHook function. */
+    #if 0
+        if( SYSTEM_Init() == pdPASS )
+        {
+            /* Connect to the Wi-Fi before running the tests. */
+            prvWifiConnect();
+
+            /* Provision the device with AWS certificate and private key. */
+            vDevModeKeyProvisioning();
+
+            /* Create the task to run unit tests. */
+            xTaskCreate( TEST_RUNNER_RunTests_task,
+                         "RunTests_task",
+                         mainTEST_RUNNER_TASK_STACK_SIZE,
+                         NULL,
+                         tskIDLE_PRIORITY,
+                         NULL );
+        }
+    #endif /* if 0 */
+}
+/*-----------------------------------------------------------*/
+#if 0
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
+{
+    /* FIX ME: If your application is using Ethernet network connections and the 
+     * FreeRTOS+TCP stack, delete the surrounding compiler directives to enable the 
+     * unit tests and after MQTT, Bufferpool, and Secure Sockets libraries have been 
+     * imported into the project. If you are not using Ethernet see the 
+     * vApplicationDaemonTaskStartupHook function. */
+    #if 0
+    static BaseType_t xTasksAlreadyCreated = pdFALSE;
+
+    /* If the network has just come up...*/
+    if( eNetworkEvent == eNetworkUp )
+    {
+        if( ( xTasksAlreadyCreated == pdFALSE ) && ( SYSTEM_Init() == pdPASS ) )
+        {
+            xTaskCreate( TEST_RUNNER_RunTests_task,
+                         "TestRunner",
+                         TEST_RUNNER_TASK_STACK_SIZE,
+                         NULL,
+                         tskIDLE_PRIORITY, NULL );
+
+            xTasksAlreadyCreated = pdTRUE;
+        }
+    }
+    #endif /* if 0 */
+}
+#endif
+/*-----------------------------------------------------------*/
+
+void prvWifiConnect( void )
+{
+    /* FIX ME: Delete surrounding compiler directives when the Wi-Fi library is ported. */
+    #if 0
+        WIFINetworkParams_t xNetworkParams;
+        WIFIReturnCode_t xWifiStatus;
+        uint8_t ucTempIp[4] = { 0 };
+
+        xWifiStatus = WIFI_On();
+
+        if( xWifiStatus == eWiFiSuccess )
+        {
+            configPRINTF( ( "Wi-Fi module initialized. Connecting to AP...\r\n" ) );
+        }
+        else
+        {
+            configPRINTF( ( "Wi-Fi module failed to initialize.\r\n" ) );
+
+            /* Delay to allow the lower priority logging task to print the above status. 
+             * The while loop below will block the above printing. */
+            TaskDelay( mainLOGGING_WIFI_STATUS_DELAY );
+
+            while( 1 )
+            {
+            }
+        }
+
+        /* Setup parameters. */
+        xNetworkParams.pcSSID = clientcredentialWIFI_SSID;
+        xNetworkParams.ucSSIDLength = sizeof( clientcredentialWIFI_SSID );
+        xNetworkParams.pcPassword = clientcredentialWIFI_PASSWORD;
+        xNetworkParams.ucPasswordLength = sizeof( clientcredentialWIFI_PASSWORD );
+        xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
+        xNetworkParams.cChannel = 0;
+
+        xWifiStatus = WIFI_ConnectAP( &( xNetworkParams ) );
+
+        if( xWifiStatus == eWiFiSuccess )
+        {
+            configPRINTF( ( "Wi-Fi Connected to AP. Creating tasks which use network...\r\n" ) );
+            
+            xWifiStatus = WIFI_GetIP( ucTempIp );
+            if ( eWiFiSuccess == xWifiStatus ) 
+            {
+                configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
+                                ucTempIp[ 0 ], ucTempIp[ 1 ], ucTempIp[ 2 ], ucTempIp[ 3 ] ) );
+            }
+        }
+        else
+        {
+            configPRINTF( ( "Wi-Fi failed to connect to AP.\r\n" ) );
+
+            /* Delay to allow the lower priority logging task to print the above status. 
+             * The while loop below will block the above printing. */
+            TaskDelay( mainLOGGING_WIFI_STATUS_DELAY );
+
+            while( 1 )
+            {
+            }
+        }
+    #endif /* if 0 */
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This is to provide memory that is used by the Idle task.
+ *
+ * If configUSE_STATIC_ALLOCATION is set to 1, then the application must provide an
+ * implementation of vApplicationGetIdleTaskMemory() in order to provide memory to
+ * the Idle task.
+ */
+// void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+//                                     StackType_t ** ppxIdleTaskStackBuffer,
+//                                     uint32_t * pulIdleTaskStackSize )
+// {
+//     /* If the buffers to be provided to the Idle task are declared inside this
+//      * function then they must be declared static - otherwise they will be allocated on
+//      * the stack and so not exists after this function exits. */
+//     static StaticTask_t xIdleTaskTCB;
+//     static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+//     /* Pass out a pointer to the StaticTask_t structure in which the Idle
+//      * task's state will be stored. */
+//     *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+//     /* Pass out the array that will be used as the Idle task's stack. */
+//     *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+//     /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+//      * Note that, as the array is necessarily of type StackType_t,
+//      * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+//     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+// }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This is to provide the memory that is used by the RTOS daemon/time task.
+ *
+ * If configUSE_STATIC_ALLOCATION is set to 1, then application must provide an
+ * implementation of vApplicationGetTimerTaskMemory() in order to provide memory
+ * to the RTOS daemon/time task.
+ */
+// void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+//                                      StackType_t ** ppxTimerTaskStackBuffer,
+//                                      uint32_t * pulTimerTaskStackSize )
+// {
+//     /* If the buffers to be provided to the Timer task are declared inside this
+//      * function then they must be declared static - otherwise they will be allocated on
+//      * the stack and so not exists after this function exits. */
+//     static StaticTask_t xTimerTaskTCB;
+//     static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+//     /* Pass out a pointer to the StaticTask_t structure in which the Idle
+//      * task's state will be stored. */
+//     *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+//     /* Pass out the array that will be used as the Timer task's stack. */
+//     *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+//     /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+//      * Note that, as the array is necessarily of type StackType_t,
+//      * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+//     *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+// }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Warn user if pvPortMalloc fails.
+ *
+ * Called if a call to pvPortMalloc() fails because there is insufficient
+ * free memory available in the FreeRTOS heap.  pvPortMalloc() is called
+ * internally by FreeRTOS API functions that create tasks, queues, software
+ * timers, and semaphores.  The size of the FreeRTOS heap is set by the
+ * configTOTAL_HEAP_SIZE configuration constant in FreeRTOSConfig.h.
+ *
+ */
+// void vApplicationMallocFailedHook()
+// {
+//     /* The TCP tests will test behavior when the entire heap is allocated. In
+//      * order to avoid interfering with those tests, this function does nothing. */
+// }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Loop forever if stack overflow is detected.
+ *
+ * If configCHECK_FOR_STACK_OVERFLOW is set to 1,
+ * this hook provides a location for applications to
+ * define a response to a stack overflow.
+ *
+ * Use this hook to help identify that a stack overflow
+ * has occurred.
+ *
+ */
+// void vApplicationStackOverflowHook( TaskHandle_t xTask,
+//                                     char * pcTaskName )
+// {
+//     portDISABLE_INTERRUPTS();
+
+//     /* Loop forever */
+//     for( ; ; )
+//     {
+//     }
+// }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined Idle task function.
+ *
+ * @note Do not make any blocking operations in this function.
+ */
+void vApplicationIdleHook( void )
+{
+    /* FIX ME. If necessary, update to application idle periodic actions. */
+
+    static TickType_t xLastPrint = 0;
+    TickType_t xTimeNow;
+    const TickType_t xPrintFrequency = pdMS_TO_TICKS( 5000 );
+
+    xTimeNow = xTaskGetTickCount();
+
+    if( ( xTimeNow - xLastPrint ) > xPrintFrequency )
+    {
+        configPRINT( "." );
+        xLastPrint = xTimeNow;
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+* @brief User defined application hook to process names returned by the DNS server.
+*/
+#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
+    BaseType_t xApplicationDNSQueryHook( const char * pcName )
+    {
+        /* FIX ME. If necessary, update to applicable DNS name lookup actions. */
+
+        BaseType_t xReturn;
+
+        /* Determine if a name lookup is for this node.  Two names are given
+         * to this node: that returned by pcApplicationHostnameHook() and that set
+         * by mainDEVICE_NICK_NAME. */
+        if( strcmp( pcName, pcApplicationHostnameHook() ) == 0 )
+        {
+            xReturn = pdPASS;
+        }
+        else if( strcmp( pcName, mainDEVICE_NICK_NAME ) == 0 )
+        {
+            xReturn = pdPASS;
+        }
+        else
+        {
+            xReturn = pdFAIL;
+        }
+
+        return xReturn;
+    }
+	
+#endif /* if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined assertion call. This function is plugged into configASSERT.
+ * See FreeRTOSConfig.h to define configASSERT to something different.
+ */
+void vAssertCalled(const char * pcFile,
+	uint32_t ulLine)
+{
+    /* FIX ME. If necessary, update to applicable assertion routine actions. */
+
+	const uint32_t ulLongSleep = 1000UL;
+	volatile uint32_t ulBlockVariable = 0UL;
+	volatile char * pcFileName = (volatile char *)pcFile;
+	volatile uint32_t ulLineNumber = ulLine;
+
+	(void)pcFileName;
+	(void)ulLineNumber;
+
+	printf("vAssertCalled %s, %ld\n", pcFile, (long)ulLine);
+	fflush(stdout);
+
+	/* Setting ulBlockVariable to a non-zero value in the debugger will allow
+	* this function to be exited. */
+	taskDISABLE_INTERRUPTS();
+	{
+		while (ulBlockVariable == 0UL)
+		{
+			vTaskDelay( pdMS_TO_TICKS( ulLongSleep ) );
+		}
+	}
+	taskENABLE_INTERRUPTS();
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief User defined application hook need by the FreeRTOS-Plus-TCP library.
+ */
+#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+    const char * pcApplicationHostnameHook(void)
+    {
+        /* FIX ME: If necessary, update to applicable registration name. */
+
+        /* This function will be called during the DHCP: the machine will be registered 
+         * with an IP address plus this name. */
+        return clientcredentialIOT_THING_NAME;
+    }
+
+#endif

--- a/vendors/synopsys/boards/embARC/aws_tests/application_code/synopsys_code/ReadMe.txt
+++ b/vendors/synopsys/boards/embARC/aws_tests/application_code/synopsys_code/ReadMe.txt
@@ -1,0 +1,1 @@
+Place board support specific code in this directory.

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/FreeRTOSConfig.h
@@ -1,0 +1,273 @@
+/*
+FreeRTOS Kernel V10.2.0
+Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ http://aws.amazon.com/freertos
+ http://www.FreeRTOS.org
+*/
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/* Unity includes for testing. */
+#include "unity_internals.h"
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* http://www.freertos.org/a00110.html
+*
+* The bottom of this file contains some constants specific to running the UDP
+* stack in this demo.  Constants specific to FreeRTOS+TCP itself (rather than
+* the demo) are contained in FreeRTOSIPConfig.h.
+*----------------------------------------------------------*/
+
+/* FIX ME: Uncomment and set to the specifications for your MCU. */
+#define configCPU_CLOCK_HZ                        ( ( unsigned long ) BOARD_CPU_CLOCK )
+
+#define configUSE_DAEMON_TASK_STARTUP_HOOK         1
+#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configUSE_PREEMPTION                       1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
+#define configMAX_PRIORITIES                       ( 7 )
+#define configTICK_RATE_HZ                         ( 1000 )
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 )
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
+#define configMAX_TASK_NAME_LEN                    ( 15 )
+#define configUSE_TRACE_FACILITY                   1
+#define configUSE_16_BIT_TICKS                     0
+#define configIDLE_SHOULD_YIELD                    1
+#define configUSE_CO_ROUTINES                      0
+#define configUSE_MUTEXES                          1
+#define configUSE_RECURSIVE_MUTEXES                1
+#define configQUEUE_REGISTRY_SIZE                  0
+#define configUSE_APPLICATION_TASK_TAG             0
+#define configUSE_COUNTING_SEMAPHORES              1
+#define configUSE_ALTERNATIVE_API                  0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    3      /* FreeRTOS+FAT requires 2 pointers if a CWD is supported. */
+#define configRECORD_STACK_HIGH_ADDRESS            1
+
+/* Hook function related definitions. */
+#define configUSE_TICK_HOOK                        0
+#define configUSE_IDLE_HOOK                        1
+#define configUSE_MALLOC_FAILED_HOOK               0
+#define configCHECK_FOR_STACK_OVERFLOW             0      /* use arc stack check */
+
+/* Software timer related definitions. */
+#define configUSE_TIMERS                           1
+#define configTIMER_TASK_PRIORITY                  ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                   5
+#define configTIMER_TASK_STACK_DEPTH               ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Event group related definitions. */
+#define configUSE_EVENT_GROUPS                     1
+
+/* Run time stats gathering definitions. */
+/* FIX ME: Uncomment if you plan to use Tracealyzer.
+unsigned long ulGetRunTimeCounterValue( void );
+void vConfigureTimerForRunTimeStats( void );
+#define configGENERATE_RUN_TIME_STATS    1
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+*/
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+
+/* Currently the TCP/IP stack is using dynamic allocation, and the MQTT task is
+ * using static allocation. */
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+#define configSUPPORT_STATIC_ALLOCATION         1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskCleanUpResources           0
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_uxTaskGetStackHighWaterMark     0
+#define INCLUDE_xTaskGetSchedulerState          1
+#define INCLUDE_xTimerGetTimerTaskHandle        0
+#define INCLUDE_xTaskGetIdleTaskHandle          0
+#define INCLUDE_xQueueGetMutexHolder            1
+#define INCLUDE_eTaskGetState                   1
+#define INCLUDE_xEventGroupSetBitsFromISR       1
+#define INCLUDE_xTimerPendFunctionCall          1
+#define INCLUDE_xTaskGetCurrentTaskHandle       1
+#define INCLUDE_xTaskAbortDelay                 1
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+    /* __NVIC_PRIO_BITS will be specified when CMSIS is being used. */
+    #define configPRIO_BITS    __NVIC_PRIO_BITS
+#else
+    #define configPRIO_BITS    3                                 /* 8 priority levels. */
+#endif
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations.  configUSE_STATS_FORMATTING_FUNCTIONS
+ * is set to 2 so the formatting functions are included without the stdio.h being
+ * included in tasks.c.  That is because this project defines its own sprintf()
+ * functions. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+/* Assert call defined for debug builds. */
+void vAssertCalled( const char * pcFile,
+                    uint32_t ulLine );
+
+#define configASSERT( x )    if( ( x ) == 0 )  TEST_ABORT()
+
+/* The function that implements FreeRTOS printf style output, and the macro
+ * that maps the configPRINTF() macros to that function. */
+extern void vLoggingPrintf( const char * pcFormat, ... );
+#define configPRINTF( X )    vLoggingPrintf X
+
+/* Non-format version thread-safe print */
+extern void vLoggingPrint( const char * pcMessage );
+#define configPRINT( X )     vLoggingPrint( X )
+
+/* Map the logging task's printf to the board specific output function. */
+#include <stdio.h>
+#include "embARC_debug.h"
+#define configPRINT_STRING( X )    EMBARC_PRINTF( X );
+/* Sets the length of the buffers into which logging messages are written - so
+ * also defines the maximum length of each log message. */
+#define configLOGGING_MAX_MESSAGE_LENGTH            100
+
+/* Set to 1 to prepend each log message with a message number, the task name,
+ * and a time stamp. */
+#define configLOGGING_INCLUDE_TIME_AND_TASK_NAME    1
+
+/* The priority at which the tick interrupt runs.  This should probably be kept at 1. */
+#define configKERNEL_INTERRUPT_PRIORITY             1
+
+/* The maximum interrupt priority from which FreeRTOS API functions can be called.
+ * Only API functions that end in ...FromISR() can be used within interrupts. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY        ( 1 << 5 )
+
+/* Application specific definitions follow. **********************************/
+
+/* If configINCLUDE_DEMO_DEBUG_STATS is set to one, then a few basic IP trace
+ * macros are defined to gather some UDP stack statistics that can then be viewed
+ * through the CLI interface. */
+#define configINCLUDE_DEMO_DEBUG_STATS       1
+
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
+/* Only used when running in the FreeRTOS Windows simulator.  Defines the
+ * priority of the task used to simulate Ethernet interrupts. */
+#define configMAC_ISR_SIMULATOR_PRIORITY     ( configMAX_PRIORITIES - 1 )
+
+/* This demo creates a virtual network connection by accessing the raw Ethernet
+ * or WiFi data to and from a real network connection.  Many computers have more
+ * than one real network port, and configNETWORK_INTERFACE_TO_USE is used to tell
+ * the demo which real port should be used to create the virtual port.  The ports
+ * available are displayed on the console when the application is executed.  For
+ * example, on my development laptop setting configNETWORK_INTERFACE_TO_USE to 4
+ * results in the wired network being used, while setting
+ * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
+ * used. */
+#define configNETWORK_INTERFACE_TO_USE       2L
+
+/* The address of an echo server that will be used by the two demo echo client
+ * tasks:
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Echo_Clients.html,
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/UDP_Echo_Clients.html. */
+#define configECHO_SERVER_ADDR0              192
+#define configECHO_SERVER_ADDR1              168
+#define configECHO_SERVER_ADDR2              0
+#define configECHO_SERVER_ADDR3              105
+#define configTCP_ECHO_CLIENT_PORT           45000
+
+/* Default MAC address configuration.  The demo creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition above for information on how to
+ * configure the real network connection to use. */
+#define configMAC_ADDR0                      0x00
+#define configMAC_ADDR1                      0x11
+#define configMAC_ADDR2                      0x22
+#define configMAC_ADDR3                      0x33
+#define configMAC_ADDR4                      0x44
+#define configMAC_ADDR5                      0x21
+
+/* Default IP address configuration.  Used in ipconfigUSE_DHCP is set to 0, or
+ * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configIP_ADDR0                       192
+#define configIP_ADDR1                       168
+#define configIP_ADDR2                       0
+#define configIP_ADDR3                       105
+
+/* Default gateway IP address configuration.  Used in ipconfigUSE_DHCP is set to
+ * 0, or ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configGATEWAY_ADDR0                  192
+#define configGATEWAY_ADDR1                  168
+#define configGATEWAY_ADDR2                  0
+#define configGATEWAY_ADDR3                  1
+
+/* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
+ * 208.67.220.220.  Used in ipconfigUSE_DHCP is set to 0, or ipconfigUSE_DHCP is
+ * set to 1 but a DNS server cannot be contacted.*/
+#define configDNS_SERVER_ADDR0               208
+#define configDNS_SERVER_ADDR1               67
+#define configDNS_SERVER_ADDR2               222
+#define configDNS_SERVER_ADDR3               222
+
+/* Default netmask configuration.  Used in ipconfigUSE_DHCP is set to 0, or
+ * ipconfigUSE_DHCP is set to 1 but a DNS server cannot be contacted. */
+#define configNET_MASK0                      255
+#define configNET_MASK1                      255
+#define configNET_MASK2                      255
+#define configNET_MASK3                      0
+
+/* The UDP port to which print messages are sent. */
+#define configPRINT_PORT                     ( 15000 )
+
+#define configPROFILING                      ( 0 )
+
+/* Pseudo random number generater used by some demo tasks. */
+extern uint32_t ulRand();
+#define configRAND32()    ulRand()
+
+/* FIX ME: The platform FreeRTOS is running on. */
+#define configPLATFORM_NAME    "Unknown"
+
+/* Header required for the tracealyzer recorder library. */
+/* #include "trcRecorder.h" */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -1,0 +1,307 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    0
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket. */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                         1
+#define ipconfigDHCP_REGISTER_HOSTNAME           1
+#define ipconfigDHCP_USES_UNICAST                1
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                    0
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD \
+    ( 120000 / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1200
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 0
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                0
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      240
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 0 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 0 )
+
+
+#define portINLINE                               __inline
+
+void vApplicationMQTTGetKeys( const char ** ppcRootCA,
+                              const char ** ppcClientCert,
+                              const char ** ppcClientPrivateKey );
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_bufferpool_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_bufferpool_config.h
@@ -1,0 +1,44 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_bufferpool_config.h
+ * @brief Buffer Pool config options.
+ */
+
+#ifndef _AWS_BUFFER_POOL_CONFIG_H_
+#define _AWS_BUFFER_POOL_CONFIG_H_
+
+/**
+ * @brief The number of buffers in the static buffer pool.
+ */
+#define bufferpoolconfigNUM_BUFFERS    ( 8 )
+
+/**
+ * @brief The size of each buffer in the static buffer pool.
+ */
+#define bufferpoolconfigBUFFER_SIZE    ( 1024 )
+
+#endif /* _AWS_BUFFER_POOL_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_ggd_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_ggd_config.h
@@ -1,0 +1,46 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/**
+ * @file aws_ggd_config.h
+ * @brief GGD config options.
+ */
+
+#ifndef _AWS_GGD_CONFIG_H_
+#define _AWS_GGD_CONFIG_H_
+
+
+/**
+ * @brief The number of your network interface here.
+ */
+#define ggdconfigCORE_NETWORK_INTERFACE     ( 0 )
+
+/**
+ * @brief Size of the array used by jsmn to store the tokens.
+ */
+#define ggdconfigJSON_MAX_TOKENS            ( 128 )
+
+#endif /* _AWS_GGD_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_mqtt_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_mqtt_config.h
@@ -1,0 +1,72 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_mqtt_config.h
+ * @brief MQTT config options.
+ */
+
+#ifndef _AWS_MQTT_CONFIG_H_
+#define _AWS_MQTT_CONFIG_H_
+
+/* Unity includes. */
+#include "unity_internals.h"
+
+/**
+ * @brief Define assert for test project.
+ */
+#define mqttconfigASSERT( x )    if( ( x ) == 0 ) TEST_ABORT()
+
+/**
+ * @brief Enable subscription management.
+ *
+ * This gives the user flexibility of registering a callback per subscription.
+ */
+#define mqttconfigENABLE_SUBSCRIPTION_MANAGEMENT            ( 1 )
+
+/**
+ * @brief Maximum length of the topic which can be stored in subscription
+ * manager.
+ */
+#define mqttconfigSUBSCRIPTION_MANAGER_MAX_TOPIC_LENGTH     ( 128 )
+
+/**
+ * @brief Maximum number of subscriptions which can be stored in subscription
+ * manager.
+ */
+#define mqttconfigSUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS    ( 8 )
+
+/*
+ * Uncomment the following two lines to enable asserts.
+ */
+/* extern void vAssertCalled( const char *pcFile, uint32_t ulLine ); */
+/* #define mqttconfigASSERT( x ) if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ ) */
+
+/**
+ * @brief Set this macro to 1 for enabling debug logs.
+ */
+#define mqttconfigENABLE_DEBUG_LOGS                 ( 0 )
+
+#endif /* _AWS_MQTT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_ota_agent_config.h
@@ -1,0 +1,88 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_ota_agent_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef _AWS_OTA_AGENT_CONFIG_H_
+#define _AWS_OTA_AGENT_CONFIG_H_
+
+/**
+ * @brief The number of words allocated to the stack for the OTA agent.
+ */
+#define otaconfigSTACK_SIZE                     630U    /* FIX ME. */
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL    /* FIX ME. */
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U  /* FIX ME. */
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA service so we will only send
+ * the request message after being idle for this amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U   /* FIX ME. */
+
+/**
+ * @brief The OTA agent task priority. Normally it runs at a low priority.
+ */
+#define otaconfigAGENT_PRIORITY                 tskIDLE_PRIORITY /* FIX ME. */
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the broker.
+ * Likewise, the OTA agent requires the developer to construct and pass in the Thing name when
+ * initializing the OTA agent. The agent uses this size to allocate static storage for the
+ * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ *  This configuration parameter is sent with data requests and represents the maximum number of
+ *  data blocks the service will send in response. The maximum limit for this must be calculated
+ *  from the maximum data response limit (128 KB from service) divided by the block size.
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
+ *  how many data blocks response is expected for each data requests.
+ *  Please note that this must be set larger than zero.
+ *
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+
+#endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_secure_sockets_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_secure_sockets_config.h
@@ -1,0 +1,51 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_secure_sockets_config.h
+ * @brief Secure sockets configuration options.
+ */
+
+#ifndef _AWS_SECURE_SOCKETS_CONFIG_H_
+#define _AWS_SECURE_SOCKETS_CONFIG_H_
+
+/**
+ * @brief Byte order of the target MCU.
+ *
+ * Valid values are pdLITTLE_ENDIAN and pdBIG_ENDIAN.
+ */
+#define socketsconfigBYTE_ORDER              pdLITTLE_ENDIAN
+
+/**
+ * @brief Default socket send timeout.
+ */
+#define socketsconfigDEFAULT_SEND_TIMEOUT    ( 10000 )
+
+/**
+ * @brief Default socket receive timeout.
+ */
+#define socketsconfigDEFAULT_RECV_TIMEOUT    ( 10000 )
+
+#endif /* _AWS_SECURE_SOCKETS_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_shadow_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_shadow_config.h
@@ -1,0 +1,93 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_shadow_config.h
+ * @brief Configuration constants used by the Shadow library.
+ */
+
+#ifndef _AWS_SHADOW_CONFIG_H_
+#define _AWS_SHADOW_CONFIG_H_
+
+/**
+ * @brief Number of jsmn tokens to use in parsing.  Each jsmn token contains 4 ints.
+ * Ensure that the number of tokens does not overflow the calling task's stack,
+ * but is also sufficient to parse the largest expected JSON documents. */
+#define shadowconfigJSON_JSMN_TOKENS             ( 64 )
+
+/**
+ * @brief Maximum number of Shadow Clients.
+ *
+ * Up to this number of Shadow Clients may be successfully created with
+ * #SHADOW_ClientCreate. Shadow clients are allocated in the global data
+ * segment. Ensure that there is enough memory to accommodate the Shadow
+ * Clients.
+ *
+ * @note Should be less than 256.
+ */
+#define shadowconfigMAX_CLIENTS                  ( 2 )
+
+/**
+ * @brief Shadow debug message setting.
+ *
+ * Set this value to @c 0 to disable Shadow Client debug messages; or set
+ * it to @c 1 to enable debug messages. Ensure that the macro @c configPRINTF
+ * is available if debugging is enabled.
+ */
+#define shadowconfigENABLE_DEBUG_LOGS            ( 0 )
+
+/**
+ * @brief Number of unique Things for which user notify callbacks can be
+ * registered in each Shadow Client.
+ *
+ * Each Shadow Client stores the Things with user notify callbacks registered.
+ * Define how many unique Things require user notify callbacks here.
+ *
+ * @note Should be less than 256.
+ */
+#define shadowconfigMAX_THINGS_WITH_CALLBACKS    ( 4 )
+
+/**
+ * @brief Time (in milliseconds) a Shadow Client may block during cleanup @b IF
+ * a timeout occurs.
+ *
+ * Should a Shadow API call time out, the Shadow Client will stop its current
+ * operation and cleanup before returning. The time below (in milliseconds) is
+ * the amount of additional time that the Shadow Client may block to cleanup @b
+ * IF the user's given timeout is inadequate. In general, 5000 ms is sufficient
+ * for cleanup on a good connection; more time should be given if the connection
+ * is unreliable.
+ *
+ * @note If a user gives a Shadow API call @a x milliseconds of block time but
+ * @a x is insufficient time to complete the API call, then function may block
+ * for up to (@a x + #shadowCLEANUP_TIME_MS) milliseconds. However, if @a x is
+ * sufficient time for the API call, then block time will be at most @a x
+ * milliseconds.
+ * @warning If cleanup doesn't fully complete, users may be billed for MQTT
+ * messages on topics that weren't properly cleaned up!
+ */
+#define shadowconfigCLEANUP_TIME_MS              ( 5000UL )
+
+#endif /* _AWS_SHADOW_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_ota_config.h
@@ -1,0 +1,79 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_test_ota_config.h
+ * @brief Port-specific variables for firmware Over-the-Air Update tests. */
+
+#ifndef _AWS_TEST_OTA_CONFIG_H_
+#define _AWS_TEST_OTA_CONFIG_H_
+
+ /**
+ * @brief Path to cert for OTA test PAL. Used to verify signature.
+ * If applicable, the device must be pre-provisioned with this certificate. Please see
+ * test/common/ota/test_files for the set of certificates.
+ */
+#define otatestpalCERTIFICATE_FILE    "ecdsa-sha256-signer.crt.pem" /* FIX ME. */
+
+ /**
+ * @brief Some boards have a hard-coded name for the firmware image to boot.
+ */
+#define otatestpalFIRMWARE_FILE  "dummy.bin"
+
+/**
+ * @brief Some boards OTA PAL layers will use the file names passed into it for the 
+ * image and the certificates because their non-volatile memory is abstracted by a
+ * file system. Set this to 1 if that is the case for your device.
+ */
+#define otatestpalUSE_FILE_SYSTEM     1 /* FIX ME. */
+
+/**
+ * @brief 1 if prvPAL_CheckFileSignature is implemented in aws_ota_pal.c.
+ */
+#define otatestpalCHECK_FILE_SIGNATURE_SUPPORTED           1   /* FIX ME. */
+
+/**
+ * @brief 1 if prvPAL_ReadAndAssumeCertificate is implemented in the aws_ota_pal.c.
+ */
+#define otatestpalREAD_AND_ASSUME_CERTIFICATE_SUPPORTED    1   /* FIX ME. */
+
+/**
+ * @brief 1 if using PKCS #11 to access the code sign certificate from NVM.
+ */
+#define otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11    1   /* FIX ME. */
+
+/**
+ * @brief Include of signature testing data applicable to this device.
+ */
+#include "aws_test_ota_pal_ecdsa_sha256_signature.h" /* FIX ME. */
+
+/**
+ * @brief Define a valid and invalid signature verification method for this
+ * platform (Windows). These are used for generating test JSON docs.
+ */
+#define otatestVALID_SIG_METHOD                         "sig-sha256-rsa"    /* FIX ME. */
+#define otatestINVALID_SIG_METHOD                       "sig-sha256-ecdsa"  /* FIX ME. */
+
+#endif /* ifndef _AWS_TEST_OTA_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_runner_config.h
@@ -1,0 +1,53 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef AWS_TEST_RUNNER_CONFIG_H
+#define AWS_TEST_RUNNER_CONFIG_H
+
+/* Uncomment this line if you want to run AFQP tests only. */
+/* #define testrunnerAFQP_ENABLED */
+
+#define testrunnerUNSUPPORTED                      0
+
+/* Enable tests by setting defines to 1 */
+#define testrunnerFULL_OTA_CBOR_ENABLED            0
+#define testrunnerFULL_OTA_AGENT_ENABLED           0
+#define testrunnerFULL_OTA_PAL_ENABLED             0
+#define testrunnerFULL_MQTT_ALPN_ENABLED           0
+#define testrunnerFULL_PKCS11_ENABLED              0
+#define testrunnerFULL_CRYPTO_ENABLED              0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
+#define testrunnerFULL_MQTT_AGENT_ENABLED          0
+#define testrunnerFULL_TCP_ENABLED                 0
+#define testrunnerFULL_GGD_ENABLED                 0
+#define testrunnerFULL_GGD_HELPER_ENABLED          0
+#define testrunnerFULL_SHADOW_ENABLED              0
+#define testrunnerFULL_MQTTv4_ENABLED              0
+#define testrunnerFULL_WIFI_ENABLED                0
+#define testrunnerFULL_MEMORYLEAK_ENABLED          1
+#define testrunnerFULL_TLS_ENABLED                 0
+#define testrunnerFULL_HTTPS_CLIENT_ENABLED        0
+
+#endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_tcp_config.h
@@ -1,0 +1,74 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef AWS_INTEGRATION_TEST_TCP_CONFIG_H
+#define AWS_INTEGRATION_TEST_TCP_CONFIG_H
+
+/**
+ * @file aws_integration_test_tcp_portable.h
+ * @brief Port-specific variables for TCP tests. */
+
+/**
+ * @brief Port-specific maximum number of concurrent sockets
+ * Do not define this if the number is limited only by free memory.
+ */
+#if 0
+#define         integrationtestportableMAX_NUM_UNSECURE_SOCKETS    1    /* FIX ME. */
+#endif
+
+/**
+ * @brief Indicates how much longer than the specified timeout is acceptable for
+ * RCVTIMEO tests.
+ *
+ * This value can be used to compensate for clock differences, and other
+ * code overhead.
+ */
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20    /* FIX ME. */
+
+/**
+ * @brief Indicates how much less time than the specified timeout is acceptable for
+ * RCVTIMEO tests.
+ *
+ * This value must be 0 unless networking is performs on a separate processor.
+ * If networking and tests are on different CPUs, an "under tolerance" is acceptable.
+ * For tests where same clock is used for networking and tests.
+ */
+#define         integrationtestportableTIMEOUT_UNDER_TOLERANCE     0     /* FIX ME. */
+
+/**
+ *  @brief Indicates how long  receive needs to wait for data before Timeout happens.
+ *
+ */
+#define         integrationtestportableRECEIVE_TIMEOUT             2000  /* FIX ME. */
+
+/**
+ * @brief Indicates how long  send needs to wait before Timeout happens.
+ *
+ */
+#define         integrationtestportableSEND_TIMEOUT                2000  /* FIX ME. */
+
+
+
+#endif /*AWS_INTEGRATION_TEST_TCP_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_wifi_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_test_wifi_config.h
@@ -1,0 +1,43 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_test_wifi_config.h
+ * @brief Port-specific variables for Wi-Fi tests.
+ */
+#ifndef _AWS_TEST_WIFI_CONFIG_H_
+#define _AWS_TEST_WIFI_CONFIG_H_
+
+/**
+ * @brief The task stack size used in all Wi-Fi multi-task tests.
+ */
+#define testwifiTASK_STACK_SIZE             ( configMINIMAL_STACK_SIZE * 4 )    /* FIX ME. */
+
+/**
+ * @brief The task priority used in all Wi-Fi mulit-task tests. 
+ */
+#define testwifiTASK_PRIORITY               ( tskIDLE_PRIORITY )                /* FIX ME. */
+
+#endif /* _AWS_TEST_WIFI_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_wifi_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/aws_wifi_config.h
@@ -1,0 +1,97 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_wifi_config.h
+ * @brief WiFi module configuration parameters.
+ */
+
+#ifndef _AWS_WIFI_CONFIG_H_
+#define _AWS_WIFI_CONFIG_H_
+
+/**
+ * @brief Maximum number of sockets that can be created simultaneously.
+ */
+#define wificonfigMAX_SOCKETS                 ( 4 )
+
+/**
+ * @brief Maximum number of connection retries.
+ */
+#define wificonfigNUM_CONNECTION_RETRY        ( 3 )
+
+/**
+ * @brief Maximum number of connected station in Access Point mode.
+ */
+#define wificonfigMAX_CONNECTED_STATIONS      ( 4 )
+
+/**
+ * @brief Max number of network profiles stored in Non Volatile memory,
+ * set to zero if not supported.
+ */
+#define wificonfigMAX_NETWORK_PROFILES        ( 0 )
+
+/**
+ * @brief Max SSID length
+ */
+#define wificonfigMAX_SSID_LEN                ( 32 )
+
+/**
+ * @brief Max BSSID length
+ */
+#define wificonfigMAX_BSSID_LEN               ( 6 )
+
+/**
+ * @brief Max passphrase length
+ */
+#define wificonfigMAX_PASSPHRASE_LEN          ( 32 )
+
+/**
+ * @brief Soft Access point SSID
+ */
+#define wificonfigACCESS_POINT_SSID_PREFIX    ( "Enter SSID for Soft AP" )
+
+/**
+ * @brief Soft Access point Passkey
+ */
+#define wificonfigACCESS_POINT_PASSKEY        ( "Enter Password for Soft AP" )
+
+/**
+ * @brief Soft Access point Channel
+ */
+#define wificonfigACCESS_POINT_CHANNEL        ( 11 )
+
+/**
+ * @brief WiFi semaphore timeout
+ */
+#define wificonfigMAX_SEMAPHORE_WAIT_TIME_MS  ( 60000 )
+
+/**
+ * @brief Soft Access point security
+ * WPA2 Security, see WIFISecurity_t
+ * other values are - eWiFiSecurityOpen, eWiFiSecurityWEP, eWiFiSecurityWPA
+ */
+#define wificonfigACCESS_POINT_SECURITY       ( eWiFiSecurityWPA2 )
+
+#endif /* _AWS_WIFI_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_config.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* This file contains configuration settings for the demos. */
+
+#ifndef IOT_CONFIG_H_
+#define IOT_CONFIG_H_
+
+/* Platform thread priority. */
+#define IOT_THREAD_DEFAULT_PRIORITY      5
+
+// #define WIFI_SUPPORTED 					(0)
+
+/* Include the common configuration file for FreeRTOS. */
+#include "iot_config_common.h"
+
+#endif /* ifndef IOT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_mqtt_agent_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_mqtt_agent_config.h
@@ -1,0 +1,106 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_mqtt_agent_config.h
+ * @brief MQTT agent config options.
+ */
+
+#ifndef _AWS_MQTT_AGENT_CONFIG_H_
+#define _AWS_MQTT_AGENT_CONFIG_H_
+
+#include "FreeRTOS.h"
+
+/**
+ * @brief Controls whether or not to report usage metrics to the
+ * AWS IoT broker.
+ *
+ * If mqttconfigENABLE_METRICS is set to 1, a string containing
+ * metric information will be included in the "username" field of
+ * the MQTT connect messages.
+ */
+#define mqttconfigENABLE_METRICS                      ( 1 )
+
+/**
+ * @brief The maximum time interval in seconds allowed to elapse between 2 consecutive
+ * control packets.
+ */
+#define mqttconfigKEEP_ALIVE_INTERVAL_SECONDS         ( 1200 )
+
+/**
+ * @brief Defines the frequency at which the client should send Keep Alive messages.
+ *
+ * Even though the maximum time allowed between 2 consecutive control packets
+ * is defined by the mqttconfigKEEP_ALIVE_INTERVAL_SECONDS macro, the user
+ * can and should send Keep Alive messages at a slightly faster rate to ensure
+ * that the connection is not closed by the server because of network delays.
+ * This macro defines the interval of inactivity after which a keep alive messages
+ * is sent.
+ */
+#define mqttconfigKEEP_ALIVE_ACTUAL_INTERVAL_TICKS    ( pdMS_TO_TICKS( 300000 ) )
+
+/**
+ * @brief The maximum interval in ticks to wait for PINGRESP.
+ *
+ * If PINGRESP is not received within this much time after sending PINGREQ,
+ * the client assumes that the PINGREQ timed out.
+ */
+#define mqttconfigKEEP_ALIVE_TIMEOUT_TICKS            ( 1000 )
+
+/**
+ * @defgroup MQTTTask MQTT task configuration parameters.
+ */
+/** @{ */
+#define mqttconfigMQTT_TASK_STACK_DEPTH    ( configMINIMAL_STACK_SIZE * 4 )
+#define mqttconfigMQTT_TASK_PRIORITY       ( configMAX_PRIORITIES - 3 )
+/** @} */
+
+/**
+ * @brief Maximum number of MQTT clients that can exist simultaneously.
+ */
+#define mqttconfigMAX_BROKERS                  ( 4 )
+
+/**
+ * @brief Maximum number of parallel operations per client.
+ */
+#define mqttconfigMAX_PARALLEL_OPS             ( 5 )
+
+/**
+ * @brief Time in milliseconds after which the TCP send operation should timeout.
+ */
+#define mqttconfigTCP_SEND_TIMEOUT_MS          ( 2000 )
+
+/**
+ * @brief Length of the buffer used to receive data.
+ */
+#define mqttconfigRX_BUFFER_SIZE               ( 128 )
+
+/**
+ * @brief The maximum time in ticks for which the MQTT task is permitted to block.
+ */
+#define mqttconfigMQTT_TASK_MAX_BLOCK_TICKS    ( 100 )
+
+
+#endif /* _AWS_MQTT_AGENT_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_pkcs11_config.h
@@ -1,0 +1,131 @@
+/*
+ * Amazon FreeRTOS V1.1.4
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_pkcs11_config.h
+ * @brief PCKS#11 config options.
+ */
+
+
+#ifndef _AWS_PKCS11_CONFIG_H_
+#define _AWS_PKCS11_CONFIG_H_
+
+/* A non-standard version of C_INITIALIZE should be used by this port. */
+/* #define pkcs11configC_INITIALIZE_ALT */
+
+/**
+ * @brief PKCS #11 default user PIN.
+ *
+ * The PKCS #11 standard specifies the presence of a user PIN. That feature is
+ * sensible for applications that have an interactive user interface and memory
+ * protections. However, since typical microcontroller applications lack one or
+ * both of those, the user PIN is assumed to be used herein for interoperability
+ * purposes only, and not as a security feature.
+ */
+#define configPKCS11_DEFAULT_USER_PIN    "0000"
+
+/**
+ * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
+ * attribute.
+ */
+#define pkcs11configMAX_LABEL_LENGTH     32
+
+/**
+ * @brief Maximum number of token objects that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_NUM_OBJECTS      6
+
+/**
+ * @brief Set to 1 if a PAL destroy object is implemented.
+ *
+ * If set to 0, no PAL destroy object is implemented, and this functionality
+ * is implemented in the common PKCS #11 layer.
+ */
+#define pkcs11configPAL_DESTROY_SUPPORTED                  0
+
+/**
+ * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
+ *
+ * If set to 0, OTA code signing certificate is built in via
+ * aws_ota_codesigner_certificate.h.
+ */
+#define pkcs11configOTA_SUPPORTED                          0
+
+/**
+ * @brief Set to 1 if PAL supports storage for JITP certificate,
+ * code verify certificate, and trusted server root certificate.
+ *
+ * If set to 0, PAL does not support storage mechanism for these, and
+ * they are accessed via headers compiled into the code.
+ */
+#define pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED    0
+
+/**
+ * @brief The PKCS #11 label for device private key.
+ *
+ * Private key for connection to AWS IoT endpoint.  The corresponding
+ * public key should be registered with the AWS IoT endpoint.
+ */
+#define pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "Device Priv TLS Key"
+
+/**
+ * @brief The PKCS #11 label for device public key.
+ *
+ * The public key corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "Device Pub TLS Key"
+
+/**
+ * @brief The PKCS #11 label for the device certificate.
+ *
+ * Device certificate corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
+#define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
+
+/**
+ * @brief The PKCS #11 label for the object to be used for code verification.
+ *
+ * Used by over-the-air update code to verify an incoming signed image.
+ */
+#define pkcs11configLABEL_CODE_VERIFICATION_KEY            "Code Verify Key"
+
+/**
+ * @brief The PKCS #11 label for Just-In-Time-Provisioning.
+ *
+ * The certificate corresponding to the issuer of the device certificate
+ * (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
+ * JITP flow.
+ */
+#define pkcs11configLABEL_JITP_CERTIFICATE                 "JITP Cert"
+
+/**
+ * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
+ *
+ * @see aws_default_root_certificates.h
+ */
+#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
+
+#endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_test_pkcs11_config.h
+ * @brief Port-specific variables for PKCS11 tests. 
+ */
+#ifndef _AWS_TEST_PKCS11_CONFIG_H_
+#define _AWS_TEST_PKCS11_CONFIG_H_
+/**
+ * @brief Number of simultaneous tasks for multithreaded tests.
+ *
+ * Each task consumes both stack and heap space, which may cause memory allocation
+ * failures if too many tasks are created.
+ */
+#define pkcs11testMULTI_THREAD_TASK_COUNT     ( 2 )   /* FIXME. */
+
+/**
+ * @brief The number of iterations of the test that will run in multithread tests.
+ *
+ * A single iteration of Signing and Verifying may take up to a minute on some
+ * boards. Ensure that pkcs11testEVENT_GROUP_TIMEOUT is long enough to accommodate
+ * all iterations of the loop.
+ */
+#define pkcs11testMULTI_THREAD_LOOP_COUNT     ( 10 )  /* FIXME. */
+
+/**
+ * @brief
+ *
+ * All tasks of the SignVerifyRoundTrip_MultitaskLoop test must finish within
+ * this timeout, or the test will fail.
+ */
+#define pkcs11testEVENT_GROUP_TIMEOUT_MS      ( pdMS_TO_TICKS( 1000000UL ) )  /* FIXME. */
+
+/**
+ * @brief The index of the slot that should be used to open sessions for PKCS #11 tests.
+ */
+#define pkcs11testSLOT_NUMBER                 ( 0 )  /* FIXME. */
+
+/*
+ * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
+ */
+#define pkcs11testRSA_KEY_SUPPORT             ( 1 )  /* FIXME. */
+
+/*
+ * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.
+ */
+#define pkcs11testEC_KEY_SUPPORT              ( 1 )  /* FIXME. */
+
+/*
+ * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
+ */
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT       ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED )  /* FIXME. */
+
+/*
+ * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
+ */
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT    ( 1 )  /* FIXME. */
+
+/**
+ * @brief The PKCS #11 label for device private key for test.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
+
+/**
+ * @brief The PKCS #11 label for device public key.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS
+
+/**
+ * @brief The PKCS #11 label for the device certificate.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS       pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS
+
+/**
+ * @brief The PKCS #11 label for the object to be used for code verification.
+ *
+ * Used by over-the-air update code to verify an incoming signed image.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_CODE_VERIFICATION_KEY            pkcs11configLABEL_CODE_VERIFICATION_KEY
+
+/**
+ * @brief The PKCS #11 label for Just-In-Time-Provisioning.
+ *
+ * The certificate corresponding to the issuer of the device certificate
+ * (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
+ * JITP flow.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_JITP_CERTIFICATE                 pkcs11configLABEL_JITP_CERTIFICATE
+
+/**
+ * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
+ *
+ * @see aws_default_root_certificates.h
+ */
+#define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
+
+#endif /* _AWS_TEST_PKCS11_CONFIG_H_ */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/trcConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/trcConfig.h
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Trace Recorder Library for Tracealyzer v3.1.2
+ * Percepio AB, www.percepio.com
+ *
+ * trcConfig.h
+ *
+ * Main configuration parameters for the trace recorder library.
+ * More settings can be found in trcStreamingConfig.h and trcSnapshotConfig.h.
+ *
+ * Read more at http://percepio.com/2016/10/05/rtos-tracing/
+ *
+ * Terms of Use
+ * This file is part of the trace recorder library (RECORDER), which is the
+ * intellectual property of Percepio AB (PERCEPIO) and provided under a
+ * license as follows.
+ * The RECORDER may be used free of charge for the purpose of recording data
+ * intended for analysis in PERCEPIO products. It may not be used or modified
+ * for other purposes without explicit permission from PERCEPIO.
+ * You may distribute the RECORDER in its original source code form, assuming
+ * this text (terms of use, disclaimer, copyright notice) is unchanged. You are
+ * allowed to distribute the RECORDER with minor modifications intended for
+ * configuration or porting of the RECORDER, e.g., to allow using it on a
+ * specific processor, processor family or with a specific communication
+ * interface. Any such modifications should be documented directly below
+ * this comment block.
+ *
+ * Disclaimer
+ * The RECORDER is being delivered to you AS IS and PERCEPIO makes no warranty
+ * as to its use or performance. PERCEPIO does not and cannot warrant the
+ * performance or results you may obtain by using the RECORDER or documentation.
+ * PERCEPIO make no warranties, express or implied, as to noninfringement of
+ * third party rights, merchantability, or fitness for any particular purpose.
+ * In no event will PERCEPIO, its technology partners, or distributors be liable
+ * to you for any consequential, incidental or special damages, including any
+ * lost profits or lost savings, even if a representative of PERCEPIO has been
+ * advised of the possibility of such damages, or for any claim by any third
+ * party. Some jurisdictions do not allow the exclusion or limitation of
+ * incidental, consequential or special damages, or the exclusion of implied
+ * warranties or limitations on how long an implied warranty may last, so the
+ * above limitations may not apply to you.
+ *
+ * Tabs are used for indent in this file (1 tab = 4 spaces)
+ *
+ * Copyright Percepio AB, 2016.
+ * www.percepio.com
+ ******************************************************************************/
+
+#ifndef TRC_CONFIG_H
+#define TRC_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "trcPortDefines.h"
+
+/******************************************************************************
+ * Include of processor header file
+ *
+ * Here you may need to include the header file for your processor. This is
+ * required at least for the ARM Cortex-M port, that uses the ARM CMSIS API.
+ * Try that in case of build problems. Otherwise, remove the #error line below.
+ *****************************************************************************/
+//#error "Trace Recorder: Please include your processor's header file here and remove this line."
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_HARDWARE_PORT
+ *
+ * Specify what hardware port to use (i.e., the "timestamping driver").
+ *
+ * All ARM Cortex-M MCUs are supported by "TRC_HARDWARE_PORT_ARM_Cortex_M".
+ * This port uses the DWT cycle counter for Cortex-M3/M4/M7 devices, which is
+ * available on most such devices. In case your device don't have DWT support,
+ * you will get an error message opening the trace. In that case, you may
+ * force the recorder to use SysTick timestamping instead, using this define:
+ *
+ * #define TRC_CFG_ARM_CM_USE_SYSTICK
+ *
+ * For ARM Cortex-M0/M0+ devices, SysTick mode is used automatically.
+ *
+ * See trcHardwarePort.h for available ports and information on how to
+ * define your own port, if not already present.
+ ******************************************************************************/
+#define TRC_CFG_HARDWARE_PORT TRC_HARDWARE_PORT_Win32
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_RECORDER_MODE
+ *
+ * Specify what recording mode to use. Snapshot means that the data is saved in
+ * an internal RAM buffer, for later upload. Streaming means that the data is
+ * transferred continuously to the host PC.
+ *
+ * For more information, see http://percepio.com/2016/10/05/rtos-tracing/
+ * and the Tracealyzer User Manual.
+ *
+ * Values:
+ * TRC_RECORDER_MODE_SNAPSHOT
+ * TRC_RECORDER_MODE_STREAMING
+ ******************************************************************************/
+#define TRC_CFG_RECORDER_MODE TRC_RECORDER_MODE_SNAPSHOT
+
+/*******************************************************************************
+ * Configuration Macro: TRC_CFG_RECORDER_BUFFER_ALLOCATION
+ *
+ * Specifies how the recorder buffer is allocated (also in case of streaming, in
+ * port using the recorder's internal temporary buffer)
+ *
+ * Values:
+ * TRC_RECORDER_BUFFER_ALLOCATION_STATIC  - Static allocation (internal)
+ * TRC_RECORDER_BUFFER_ALLOCATION_DYNAMIC - Malloc in vTraceEnable
+ * TRC_RECORDER_BUFFER_ALLOCATION_CUSTOM  - Use vTraceSetRecorderDataBuffer
+ *
+ * Static and dynamic mode does the allocation for you, either in compile time
+ * (static) or in runtime (malloc).
+ * The custom mode allows you to control how and where the allocation is made,
+ * for details see TRC_ALLOC_CUSTOM_BUFFER and vTraceSetRecorderDataBuffer().
+ ******************************************************************************/
+#define TRC_CFG_RECORDER_BUFFER_ALLOCATION TRC_RECORDER_BUFFER_ALLOCATION_STATIC
+
+/******************************************************************************
+ * TRC_CFG_FREERTOS_VERSION
+ *
+ * Specify what version of FreeRTOS that is used (don't change unless using the
+ * trace recorder library with an older version of FreeRTOS).
+ *
+ * TRC_FREERTOS_VERSION_7_3_OR_7_4				If using FreeRTOS v7.3.0 - v7.4.2
+ * TRC_FREERTOS_VERSION_7_5_OR_7_6				If using FreeRTOS v7.5.0 - v7.6.0
+ * TRC_FREERTOS_VERSION_8_X						If using FreeRTOS v8.X.X
+ * TRC_FREERTOS_VERSION_9_X						If using FreeRTOS v9.X.X
+ *****************************************************************************/
+#define TRC_CFG_FREERTOS_VERSION	TRC_FREERTOS_VERSION_9_X
+
+/******************************************************************************
+ * TRC_CFG_MAX_ISR_NESTING
+ *
+ * Defines how many levels of interrupt nesting the recorder can handle, in
+ * case multiple ISRs are traced and ISR nesting is possible. If this
+ * is exceeded, the particular ISR will not be traced and the recorder then
+ * logs an error message. This setting is used to allocate an internal stack
+ * for keeping track of the previous execution context (4 byte per entry).
+ *
+ * This value must be a non-zero positive constant, at least 1.
+ *
+ * Default value: 8
+ *****************************************************************************/
+#define TRC_CFG_MAX_ISR_NESTING 8
+
+/* Specific configuration, depending on Streaming/Snapshot mode */
+#if (TRC_CFG_RECORDER_MODE == TRC_RECORDER_MODE_SNAPSHOT)
+#include "trcSnapshotConfig.h"
+#elif (TRC_CFG_RECORDER_MODE == TRC_RECORDER_MODE_STREAMING)
+#include "trcStreamingConfig.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TRC_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/trcSnapshotConfig.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/trcSnapshotConfig.h
@@ -1,0 +1,472 @@
+/*******************************************************************************
+ * Trace Recorder Library for Tracealyzer v3.1.2
+ * Percepio AB, www.percepio.com
+ *
+ * trcSnapshotConfig.h
+ *
+ * Configuration parameters for trace recorder library in snapshot mode.
+ * Read more at http://percepio.com/2016/10/05/rtos-tracing/
+ *
+ * Terms of Use
+ * This file is part of the trace recorder library (RECORDER), which is the
+ * intellectual property of Percepio AB (PERCEPIO) and provided under a
+ * license as follows.
+ * The RECORDER may be used free of charge for the purpose of recording data
+ * intended for analysis in PERCEPIO products. It may not be used or modified
+ * for other purposes without explicit permission from PERCEPIO.
+ * You may distribute the RECORDER in its original source code form, assuming
+ * this text (terms of use, disclaimer, copyright notice) is unchanged. You are
+ * allowed to distribute the RECORDER with minor modifications intended for
+ * configuration or porting of the RECORDER, e.g., to allow using it on a
+ * specific processor, processor family or with a specific communication
+ * interface. Any such modifications should be documented directly below
+ * this comment block.
+ *
+ * Disclaimer
+ * The RECORDER is being delivered to you AS IS and PERCEPIO makes no warranty
+ * as to its use or performance. PERCEPIO does not and cannot warrant the
+ * performance or results you may obtain by using the RECORDER or documentation.
+ * PERCEPIO make no warranties, express or implied, as to noninfringement of
+ * third party rights, merchantability, or fitness for any particular purpose.
+ * In no event will PERCEPIO, its technology partners, or distributors be liable
+ * to you for any consequential, incidental or special damages, including any
+ * lost profits or lost savings, even if a representative of PERCEPIO has been
+ * advised of the possibility of such damages, or for any claim by any third
+ * party. Some jurisdictions do not allow the exclusion or limitation of
+ * incidental, consequential or special damages, or the exclusion of implied
+ * warranties or limitations on how long an implied warranty may last, so the
+ * above limitations may not apply to you.
+ *
+ * Tabs are used for indent in this file (1 tab = 4 spaces)
+ *
+ * Copyright Percepio AB, 2017.
+ * www.percepio.com
+ ******************************************************************************/
+
+#ifndef TRC_SNAPSHOT_CONFIG_H
+#define TRC_SNAPSHOT_CONFIG_H
+
+#define TRC_SNAPSHOT_MODE_RING_BUFFER       ( 0x01 )
+#define TRC_SNAPSHOT_MODE_STOP_WHEN_FULL    ( 0x02 )
+
+/******************************************************************************
+ * TRC_CFG_SNAPSHOT_MODE
+ *
+ * Macro which should be defined as one of:
+ * - TRC_SNAPSHOT_MODE_RING_BUFFER
+ * - TRC_SNAPSHOT_MODE_STOP_WHEN_FULL
+ * Default is TRC_SNAPSHOT_MODE_RING_BUFFER.
+ *
+ * With TRC_CFG_SNAPSHOT_MODE set to TRC_SNAPSHOT_MODE_RING_BUFFER, the
+ * events are stored in a ring buffer, i.e., where the oldest events are
+ * overwritten when the buffer becomes full. This allows you to get the last
+ * events leading up to an interesting state, e.g., an error, without having
+ * to store the whole run since startup.
+ *
+ * When TRC_CFG_SNAPSHOT_MODE is TRC_SNAPSHOT_MODE_STOP_WHEN_FULL, the
+ * recording is stopped when the buffer becomes full. This is useful for
+ * recording events following a specific state, e.g., the startup sequence.
+ *****************************************************************************/
+#define TRC_CFG_SNAPSHOT_MODE               TRC_SNAPSHOT_MODE_RING_BUFFER
+
+/*******************************************************************************
+ * TRC_CFG_SCHEDULING_ONLY
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * If this setting is enabled (= 1), only scheduling events are recorded.
+ * If disabled (= 0), all events are recorded.
+ *
+ * For users of Tracealyzer Free Edition, that only displays scheduling events, this
+ * option can be used to avoid storing other events.
+ *
+ * Default value is 0 (store all enabled events).
+ *
+ ******************************************************************************/
+#define TRC_CFG_SCHEDULING_ONLY             0
+
+/*******************************************************************************
+ * TRC_CFG_EVENT_BUFFER_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the event buffer, i.e., the number of records
+ * it may store. Most events use one record (4 byte), although some events
+ * require multiple 4-byte records. You should adjust this to the amount of RAM
+ * available in the target system.
+ *
+ * Default value is 1000, which means that 4000 bytes is allocated for the
+ * event buffer.
+ ******************************************************************************/
+#define TRC_CFG_EVENT_BUFFER_SIZE           15000
+
+/*******************************************************************************
+ * TRC_CFG_NTASK, TRC_CFG_NISR, TRC_CFG_NQUEUE, TRC_CFG_NSEMAPHORE...
+ *
+ * A group of macros which should be defined as integer values, zero or larger.
+ *
+ * These define the capacity of the Object Property Table, i.e., the maximum
+ * number of objects active at any given point, within each object class (e.g.,
+ * task, queue, semaphore, ...).
+ *
+ * If tasks or other objects are deleted in your system, this
+ * setting does not limit the total amount of objects created, only the number
+ * of objects that have been successfully created but not yet deleted.
+ *
+ * Using too small values will cause vTraceError to be called, which stores an
+ * error message in the trace that is shown when opening the trace file. The
+ * error message can also be retrieved using xTraceGetLastError.
+ *
+ * It can be wise to start with large values for these constants,
+ * unless you are very confident on these numbers. Then do a recording and
+ * check the actual usage by selecting View menu -> Trace Details ->
+ * Resource Usage -> Object Table.
+ ******************************************************************************/
+#define TRC_CFG_NTASK                       150
+#define TRC_CFG_NISR                        90
+#define TRC_CFG_NQUEUE                      90
+#define TRC_CFG_NSEMAPHORE                  90
+#define TRC_CFG_NMUTEX                      90
+#define TRC_CFG_NTIMER                      250
+#define TRC_CFG_NEVENTGROUP                 90
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_MEMMANG_EVENTS
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * This controls if malloc and free calls should be traced. Set this to zero (0)
+ * to exclude malloc/free calls, or one (1) to include such events in the trace.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_MEMMANG_EVENTS      1
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_USER_EVENTS
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If this is zero (0) the code for creating User Events is excluded to
+ * reduce code size. User Events are application-generated events, like
+ * "printf" but for the trace log and the formatting is done offline, by the
+ * Tracealyzer visualization tool. User Events are much faster than a printf
+ * and can therefore be used in timing critical code.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_USER_EVENTS         1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_ISR_TRACING
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If this is zero (0), the code for recording Interrupt Service Routines is
+* excluded, in order to reduce code size.
+*
+* Default value is 1.
+*
+* Note: tracing ISRs requires that you insert calls to vTraceStoreISRBegin
+* and vTraceStoreISREnd in your interrupt handlers.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_ISR_TRACING         1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_READY_EVENTS
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If one (1), events are recorded when tasks enter scheduling state "ready".
+* This allows Tracealyzer to show the initial pending time before tasks enter
+* the execution state, and present accurate response times.
+* If zero (0), "ready events" are not created, which allows for recording
+* longer traces in the same amount of RAM.
+*
+* Default value is 1.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_READY_EVENTS        1
+
+/*****************************************************************************
+* TRC_CFG_INCLUDE_OSTICK_EVENTS
+*
+* Macro which should be defined as either zero (0) or one (1).
+*
+* If this is one (1), events will be generated whenever the OS clock is
+* increased. If zero (0), OS tick events are not generated, which allows for
+* recording longer traces in the same amount of RAM.
+*
+* Default value is 0.
+*****************************************************************************/
+#define TRC_CFG_INCLUDE_OSTICK_EVENTS       1
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_FLOAT_SUPPORT
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If this is zero (0), the support for logging floating point values in
+ * vTracePrintF is stripped out, in case floating point values are not used or
+ * supported by the platform used.
+ *
+ * Floating point values are only used in vTracePrintF and its subroutines, to
+ * allow for storing float (%f) or double (%lf) arguments.
+ *
+ * vTracePrintF can be used with integer and string arguments in either case.
+ *
+ * Default value is 0.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_FLOAT_SUPPORT       0
+
+/******************************************************************************
+ * TRC_CFG_INCLUDE_OBJECT_DELETE
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * This must be enabled (1) if tasks, queues or other
+ * traced kernel objects are deleted at runtime. If no deletes are made, this
+ * can be set to 0 in order to exclude the delete-handling code.
+ *
+ * Default value is 1.
+ *****************************************************************************/
+#define TRC_CFG_INCLUDE_OBJECT_DELETE       1
+
+/*******************************************************************************
+ * TRC_CFG_SYMBOL_TABLE_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the symbol table, in bytes. This symbol table
+ * stores User Events labels and names of deleted tasks, queues, or other kernel
+ * objects. If you don't use User Events or delete any kernel
+ * objects you set this to a very low value. The minimum recommended value is 4.
+ * A size of zero (0) is not allowed since a zero-sized array may result in a
+ * 32-bit pointer, i.e., using 4 bytes rather than 0.
+ *
+ * Default value is 800.
+ ******************************************************************************/
+#define TRC_CFG_SYMBOL_TABLE_SIZE           5000
+
+#if ( TRC_CFG_SYMBOL_TABLE_SIZE == 0 )
+    #error "TRC_CFG_SYMBOL_TABLE_SIZE may not be zero!"
+#endif
+
+/******************************************************************************
+ * TRC_CFG_NAME_LEN_TASK, TRC_CFG_NAME_LEN_QUEUE, ...
+ *
+ * Macros that specify the maximum lengths (number of characters) for names of
+ * kernel objects, such as tasks and queues. If longer names are used, they will
+ * be truncated when stored in the recorder.
+ *****************************************************************************/
+#define TRC_CFG_NAME_LEN_TASK          15
+#define TRC_CFG_NAME_LEN_ISR           15
+#define TRC_CFG_NAME_LEN_QUEUE         15
+#define TRC_CFG_NAME_LEN_SEMAPHORE     15
+#define TRC_CFG_NAME_LEN_MUTEX         15
+#define TRC_CFG_NAME_LEN_TIMER         15
+#define TRC_CFG_NAME_LEN_EVENTGROUP    15
+
+/******************************************************************************
+ *** ADVANCED SETTINGS ********************************************************
+ ******************************************************************************
+ * The remaining settings are not necessary to modify but allows for optimizing
+ * the recorder setup for your specific needs, e.g., to exclude events that you
+ * are not interested in, in order to get longer traces.
+ *****************************************************************************/
+
+/******************************************************************************
+* TRC_CFG_HEAP_SIZE_BELOW_16M
+*
+* An integer constant that can be used to reduce the buffer usage of memory
+* allocation events (malloc/free). This value should be 1 if the heap size is
+* below 16 MB (2^24 byte), and you can live with reported addresses showing the
+* lower 24 bits only. If 0, you get the full 32-bit addresses.
+*
+* Default value is 0.
+******************************************************************************/
+#define TRC_CFG_HEAP_SIZE_BELOW_16M                0
+
+/******************************************************************************
+ * TRC_CFG_USE_IMPLICIT_IFE_RULES
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ * Default is 1.
+ *
+ * Tracealyzer groups the events into "instances" based on Instance Finish
+ * Events (IFEs), produced either by default rules or calls to the recorder
+ * functions vTraceInstanceFinishedNow and vTraceInstanceFinishedNext.
+ *
+ * If TRC_CFG_USE_IMPLICIT_IFE_RULES is one (1), the default IFE rules is
+ * used, resulting in a "typical" grouping of events into instances.
+ * If these rules don't give appropriate instances in your case, you can
+ * override the default rules using vTraceInstanceFinishedNow/Next for one
+ * or several tasks. The default IFE rules are then disabled for those tasks.
+ *
+ * If TRC_CFG_USE_IMPLICIT_IFE_RULES is zero (0), the implicit IFE rules are
+ * disabled globally. You must then call vTraceInstanceFinishedNow or
+ * vTraceInstanceFinishedNext to manually group the events into instances,
+ * otherwise the tasks will appear a single long instance.
+ *
+ * The default IFE rules count the following events as "instance finished":
+ * - Task delay, delay until
+ * - Task suspend
+ * - Blocking on "input" operations, i.e., when the task is waiting for the
+ *   next a message/signal/event. But only if this event is blocking.
+ *
+ * For details, see trcSnapshotKernelPort.h and look for references to the
+ * macro trcKERNEL_HOOKS_SET_TASK_INSTANCE_FINISHED.
+ *****************************************************************************/
+#define TRC_CFG_USE_IMPLICIT_IFE_RULES             1
+
+/******************************************************************************
+ * TRC_CFG_USE_16BIT_OBJECT_HANDLES
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ *
+ * If set to 0 (zero), the recorder uses 8-bit handles to identify kernel
+ * objects such as tasks and queues. This limits the supported number of
+ * concurrently active objects to 255 of each type (tasks, queues, mutexes,
+ * etc.) Note: 255, not 256, since handle 0 is reserved.
+ *
+ * If set to 1 (one), the recorder uses 16-bit handles to identify kernel
+ * objects such as tasks and queues. This limits the supported number of
+ * concurrent objects to 65535 of each type (object class). However, since the
+ * object property table is limited to 64 KB, the practical limit is about
+ * 3000 objects in total.
+ *
+ * Default is 0 (8-bit handles)
+ *
+ * NOTE: An object with handle above 255 will use an extra 4-byte record in
+ * the event buffer whenever the object is referenced. Moreover, some internal
+ * tables in the recorder gets slightly larger when using 16-bit handles.
+ *****************************************************************************/
+#define TRC_CFG_USE_16BIT_OBJECT_HANDLES           0
+
+/******************************************************************************
+ * TRC_CFG_USE_TRACE_ASSERT
+ *
+ * Macro which should be defined as either zero (0) or one (1).
+ * Default is 1.
+ *
+ * If this is one (1), the TRACE_ASSERT macro (used at various locations in the
+ * trace recorder) will verify that a relevant condition is true.
+ * If the condition is false, prvTraceError() will be called, which stops the
+ * recording and stores an error message that is displayed when opening the
+ * trace in Tracealyzer.
+ *
+ * This is used on several places in the recorder code for sanity checks on
+ * parameters. Can be switched off to reduce the footprint of the tracing, but
+ * we recommend to have it enabled initially.
+ *****************************************************************************/
+#define TRC_CFG_USE_TRACE_ASSERT                   1
+
+/*******************************************************************************
+ * TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * Set TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER to 1 to enable the
+ * separate user event buffer (UB).
+ * In this mode, user events are stored separately from other events,
+ * e.g., RTOS events. Thereby you can get a much longer history of
+ * user events as they don't need to share the buffer space with more
+ * frequent events.
+ *
+ * The UB is typically used with the snapshot ring-buffer mode, so the
+ * recording can continue when the main buffer gets full. And since the
+ * main buffer then overwrites the earliest events, Tracealyzer displays
+ * "Unknown Actor" instead of task scheduling for periods with UB data only.
+ *
+ * In UB mode, user events are structured as UB channels, which contains
+ * a channel name and a default format string. Register a UB channel using
+ * xTraceRegisterUBChannel.
+ *
+ * Events and data arguments are written using vTraceUBEvent and
+ * vTraceUBData. They are designed to provide efficient logging of
+ * repeating events, using the same format string within each channel.
+ *
+ * Examples:
+ *
+ *  traceString chn1 = xTraceRegisterString("Channel 1");
+ *  traceString fmt1 = xTraceRegisterString("Event!");
+ *  traceUBChannel UBCh1 = xTraceRegisterUBChannel(chn1, fmt1);
+ *
+ *  traceString chn2 = xTraceRegisterString("Channel 2");
+ *  traceString fmt2 = xTraceRegisterString("X: %d, Y: %d");
+ *	traceUBChannel UBCh2 = xTraceRegisterUBChannel(chn2, fmt2);
+ *
+ *  // Result in "[Channel 1] Event!"
+ *	vTraceUBEvent(UBCh1);
+ *
+ *  // Result in "[Channel 2] X: 23, Y: 19"
+ *	vTraceUBData(UBCh2, 23, 19);
+ *
+ * You can also use the other user event functions, like vTracePrintF.
+ * as they are then rerouted to the UB instead of the main event buffer.
+ * vTracePrintF then looks up the correct UB channel based on the
+ * provided channel name and format string, or creates a new UB channel
+ * if no match is found. The format string should therefore not contain
+ * "random" messages but mainly format specifiers. Random strings should
+ * be stored using %s and with the string as an argument.
+ *
+ *  // Creates a new UB channel ("Channel 2", "%Z: %d")
+ *  vTracePrintF(chn2, "%Z: %d", value1);
+ *
+ *  // Finds the existing UB channel
+ *  vTracePrintF(chn2, "%Z: %d", value2);
+ *
+ ******************************************************************************/
+#define TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER     0
+
+/*******************************************************************************
+ * TRC_CFG_SEPARATE_USER_EVENT_BUFFER_SIZE
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the capacity of the user event buffer (UB), in number of slots.
+ * A single user event can use multiple slots, depending on the arguments.
+ *
+ * Only applicable if TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER is 1.
+ ******************************************************************************/
+#define TRC_CFG_SEPARATE_USER_EVENT_BUFFER_SIZE    200
+
+/*******************************************************************************
+ * TRC_CFG_UB_CHANNELS
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * This defines the number of User Event Buffer Channels (UB channels).
+ * These are used to structure the events when using the separate user
+ * event buffer, and contains both a User Event Channel (the name) and
+ * a default format string for the channel.
+ *
+ * Only applicable if TRC_CFG_USE_SEPARATE_USER_EVENT_BUFFER is 1.
+ ******************************************************************************/
+#define TRC_CFG_UB_CHANNELS                        32
+
+/*******************************************************************************
+ * TRC_CFG_ISR_TAILCHAINING_THRESHOLD
+ *
+ * Macro which should be defined as an integer value.
+ *
+ * If tracing multiple ISRs, this setting allows for accurate display of the
+ * context-switching also in cases when the ISRs execute in direct sequence.
+ *
+ * vTraceStoreISREnd normally assumes that the ISR returns to the previous
+ * context, i.e., a task or a preempted ISR. But if another traced ISR
+ * executes in direct sequence, Tracealyzer may incorrectly display a minimal
+ * fragment of the previous context in between the ISRs.
+ *
+ * By using TRC_CFG_ISR_TAILCHAINING_THRESHOLD you can avoid this. This is
+ * however a threshold value that must be measured for your specific setup.
+ * See http://percepio.com/2014/03/21/isr_tailchaining_threshold/
+ *
+ * The default setting is 0, meaning "disabled" and that you may get an
+ * extra fragments of the previous context in between tail-chained ISRs.
+ *
+ * Note: This setting has separate definitions in trcSnapshotConfig.h and
+ * trcStreamingConfig.h, since it is affected by the recorder mode.
+ ******************************************************************************/
+#define TRC_CFG_ISR_TAILCHAINING_THRESHOLD         0
+
+#endif /*TRC_SNAPSHOT_CONFIG_H*/

--- a/vendors/synopsys/boards/embARC/aws_tests/config_files/unity_config.h
+++ b/vendors/synopsys/boards/embARC/aws_tests/config_files/unity_config.h
@@ -1,0 +1,242 @@
+/* Unity Configuration
+ * As of May 11th, 2016 at ThrowTheSwitch/Unity commit 837c529
+ * Update: December 29th, 2016
+ * See Also: Unity/docs/UnityConfigurationGuide.pdf
+ *
+ * Unity is designed to run on almost anything that is targeted by a C compiler.
+ * It would be awesome if this could be done with zero configuration. While
+ * there are some targets that come close to this dream, it is sadly not
+ * universal. It is likely that you are going to need at least a couple of the
+ * configuration options described in this document.
+ *
+ * All of Unity's configuration options are `#defines`. Most of these are simple
+ * definitions. A couple are macros with arguments. They live inside the
+ * unity_internals.h header file. We don't necessarily recommend opening that
+ * file unless you really need to. That file is proof that a cross-platform
+ * library is challenging to build. From a more positive perspective, it is also
+ * proof that a great deal of complexity can be centralized primarily to one
+ * place in order to provide a more consistent and simple experience elsewhere.
+ *
+ * Using These Options
+ * It doesn't matter if you're using a target-specific compiler and a simulator
+ * or a native compiler. In either case, you've got a couple choices for
+ * configuring these options:
+ *
+ *  1. Because these options are specified via C defines, you can pass most of
+ *     these options to your compiler through command line compiler flags. Even
+ *     if you're using an embedded target that forces you to use their
+ *     overbearing IDE for all configuration, there will be a place somewhere in
+ *     your project to configure defines for your compiler.
+ *  2. You can create a custom `unity_config.h` configuration file (present in
+ *     your toolchain's search paths). In this file, you will list definitions
+ *     and macros specific to your target. All you must do is define
+ *     `UNITY_INCLUDE_CONFIG_H` and Unity will rely on `unity_config.h` for any
+ *     further definitions it may need.
+ */
+
+#ifndef UNITY_CONFIG_H
+#define UNITY_CONFIG_H
+
+/* ************************* AUTOMATIC INTEGER TYPES ***************************
+ * C's concept of an integer varies from target to target. The C Standard has
+ * rules about the `int` matching the register size of the target
+ * microprocessor. It has rules about the `int` and how its size relates to
+ * other integer types. An `int` on one target might be 16 bits while on another
+ * target it might be 64. There are more specific types in compilers compliant
+ * with C99 or later, but that's certainly not every compiler you are likely to
+ * encounter. Therefore, Unity has a number of features for helping to adjust
+ * itself to match your required integer sizes. It starts off by trying to do it
+ * automatically.
+ **************************************************************************** */
+
+/* The first attempt to guess your types is to check `limits.h`. Some compilers
+ * that don't support `stdint.h` could include `limits.h`. If you don't
+ * want Unity to check this file, define this to make it skip the inclusion.
+ * Unity looks at UINT_MAX & ULONG_MAX, which were available since C89.
+ */
+/* #define UNITY_EXCLUDE_LIMITS_H */
+
+/* The second thing that Unity does to guess your types is check `stdint.h`.
+ * This file defines `UINTPTR_MAX`, since C99, that Unity can make use of to
+ * learn about your system. It's possible you don't want it to do this or it's
+ * possible that your system doesn't support `stdint.h`. If that's the case,
+ * you're going to want to define this. That way, Unity will know to skip the
+ * inclusion of this file and you won't be left with a compiler error.
+ */
+/* #define UNITY_EXCLUDE_STDINT_H */
+
+/* ********************** MANUAL INTEGER TYPE DEFINITION ***********************
+ * If you've disabled all of the automatic options above, you're going to have
+ * to do the configuration yourself. There are just a handful of defines that
+ * you are going to specify if you don't like the defaults.
+ **************************************************************************** */
+
+/* Define this to be the number of bits an `int` takes up on your system. The
+ * default, if not auto-detected, is 32 bits.
+ *
+ * Example:
+ */
+/* #define UNITY_INT_WIDTH 16 */
+
+/* Define this to be the number of bits a `long` takes up on your system. The
+ * default, if not autodetected, is 32 bits. This is used to figure out what
+ * kind of 64-bit support your system can handle.  Does it need to specify a
+ * `long` or a `long long` to get a 64-bit value. On 16-bit systems, this option
+ * is going to be ignored.
+ *
+ * Example:
+ */
+/* #define UNITY_LONG_WIDTH 16 */
+
+/* Define this to be the number of bits a pointer takes up on your system. The
+ * default, if not autodetected, is 32-bits. If you're getting ugly compiler
+ * warnings about casting from pointers, this is the one to look at.
+ *
+ * Example:
+ */
+/* #define UNITY_POINTER_WIDTH 64 */
+
+/* Unity will automatically include 64-bit support if it auto-detects it, or if
+ * your `int`, `long`, or pointer widths are greater than 32-bits. Define this
+ * to enable 64-bit support if none of the other options already did it for you.
+ * There can be a significant size and speed impact to enabling 64-bit support
+ * on small targets, so don't define it if you don't need it.
+ */
+/* #define UNITY_INCLUDE_64 */
+
+
+/* *************************** FLOATING POINT TYPES ****************************
+ * In the embedded world, it's not uncommon for targets to have no support for
+ * floating point operations at all or to have support that is limited to only
+ * single precision. We are able to guess integer sizes on the fly because
+ * integers are always available in at least one size. Floating point, on the
+ * other hand, is sometimes not available at all. Trying to include `float.h` on
+ * these platforms would result in an error. This leaves manual configuration as
+ * the only option.
+ **************************************************************************** */
+
+/* By default, Unity guesses that you will want single precision floating point
+ * support, but not double precision. It's easy to change either of these using
+ * the include and exclude options here. You may include neither, just float,
+ * or both, as suits your needs.
+ */
+/* #define UNITY_EXCLUDE_FLOAT  */
+/* #define UNITY_INCLUDE_DOUBLE */
+/* #define UNITY_EXCLUDE_DOUBLE */
+
+/* For features that are enabled, the following floating point options also
+ * become available.
+ */
+
+/* Unity aims for as small of a footprint as possible and avoids most standard
+ * library calls (some embedded platforms don't have a standard library!).
+ * Because of this, its routines for printing integer values are minimalist and
+ * hand-coded. To keep Unity universal, though, we eventually chose to develop
+ * our own floating point print routines. Still, the display of floating point
+ * values during a failure are optional. By default, Unity will print the
+ * actual results of floating point assertion failures. So a failed assertion
+ * will produce a message like "Expected 4.0 Was 4.25". If you would like less
+ * verbose failure messages for floating point assertions, use this option to
+ * give a failure message `"Values Not Within Delta"` and trim the binary size.
+ */
+/* #define UNITY_EXCLUDE_FLOAT_PRINT */
+
+/* If enabled, Unity assumes you want your `FLOAT` asserts to compare standard C
+ * floats. If your compiler supports a specialty floating point type, you can
+ * always override this behavior by using this definition.
+ *
+ * Example:
+ */
+/* #define UNITY_FLOAT_TYPE float16_t */
+
+/* If enabled, Unity assumes you want your `DOUBLE` asserts to compare standard
+ * C doubles. If you would like to change this, you can specify something else
+ * by using this option. For example, defining `UNITY_DOUBLE_TYPE` to `long
+ * double` could enable gargantuan floating point types on your 64-bit processor
+ * instead of the standard `double`.
+ *
+ * Example:
+ */
+/* #define UNITY_DOUBLE_TYPE long double */
+
+/* If you look up `UNITY_ASSERT_EQUAL_FLOAT` and `UNITY_ASSERT_EQUAL_DOUBLE` as
+ * documented in the Unity Assertion Guide, you will learn that they are not
+ * really asserting that two values are equal but rather that two values are
+ * "close enough" to equal. "Close enough" is controlled by these precision
+ * configuration options. If you are working with 32-bit floats and/or 64-bit
+ * doubles (the normal on most processors), you should have no need to change
+ * these options. They are both set to give you approximately 1 significant bit
+ * in either direction. The float precision is 0.00001 while the double is
+ * 10^-12. For further details on how this works, see the appendix of the Unity
+ * Assertion Guide.
+ *
+ * Example:
+ */
+/* #define UNITY_FLOAT_PRECISION 0.001f  */
+/* #define UNITY_DOUBLE_PRECISION 0.001f */
+
+
+/* *************************** TOOLSET CUSTOMIZATION ***************************
+ * In addition to the options listed above, there are a number of other options
+ * which will come in handy to customize Unity's behavior for your specific
+ * toolchain. It is possible that you may not need to touch any of these but
+ * certain platforms, particularly those running in simulators, may need to jump
+ * through extra hoops to operate properly. These macros will help in those
+ * situations.
+ **************************************************************************** */
+
+/* By default, Unity prints its results to `stdout` as it runs. This works
+ * perfectly fine in most situations where you are using a native compiler for
+ * testing. It works on some simulators as well so long as they have `stdout`
+ * routed back to the command line. There are times, however, where the
+ * simulator will lack support for dumping results or you will want to route
+ * results elsewhere for other reasons. In these cases, you should define the
+ * `UNITY_OUTPUT_CHAR` macro. This macro accepts a single character at a time
+ * (as an `int`, since this is the parameter type of the standard C `putchar`
+ * function most commonly used). You may replace this with whatever function
+ * call you like.
+ *
+ * Example:
+ * Say you are forced to run your test suite on an embedded processor with no
+ * `stdout` option. You decide to route your test result output to a custom
+ * serial `RS232_putc()` function you wrote like thus:
+ */
+/* #define UNITY_OUTPUT_CHAR(a)                    RS232_putc(a) */
+/* #define UNITY_OUTPUT_CHAR_HEADER_DECLARATION    RS232_putc(int) */
+/* #define UNITY_OUTPUT_FLUSH()                    RS232_flush() */
+/* #define UNITY_OUTPUT_FLUSH_HEADER_DECLARATION   RS232_flush(void) */
+/* #define UNITY_OUTPUT_START()                    RS232_config(115200,1,8,0) */
+/* #define UNITY_OUTPUT_COMPLETE()                 RS232_close() */
+
+/* For some targets, Unity can make the otherwise required `setUp()` and
+ * `tearDown()` functions optional. This is a nice convenience for test writers
+ * since `setUp` and `tearDown` don't often actually _do_ anything. If you're
+ * using gcc or clang, this option is automatically defined for you. Other
+ * compilers can also support this behavior, if they support a C feature called
+ * weak functions. A weak function is a function that is compiled into your
+ * executable _unless_ a non-weak version of the same function is defined
+ * elsewhere. If a non-weak version is found, the weak version is ignored as if
+ * it never existed. If your compiler supports this feature, you can let Unity
+ * know by defining `UNITY_SUPPORT_WEAK` as the function attributes that would
+ * need to be applied to identify a function as weak. If your compiler lacks
+ * support for weak functions, you will always need to define `setUp` and
+ * `tearDown` functions (though they can be and often will be just empty). The
+ * most common options for this feature are:
+ */
+/* #define UNITY_SUPPORT_WEAK weak */
+/* #define UNITY_SUPPORT_WEAK __attribute__((weak)) */
+/* #define UNITY_NO_WEAK */
+
+/* Some compilers require a custom attribute to be assigned to pointers, like
+ * `near` or `far`. In these cases, you can give Unity a safe default for these
+ * by defining this option with the attribute you would like.
+ *
+ * Example:
+ */
+/* #define UNITY_PTR_ATTRIBUTE __attribute__((far)) */
+/* #define UNITY_PTR_ATTRIBUTE near */
+
+/* Default unity config. Define your own macros above this include to overwrite. */
+#include "aws_unity_config.h"
+
+#endif /* UNITY_CONFIG_H */

--- a/vendors/synopsys/boards/embARC/embARC.cmake
+++ b/vendors/synopsys/boards/embARC/embARC.cmake
@@ -1,0 +1,116 @@
+# ========================================================
+#   embARC cmake for external projects
+# ========================================================
+
+# source directory
+if(NOT DEFINED embARC_src_dir)
+	message(FATAL_ERROR "embARC: embARC_src_dir is not defined")
+endif()
+message("embARC: embARC_src_dir is ${embARC_src_dir}")
+
+if(NOT DEFINED embARC_ROOT)
+	message(WARNING "embARC: embARC_ROOT is not defined")
+else()
+	message("embARC: embARC_ROOT is ${embARC_ROOT}")
+	set(embARC_ROOT EMBARC_ROOT=${embARC_ROOT})
+endif()
+
+#parameters check
+if(NOT DEFINED embARC_BOARD)
+	message(WARNING "embARC: embARC_BOARD is not defined, setting to default")
+	set(embARC_BOARD "emsdp")
+endif()
+if(NOT DEFINED embARC_BOARD_VER)
+	message(WARNING "embARC: embARC_BOARD_VER is not defined, setting to default")
+	if(${embARC_BOARD} STREQUAL "emsdp")
+	    set(embARC_BOARD_VER rev2)
+	elseif(${embARC_BOARD} STREQUAL "emsk")
+	    set(embARC_BOARD_VER 22)
+	endif()
+endif()
+if(NOT DEFINED embARC_CUR_CORE)
+	message(WARNING "embARC: embARC_CUR_CORE is not defined, setting to default")
+	if(${embARC_BOARD} STREQUAL "emsdp")
+	    set(embARC_CUR_CORE em11d_dfss)
+	elseif(${embARC_BOARD} STREQUAL "emsk")
+	    set(embARC_CUR_CORE arcem7d)
+	endif()
+endif()
+if(NOT DEFINED embARC_TOOLCHAIN)
+	message(WARNING "embARC: embARC_TOOLCHAIN is not defined, setting to default")
+	set(embARC_TOOLCHAIN "gnu")
+endif()
+
+if(${embARC_TOOLCHAIN} STREQUAL "gnu")
+    set(make_exe make)
+elseif(${embARC_TOOLCHAIN} STREQUAL "mw")
+    set(make_exe gmake)
+endif()
+
+# output directory
+message("embARC: CMAKE_BINARY_DIR is ${CMAKE_BINARY_DIR}")
+# library settings
+message("embARC: embARC_BOARD is ${embARC_BOARD}")
+message("embARC: embARC_BOARD_VER is ${embARC_BOARD_VER}")
+message("embARC: embARC_CUR_CORE is ${embARC_CUR_CORE}")
+message("embARC: embARC_TOOLCHAIN is ${embARC_TOOLCHAIN}")
+
+include(ExternalProject)
+
+ExternalProject_Add(
+        embARC                 # Name for custom target
+        GIT_REPOSITORY		https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp.git
+        GIT_TAG    			upstream	#branch name
+        PATCH_COMMAND		git apply --check ${CMAKE_CURRENT_LIST_DIR}/0001-arc-add-support-to-nest-exception.patch && git am ${CMAKE_CURRENT_LIST_DIR}/0001-arc-add-support-to-nest-exception.patch || git status
+        PREFIX    			${CMAKE_BINARY_DIR} # Root dir for entire project
+        SOURCE_DIR 			${embARC_src_dir}
+        BINARY_DIR 			${CMAKE_BINARY_DIR}/embARC_build
+        CONFIGURE_COMMAND 	cp ${CMAKE_CURRENT_LIST_DIR}/makefile_template ${CMAKE_BINARY_DIR}/embARC_build/makefile
+        BUILD_COMMAND 		${make_exe} BOARD=${embARC_BOARD} ${embARC_ROOT} TOOLCHAIN=${embARC_TOOLCHAIN} BD_VER=${embARC_BOARD_VER} CUR_CORE=${embARC_CUR_CORE} embarc_lib
+        INSTALL_COMMAND 	cp ${CMAKE_BINARY_DIR}/embARC_build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/linker_${embARC_TOOLCHAIN}.ldf ${CMAKE_BINARY_DIR}/embARC_build/linker_${embARC_TOOLCHAIN}.ldf
+        BUILD_BYPRODUCTS 	${CMAKE_BINARY_DIR}/embARC_build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/libembARC.a
+    )
+
+#force embARC_lib to compile/update
+add_custom_target(embARC_lib
+	ALL
+	DEPENDS embARC
+	COMMAND pwd
+	# COMMAND cp ${embARC_src_dir}/options/makefile_template ${CMAKE_BINARY_DIR}/embARC_build/makefile
+	# COMMAND make BOARD=${embARC_BOARD} EMBARC_ROOT=../../vendors/synopsys/embarc_bsp TOOLCHAIN=${embARC_TOOLCHAIN} BD_VER=${embARC_BOARD_VER} CUR_CORE=${embARC_CUR_CORE} embarc_lib
+	# COMMAND cp ${CMAKE_BINARY_DIR}/embARC_build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/linker_${embARC_TOOLCHAIN}.ldf ${CMAKE_BINARY_DIR}/embARC_build/linker_${embARC_TOOLCHAIN}.ldf
+	BYPRODUCTS ${CMAKE_BINARY_DIR}/embARC_build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/libembARC.a
+	)
+
+if(${embARC_BOARD} STREQUAL "emsdp")
+    set(BOARD_INC
+		${embARC_src_dir}/board
+    	${embARC_src_dir}/board/${embARC_BOARD}/${embARC_BOARD_VER}/configs
+    	${embARC_src_dir}/board/${embARC_BOARD}/${embARC_BOARD_VER}/configs/${embARC_CUR_CORE}/include
+    )
+else()
+    set(BOARD_INC
+		${embARC_src_dir}/board
+    	${embARC_src_dir}/board/${embARC_BOARD}/configs/${embARC_BOARD_VER}
+    )
+endif()
+
+set(
+	embARC_LIB_DIR
+	"${CMAKE_BINARY_DIR}/embARC_build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}"
+)
+set(
+	embARC_INC_DIR
+	"${embARC_src_dir}/include"
+	"${embARC_src_dir}/library"
+	${BOARD_INC}
+	# ${embARC_LIB_DIR}/embARC_generated
+)
+
+# include_directories(${embARC_INC_DIR})
+
+# mdb -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent -OS=FreeRTOS -run obj_emsk_23/mw_arcem9d/blinky_mw_arcem9d.elf
+# mdb -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent -OS=FreeRTOS
+# mdb  -source_path=${embARC_src_dir}/arc/startup -nooptions -nogoifmain -toggle=include_local_symbols=1 -hard -digilent ${target_name}.elf
+# arc-elf32-gdb -ex "target remote | openocd --pipe -s  c:/arc_gnu/bin/../lib/gcc/arc-elf32/8.3.1/../../../../arc-elf32/bin/../../share/openocd/scripts -f  c:/arc_gnu/bin/../lib/gcc/arc-elf32/8.3.1/../../../../arc-elf32/bin/../../share/openocd/scripts/board/snps_em_sk_v2.2.cfg" -ex "load" -ex "c" obj_emsk_23/gnu_arcem9d/blinky_gnu_arcem9d.elf
+# arc-elf32-gdb -ex "target remote | openocd --pipe -s  c:/arc_gnu/bin/../lib/gcc/arc-elf32/8.3.1/../../../../arc-elf32/bin/../../share/openocd/scripts -f  c:/arc_gnu/bin/../lib/gcc/arc-elf32/8.3.1/../../../../arc-elf32/bin/../../share/openocd/scripts/board/snps_em_sk_v2.2.cfg" -ex "load" obj_emsk_23/gnu_arcem9d/blinky_gnu_arcem9d.elf

--- a/vendors/synopsys/boards/embARC/embARC_emsdp.cmake
+++ b/vendors/synopsys/boards/embARC/embARC_emsdp.cmake
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+# Provide metadata for listing on Amazon FreeRTOS console.
+afr_set_board_metadata(NAME "Synopsys-ARC-EMSDP")
+afr_set_board_metadata(DISPLAY_NAME "Synopsys ARC EMSDP")
+afr_set_board_metadata(DESCRIPTION "Software Development Platform for Synopsys ARC EM core")
+afr_set_board_metadata(VENDOR_NAME "Synopsys")
+afr_set_board_metadata(FAMILY_NAME "ARC EM")
+afr_set_board_metadata(DATA_RAM_MEMORY "16MB")
+afr_set_board_metadata(PROGRAM_MEMORY "16MB")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(SUPPORTED_IDE "Metaware;GNU")
+afr_set_board_metadata(IDE_Metaware_NAME "Synopsys DesignWare ARC MetaWare Development Toolkit")
+afr_set_board_metadata(IDE_Metaware_COMPILERS "Metaware")
+afr_set_board_metadata(IDE_GNU_NAME "GNU")
+afr_set_board_metadata(IDE_GNU_COMPILERS "GNU")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")

--- a/vendors/synopsys/boards/embARC/embARC_emsk.cmake
+++ b/vendors/synopsys/boards/embARC/embARC_emsk.cmake
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+# Provide metadata for listing on Amazon FreeRTOS console.
+afr_set_board_metadata(NAME "Synopsys-ARC-EMSK")
+afr_set_board_metadata(DISPLAY_NAME "Synopsys ARC EMSK")
+afr_set_board_metadata(DESCRIPTION "The DesignWare ARC EM Starter Kit")
+afr_set_board_metadata(VENDOR_NAME "Synopsys")
+afr_set_board_metadata(FAMILY_NAME "ARC EM")
+afr_set_board_metadata(DATA_RAM_MEMORY "128MB")
+afr_set_board_metadata(PROGRAM_MEMORY "32MB")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(SUPPORTED_IDE "Metaware;GNU")
+afr_set_board_metadata(IDE_Metaware_NAME "Synopsys DesignWare ARC MetaWare Development Toolkit")
+afr_set_board_metadata(IDE_Metaware_COMPILERS "Metaware")
+afr_set_board_metadata(IDE_GNU_NAME "GNU")
+afr_set_board_metadata(IDE_GNU_COMPILERS "GNU")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")

--- a/vendors/synopsys/boards/embARC/embARC_hsdk.cmake
+++ b/vendors/synopsys/boards/embARC/embARC_hsdk.cmake
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+# Provide metadata for listing on Amazon FreeRTOS console.
+afr_set_board_metadata(NAME "Synopsys-ARC-HSDK")
+afr_set_board_metadata(DISPLAY_NAME "Synopsys ARC HSDK")
+afr_set_board_metadata(DESCRIPTION "The ARC HS Development Kit")
+afr_set_board_metadata(VENDOR_NAME "Synopsys")
+afr_set_board_metadata(FAMILY_NAME "ARC HS")
+afr_set_board_metadata(DATA_RAM_MEMORY "4GB")
+afr_set_board_metadata(PROGRAM_MEMORY "2MB")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(SUPPORTED_IDE "Metaware;GNU")
+afr_set_board_metadata(IDE_Metaware_NAME "Synopsys DesignWare ARC MetaWare Development Toolkit")
+afr_set_board_metadata(IDE_Metaware_COMPILERS "Metaware")
+afr_set_board_metadata(IDE_GNU_NAME "GNU")
+afr_set_board_metadata(IDE_GNU_COMPILERS "GNU")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")

--- a/vendors/synopsys/boards/embARC/embARC_iotdk.cmake
+++ b/vendors/synopsys/boards/embARC/embARC_iotdk.cmake
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS Console metadata
+# -------------------------------------------------------------------------------------------------
+# Provide metadata for listing on Amazon FreeRTOS console.
+afr_set_board_metadata(NAME "Synopsys-ARC-IOTDK")
+afr_set_board_metadata(DISPLAY_NAME "Synopsys ARC IOTDK")
+afr_set_board_metadata(DESCRIPTION "The ARC IoT Development Kit")
+afr_set_board_metadata(VENDOR_NAME "Synopsys")
+afr_set_board_metadata(FAMILY_NAME "ARC EM")
+afr_set_board_metadata(DATA_RAM_MEMORY "128KB")
+afr_set_board_metadata(PROGRAM_MEMORY "2MB")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(SUPPORTED_IDE "Metaware;GNU")
+afr_set_board_metadata(IDE_Metaware_NAME "Synopsys DesignWare ARC MetaWare Development Toolkit")
+afr_set_board_metadata(IDE_Metaware_COMPILERS "Metaware")
+afr_set_board_metadata(IDE_GNU_NAME "GNU")
+afr_set_board_metadata(IDE_GNU_COMPILERS "GNU")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")

--- a/vendors/synopsys/boards/embARC/gcc.cmake
+++ b/vendors/synopsys/boards/embARC/gcc.cmake
@@ -1,0 +1,102 @@
+if(NOT DEFINED embARC_map_name)
+    set(embARC_map_name "embARC_${embARC_BOARD}_${embARC_CUR_CORE}")
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+
+if(${AFR_TOOLCHAIN} STREQUAL "nsim")
+    set(LIBGROSS_MACRO -U_HAVE_LIBGLOSS_)
+else()
+    set(LIBGROSS_MACRO _HAVE_LIBGLOSS_)
+endif()
+
+# message("gcc.cmake: ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}")
+set(arg_dir
+    ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/embARC_generated/gcc.arg
+    )
+
+string(TOUPPER BOARD_${embARC_BOARD} BOARD_MACRO)
+set(compiler_defined_symbols
+    __GNU__
+    ${BOARD_MACRO}
+    HW_VERSION=${embARC_BOARD_VER}
+    ${LIBGROSS_MACRO}
+    LIB_CLIB
+    LIB_CONSOLE
+    EMBARC_TCF_GENERATED
+)
+
+# set(assembler_defined_symbols
+#     __GNU__
+#     ${BOARD_MACRO}
+#     HW_VERSION=${embARC_BOARD_VER}
+#     EMBARC_TCF_GENERATED
+# )
+
+# Get the directory of compiler out of the full path
+# get_filename_component(compiler_dir ${CMAKE_C_COMPILER} DIRECTORY)
+
+set(basic_flags
+    @${arg_dir}
+    -ffunction-sections
+    -fdata-sections
+    -mno-sdata
+    -O2
+    -g
+)
+
+set(extra_flags_c
+    -std=gnu99
+)
+
+set(extra_flags_asm
+    -x assembler-with-cpp
+)
+
+set(c_flags
+    ${basic_flags}
+    ${extra_flags_c}
+)
+
+set(cxx_flags
+    ${basic_flags}
+)
+
+set(assembler_flags
+    ${basic_flags}
+    ${extra_flags_asm}
+)
+
+set(link_dependent_libs
+    -Wl,--start-group ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/libembarc.a -lm -lc -lgcc -Wl,--end-group
+)
+
+set(linker_flags
+    @${arg_dir}
+    -Wl,--gc-sections
+    -mno-sdata
+    -nostartfiles
+    -Wl,-M,-Map=${embARC_map_name}.map
+    -lm
+    -Wl,--script=${CMAKE_BINARY_DIR}/build/linker_gnu.ldf
+    # -Wl,--start-group
+    # ${link_dependent_libs}
+    # -lm -lc -lgcc
+    # -Wl,--end-group
+)
+
+# unset(link_dependent_libs)
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS portable layers
+# -------------------------------------------------------------------------------------------------
+
+set(compiler_specific_src
+    ""
+)
+
+set(compiler_specific_include
+    ""
+)

--- a/vendors/synopsys/boards/embARC/makefile_template
+++ b/vendors/synopsys/boards/embARC/makefile_template
@@ -1,0 +1,21 @@
+# Application name
+APPL ?= embARC
+
+#
+# root dir of embARC
+#
+EMBARC_ROOT ?= ..
+
+# application source dirs
+APPL_CSRC_DIR = .
+APPL_ASMSRC_DIR = .
+
+# application include dirs
+APPL_INC_DIR = .
+
+# include current project makefile
+COMMON_COMPILE_PREREQUISITES += makefile
+
+### Options above must be added before include options.mk ###
+# include key embARC build system makefile
+include $(EMBARC_ROOT)/options/options.mk

--- a/vendors/synopsys/boards/embARC/mw.cmake
+++ b/vendors/synopsys/boards/embARC/mw.cmake
@@ -1,0 +1,87 @@
+if(NOT DEFINED embARC_map_name)
+    set(embARC_map_name "embARC_${embARC_BOARD}_${embARC_CUR_CORE}")
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Compiler settings
+# -------------------------------------------------------------------------------------------------
+
+# message("mw.cmake: ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}")
+set(arg_dir
+    ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/embARC_generated/ccac.arg
+    )
+
+string(TOUPPER BOARD_${embARC_BOARD} BOARD_MACRO)
+set(compiler_defined_symbols
+    __MW__
+    ${BOARD_MACRO}
+    HW_VERSION=${embARC_BOARD_VER}
+    LIB_CLIB
+    LIB_CONSOLE
+    EMBARC_TCF_GENERATED
+)
+
+set(basic_flags
+    @${arg_dir}
+    -Hnoccm
+    -Hnosdata
+    -Wincompatible-pointer-types
+    -Hnocopyr
+    -Hpurge
+    -O2
+    -g
+)
+
+set(extra_flags_c
+    -Hnocplus
+)
+
+set(extra_flags_asm
+    -Hasmcpp
+)
+
+set(c_flags
+    ${basic_flags}
+    ${extra_flags_c}
+)
+
+set(cxx_flags
+    ${basic_flags}
+)
+
+set(assembler_flags
+    ${basic_flags}
+    ${extra_flags_asm}
+)
+
+set(link_dependent_libs
+    ${CMAKE_BINARY_DIR}/build/obj_${embARC_BOARD}_${embARC_BOARD_VER}/${embARC_TOOLCHAIN}_${embARC_CUR_CORE}/libembarc.a
+)
+
+set(linker_flags
+    @${arg_dir}
+    -Hpurge
+    -Hnocopyr
+    -Hnosdata
+    -Hnocrt
+    -Hldopt=-Coutput=${embARC_map_name}.map
+    -Hldopt=-Csections
+    -Hldopt=-Ccrossfunc
+    -Hldopt=-Csize
+    -zstdout
+    -Hldopt=-Bgrouplib
+    ${CMAKE_BINARY_DIR}/build/linker_mw.ldf
+)
+
+
+# -------------------------------------------------------------------------------------------------
+# Amazon FreeRTOS portable layers
+# -------------------------------------------------------------------------------------------------
+
+set(compiler_specific_src
+    ""
+)
+
+set(compiler_specific_include
+    ""
+)

--- a/vendors/synopsys/boards/embARC/ports/ota/aws_ota_pal.c
+++ b/vendors/synopsys/boards/embARC/ports/ota/aws_ota_pal.c
@@ -1,0 +1,182 @@
+/*
+ * Amazon FreeRTOS OTA PAL V1.0.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* C Runtime includes. */
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Amazon FreeRTOS include. */
+#include "FreeRTOS.h"
+#include "aws_iot_ota_pal.h"
+#include "aws_iot_ota_agent_internal.h"
+
+/* Specify the OTA signature algorithm we support on this platform. */
+const char cOTA_JSON_FileSignatureKey[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ] = "sig-sha256-ecdsa";   /* FIX ME. */
+
+
+/* The static functions below (prvPAL_CheckFileSignature and prvPAL_ReadAndAssumeCertificate)
+ * are optionally implemented. If these functions are implemented then please set the following macros in
+ * aws_test_ota_config.h to 1:
+ * otatestpalCHECK_FILE_SIGNATURE_SUPPORTED
+ * otatestpalREAD_AND_ASSUME_CERTIFICATE_SUPPORTED
+ */
+
+/**
+ * @brief Verify the signature of the specified file.
+ *
+ * This function should be implemented if signature verification is not offloaded
+ * to non-volatile memory io functions.
+ *
+ * This function is called from prvPAL_Close().
+ *
+ * @param[in] C OTA file context information.
+ *
+ * @return Below are the valid return values for this function.
+ * kOTA_Err_None if the signature verification passes.
+ * kOTA_Err_SignatureCheckFailed if the signature verification fails.
+ * kOTA_Err_BadSignerCert if the if the signature verification certificate cannot be read.
+ *
+ */
+static OTA_Err_t prvPAL_CheckFileSignature( OTA_FileContext_t * const C );
+
+/**
+ * @brief Read the specified signer certificate from the filesystem into a local buffer.
+ *
+ * The allocated memory returned becomes the property of the caller who is responsible for freeing it.
+ *
+ * This function is called from prvPAL_CheckFileSignature(). It should be implemented if signature
+ * verification is not offloaded to non-volatile memory io function.
+ *
+ * @param[in] pucCertName The file path of the certificate file.
+ * @param[out] ulSignerCertSize The size of the certificate file read.
+ *
+ * @return A pointer to the signer certificate in the file system. NULL if the certificate cannot be read.
+ * This returned pointer is the responsibility of the caller; if the memory is allocated the caller must free it.
+ */
+static uint8_t * prvPAL_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize );
+
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_CreateFileForRx( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CreateFileForRx" );
+
+    /* FIX ME. */
+    return kOTA_Err_RxFileCreateFailed;
+}
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_Abort( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_Abort" );
+
+    /* FIX ME. */
+    return kOTA_Err_FileAbort;
+}
+/*-----------------------------------------------------------*/
+
+/* Write a block of data to the specified file. */
+int16_t prvPAL_WriteBlock( OTA_FileContext_t * const C,
+                           uint32_t ulOffset,
+                           uint8_t * const pacData,
+                           uint32_t ulBlockSize )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_WriteBlock" );
+
+    /* FIX ME. */
+    return -1;
+}
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_CloseFile( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CloseFile" );
+
+    /* FIX ME. */
+    return kOTA_Err_FileClose;
+}
+/*-----------------------------------------------------------*/
+
+
+static OTA_Err_t prvPAL_CheckFileSignature( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CheckFileSignature" );
+
+    /* FIX ME. */
+    return kOTA_Err_SignatureCheckFailed;
+}
+/*-----------------------------------------------------------*/
+
+static uint8_t * prvPAL_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_ReadAndAssumeCertificate" );
+
+    /* FIX ME. */
+    return NULL;
+}
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_ResetDevice( void )
+{
+    DEFINE_OTA_METHOD_NAME("prvPAL_ResetDevice");
+
+    /* FIX ME. */
+    return kOTA_Err_ResetNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_ActivateNewImage( void )
+{
+    DEFINE_OTA_METHOD_NAME("prvPAL_ActivateNewImage");
+
+    /* FIX ME. */
+    return kOTA_Err_Uninitialized;
+}
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_SetPlatformImageState( OTA_ImageState_t eState )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_SetPlatformImageState" );
+
+    /* FIX ME. */
+    return kOTA_Err_BadImageState;
+}
+/*-----------------------------------------------------------*/
+
+OTA_PAL_ImageState_t prvPAL_GetPlatformImageState( void )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_GetPlatformImageState" );
+
+    /* FIX ME. */
+    return eOTA_ImageState_Unknown;
+}
+/*-----------------------------------------------------------*/
+
+/* Provide access to private members for testing. */
+#ifdef AMAZON_FREERTOS_ENABLE_UNIT_TESTS
+    #include "aws_ota_pal_test_access_define.h"
+#endif

--- a/vendors/synopsys/boards/embARC/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/synopsys/boards/embARC/ports/pkcs11/iot_pkcs11_pal.c
@@ -1,0 +1,135 @@
+/*
+ * Amazon FreeRTOS PKCS #11 PAL V1.0.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_pkcs11_pal.c
+ * @brief Device specific helpers for PKCS11 Interface.
+ */
+
+/* Amazon FreeRTOS Includes. */
+#include "iot_pkcs11.h"
+#include "FreeRTOS.h"
+
+/* C runtime includes. */
+#include <stdio.h>
+#include <string.h>
+
+
+/**
+* @brief Writes a file to local storage.
+*
+* Port-specific file write for crytographic information.
+*
+* @param[in] pxLabel       Label of the object to be saved.
+* @param[in] pucData       Data buffer to be written to file
+* @param[in] ulDataSize    Size (in bytes) of data to be saved.
+*
+* @return The file handle of the object that was stored.
+*/
+CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
+    uint8_t * pucData,
+    uint32_t ulDataSize )
+{
+    CK_OBJECT_HANDLE xHandle = 0;
+    return xHandle;
+}
+
+/**
+* @brief Translates a PKCS #11 label into an object handle.
+*
+* Port-specific object handle retrieval.
+*
+*
+* @param[in] pLabel         Pointer to the label of the object
+*                           who's handle should be found.
+* @param[in] usLength       The length of the label, in bytes.
+*
+* @return The object handle if operation was successful.
+* Returns eInvalidHandle if unsuccessful.
+*/
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
+    uint8_t usLength )
+{
+    CK_OBJECT_HANDLE xHandle = 0;
+    return xHandle;
+}
+
+/**
+* @brief Gets the value of an object in storage, by handle.
+*
+* Port-specific file access for cryptographic information.
+*
+* This call dynamically allocates the buffer which object value
+* data is copied into.  PKCS11_PAL_GetObjectValueCleanup()
+* should be called after each use to free the dynamically allocated
+* buffer.
+*
+* @sa PKCS11_PAL_GetObjectValueCleanup
+*
+* @param[in] pcFileName    The name of the file to be read.
+* @param[out] ppucData     Pointer to buffer for file data.
+* @param[out] pulDataSize  Size (in bytes) of data located in file.
+* @param[out] pIsPrivate   Boolean indicating if value is private (CK_TRUE)
+*                          or exportable (CK_FALSE)
+*
+* @return CKR_OK if operation was successful.  CKR_KEY_HANDLE_INVALID if
+* no such object handle was found, CKR_DEVICE_MEMORY if memory for
+* buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
+* error.
+*/
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+    uint8_t ** ppucData,
+    uint32_t * pulDataSize,
+    CK_BBOOL * pIsPrivate )
+{
+    CK_RV xReturn = CKR_OK;
+    return xReturn;
+}
+
+
+/**
+* @brief Cleanup after PKCS11_GetObjectValue().
+*
+* @param[in] pucData       The buffer to free.
+*                          (*ppucData from PKCS11_PAL_GetObjectValue())
+* @param[in] ulDataSize    The length of the buffer to free.
+*                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
+*/
+void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
+    uint32_t ulDataSize )
+{
+    
+}
+
+/*-----------------------------------------------------------*/
+
+int mbedtls_hardware_poll( void * data,
+                           unsigned char * output,
+                           size_t len,
+                           size_t * olen )
+{
+    /* FIX ME. */
+    return 0;
+}

--- a/vendors/synopsys/boards/embARC/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/synopsys/boards/embARC/ports/secure_sockets/iot_secure_sockets.c
@@ -1,0 +1,140 @@
+/*
+ * Amazon FreeRTOS Secure Socket V1.0.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_secure_sockets.c
+ * @brief WiFi and Secure Socket interface implementation.
+ */
+
+/* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
+ * from redefining in iot_secure_sockets_wrapper_metrics.h */
+#define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
+/* Socket and WiFi interface includes. */
+#include "iot_secure_sockets.h"
+
+#undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
+/*-----------------------------------------------------------*/
+
+Socket_t SOCKETS_Socket( int32_t lDomain,
+                         int32_t lType,
+                         int32_t lProtocol )
+{
+    /* FIX ME. */
+    return ( Socket_t ) SOCKETS_INVALID_SOCKET;
+}
+/*-----------------------------------------------------------*/
+
+Socket_t SOCKETS_Accept( Socket_t xSocket,
+                         SocketsSockaddr_t * pxAddress,
+                         Socklen_t * pxAddressLength )
+{
+    /* FIX ME. */
+    return SOCKETS_INVALID_SOCKET;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Connect( Socket_t xSocket,
+                         SocketsSockaddr_t * pxAddress,
+                         Socklen_t xAddressLength )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Recv( Socket_t xSocket,
+                      void * pvBuffer,
+                      size_t xBufferLength,
+                      uint32_t ulFlags )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Send( Socket_t xSocket,
+                      const void * pvBuffer,
+                      size_t xDataLength,
+                      uint32_t ulFlags )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Shutdown( Socket_t xSocket,
+                          uint32_t ulHow )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Close( Socket_t xSocket )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
+                            int32_t lLevel,
+                            int32_t lOptionName,
+                            const void * pvOptionValue,
+                            size_t xOptionLength )
+{
+    /* FIX ME. */
+    return SOCKETS_SOCKET_ERROR;
+}
+/*-----------------------------------------------------------*/
+
+uint32_t SOCKETS_GetHostByName( const char * pcHostName )
+{
+    /* FIX ME. */
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t SOCKETS_Init( void )
+{
+    /* FIX ME. */
+    return pdFAIL;
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulRand( void )
+{
+    /* FIX ME. */
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
+{
+    *( pulNumber ) = 0uL;
+    return pdFALSE;
+}

--- a/vendors/synopsys/boards/embARC/ports/wifi/iot_wifi.c
+++ b/vendors/synopsys/boards/embARC/ports/wifi/iot_wifi.c
@@ -1,0 +1,192 @@
+/*
+ * Amazon FreeRTOS Wi-Fi V1.0.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_wifi.c
+ * @brief Wi-Fi Interface.
+ */
+
+/* Socket and Wi-Fi interface includes. */
+#include "FreeRTOS.h"
+#include "iot_wifi.h"
+
+/* Wi-Fi configuration includes. */
+#include "aws_wifi_config.h"
+
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_On( void )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Off( void )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkParams )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Disconnect( void )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Reset( void )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
+                            uint8_t ucNumNetworks )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_SetMode( WIFIDeviceMode_t xDeviceMode )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetMode( WIFIDeviceMode_t * pxDeviceMode )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_NetworkAdd( const WIFINetworkProfile_t * const pxNetworkProfile,
+                                  uint16_t * pusIndex )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_NetworkGet( WIFINetworkProfile_t * pxNetworkProfile,
+                                  uint16_t usIndex )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_NetworkDelete( uint16_t usIndex )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
+                            uint16_t usCount,
+                            uint32_t ulIntervalMS )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetIP( uint8_t * pucIPAddr )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetMAC( uint8_t * pucMac )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetHostIP( char * pcHost,
+                                 uint8_t * pucIPAddr )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartAP( void )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StopAP( void )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_ConfigureAP( const WIFINetworkParams_t * const pxNetworkParams )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_SetPMMode( WIFIPMMode_t xPMModeType,
+                                 const void * pvOptionValue )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetPMMode( WIFIPMMode_t * pxPMModeType,
+                                 void * pvOptionValue )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t WIFI_IsConnected(void)
+{
+	/* FIX ME. */
+	return pdFALSE;
+}

--- a/vendors/synopsys/manifest.cmake
+++ b/vendors/synopsys/manifest.cmake
@@ -1,0 +1,14 @@
+set(
+    AFR_MANIFEST_SUPPORTED_BOARDS
+    emsdp
+	emsk
+	iotdk
+	hsdk
+    CACHE INTERNAL "Supported boards list."
+)
+
+set(AFR_MANIFEST_BOARD_DIR "boards")
+set(AFR_MANIFEST_BOARD_DIR_emsdp "boards/embARC")
+set(AFR_MANIFEST_BOARD_DIR_emsk "boards/embARC")
+set(AFR_MANIFEST_BOARD_DIR_iotdk "boards/embARC")
+set(AFR_MANIFEST_BOARD_DIR_hsdk "boards/embARC")


### PR DESCRIPTION

<!--- Title -->

Description
-----------
This is a port from Synopsys ARC to AWS, the  port is based on [Synopsys embARC BSP](https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp/tree/upstream)
It requires [ARC port to FreeRTOS-Kernel](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/8) to work

The supported cores are ARC EM and HS series
The supported boards are EMSDP, EMSK, HSDK and IoTDK (with default cores)

Limits and Issues:
-----------

- This is a basic port which only have console and Kernel ported. Currently the boards do not have WiFi and BLE modules. 
- It uses cmake ExternalProject_Add() to pull embARC BSP code and then patch on it. Therefore it could have some git problems if embARC BSP have updates in the future. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.