### PR TITLE
Fix CLI command for non-prod stage in OTA E2E

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_aws_agent.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_aws_agent.py
@@ -384,7 +384,7 @@ class OtaAwsAgent:
                 '--protocols ' + \
                 ' '.join(protocols) + ' ' + \
                 '--aws-job-presigned-url-config ' + \
-                'expiresInSec=' + urlExpired,
+                'expiresInSec=' + str(urlExpired),
                 self._stageParams
             )
         else:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fix a bug in OTA E2E script when it's called with non-prod stage.

Sanity check: https://amazon-freertos-ci.corp.amazon.com/job/esp-ota-e2e-release-1.5/610/testReport/esp32_wrover_kit/OTAEndToEndTests/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.