### PR TITLE
Fix Flash test code to not overflow the size of flash.

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -705,7 +705,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress)
     /* Erase a Block minus sector size starting at block boundry plus sector size */
     lRetVal = iot_flash_erase_sectors(xFlashHandle,
                                             ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize,
-                                            pxFlashInfo->ulBlockSize);
+                                            pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
     TEST_ASSERT_EQUAL(IOT_FLASH_SUCCESS, lRetVal);
 
     if ( pxFlashInfo->ucAsyncSupported )


### PR DESCRIPTION
None

None

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.