### PR TITLE
OTA e2e scripts: Replace dots with underscores

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -66,7 +66,7 @@ class OtaTestRunner:
         self._stageParams = stageParams
         self._otaConfig = boardConfig['ota_config']
         self._otaProject = OtaAfrProject(boardConfig)
-        self._otaAwsAgent = OtaAwsAgent(self._boardConfig['name'], self._otaConfig, stageParams, True)
+        self._otaAwsAgent = OtaAwsAgent(self._boardConfig['name'].replace('.', '_'), self._otaConfig, stageParams, True)
         # FlashSerialComm opens a thread. If there is an exception in OtaAwsAgent we want to exit the program, so this is initialized last.
         self._flashComm = FlashSerialComm(boardConfig['flash_config'], boardConfig['flash_config']['output'], self._otaConfig['device_firmware_file_name'])
 

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_runner.py
@@ -66,6 +66,7 @@ class OtaTestRunner:
         self._stageParams = stageParams
         self._otaConfig = boardConfig['ota_config']
         self._otaProject = OtaAfrProject(boardConfig)
+        # OTA jobs only accept underscore and no dots. We replace dots with underscores for all IoT Core related names.
         self._otaAwsAgent = OtaAwsAgent(self._boardConfig['name'].replace('.', '_'), self._otaConfig, stageParams, True)
         # FlashSerialComm opens a thread. If there is an exception in OtaAwsAgent we want to exit the program, so this is initialized last.
         self._flashComm = FlashSerialComm(boardConfig['flash_config'], boardConfig['flash_config']['output'], self._otaConfig['device_firmware_file_name'])


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
For OTA Jobs, dots are not accepted. If a dot is provided, we will replace it to an underscore in the script for IoT Core related actions.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.