### PR TITLE
Fix timer test code to wait before trying to get the count

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -41,7 +41,7 @@
 #include "task.h"
 
 #define testIotTIMER_DEFAULT_DELAY_US 500 //500 usec
-#define testIotTIMER_SLEEP_DELAY_MS 5 //5 msec
+#define testIotTIMER_SLEEP_DELAY_MS 1 //1 msec
 
 
 /*-----------------------------------------------------------*/
@@ -171,6 +171,9 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Running)
     lRetVal = iot_timer_start(xTimerHandle);
     TEST_ASSERT_EQUAL(IOT_TIMER_SUCCESS, lRetVal);
 
+    /* Delay for 1 msec. */
+    vTaskDelay(testIotTIMER_SLEEP_DELAY_MS / portTICK_PERIOD_MS);
+
     /* Get the time in micro seconds */
     lRetVal = iot_timer_get_value(xTimerHandle, &ulMicroSeconds1);
     TEST_ASSERT_EQUAL(IOT_TIMER_SUCCESS, lRetVal);
@@ -179,7 +182,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Running)
     TEST_ASSERT_NOT_EQUAL(0, ulMicroSeconds1);
 
     /* Delay for 5 msec. */
-    vTaskDelay(testIotTIMER_SLEEP_DELAY_MS / portTICK_PERIOD_MS);
+    vTaskDelay( (testIotTIMER_SLEEP_DELAY_MS * 5) / portTICK_PERIOD_MS);
 
     /* Get the time in micro seconds */
     lRetVal = iot_timer_get_value(xTimerHandle, &ulMicroSeconds2);
@@ -218,6 +221,9 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Stop)
     lRetVal = iot_timer_start(xTimerHandle);
     TEST_ASSERT_EQUAL(IOT_TIMER_SUCCESS, lRetVal);
 
+    /* Delay for 1 msec. */
+    vTaskDelay(testIotTIMER_SLEEP_DELAY_MS / portTICK_PERIOD_MS);
+
     /* Get the time in micro seconds */
     lRetVal = iot_timer_get_value(xTimerHandle, &ulMicroSeconds1);
     TEST_ASSERT_EQUAL(IOT_TIMER_SUCCESS, lRetVal);
@@ -226,7 +232,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Stop)
     TEST_ASSERT_NOT_EQUAL(0, ulMicroSeconds1);
 
     /* Delay for 5 msec. */
-    vTaskDelay(testIotTIMER_SLEEP_DELAY_MS / portTICK_PERIOD_MS);
+    vTaskDelay( (testIotTIMER_SLEEP_DELAY_MS * 5) / portTICK_PERIOD_MS);
 
     /* Get the time in micro seconds */
     lRetVal = iot_timer_get_value(xTimerHandle, &ulMicroSeconds2);

--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -40,8 +40,8 @@
 #include "semphr.h"
 #include "task.h"
 
-#define testIotTIMER_DEFAULT_DELAY_US 500 //500 usec
-#define testIotTIMER_SLEEP_DELAY_MS 1 //1 msec
+#define testIotTIMER_DEFAULT_DELAY_US 500
+#define testIotTIMER_SLEEP_DELAY_MS 1
 
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Wait for 1ms before getting the timer count. Timer count may still be zero


Description
-----------
Wait for 1ms before getting the timer count. Timer count may still be zero

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.