### PR TITLE
Check in assisted tests for I2C master

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -56,6 +56,7 @@
 #define testIotI2C_INVALID_IOCTL_INDEX    UINT32_MAX
 #define testIotI2C_HANDLE_NUM             4
 #define testIotI2C_MAX_TIMEOUT            pdMS_TO_TICKS( 10000 )
+#define testIotI2C_MESSAGE_LENGTH         50
 /*-----------------------------------------------------------*/
 
 typedef struct CallbackParam
@@ -79,6 +80,8 @@ uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to de
 uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
 uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
 
+uint8_t ucAssistedTestIotI2CSlaveAddr = 0;     /**< The slave address to be set for the assisted test. */
+
 extern IotI2CHandle_t gIotI2cHandle[ testIotI2C_HANDLE_NUM ];
 
 /*-----------------------------------------------------------*/
@@ -89,6 +92,11 @@ static SemaphoreHandle_t xtestIotI2CSemaphore = NULL;
 /*-----------------------------------------------------------*/
 /* Private Functions */
 /*-----------------------------------------------------------*/
+
+static void prvAppendToMessage( size_t * pOffset,
+                                uint8_t * pBuffer,
+                                size_t bufferLen,
+                                char* cMsg);
 
 /*-----------------------------------------------------------*/
 
@@ -112,6 +120,12 @@ TEST_SETUP( TEST_IOT_I2C )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         gIotI2cHandle[ testIotI2C_INSTANCE ] = NULL;
+    }
+
+    if(xtestIotI2CSemaphore == NULL)
+    {
+        xtestIotI2CSemaphore = xSemaphoreCreateBinary();
+        TEST_ASSERT_NOT_EQUAL(NULL, xtestIotI2CSemaphore);
     }
 }
 
@@ -173,9 +187,6 @@ static void prvChainToReadCallback( IotI2COperationStatus_t xOpStatus,
  */
 TEST_GROUP_RUNNER( TEST_IOT_I2C )
 {
-    xtestIotI2CSemaphore = xSemaphoreCreateBinary();
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotI2CSemaphore );
-
     RUN_TEST_CASE( TEST_IOT_I2C, AFQP_IotI2COpenCloseSuccess );
     RUN_TEST_CASE( TEST_IOT_I2C, AFQP_IotI2COpenCloseFail );
     RUN_TEST_CASE( TEST_IOT_I2C, AFQP_IotI2COpenCloseFailUnsupportInst );
@@ -445,6 +456,70 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadAsyncSuccess )
 
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test Function for I2C async read success
+ */
+TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
+{
+    IotI2CHandle_t xI2CHandle;
+    int32_t lRetVal;
+    uint8_t ucReadBuf[16];
+    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    size_t msgOffset = 0;
+
+    IotI2CConfig_t xI2CConfig = {
+        .ulBusFreq = testIotI2C_BAUDRATE,
+        .ulMasterTimeout =  testIotI2C_DEFAULT_TIMEOUT
+    };
+
+    if(TEST_PROTECT())
+    {
+        /* Open i2c to initialize hardware */
+        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
+        /* Set completion callback */
+        iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
+
+        /* Set i2c congifuration */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c slave address for writing the device register */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c not stop between transaction */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSendNoStopFlag, NULL);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Write the device register address */
+        lRetVal = iot_i2c_write_sync(xI2CHandle, &xtestIotI2CDeviceRegister, sizeof(xtestIotI2CDeviceRegister));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c slave address to read from the device register */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Read from i2c device */
+        lRetVal = iot_i2c_read_async(xI2CHandle, &ucReadBuf, sizeof(ucReadBuf));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        lRetVal = xSemaphoreTake(xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT);
+        TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
+
+    lRetVal = iot_i2c_close(xI2CHandle);
+    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+    /* Create a string with read bytes and print it to console */
+    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof(ucReadBuf), cMsg );
+
+    TEST_IGNORE_MESSAGE(cMsg);
 }
 
 /*-----------------------------------------------------------*/
@@ -866,6 +941,66 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Assisted Test Function for I2C async write
+ */
+TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
+{
+    IotI2CHandle_t xI2CHandle;
+    int32_t lRetVal;
+    uint8_t writeVal[16] = {xtestIotI2CDeviceRegister};
+    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    size_t msgOffset = 0;
+
+    /* Generate bytes to write randomly */
+    srand(xTaskGetTickCount());
+
+    /* Create a string with write bytes and print it to console later */
+    for(int i=1, len=sizeof(writeVal); i<len; i++)
+    {
+        writeVal[i]=(uint8_t)rand();
+    }
+
+    prvAppendToMessage( &msgOffset, writeVal, sizeof(writeVal), cMsg );
+
+    IotI2CConfig_t xI2CConfig = {
+        .ulBusFreq = testIotI2C_BAUDRATE,
+        .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
+    };
+
+    if( TEST_PROTECT() )
+    {
+        /* Open i2c to initialize hardware */
+        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
+        /* Set completion callback */
+        iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
+
+        /* Set i2c congifuration */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c slave address */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Write the value to the device */
+        lRetVal = iot_i2c_write_async(xI2CHandle, writeVal, sizeof(writeVal));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        lRetVal = xSemaphoreTake(xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT);
+        TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+    }
+
+    lRetVal = iot_i2c_close(xI2CHandle);
+    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+    TEST_IGNORE_MESSAGE(cMsg);
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Test Function for I2C async write fail to do ioctl
  */
 TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailIoctl )
@@ -1031,6 +1166,64 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadSyncSuccess )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Test Function for I2C sync read
+ */
+TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
+{
+    IotI2CHandle_t xI2CHandle;
+    int32_t lRetVal;
+    uint8_t ucReadBuf[16];
+    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    size_t msgOffset = 0;
+
+    IotI2CConfig_t xI2CConfig = {
+        .ulBusFreq = testIotI2C_BAUDRATE,
+        .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT,
+    };
+
+    if( TEST_PROTECT() )
+    {
+        /* Open i2c to initialize hardware */
+        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
+        /* Set i2c congifuration */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c slave address */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c congifuration */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSendNoStopFlag, NULL);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Write the device register address */
+        lRetVal = iot_i2c_write_sync(xI2CHandle, &xtestIotI2CDeviceRegister, sizeof(xtestIotI2CDeviceRegister));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Repeated start to read */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Read from i2c device */
+        lRetVal = iot_i2c_read_sync(xI2CHandle, &ucReadBuf, sizeof(ucReadBuf));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    }
+
+    lRetVal = iot_i2c_close(xI2CHandle);
+    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+    /* Create a string with read bytes and print it to console */
+    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof(ucReadBuf), cMsg );
+
+    TEST_IGNORE_MESSAGE(cMsg);
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Test Function for I2C sync read Fail
  */
 TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncFail )
@@ -1118,6 +1311,60 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncSuccess )
 
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Assisted Test Function for I2C sync write
+ */
+TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
+{
+    IotI2CHandle_t xI2CHandle;
+    int32_t lRetVal;
+    uint8_t writeVal[16] = {xtestIotI2CDeviceRegister};
+    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    size_t msgOffset = 0;
+
+    /* Generate bytes to write randomly */
+    srand(xTaskGetTickCount());
+
+    /* Create a string with write bytes and print it to console later */
+    for(int i=1, len=sizeof(writeVal); i<len; i++)
+    {
+        writeVal[i]=(uint8_t)rand();
+    }
+
+    prvAppendToMessage( &msgOffset, writeVal, sizeof(writeVal), cMsg );
+
+    IotI2CConfig_t xI2CConfig = {
+        .ulBusFreq = testIotI2C_BAUDRATE,
+        .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
+    };
+
+    if( TEST_PROTECT() )
+    {
+        /* Open i2c to initialize hardware */
+        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
+        /* Set i2c congifuration */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Set i2c slave address */
+        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+        /* Wirte the value to the device */
+        lRetVal = iot_i2c_write_sync(xI2CHandle, writeVal, sizeof(writeVal));
+        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    }
+
+    lRetVal = iot_i2c_close(xI2CHandle);
+    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+
+    TEST_IGNORE_MESSAGE(cMsg);
 }
 
 /*-----------------------------------------------------------*/
@@ -1239,4 +1486,31 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSendNoStopUnsupported )
 
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
+}
+
+/*-----------------------------------------------------------*/
+/**
+ * @brief Append bytes in the buffer to _cMsg, starting at given offset.
+ */
+
+static void prvAppendToMessage( size_t * pOffset,
+                                uint8_t * pBuffer,
+                                size_t bufferLen,
+                                char* cMsg)
+{
+    size_t i = 0;
+    size_t offset = *pOffset;
+
+    if( pOffset == NULL || pBuffer==NULL || cMsg==NULL )
+        return;
+
+    for( ; i < bufferLen && offset + 2 < testIotI2C_MESSAGE_LENGTH; i++ )
+    {
+        cMsg[ offset++ ] = ',';
+        uint8_t upp = pBuffer[ i ] >> 4, low = pBuffer[ i ] & 0xF;
+        cMsg[ offset++ ] = upp + ( upp > 9 ? 'A' - 10 : '0' );
+        cMsg[ offset++ ] = low + ( low > 9 ? 'A' - 10 : '0' );
+    }
+
+    *pOffset = offset;
 }

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -80,7 +80,7 @@ uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to de
 uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
 uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
 
-uint8_t ucAssistedTestIotI2CSlaveAddr = 0;     /**< The slave address to be set for the assisted test. */
+uint8_t ucAssistedTestIotI2CSlaveAddr = 0;   /**< The slave address to be set for the assisted test. */
 
 extern IotI2CHandle_t gIotI2cHandle[ testIotI2C_HANDLE_NUM ];
 
@@ -476,12 +476,12 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
         .ulMasterTimeout =  testIotI2C_DEFAULT_TIMEOUT
     };
 
+    /* Open i2c to initialize hardware */
+    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
     if(TEST_PROTECT())
     {
-        /* Open i2c to initialize hardware */
-        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
-
         /* Set completion callback */
         iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
 
@@ -498,7 +498,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
 
         /* Write the device register address */
-        lRetVal = iot_i2c_write_sync(xI2CHandle, &xtestIotI2CDeviceRegister, sizeof(xtestIotI2CDeviceRegister));
+        lRetVal = iot_i2c_write_sync(xI2CHandle, &uctestIotI2CDeviceRegister, sizeof(uctestIotI2CDeviceRegister));
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
 
         /* Set i2c slave address to read from the device register */
@@ -947,7 +947,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[16] = {xtestIotI2CDeviceRegister};
+    uint8_t writeVal[16] = {uctestIotI2CDeviceRegister};
     char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
     size_t msgOffset = 0;
 
@@ -967,12 +967,12 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
+    /* Open i2c to initialize hardware */
+    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
     if( TEST_PROTECT() )
     {
-        /* Open i2c to initialize hardware */
-        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
-
         /* Set completion callback */
         iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
 
@@ -1181,12 +1181,12 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT,
     };
 
+    /* Open i2c to initialize hardware */
+    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
     if( TEST_PROTECT() )
     {
-        /* Open i2c to initialize hardware */
-        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
-
         /* Set i2c congifuration */
         lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
@@ -1200,7 +1200,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
 
         /* Write the device register address */
-        lRetVal = iot_i2c_write_sync(xI2CHandle, &xtestIotI2CDeviceRegister, sizeof(xtestIotI2CDeviceRegister));
+        lRetVal = iot_i2c_write_sync(xI2CHandle, &uctestIotI2CDeviceRegister, sizeof(uctestIotI2CDeviceRegister));
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
 
         /* Repeated start to read */
@@ -1322,7 +1322,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[16] = {xtestIotI2CDeviceRegister};
+    uint8_t writeVal[16] = {uctestIotI2CDeviceRegister};
     char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
     size_t msgOffset = 0;
 
@@ -1342,12 +1342,12 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
+    /* Open i2c to initialize hardware */
+    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
+    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+
     if( TEST_PROTECT() )
     {
-        /* Open i2c to initialize hardware */
-        xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-        TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
-
         /* Set i2c congifuration */
         lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
         TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -75,7 +75,7 @@ typedef struct CallbackParam
 
 uint8_t uctestIotI2CSlaveAddr = 0;           /**< The slave address to be set for the I2C port. */
 uint8_t uctestIotI2CInvalidSlaveAddr = 0xFF; /**< The slave address to be set for the I2C port. */
-uint8_t uctestIotI2CDeviceRegister = 0;       /**< The device register to be set for the I2C port. */
+uint8_t uctestIotI2CDeviceRegister = 0;      /**< The device register to be set for the I2C port. */
 uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to device. */
 uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
 uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
@@ -96,7 +96,7 @@ static SemaphoreHandle_t xtestIotI2CSemaphore = NULL;
 static void prvAppendToMessage( size_t * pOffset,
                                 uint8_t * pBuffer,
                                 size_t bufferLen,
-                                char* cMsg);
+                                char * cMsg );
 
 /*-----------------------------------------------------------*/
 
@@ -122,10 +122,10 @@ TEST_SETUP( TEST_IOT_I2C )
         gIotI2cHandle[ testIotI2C_INSTANCE ] = NULL;
     }
 
-    if(xtestIotI2CSemaphore == NULL)
+    if( xtestIotI2CSemaphore == NULL )
     {
         xtestIotI2CSemaphore = xSemaphoreCreateBinary();
-        TEST_ASSERT_NOT_EQUAL(NULL, xtestIotI2CSemaphore);
+        TEST_ASSERT_NOT_EQUAL( NULL, xtestIotI2CSemaphore );
     }
 }
 
@@ -467,59 +467,60 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t ucReadBuf[16];
-    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    uint8_t ucReadBuf[ 16 ];
+    char cMsg[ testIotI2C_MESSAGE_LENGTH ] = { 0 };
     size_t msgOffset = 0;
 
-    IotI2CConfig_t xI2CConfig = {
-        .ulBusFreq = testIotI2C_BAUDRATE,
-        .ulMasterTimeout =  testIotI2C_DEFAULT_TIMEOUT
+    IotI2CConfig_t xI2CConfig =
+    {
+        .ulBusFreq       = testIotI2C_BAUDRATE,
+        .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
-    if(TEST_PROTECT())
+    if( TEST_PROTECT() )
     {
         /* Set completion callback */
-        iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
+        iot_i2c_set_callback( xI2CHandle, prvI2CCallback, NULL );
 
         /* Set i2c congifuration */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetMasterConfig, &xI2CConfig );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address for writing the device register */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c not stop between transaction */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSendNoStopFlag, NULL);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSendNoStopFlag, NULL );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Write the device register address */
-        lRetVal = iot_i2c_write_sync(xI2CHandle, &uctestIotI2CDeviceRegister, sizeof(uctestIotI2CDeviceRegister));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address to read from the device register */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Read from i2c device */
-        lRetVal = iot_i2c_read_async(xI2CHandle, &ucReadBuf, sizeof(ucReadBuf));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_read_async( xI2CHandle, &ucReadBuf, sizeof( ucReadBuf ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-        lRetVal = xSemaphoreTake(xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT);
-        TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+        lRetVal = xSemaphoreTake( xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT );
+        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
     }
 
-    lRetVal = iot_i2c_close(xI2CHandle);
-    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    lRetVal = iot_i2c_close( xI2CHandle );
+    TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
     /* Create a string with read bytes and print it to console */
-    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof(ucReadBuf), cMsg );
+    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof( ucReadBuf ), cMsg );
 
-    TEST_IGNORE_MESSAGE(cMsg);
+    TEST_IGNORE_MESSAGE( cMsg );
 }
 
 /*-----------------------------------------------------------*/
@@ -947,55 +948,56 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[16] = {uctestIotI2CDeviceRegister};
-    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    uint8_t writeVal[ 16 ] = { uctestIotI2CDeviceRegister };
+    char cMsg[ testIotI2C_MESSAGE_LENGTH ] = { 0 };
     size_t msgOffset = 0;
 
     /* Generate bytes to write randomly */
-    srand(xTaskGetTickCount());
+    srand( xTaskGetTickCount() );
 
     /* Create a string with write bytes and print it to console later */
-    for(int i=1, len=sizeof(writeVal); i<len; i++)
+    for( int i = 1, len = sizeof( writeVal ); i < len; i++ )
     {
-        writeVal[i]=(uint8_t)rand();
+        writeVal[ i ] = ( uint8_t ) rand();
     }
 
-    prvAppendToMessage( &msgOffset, writeVal, sizeof(writeVal), cMsg );
+    prvAppendToMessage( &msgOffset, writeVal, sizeof( writeVal ), cMsg );
 
-    IotI2CConfig_t xI2CConfig = {
-        .ulBusFreq = testIotI2C_BAUDRATE,
+    IotI2CConfig_t xI2CConfig =
+    {
+        .ulBusFreq       = testIotI2C_BAUDRATE,
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
     {
         /* Set completion callback */
-        iot_i2c_set_callback(xI2CHandle, prvI2CCallback, NULL );
+        iot_i2c_set_callback( xI2CHandle, prvI2CCallback, NULL );
 
         /* Set i2c congifuration */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetMasterConfig, &xI2CConfig );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Write the value to the device */
-        lRetVal = iot_i2c_write_async(xI2CHandle, writeVal, sizeof(writeVal));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_write_async( xI2CHandle, writeVal, sizeof( writeVal ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-        lRetVal = xSemaphoreTake(xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT);
-        TEST_ASSERT_EQUAL(pdTRUE, lRetVal);
+        lRetVal = xSemaphoreTake( xtestIotI2CSemaphore, testIotI2C_MAX_TIMEOUT );
+        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
     }
 
-    lRetVal = iot_i2c_close(xI2CHandle);
-    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    lRetVal = iot_i2c_close( xI2CHandle );
+    TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-    TEST_IGNORE_MESSAGE(cMsg);
+    TEST_IGNORE_MESSAGE( cMsg );
 }
 
 /*-----------------------------------------------------------*/
@@ -1172,53 +1174,54 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t ucReadBuf[16];
-    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    uint8_t ucReadBuf[ 16 ];
+    char cMsg[ testIotI2C_MESSAGE_LENGTH ] = { 0 };
     size_t msgOffset = 0;
 
-    IotI2CConfig_t xI2CConfig = {
-        .ulBusFreq = testIotI2C_BAUDRATE,
+    IotI2CConfig_t xI2CConfig =
+    {
+        .ulBusFreq       = testIotI2C_BAUDRATE,
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT,
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
     {
         /* Set i2c congifuration */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetMasterConfig, &xI2CConfig );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c congifuration */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSendNoStopFlag, NULL);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSendNoStopFlag, NULL );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Write the device register address */
-        lRetVal = iot_i2c_write_sync(xI2CHandle, &uctestIotI2CDeviceRegister, sizeof(uctestIotI2CDeviceRegister));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_write_sync( xI2CHandle, &uctestIotI2CDeviceRegister, sizeof( uctestIotI2CDeviceRegister ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Repeated start to read */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Read from i2c device */
-        lRetVal = iot_i2c_read_sync(xI2CHandle, &ucReadBuf, sizeof(ucReadBuf));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_read_sync( xI2CHandle, &ucReadBuf, sizeof( ucReadBuf ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
     }
 
-    lRetVal = iot_i2c_close(xI2CHandle);
-    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    lRetVal = iot_i2c_close( xI2CHandle );
+    TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
     /* Create a string with read bytes and print it to console */
-    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof(ucReadBuf), cMsg );
+    prvAppendToMessage( &msgOffset, ucReadBuf, sizeof( ucReadBuf ), cMsg );
 
-    TEST_IGNORE_MESSAGE(cMsg);
+    TEST_IGNORE_MESSAGE( cMsg );
 }
 
 /*-----------------------------------------------------------*/
@@ -1322,49 +1325,50 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
 {
     IotI2CHandle_t xI2CHandle;
     int32_t lRetVal;
-    uint8_t writeVal[16] = {uctestIotI2CDeviceRegister};
-    char cMsg[testIotI2C_MESSAGE_LENGTH] = {0};
+    uint8_t writeVal[ 16 ] = { uctestIotI2CDeviceRegister };
+    char cMsg[ testIotI2C_MESSAGE_LENGTH ] = { 0 };
     size_t msgOffset = 0;
 
     /* Generate bytes to write randomly */
-    srand(xTaskGetTickCount());
+    srand( xTaskGetTickCount() );
 
     /* Create a string with write bytes and print it to console later */
-    for(int i=1, len=sizeof(writeVal); i<len; i++)
+    for( int i = 1, len = sizeof( writeVal ); i < len; i++ )
     {
-        writeVal[i]=(uint8_t)rand();
+        writeVal[ i ] = ( uint8_t ) rand();
     }
 
-    prvAppendToMessage( &msgOffset, writeVal, sizeof(writeVal), cMsg );
+    prvAppendToMessage( &msgOffset, writeVal, sizeof( writeVal ), cMsg );
 
-    IotI2CConfig_t xI2CConfig = {
-        .ulBusFreq = testIotI2C_BAUDRATE,
+    IotI2CConfig_t xI2CConfig =
+    {
+        .ulBusFreq       = testIotI2C_BAUDRATE,
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open(testIotI2C_INSTANCE);
-    TEST_ASSERT_NOT_EQUAL(NULL, xI2CHandle);
+    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
     {
         /* Set i2c congifuration */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetMasterConfig, &xI2CConfig);
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetMasterConfig, &xI2CConfig );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Set i2c slave address */
-        lRetVal = iot_i2c_ioctl(xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSetSlaveAddr, &ucAssistedTestIotI2CSlaveAddr );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* Wirte the value to the device */
-        lRetVal = iot_i2c_write_sync(xI2CHandle, writeVal, sizeof(writeVal));
-        TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+        lRetVal = iot_i2c_write_sync( xI2CHandle, writeVal, sizeof( writeVal ) );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
     }
 
-    lRetVal = iot_i2c_close(xI2CHandle);
-    TEST_ASSERT_EQUAL(IOT_I2C_SUCCESS, lRetVal);
+    lRetVal = iot_i2c_close( xI2CHandle );
+    TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-    TEST_IGNORE_MESSAGE(cMsg);
+    TEST_IGNORE_MESSAGE( cMsg );
 }
 
 /*-----------------------------------------------------------*/
@@ -1489,6 +1493,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSendNoStopUnsupported )
 }
 
 /*-----------------------------------------------------------*/
+
 /**
  * @brief Append bytes in the buffer to _cMsg, starting at given offset.
  */
@@ -1496,13 +1501,15 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSendNoStopUnsupported )
 static void prvAppendToMessage( size_t * pOffset,
                                 uint8_t * pBuffer,
                                 size_t bufferLen,
-                                char* cMsg)
+                                char * cMsg )
 {
     size_t i = 0;
     size_t offset = *pOffset;
 
-    if( pOffset == NULL || pBuffer==NULL || cMsg==NULL )
+    if( ( pOffset == NULL ) || ( pBuffer == NULL ) || ( cMsg == NULL ) )
+    {
         return;
+    }
 
     for( ; i < bufferLen && offset + 2 < testIotI2C_MESSAGE_LENGTH; i++ )
     {

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -41,83 +41,83 @@
  */
 
 #ifndef IOT_TEST_COMMON_IO_UART_SUPPORTED
- #define IOT_TEST_COMMON_IO_UART_SUPPORTED  1
+    #define IOT_TEST_COMMON_IO_UART_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_FLASH_SUPPORTED
- #define IOT_TEST_COMMON_IO_FLASH_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_FLASH_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED
- #define IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_GPIO_SUPPORTED
- #define IOT_TEST_COMMON_IO_GPIO_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_GPIO_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_RTC_SUPPORTED
- #define IOT_TEST_COMMON_IO_RTC_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_RTC_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_TIMER_SUPPORTED
- #define IOT_TEST_COMMON_IO_TIMER_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_TIMER_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_ADC_SUPPORTED
- #define IOT_TEST_COMMON_IO_ADC_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_ADC_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_RESET_SUPPORTED
- #define IOT_TEST_COMMON_IO_RESET_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_RESET_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
- #define IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_PWM_SUPPORTED
- #define IOT_TEST_COMMON_IO_PWM_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_PWM_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_I2C_SUPPORTED
- #define IOT_TEST_COMMON_IO_I2C_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_I2C_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED
- #define IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_POWER_SUPPORTED
- #define IOT_TEST_COMMON_IO_POWER_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_POWER_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_BATTERY_SUPPORTED
- #define IOT_TEST_COMMON_IO_BATTERY_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_BATTERY_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_EFUSE_SUPPORTED
- #define IOT_TEST_COMMON_IO_EFUSE_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_EFUSE_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_SPI_SUPPORTED
- #define IOT_TEST_COMMON_IO_SPI_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_SPI_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED
- #define IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_USB_HOST_SUPPORTED
- #define IOT_TEST_COMMON_IO_USB_HOST_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_USB_HOST_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_SDIO_SUPPORTED
- #define IOT_TEST_COMMON_IO_SDIO_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_SDIO_SUPPORTED    1
 #endif
 
 #ifndef IOT_TEST_COMMON_IO_I2S_SUPPORTED
- #define IOT_TEST_COMMON_IO_I2S_SUPPORTED 1
+    #define IOT_TEST_COMMON_IO_I2S_SUPPORTED    1
 #endif
 
 
@@ -129,85 +129,85 @@
  */
 
 /* Uart */
-extern uint8_t uctestIotUartPort;                       /* The index of the UART that will be tested */
+extern uint8_t uctestIotUartPort; /* The index of the UART that will be tested */
 
 /* Flash */
-extern uint32_t ultestIotFlashStartOffset;              /* The Flash offset at which the flash operations in the test will take place */
+extern uint32_t ultestIotFlashStartOffset; /* The Flash offset at which the flash operations in the test will take place */
 
 /* GPIO */
-extern int32_t ltestIotGpioPortA;                       /* The 1st GPIO port used in the loop back test */
-extern int32_t ltestIotGpioPortB;                       /* The 2nd GPIO port used in the loop back test */
-extern uint16_t ustestIotGpioConfig;                    /* The configuration of GPIO in the test (port, direction, irq, write value)
-                                                         * Check test_iot_gpio.c for its bit assignment */
-extern uint32_t ultestIotGpioWaitTime;                  /* Wait time for GPIO port A to receive GPIO interrupt from port B during the test
-                                                         * This is needed to avoid indefinite wait during the test */
-extern uint32_t ultestIotGpioSlowSpeed;                 /* Based on the underlying HW, set the slow speed setting of GPIO */
-extern uint32_t ultestIotGpioFastSpeed;                 /* Based on the underlying HW, set the high speed setting of GPIO */
-extern uint32_t ultestIotGpioFunction;                  /* Alt Function for GPIO for the pin */
+extern int32_t ltestIotGpioPortA;       /* The 1st GPIO port used in the loop back test */
+extern int32_t ltestIotGpioPortB;       /* The 2nd GPIO port used in the loop back test */
+extern uint16_t ustestIotGpioConfig;    /* The configuration of GPIO in the test (port, direction, irq, write value)
+                                         * Check test_iot_gpio.c for its bit assignment */
+extern uint32_t ultestIotGpioWaitTime;  /* Wait time for GPIO port A to receive GPIO interrupt from port B during the test
+                                         * This is needed to avoid indefinite wait during the test */
+extern uint32_t ultestIotGpioSlowSpeed; /* Based on the underlying HW, set the slow speed setting of GPIO */
+extern uint32_t ultestIotGpioFastSpeed; /* Based on the underlying HW, set the high speed setting of GPIO */
+extern uint32_t ultestIotGpioFunction;  /* Alt Function for GPIO for the pin */
 
 
 /* Timer */
-extern int32_t ltestIotTimerInstance;                   /* HW timer instance to use */
+extern int32_t ltestIotTimerInstance; /* HW timer instance to use */
 
 /* SPI */
-extern uint32_t ultestIotSpiInstance;                   /* SPI instance that we plan to test */
-extern uint32_t ulAssistedTestIotSpiInstance;           /* SPI assisted tests */
-extern uint32_t ultestIotSpiSlave;                      /* SPI assisted tests */
-extern uint32_t ulAssistedTestIotSpiSlave;              /* SPI assisted tests */
+extern uint32_t ultestIotSpiInstance;         /* SPI instance that we plan to test */
+extern uint32_t ulAssistedTestIotSpiInstance; /* SPI assisted tests */
+extern uint32_t ultestIotSpiSlave;            /* SPI assisted tests */
+extern uint32_t ulAssistedTestIotSpiSlave;    /* SPI assisted tests */
 
 /* ADC */
-extern uint8_t uctestIotAdcChListLen;                   /* Length of ADC chains used in the test. The chains are ADC channels
-                                                         * that would be sampled with a single trigger */
-extern uint8_t * puctestIotAdcChList;                   /* The ADC chains used in the tests */
-extern uint8_t ucAssistedTestIotAdcChannel;             /* Assisted Tests: ADC Channel list */
+extern uint8_t uctestIotAdcChListLen;       /* Length of ADC chains used in the test. The chains are ADC channels
+                                             * that would be sampled with a single trigger */
+extern uint8_t * puctestIotAdcChList;       /* The ADC chains used in the tests */
+extern uint8_t ucAssistedTestIotAdcChannel; /* Assisted Tests: ADC Channel list */
 
 /* PWM */
-extern uint32_t ultestIotPwmGpioInputPin;               /* GPIO used to measure PWM accuracy */
-extern uint32_t ultestIotPwmInstance;                   /* PWM instance */
-extern uint32_t ultestIotPwmFrequency;                  /* PWM freq */
-extern uint32_t ultestIotPwmDutyCycle;                  /* PWM duty cycle */
-extern uint32_t ultestIotPwmChannel;                    /* PWM Channel */
-extern uint32_t ulAssistedTestIotPwmGpioInputPin;       /* PWM assisted tests only */
+extern uint32_t ultestIotPwmGpioInputPin;         /* GPIO used to measure PWM accuracy */
+extern uint32_t ultestIotPwmInstance;             /* PWM instance */
+extern uint32_t ultestIotPwmFrequency;            /* PWM freq */
+extern uint32_t ultestIotPwmDutyCycle;            /* PWM duty cycle */
+extern uint32_t ultestIotPwmChannel;              /* PWM Channel */
+extern uint32_t ulAssistedTestIotPwmGpioInputPin; /* PWM assisted tests only */
 
 /* I2C */
-extern uint8_t uctestIotI2CSlaveAddr;                   /* Address of Slave I2C (7-bit address) connected to the bus */
-extern uint8_t uctestIotI2CDeviceRegister;              /* Slave I2C register address used in read/write tests */
-extern uint8_t uctestIotI2CWriteVal;                    /* Write value that will be used in the register write test */
-extern uint8_t uctestIotI2CInstanceIdx;                 /* I2C instance used in the test */
-extern uint8_t uctestIotI2CInstanceNum;                 /* The total number of I2C instances on the device */
-extern uint8_t ucAssistedTestIotI2CSlaveAddr;           /* The slave address to be set for the assisted test. */
+extern uint8_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
+extern uint8_t uctestIotI2CDeviceRegister;    /* Slave I2C register address used in read/write tests */
+extern uint8_t uctestIotI2CWriteVal;          /* Write value that will be used in the register write test */
+extern uint8_t uctestIotI2CInstanceIdx;       /* I2C instance used in the test */
+extern uint8_t uctestIotI2CInstanceNum;       /* The total number of I2C instances on the device */
+extern uint8_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
 
 /* I2S */
-extern int32_t ltestIotI2sInputInstance;                /* used in assisted tests */
-extern int32_t ltestIotI2sOutputInstance;               /* used in assisted tests */
-extern int32_t ltestIotI2SReadSize;                     /* used in assisted tests */
+extern int32_t ltestIotI2sInputInstance;  /* used in assisted tests */
+extern int32_t ltestIotI2sOutputInstance; /* used in assisted tests */
+extern int32_t ltestIotI2SReadSize;       /* used in assisted tests */
 
 /* EFUSE */
-extern uint32_t ultestIotEfuse16BitWordValidIdx;        /* Efuse index for valid 16-bit R/W operations */
-extern uint32_t ultestIotEfuse16BitWordInvalidIdx;      /* Efuse index that is not valid for 16-bit R/W operations */
-extern uint32_t ustestIotEfuse16BitWordWriteVal;        /* 16-bit value to write to eFuse at index uctestIotEfuse16BitWordValidIdx */
-extern uint32_t ultestIotEfuse32BitWordValidIdx;        /* Efuse index for valid 32-bit R/W operations */
-extern uint32_t ultestIotEfuse32BitWordInvalidIdx;      /* Efuse index that is not valid for 32-bit R/W operations */
-extern uint32_t ultestIotEfuse32BitWordWriteVal;        /* 32-bit value to write to eFuse at index uctestIotEfuse32BitWordValidIdx */
+extern uint32_t ultestIotEfuse16BitWordValidIdx;   /* Efuse index for valid 16-bit R/W operations */
+extern uint32_t ultestIotEfuse16BitWordInvalidIdx; /* Efuse index that is not valid for 16-bit R/W operations */
+extern uint32_t ustestIotEfuse16BitWordWriteVal;   /* 16-bit value to write to eFuse at index uctestIotEfuse16BitWordValidIdx */
+extern uint32_t ultestIotEfuse32BitWordValidIdx;   /* Efuse index for valid 32-bit R/W operations */
+extern uint32_t ultestIotEfuse32BitWordInvalidIdx; /* Efuse index that is not valid for 32-bit R/W operations */
+extern uint32_t ultestIotEfuse32BitWordWriteVal;   /* 32-bit value to write to eFuse at index uctestIotEfuse32BitWordValidIdx */
 
 /* TSensor */
-extern uint8_t uctestIotTsensorInstance;                /* I2C instance used in the test */
+extern uint8_t uctestIotTsensorInstance; /* I2C instance used in the test */
 
 /* Power */
-extern uint32_t ultestIotPowerDelay;                    /* Delay used to wait for the DUT enter idle */
+extern uint32_t ultestIotPowerDelay;               /* Delay used to wait for the DUT enter idle */
 
-extern uint32_t ultestIotPowerPcWakeThreshold;          /* Threshold (minimum idle Time required to enter PC Idle Mode */
-extern uint32_t ultestIotPowerClkSrcOffThreshold;       /* Threshold (minimum idle Time required to enter ClkSrc Off Idle Mode */
-extern uint32_t ultestIotPowerVddOffThreshold;          /* Threshold (minimum idle Time required to enter Vdd Off Idle Mode */
+extern uint32_t ultestIotPowerPcWakeThreshold;     /* Threshold (minimum idle Time required to enter PC Idle Mode */
+extern uint32_t ultestIotPowerClkSrcOffThreshold;  /* Threshold (minimum idle Time required to enter ClkSrc Off Idle Mode */
+extern uint32_t ultestIotPowerVddOffThreshold;     /* Threshold (minimum idle Time required to enter Vdd Off Idle Mode */
 
-extern uint32_t ultestIotPowerInterruptConfig1;         /* ARM-only: NVIC interrupt mask to disable, for interrupts 0-31 */
-extern uint32_t ultestIotPowerInterruptConfig2;         /* ARM-only: NVIC interrupt mask to disable, for interrupts 32-63 */
+extern uint32_t ultestIotPowerInterruptConfig1;    /* ARM-only: NVIC interrupt mask to disable, for interrupts 0-31 */
+extern uint32_t ultestIotPowerInterruptConfig2;    /* ARM-only: NVIC interrupt mask to disable, for interrupts 32-63 */
 
-extern uint16_t ustestIotPowerWakeupSourcesLength;      /* Number of wakeup source listed in puctestIotPowerWakeupSources */
-extern uint8_t * puctestIotPowerWakeupSources;          /* Array of wakeup sources, HW-dependent */
+extern uint16_t ustestIotPowerWakeupSourcesLength; /* Number of wakeup source listed in puctestIotPowerWakeupSources */
+extern uint8_t * puctestIotPowerWakeupSources;     /* Array of wakeup sources, HW-dependent */
 
 /* USB Device */
-extern uint8_t uctestIotUsbDeviceControllerId;          /* USB Device controller ID used */
+extern uint8_t uctestIotUsbDeviceControllerId; /* USB Device controller ID used */
 
 
 /**
@@ -336,7 +336,7 @@ void SET_TEST_IOT_TEMP_SENSOR_CONFIG( int testSet );
  * @param: testSet: number of config set to be test
  * @return None
  */
-void SET_TEST_IOT_EFUSE_CONFIG(int testSet);
+void SET_TEST_IOT_EFUSE_CONFIG( int testSet );
 
 /**
  * Board specific I2S config set
@@ -352,4 +352,4 @@ void SET_TEST_IOT_I2S_CONFIG( int testSet );
  * @param: testSet: number of config set to be test
  * @return None
  */
-void SET_TEST_IOT_USB_DEVICE_CONFIG(int testSet);
+void SET_TEST_IOT_USB_DEVICE_CONFIG( int testSet );

--- a/libraries/abstractions/common_io/test/test_iot_internal.h
+++ b/libraries/abstractions/common_io/test/test_iot_internal.h
@@ -175,6 +175,7 @@ extern uint8_t uctestIotI2CDeviceRegister;              /* Slave I2C register ad
 extern uint8_t uctestIotI2CWriteVal;                    /* Write value that will be used in the register write test */
 extern uint8_t uctestIotI2CInstanceIdx;                 /* I2C instance used in the test */
 extern uint8_t uctestIotI2CInstanceNum;                 /* The total number of I2C instances on the device */
+extern uint8_t ucAssistedTestIotI2CSlaveAddr;           /* The slave address to be set for the assisted test. */
 
 /* I2S */
 extern int32_t ltestIotI2sInputInstance;                /* used in assisted tests */

--- a/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_i2c_master_rp3.py
+++ b/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_i2c_master_rp3.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# Amazon FreeRTOS Common IO V0.1.0
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+
+
+import time
+import pigpio
+import random
+import socket
+
+SDA = 18
+SCL = 19
+
+I2C_ADDR = 9
+HOST = ''
+PORT = 50007
+
+
+def i2c(id, tick):
+    global pi, wr_bytes, rd_bytes
+
+    s, b, d = pi.bsc_i2c(0x9)
+    if b > 1:
+        wr_bytes = d
+    elif b == 1:
+        if d[0] == 0x80:
+            rd_bytes = [random.randrange(0, 128) for i in range(0, 16)]
+            s, b, d = pi.bsc_i2c(0x9, ''.join('{}'.format(chr(b)) for b in rd_bytes))
+
+
+if __name__ == "__main__":
+
+    pi = pigpio.pi()
+
+    if not pi.connected:
+        exit()
+
+    # Add pull-ups in case external pull-ups haven't been added
+    pi.set_pull_up_down(SDA, pigpio.PUD_UP)
+    pi.set_pull_up_down(SCL, pigpio.PUD_UP)
+
+    socket.setdefaulttimeout(10)
+    # Create socket server.
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((HOST, PORT))
+    s.listen(1)
+
+    wr_bytes, rd_bytes = ([] for i in range(2))
+    # Respond to BSC slave activity
+    e = pi.event_callback(pigpio.EVENT_BSC, i2c)
+    # Configure BSC as I2C slave
+    st, b, d = pi.bsc_i2c(0x9)
+
+    conn, addr = s.accept()
+
+    # Stay in the process until host request to end.
+    time_out = 30
+    while time_out > 0:
+        try:
+            req = conn.recv(1024)
+        except:
+            print("No request from host.")
+            break
+
+        if len(req) > 0 and req[0] == 's':
+            if wr_bytes != []:
+                conn.sendall(wr_bytes)
+            elif rd_bytes != []:
+                conn.sendall(bytearray(rd_bytes))
+        else:
+            break
+
+    e.cancel()
+
+    pi.bsc_i2c(0)  # Disable BSC peripheral
+    pi.stop()
+
+    s.close()

--- a/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_i2c_master_test.py
+++ b/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_i2c_master_test.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+# Amazon FreeRTOS Common IO V0.1.0
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+
+
+import serial
+from time import sleep
+import csv
+import os, sys
+import argparse
+import threading
+import socket
+import re
+
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+parentdir = os.path.dirname(scriptdir)
+if parentdir not in sys.path:
+    print("Script Dir: %s" % scriptdir)
+    print("Parent Dir: %s" % parentdir)
+    sys.path.append(parentdir)
+from test_iot_test_template import test_template
+
+
+
+class TestI2cMasterAssisted(test_template):
+    """
+    Test class for i2c master tests.
+    """
+
+    def __init__(self, serial, ip, login, pwd, csv_handler):
+        self._func_list = [self.test_IotI2CWriteSyncAssisted,
+                           self.test_IotI2CWriteAsyncAssisted,
+                           self.test_IotI2CReadSyncAssisted,
+                           self.test_IotI2CReadAsyncAssisted
+                           ]
+
+        self._serial = serial
+        self._ip = ip
+        self._login = login
+        self._pwd = pwd
+        self._cr = csv_handler
+
+    shell_script = "%s/test_iot_runonPI_i2c_master.sh" % scriptdir
+    port = 50007
+
+    def i2c_write_test(self, cmd):
+        """
+        Test body of write test.
+        :param cmd: iot test cmd
+        :return:
+        """
+        t_shell = threading.Thread(target=self.run_shell_script,
+                                   args=(" ".join([self.shell_script, self._ip, self._login, self._pwd, '-s']),))
+        t_shell.start()
+
+        socket.setdefaulttimeout(10)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        time_out = 10
+        # Wait until connection with the process on rpi is established.
+        while s.connect_ex((self._ip, self.port)) != 0 and time_out > 0:
+            time_out -= 1
+            sleep(1)
+        if time_out == 0:
+            print("Socket connection cannot be established")
+            s.close()
+            return "Fail"
+
+        self._serial.reset_input_buffer()
+        self._serial.write('\r\n'.encode('utf-8'))
+
+        self._serial.write(cmd.encode('utf-8'))
+
+        self._serial.write('\r\n'.encode('utf-8'))
+
+        res = self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored '])).decode('utf-8')
+
+        w_bytes = []
+        for x in re.sub(r'\r', '', res).split('\n'):
+            if x.find('IGNORE') != -1:
+                w_bytes = [s for s in x.split(',') if len(s) == 2]
+                break
+
+        # Retrieve bytes read by rpi.
+        s.sendall(b's')
+        try:
+            r_bytes = s.recv(1024)
+        except:
+            print("No data received from rpi.\n", repr(res))
+            s.close()
+            return 'Fail'
+        r_bytes = ["{:02X}".format(b) for b in r_bytes]
+        # End process on the rpi.
+        s.sendall(b'E')
+
+        t_shell.join()
+        s.close()
+
+        # Compare read and write bytes.
+        if self.compare_host_dut_result(r_bytes, w_bytes) == -1:
+            print(repr(res))
+            return "Fail"
+
+        return 'Pass'
+
+    def test_IotI2CWriteSyncAssisted(self):
+        return self.i2c_write_test("iot_tests test 11 1")
+
+    def test_IotI2CWriteAsyncAssisted(self):
+        return self.i2c_write_test("iot_tests test 11 2")
+
+    def i2c_read_test(self, cmd):
+        """
+        Test body for read test. The i2c slave callback function in the rpi library is only called after i2c stop. The
+        register address cannot be read by rpi before restart so the data to send can only be loaded to rpi fifo after
+        stop. As a result, the first read from host is always the data loaded from last request or some random value if
+        fifo is never loaded before.
+        The solution with the current rpi library is to read rpi twice. Compare the second dut read data with the first
+        rpi send data.
+        :param cmd: iot test cmd
+        :return:
+        """
+        w_bytes, r_bytes = ([] for i in range(2))
+
+        t_shell = threading.Thread(target=self.run_shell_script,
+                                   args=(" ".join([self.shell_script, self._ip, self._login, self._pwd, '-s']),))
+        t_shell.start()
+
+        socket.setdefaulttimeout(10)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        time_out = 10
+        # Wait until connection with the process on rpi is established.
+        while s.connect_ex((self._ip, self.port)) != 0 and time_out > 0:
+            time_out -= 1
+            sleep(1)
+        if time_out == 0:
+            print("Socket connection cannot be established")
+            s.close()
+            return "Fail"
+
+        for i in range(2):
+            self._serial.reset_input_buffer()
+            self._serial.write('\r\n'.encode('utf-8'))
+
+            self._serial.write(cmd.encode('utf-8'))
+
+            self._serial.write('\r\n'.encode('utf-8'))
+
+            res = self._serial.read_until(terminator=serial.to_bytes([ord(c) for c in 'Ignored '])).decode('utf-8')
+
+            for x in re.sub(r'\r', '', res).split('\n'):
+                if x.find('IGNORE') != -1:
+                    r_bytes.append([s for s in x.split(',') if len(s) == 2])
+                    break
+
+            # Retrieve bytes sent by rpi
+            s.sendall(b's')
+            try:
+                data = s.recv(1024)
+            except:
+                print("No data from pi")
+                s.close()
+                return 'Fail'
+
+            w_bytes.append(["{:02X}".format(b) for b in data])
+            # Exit if failed to read bytes from DUT.
+            if len(r_bytes) != i + 1:
+                print("No data read by DUT.\n", repr(res))
+                break
+        # End process on the rpi.
+        s.sendall(b'E')
+
+        t_shell.join()
+        s.close()
+
+        if len(r_bytes) != 2 or len(w_bytes) != 2:
+            print("Write and read different number of bytes.\npi:", w_bytes, "\ndut:", r_bytes)
+            return 'Fail'
+
+        # Compare read and write bytes.
+        if self.compare_host_dut_result(w_bytes[0], r_bytes[1]) == -1:
+            print(repr(res))
+            return "Fail"
+
+        return 'Pass'
+
+    def test_IotI2CReadSyncAssisted(self):
+        return self.i2c_read_test("iot_tests test 11 3")
+
+    def test_IotI2CReadAsyncAssisted(self):
+        return self.i2c_read_test("iot_tests test 11 4")
+
+
+# unit test
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-i', '--ip', nargs=1, default=[''], help='ip address of rpi')
+    parser.add_argument('-l', '--login_name', nargs=1, default=[''], help='login name of rpi')
+    parser.add_argument('-s', '--password', nargs=1, default=[''], help='password of rpi')
+    parser.add_argument('-p', '--port', nargs=1, default=[''], help='serial port of connected platform')
+
+    args = parser.parse_args()
+
+    try:
+        serial_port = serial.Serial(port=args.port[0], timeout=5)
+    except Exception as e:
+        print(e)
+        exit()
+
+    rpi_ip = args.ip[0]
+    rpi_login = args.login_name[0]
+    rpi_pwd = args.password[0]
+
+    with open(scriptdir + 'test_result.csv', 'w', newline='') as csvfile:
+        field_name = ['test name', 'test result']
+        writer = csv.DictWriter(csvfile, fieldnames=field_name)
+        writer.writeheader()
+        t_handler = TestI2cMasterAssisted(serial_port, rpi_ip, rpi_login, rpi_pwd, writer)
+        t_handler.auto_run()
+
+    serial_port.close()

--- a/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_runonPI_i2c_master.sh
+++ b/libraries/abstractions/common_io/test/test_scripts/i2c_master/test_iot_runonPI_i2c_master.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Amazon FreeRTOS Common IO V0.1.0
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+IP=$1
+shift
+LOGINID=$1
+shift
+PASSWD=$1
+shift
+
+if [ "$1" == "-p" ]; then
+    #Secure copy the test_iot_adc_rp3.py from Host to RP3
+    sshpass -p "$PASSWD" ssh "$LOGINID"@"$IP" "mkdir -p /home/pi/Tests"
+    sshpass -p "$PASSWD" scp ${DIR}/test_iot_i2c_master_rp3.py "$LOGINID"@"$IP":/home/pi/Tests
+elif [ "$1" == "-s" ]; then
+    #Run demon
+    sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} 'sudo pigpiod -s 1 -b 200'
+    sleep .1
+    #Run rpi script
+    sshpass -p "$PASSWD" ssh "$LOGINID"@"$IP" "python /home/pi/Tests/test_iot_i2c_master_rp3.py"
+    #Kill demon
+    sshpass -p ${PASSWD} ssh ${LOGINID}@${IP} "sudo killall pigpiod"
+elif [ "$1" == "-c" ]; then
+    sshpass -p "$PASSWD" ssh "$LOGINID"@"$IP" "rm /home/pi/Tests/i2c_master_res.txt"
+fi


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Created iot test, scripts for dut, host and rpi respectively. For the i2c write test, 15 bytes are generated randomly by dut and sent to rpi. The host compares the read bytes by rpi and write bytes by dut. For the i2c read test, 16 bytes are generated randomly by rpi and sent to dut. The dut has to read twice to mitigate the limitation of rpi. The host compares the second read of dut with the first write of rpi.

Run test script in the i2c_master folder
    $ ./test_iot_i2c_master_test.py -i <ip> -l <login> -s <pwd> -p <serial>

Output result
tests start
2020-01-24 17:13:51.903284 [INFO] test_IotI2CWriteSyncAssisted 0  PASS  :  test_IotI2CWriteSyncAssisted Passed
2020-01-24 17:13:55.546245 [INFO] test_IotI2CWriteAsyncAssisted 0  PASS  :  test_IotI2CWriteAsyncAssisted Passed
2020-01-24 17:13:59.187762 [INFO] test_IotI2CReadSyncAssisted 0  PASS  :  test_IotI2CReadSyncAssisted Passed
2020-01-24 17:14:02.835503 [INFO] test_IotI2CReadAsyncAssisted 0  PASS  :  test_IotI2CReadAsyncAssisted Passed
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.