### PR TITLE
Reduce Microchip C Runtime Heap Size and Increase FreeRTOS Heap Size

### DIFF
--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -1018,7 +1018,7 @@
 				<property key="generate-16-bit-code" value="false"/>
 				<property key="generate-cross-reference-file" value="false"/>
 				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="heap-size" value="170000"/>
+				<property key="heap-size" value="10000"/>
 				<property key="input-libraries" value=""/>
 				<property key="kseg-length" value=""/>
 				<property key="kseg-origin" value=""/>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -1103,7 +1103,7 @@
 				<property key="generate-16-bit-code" value="false"/>
 				<property key="generate-cross-reference-file" value="false"/>
 				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="heap-size" value="170000"/>
+				<property key="heap-size" value="10000"/>
 				<property key="input-libraries" value=""/>
 				<property key="kseg-length" value=""/>
 				<property key="kseg-origin" value=""/>

--- a/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
+++ b/vendors/microchip/boards/curiosity_pic32mzef/CMakeLists.txt
@@ -35,7 +35,7 @@ target_compile_options(
 
 
 # Linker flags
-set(linker_flags -Wl,--script=\"${board_dir}/application_code/microchip_code/app_mz.ld\",--defsym=_min_heap_size=170000,--defsym=_min_stack_size=10000,--gc-sections,--no-code-in-dinit,--no-dinit-in-serial-mem,--memorysummary,memoryfile.xml,--allow-multiple-definition)
+set(linker_flags -Wl,--script=\"${board_dir}/application_code/microchip_code/app_mz.ld\",--defsym=_min_heap_size=10000,--defsym=_min_stack_size=10000,--gc-sections,--no-code-in-dinit,--no-dinit-in-serial-mem,--memorysummary,memoryfile.xml,--allow-multiple-definition)
 
 target_link_options(
     AFR::compiler::mcu_port

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
@@ -57,7 +57,7 @@
 #define configISR_STACK_SIZE                       ( 512 )
 #define configSUPPORT_DYNAMIC_ALLOCATION           1
 #define configSUPPORT_STATIC_ALLOCATION            1
-#define configTOTAL_HEAP_SIZE                      ( ( size_t ) 256000 )
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) 416000 )
 #define configMAX_TASK_NAME_LEN                    ( 16 )
 #define configUSE_16_BIT_TICKS                     0
 #define configIDLE_SHOULD_YIELD                    1

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
@@ -59,7 +59,7 @@
 #define configISR_STACK_SIZE                       ( 512 )
 #define configSUPPORT_DYNAMIC_ALLOCATION           1
 #define configSUPPORT_STATIC_ALLOCATION            1
-#define configTOTAL_HEAP_SIZE                      ( ( size_t ) 256000 )
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) 416000 )
 #define configMAX_TASK_NAME_LEN                    ( 16 )
 #define configUSE_16_BIT_TICKS                     0
 #define configIDLE_SHOULD_YIELD                    1


### PR DESCRIPTION
This change is necessary because FreeRTOS based projects should not use the C runtime heap. Instead
they should use the FreeRTOS managed Heap. I have changed the C runtime heap allocation from
170KB to 10KB, and in turn increased the FreeRTOS heap size by 160KB.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.