### PR TITLE
Fixed hard fault on ST and TI Caused By Call To xProvisionDevice

### DIFF
--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -1028,6 +1028,10 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
                 configPRINTF( ( "Warning: could not clean-up old crypto objects. %d \r\n", xResult ) );
             }
         }
+        else
+        {
+            xResult = CKR_ARGUMENTS_BAD;
+        }
     #endif /* if ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED == 1 ) */
 
     /* If a client certificate has been provided by the caller, attempt to
@@ -1044,6 +1048,10 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
         {
             configPRINTF( ( "ERROR: Failed to provision device certificate. %d \r\n", xResult ) );
         }
+    }
+    else
+    {
+        xResult = CKR_ARGUMENTS_BAD;
     }
 
     #if ( pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED == 1 )
@@ -1087,6 +1095,10 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
             xResult = CKR_OK;
             configPRINTF( ( "Warning: no persistent storage is available for the JITP certificate. The certificate in aws_clientcredential_keys.h will be used instead.\r\n" ) );
         }
+    }
+    else
+    {
+        xResult = CKR_ARGUMENTS_BAD;
     }
 
     /* Check whether a key pair is now present. In order to support X.509


### PR DESCRIPTION
xProvisionDevice checks for NULL certs and keys, but a path existed that caused it to try and provision a NULL private key.
This caused a hard fault on ST and TI when credentials were NULL.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.