### PR TITLE
change http echo server from 'httpbin.org' to 'postman-echo.com'

### DIFF
--- a/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
+++ b/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
@@ -55,7 +55,7 @@
  * This address MUST NOT start with http:// or https://.
  */
 #ifndef IOT_TEST_HTTPS_SERVER_HOST_NAME
-    #define IOT_TEST_HTTPS_SERVER_HOST_NAME    "httpbin.org"
+    #define IOT_TEST_HTTPS_SERVER_HOST_NAME    "postman-echo.com"
 #endif
 
 /**


### PR DESCRIPTION


<!--- Title -->

Description
-----------
HTTPS_Client_System test Group is fails for TI when connecting to
'httpbin.org'. Connect to 'postman-echo.com' to solve this issue.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.