### PR TITLE
Update FreeRTOS-Kernel submodule to V10.3.0-kernel-only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,6 @@
 [submodule "freertos_kernel"]
 	path = freertos_kernel
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-	branch = release-candidate_10.3.0_rc3
 [submodule "pkcs11"]
 	path = libraries/3rdparty/pkcs11
 	url = https://github.com/amazon-freertos/pkcs11.git


### PR DESCRIPTION


<!--- Title -->

Description
-----------
Update FreeRTOS-Kernel submodule branch from release-candidate_10.3.0_rc3 to V10.3.0-kernel-only
commit id: 210b1ffcc87bcff93871a37fbf0ad2033870ecaf

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.