### PR TITLE
Cypress projects kernel dependency fix.

### DIFF
--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
@@ -142,14 +142,14 @@
 			<locationURI>BASE_DIR/freertos_kernel/portable/MemMang/heap_3.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>demos/demo_runner/aws_demo_version.c</name>

--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
@@ -137,14 +137,14 @@
 			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/include/timers.h</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>freertos_kernel/portable/MemMang/heap_3.c</name>

--- a/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
@@ -142,14 +142,14 @@
 			<locationURI>BASE_DIR/freertos_kernel/portable/MemMang/heap_3.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>demos/demo_runner/aws_demo_version.c</name>

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
@@ -86,13 +86,13 @@ $(NAME)_ARM_CM4_SOURCES  := $($(NAME)_ARM_CM3_SOURCES)
 $(NAME)_ARM_CM4_INCLUDES := $($(NAME)_ARM_CM3_INCLUDES)
 
 # ARM Cortex R4 specific sources and includes
-#$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)lib/FreeRTOS/portable/GCC/ARM_CRx_No_GIC/port.c \
-#                          $(AMAZON_FREERTOS_PATH)lib/FreeRTOS/portable/GCC/ARM_CRx_No_GIC/portASM.S
-#$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)lib/FreeRTOS/portable/GCC/ARM_CRx_No_GIC
+$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/ARM_CRx_No_GIC/port.c \
+                          $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portASM.S
+$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/ARM_CRx_No_GIC
 
-$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/port.c \
-                          $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/portASM.S
-$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/
+#$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/port.c \
+#                          $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/portASM.S
+#$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/
 
 $(NAME)_SOURCES += $($(NAME)_$(HOST_ARCH)_SOURCES)
 GLOBAL_INCLUDES += $($(NAME)_$(HOST_ARCH)_INCLUDES)

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
@@ -90,10 +90,6 @@ $(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/A
                           $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/ARM_CRx_No_GIC/portASM.S
 $(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/GCC/ARM_CRx_No_GIC
 
-#$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/port.c \
-#                          $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/portASM.S
-#$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/
-
 $(NAME)_SOURCES += $($(NAME)_$(HOST_ARCH)_SOURCES)
 GLOBAL_INCLUDES += $($(NAME)_$(HOST_ARCH)_INCLUDES)
 GLOBAL_LDFLAGS  += $($(NAME)_$(HOST_ARCH)_LDFLAGS)

--- a/vendors/cypress/WICED_SDK/makefiles/wiced_toolchain_ARM_GNU.mk
+++ b/vendors/cypress/WICED_SDK/makefiles/wiced_toolchain_ARM_GNU.mk
@@ -198,7 +198,7 @@ CPU_LDFLAGS  := -mthumb -mcpu=cortex-m0 -Wl,-A,thumb
 endif
 
 ifeq ($(HOST_ARCH),ARM_CR4)
-CPU_BASE_FLAGS     := -mthumb -mcpu=cortex-r4 -mthumb-interwork
+CPU_BASE_FLAGS     := -mthumb -mcpu=cortex-r4 -mthumb-interwork -mfpu=vfpv3-d16 -mfloat-abi=softfp
 CPU_COMPILER_FLAGS := $(CPU_BASE_FLAGS) -fno-builtin-memcmp -fno-builtin-memcpy -fno-builtin-memset
 CPU_CFLAGS         := $(CPU_COMPILER_FLAGS)
 CPU_CXXFLAGS       := $(CPU_COMPILER_FLAGS)


### PR DESCRIPTION
Description
-----------
In previous releases, we "accidentally" committed a kernel port in kernel third party directory. This is unnecessary since third party port is essentially the same as ```GCC/ARM_CRx_No_GIC```. In this kernel release, we removed the redundant third party port. And in this PR, I'm trying to make the projects take dependency on the correct kernel port. 

Additional compiler flags are added for floating point related. Refer to https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.