### PR TITLE
Cypress kernel dependency workaround

### DIFF
--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_demos/.project
@@ -142,14 +142,14 @@
 			<locationURI>BASE_DIR/freertos_kernel/portable/MemMang/heap_3.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>BASE_DIR/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>BASE_DIR/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>demos/demo_runner/aws_demo_version.c</name>

--- a/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
+++ b/projects/cypress/CYW943907AEVAL1F/wicedstudio/aws_tests/.project
@@ -137,14 +137,14 @@
 			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/include/timers.h</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>freertos_kernel/portable/MemMang/heap_3.c</name>

--- a/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
+++ b/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_demos/.project
@@ -142,14 +142,14 @@
 			<locationURI>BASE_DIR/freertos_kernel/portable/MemMang/heap_3.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>BASE_DIR/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</name>
 			<type>1</type>
-			<locationURI>BASE_DIR/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>BASE_DIR/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>demos/demo_runner/aws_demo_version.c</name>

--- a/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_tests/.project
+++ b/projects/cypress/CYW954907AEVAL1F/wicedstudio/aws_tests/.project
@@ -137,14 +137,14 @@
 			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/include/timers.h</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/port.c</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/port.c</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</name>
+			<name>vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h</locationURI>
 		</link>
 		<link>
 			<name>freertos_kernel/portable/MemMang/heap_3.c</name>

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/FreeRTOS.mk
@@ -90,9 +90,9 @@ $(NAME)_ARM_CM4_INCLUDES := $($(NAME)_ARM_CM3_INCLUDES)
 #                          $(AMAZON_FREERTOS_PATH)lib/FreeRTOS/portable/GCC/ARM_CRx_No_GIC/portASM.S
 #$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)lib/FreeRTOS/portable/GCC/ARM_CRx_No_GIC
 
-$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/port.c \
-                          $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/portASM.S
-$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)freertos_kernel/portable/ThirdParty/GCC/Wiced_CY/
+$(NAME)_ARM_CR4_SOURCES := $(AMAZON_FREERTOS_PATH)vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c \
+                          $(AMAZON_FREERTOS_PATH)vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portASM.S
+$(NAME)_ARM_CR4_INCLUDES := $(AMAZON_FREERTOS_PATH)vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/
 
 $(NAME)_SOURCES += $($(NAME)_$(HOST_ARCH)_SOURCES)
 GLOBAL_INCLUDES += $($(NAME)_$(HOST_ARCH)_INCLUDES)

--- a/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c
+++ b/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/port.c
@@ -1,0 +1,324 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/* Standard includes. */
+#include <stdlib.h>
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+	/* Check the configuration. */
+	#if( configMAX_PRIORITIES > 32 )
+		#error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+	#endif
+#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+
+#ifndef configSETUP_TICK_INTERRUPT
+	#error configSETUP_TICK_INTERRUPT() must be defined in FreeRTOSConfig.h to call the function that sets up the tick interrupt.
+#endif
+
+#ifndef configCLEAR_TICK_INTERRUPT
+	#error configCLEAR_TICK_INTERRUPT must be defined in FreeRTOSConfig.h to clear which ever interrupt was used to generate the tick interrupt.
+#endif
+
+/* A critical section is exited when the critical section nesting count reaches
+this value. */
+#define portNO_CRITICAL_NESTING			( ( uint32_t ) 0 )
+
+/* Tasks are not created with a floating point context, but can be given a
+floating point context after they have been created.  A variable is stored as
+part of the tasks context that holds portNO_FLOATING_POINT_CONTEXT if the task
+does not have an FPU context, or any other value if the task does have an FPU
+context. */
+#define portNO_FLOATING_POINT_CONTEXT	( ( StackType_t ) 0 )
+
+/* Constants required to setup the initial task context. */
+#define portINITIAL_SPSR				( ( StackType_t ) 0x1f ) /* System mode, ARM mode, IRQ enabled FIQ enabled. */
+#define portTHUMB_MODE_BIT				( ( StackType_t ) 0x20 )
+#define portTHUMB_MODE_ADDRESS			( 0x01UL )
+
+/* Masks all bits in the APSR other than the mode bits. */
+#define portAPSR_MODE_BITS_MASK			( 0x1F )
+
+/* The value of the mode bits in the APSR when the CPU is executing in user
+mode. */
+#define portAPSR_USER_MODE				( 0x10 )
+
+/* Let the user override the pre-loading of the initial LR with the address of
+prvTaskExitError() in case it messes up unwinding of the stack in the
+debugger. */
+#ifdef configTASK_RETURN_ADDRESS
+	#define portTASK_RETURN_ADDRESS	configTASK_RETURN_ADDRESS
+#else
+	#define portTASK_RETURN_ADDRESS	prvTaskExitError
+#endif
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Starts the first task executing.  This function is necessarily written in
+ * assembly code so is implemented in portASM.s.
+ */
+extern void vPortRestoreTaskContext( void );
+
+/*
+ * Used to catch tasks that attempt to return from their implementing function.
+ */
+static void prvTaskExitError( void );
+
+/*-----------------------------------------------------------*/
+
+/* A variable is used to keep track of the critical section nesting.  This
+variable has to be stored as part of the task context and must be initialised to
+a non zero value to ensure interrupts don't inadvertently become unmasked before
+the scheduler starts.  As it is stored as part of the task context it will
+automatically be set to 0 when the first task is started. */
+volatile uint32_t ulCriticalNesting = 9999UL;
+
+/* Saved as part of the task context.  If ulPortTaskHasFPUContext is non-zero then
+a floating point context must be saved and restored for the task. */
+volatile uint32_t ulPortTaskHasFPUContext = pdFALSE;
+
+/* Set to 1 to pend a context switch from an ISR. */
+volatile uint32_t ulPortYieldRequired = pdFALSE;
+
+/* Counts the interrupt nesting depth.  A context switch is only performed if
+if the nesting depth is 0. */
+volatile uint32_t ulPortInterruptNesting = 0UL;
+
+/* Used in the asm file to clear an interrupt. */
+__attribute__(( used )) const uint32_t ulICCEOIR = configEOI_ADDRESS;
+
+/*-----------------------------------------------------------*/
+
+/*
+ * See header file for description.
+ */
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+{
+	/* Setup the initial stack of the task.  The stack is set exactly as
+	expected by the portRESTORE_CONTEXT() macro.
+
+	The fist real value on the stack is the status register, which is set for
+	system mode, with interrupts enabled.  A few NULLs are added first to ensure
+	GDB does not try decoding a non-existent return address. */
+	*pxTopOfStack = ( StackType_t ) NULL;
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) NULL;
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) NULL;
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) portINITIAL_SPSR;
+
+	if( ( ( uint32_t ) pxCode & portTHUMB_MODE_ADDRESS ) != 0x00UL )
+	{
+		/* The task will start in THUMB mode. */
+		*pxTopOfStack |= portTHUMB_MODE_BIT;
+	}
+
+	pxTopOfStack--;
+
+	/* Next the return address, which in this case is the start of the task. */
+	*pxTopOfStack = ( StackType_t ) pxCode;
+	pxTopOfStack--;
+
+	/* Next all the registers other than the stack pointer. */
+	*pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS;	/* R14 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x12121212;	/* R12 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x11111111;	/* R11 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x10101010;	/* R10 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x09090909;	/* R9 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x08080808;	/* R8 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x07070707;	/* R7 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x06060606;	/* R6 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x05050505;	/* R5 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x04040404;	/* R4 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x03030303;	/* R3 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x02020202;	/* R2 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) 0x01010101;	/* R1 */
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) pvParameters; /* R0 */
+	pxTopOfStack--;
+
+	/* The task will start with a critical nesting count of 0 as interrupts are
+	enabled. */
+	*pxTopOfStack = portNO_CRITICAL_NESTING;
+	pxTopOfStack--;
+
+	/* The task will start without a floating point context.  A task that uses
+	the floating point hardware must call vPortTaskUsesFPU() before executing
+	any floating point instructions. */
+	*pxTopOfStack = portNO_FLOATING_POINT_CONTEXT;
+
+	return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+static void prvTaskExitError( void )
+{
+	/* A function that implements a task must not exit or attempt to return to
+	its caller as there is nothing to return to.  If a task wants to exit it
+	should instead call vTaskDelete( NULL ).
+
+	Artificially force an assert() to be triggered if configASSERT() is
+	defined, then stop here so application writers can catch the error. */
+	configASSERT( ulPortInterruptNesting == ~0UL );
+	portDISABLE_INTERRUPTS();
+	for( ;; );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler( void )
+{
+uint32_t ulAPSR;
+
+	/* Only continue if the CPU is not in User mode.  The CPU must be in a
+	Privileged mode for the scheduler to start. */
+	__asm volatile ( "MRS %0, APSR" : "=r" ( ulAPSR ) );
+	ulAPSR &= portAPSR_MODE_BITS_MASK;
+	configASSERT( ulAPSR != portAPSR_USER_MODE );
+
+	if( ulAPSR != portAPSR_USER_MODE )
+	{
+		/* Start the timer that generates the tick ISR. */
+		portDISABLE_INTERRUPTS();
+		configSETUP_TICK_INTERRUPT();
+
+		/* Start the first task executing. */
+		vPortRestoreTaskContext();
+	}
+
+	/* Will only get here if vTaskStartScheduler() was called with the CPU in
+	a non-privileged mode or the binary point register was not set to its lowest
+	possible value.  prvTaskExitError() is referenced to prevent a compiler
+	warning about it being defined but not referenced in the case that the user
+	defines their own exit address. */
+	( void ) prvTaskExitError;
+	return 0;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler( void )
+{
+	/* Not implemented in ports where there is nothing to return to.
+	Artificially force an assert. */
+	configASSERT( ulCriticalNesting == 1000UL );
+}
+/*-----------------------------------------------------------*/
+
+void vPortEnterCritical( void )
+{
+	portDISABLE_INTERRUPTS();
+
+	/* Now interrupts are disabled ulCriticalNesting can be accessed
+	directly.  Increment ulCriticalNesting to keep a count of how many times
+	portENTER_CRITICAL() has been called. */
+	ulCriticalNesting++;
+
+	/* This is not the interrupt safe version of the enter critical function so
+	assert() if it is being called from an interrupt context.  Only API
+	functions that end in "FromISR" can be used in an interrupt.  Only assert if
+	the critical nesting count is 1 to protect against recursive calls if the
+	assert function also uses a critical section. */
+	if( ulCriticalNesting == 1 )
+	{
+		configASSERT( ulPortInterruptNesting == 0 );
+	}
+}
+/*-----------------------------------------------------------*/
+
+void vPortExitCritical( void )
+{
+	if( ulCriticalNesting > portNO_CRITICAL_NESTING )
+	{
+		/* Decrement the nesting count as the critical section is being
+		exited. */
+		ulCriticalNesting--;
+
+		/* If the nesting level has reached zero then all interrupt
+		priorities must be re-enabled. */
+		if( ulCriticalNesting == portNO_CRITICAL_NESTING )
+		{
+			/* Critical nesting has reached zero so all interrupt priorities
+			should be unmasked. */
+			portENABLE_INTERRUPTS();
+		}
+	}
+}
+/*-----------------------------------------------------------*/
+
+void FreeRTOS_Tick_Handler( void )
+{
+uint32_t ulInterruptStatus;
+
+	ulInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
+
+	/* Increment the RTOS tick. */
+	if( xTaskIncrementTick() != pdFALSE )
+	{
+		ulPortYieldRequired = pdTRUE;
+	}
+
+	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulInterruptStatus );
+
+	configCLEAR_TICK_INTERRUPT();
+}
+/*-----------------------------------------------------------*/
+
+void vPortTaskUsesFPU( void )
+{
+#if configFPU == 1
+uint32_t ulInitialFPSCR = 0;
+
+	/* A task is registering the fact that it needs an FPU context.  Set the
+	FPU flag (which is saved as part of the task context). */
+	ulPortTaskHasFPUContext = pdTRUE;
+
+	/* Initialise the floating point status register. */
+	__asm volatile ( "FMXR 	FPSCR, %0" :: "r" (ulInitialFPSCR) );
+#else
+	/* If FreeRTOS was built without FPU support but a task is using the FPU, we have a problem */
+	configASSERT( 0 );
+#endif
+}
+/*-----------------------------------------------------------*/
+
+

--- a/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portASM.S
+++ b/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portASM.S
@@ -1,0 +1,268 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+	.text
+	.arm
+
+	.set SYS_MODE,	0x1f
+	.set SVC_MODE,	0x13
+	.set IRQ_MODE,	0x12
+
+	/* Variables and functions. */
+	.extern ulMaxAPIPriorityMask
+	.extern _freertos_vector_table
+	.extern pxCurrentTCB
+	.extern vTaskSwitchContext
+	.extern vApplicationIRQHandler
+	.extern ulPortInterruptNesting
+	.extern ulPortTaskHasFPUContext
+	.extern ulICCEOIR
+	.extern ulPortYieldRequired
+
+	.global FreeRTOS_IRQ_Handler
+	.global FreeRTOS_SVC_Handler
+	.global vPortRestoreTaskContext
+
+
+.macro portSAVE_CONTEXT
+
+	/* Save the LR and SPSR onto the system mode stack before switching to
+	system mode to save the remaining system mode registers. */
+	SRSDB	sp!, #SYS_MODE
+	CPS		#SYS_MODE
+	PUSH	{R0-R12, R14}
+
+	/* Push the critical nesting count. */
+	LDR		R2, ulCriticalNestingConst
+	LDR		R1, [R2]
+	PUSH	{R1}
+
+	/* Does the task have a floating point context that needs saving?  If
+	ulPortTaskHasFPUContext is 0 then no. */
+	LDR		R2, ulPortTaskHasFPUContextConst
+	LDR		R3, [R2]
+	CMP		R3, #0
+
+#if configFPU == 1
+	/* Save the floating point context, if any. */
+	FMRXNE  R1,  FPSCR
+	VPUSHNE {D0-D15}
+#if configFPU_D32 == 1
+	VPUSHNE	{D16-D31}
+#endif /* configFPU_D32 */
+	PUSHNE	{R1}
+#endif
+
+	/* Save ulPortTaskHasFPUContext itself. */
+	PUSH	{R3}
+
+	/* Save the stack pointer in the TCB. */
+	LDR		R0, pxCurrentTCBConst
+	LDR		R1, [R0]
+	STR		SP, [R1]
+
+	.endm
+
+; /**********************************************************************/
+
+.macro portRESTORE_CONTEXT
+
+	/* Set the SP to point to the stack of the task being restored. */
+	LDR		R0, pxCurrentTCBConst
+	LDR		R1, [R0]
+	LDR		SP, [R1]
+
+	/* Is there a floating point context to restore?  If the restored
+	ulPortTaskHasFPUContext is zero then no. */
+	LDR		R0, ulPortTaskHasFPUContextConst
+	POP		{R1}
+	STR		R1, [R0]
+	CMP		R1, #0
+
+#if configFPU == 1
+	/* Restore the floating point context, if any. */
+	POPNE 	{R0}
+#if configFPU_D32 == 1
+	VPOPNE	{D16-D31}
+#endif /* configFPU_D32 */
+	VPOPNE	{D0-D15}
+	VMSRNE  FPSCR, R0
+#endif
+
+	/* Restore the critical section nesting depth. */
+	LDR		R0, ulCriticalNestingConst
+	POP		{R1}
+	STR		R1, [R0]
+
+	/* Restore all system mode registers other than the SP (which is already
+	being used). */
+	POP		{R0-R12, R14}
+
+	/* Return to the task code, loading CPSR on the way. */
+	RFEIA	sp!
+
+	.endm
+
+
+
+
+/******************************************************************************
+ * SVC handler is used to yield.
+ *****************************************************************************/
+.align 4
+.type FreeRTOS_SVC_Handler, %function
+FreeRTOS_SVC_Handler:
+	/* Save the context of the current task and select a new task to run. */
+	portSAVE_CONTEXT
+	LDR R0, vTaskSwitchContextConst
+	BLX	R0
+	portRESTORE_CONTEXT
+
+
+/******************************************************************************
+ * vPortRestoreTaskContext is used to start the scheduler.
+ *****************************************************************************/
+.align 4
+.type vPortRestoreTaskContext, %function
+vPortRestoreTaskContext:
+	/* Switch to system mode. */
+	CPS		#SYS_MODE
+	portRESTORE_CONTEXT
+
+.align 4
+.type FreeRTOS_IRQ_Handler, %function
+FreeRTOS_IRQ_Handler:
+	/* Return to the interrupted instruction. */
+	SUB		lr, lr, #4
+
+	/* Push the return address and SPSR. */
+	PUSH	{lr}
+	MRS		lr, SPSR
+	PUSH	{lr}
+
+	/* Change to supervisor mode to allow reentry. */
+	CPS		#0x13
+
+	/* Push used registers. */
+	PUSH	{r0-r3, r12}
+
+	/* Increment nesting count.  r3 holds the address of ulPortInterruptNesting
+	for future use.  r1 holds the original ulPortInterruptNesting value for
+	future use. */
+	LDR		r3, ulPortInterruptNestingConst
+	LDR		r1, [r3]
+	ADD		r0, r1, #1
+	STR		r0, [r3]
+
+	/* Ensure bit 2 of the stack pointer is clear.  r2 holds the bit 2 value for
+	future use. */
+	MOV		r0, sp
+	AND		r2, r0, #4
+	SUB		sp, sp, r2
+
+	/* Call the interrupt handler. */
+	PUSH	{r0-r3, lr}
+	LDR		r1, vApplicationIRQHandlerConst
+	BLX		r1
+	POP		{r0-r3, lr}
+	ADD		sp, sp, r2
+
+	CPSID	i
+	DSB
+	ISB
+
+	/* Write to the EOI register. */
+	LDR 	r0, ulICCEOIRConst
+	LDR		r2, [r0]
+	STR		r0, [r2]
+
+	/* Restore the old nesting count. */
+	STR		r1, [r3]
+
+	/* A context switch is never performed if the nesting count is not 0. */
+	CMP		r1, #0
+	BNE		exit_without_switch
+
+	/* Did the interrupt request a context switch?  r1 holds the address of
+	ulPortYieldRequired and r0 the value of ulPortYieldRequired for future
+	use. */
+	LDR		r1, ulPortYieldRequiredConst
+	LDR		r0, [r1]
+	CMP		r0, #0
+	BNE		switch_before_exit
+
+exit_without_switch:
+	/* No context switch.  Restore used registers, LR_irq and SPSR before
+	returning. */
+	POP		{r0-r3, r12}
+	CPS		#IRQ_MODE
+	POP		{LR}
+	MSR		SPSR_cxsf, LR
+	POP		{LR}
+	MOVS	PC, LR
+
+switch_before_exit:
+	/* A context swtich is to be performed.  Clear the context switch pending
+	flag. */
+	MOV		r0, #0
+	STR		r0, [r1]
+
+	/* Restore used registers, LR-irq and SPSR before saving the context
+	to the task stack. */
+	POP		{r0-r3, r12}
+	CPS		#IRQ_MODE
+	POP		{LR}
+	MSR		SPSR_cxsf, LR
+	POP		{LR}
+	portSAVE_CONTEXT
+
+	/* Call the function that selects the new task to execute.
+	vTaskSwitchContext() if vTaskSwitchContext() uses LDRD or STRD
+	instructions, or 8 byte aligned stack allocated data.  LR does not need
+	saving as a new LR will be loaded by portRESTORE_CONTEXT anyway. */
+	LDR		R0, vTaskSwitchContextConst
+	BLX		R0
+
+	/* Restore the context of, and branch to, the task selected to execute
+	next. */
+	portRESTORE_CONTEXT
+
+ulICCEOIRConst:	.word ulICCEOIR
+pxCurrentTCBConst: .word pxCurrentTCB
+ulCriticalNestingConst: .word ulCriticalNesting
+ulPortTaskHasFPUContextConst: .word ulPortTaskHasFPUContext
+vTaskSwitchContextConst: .word vTaskSwitchContext
+vApplicationIRQHandlerConst: .word vApplicationIRQHandler
+ulPortInterruptNestingConst: .word ulPortInterruptNesting
+ulPortYieldRequiredConst: .word ulPortYieldRequired
+
+.end
+
+
+
+
+

--- a/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h
+++ b/vendors/cypress/freertos_thirdparty_port/GCC/Wiced_CY/portmacro.h
@@ -1,0 +1,179 @@
+/*
+ * FreeRTOS Kernel V10.2.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+	extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the given hardware
+ * and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR		char
+#define portFLOAT		float
+#define portDOUBLE		double
+#define portLONG		long
+#define portSHORT		short
+#define portSTACK_TYPE	uint32_t
+#define portBASE_TYPE	long
+
+typedef portSTACK_TYPE StackType_t;
+typedef long BaseType_t;
+typedef unsigned long UBaseType_t;
+
+typedef uint32_t TickType_t;
+#define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+
+/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+not need to be guarded with a critical section. */
+#define portTICK_TYPE_IS_ATOMIC 1
+
+/*-----------------------------------------------------------*/
+
+/* Hardware specifics. */
+#define portSTACK_GROWTH			( -1 )
+#define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portBYTE_ALIGNMENT			8
+
+/*-----------------------------------------------------------*/
+
+/* Task utilities. */
+
+/* Called at the end of an ISR that can cause a context switch. */
+#define portEND_SWITCHING_ISR( xSwitchRequired )\
+{												\
+extern volatile uint32_t ulPortYieldRequired;	\
+												\
+	if( xSwitchRequired != pdFALSE )			\
+	{											\
+		ulPortYieldRequired = pdTRUE;			\
+	}											\
+}
+
+#define portYIELD_FROM_ISR( x ) portEND_SWITCHING_ISR( x )
+#define portYIELD() __asm volatile ( "SWI 0		\n"				\
+									 "ISB		  " );
+
+
+/*-----------------------------------------------------------
+ * Critical section control
+ *----------------------------------------------------------*/
+
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+extern uint32_t ulPortSetInterruptMask( void );
+extern void vPortClearInterruptMask( uint32_t ulNewMaskValue );
+extern void vPortInstallFreeRTOSVectorTable( void );
+
+/* The I bit within the CPSR. */
+#define portINTERRUPT_ENABLE_BIT	( 1 << 7 )
+
+/* In the absence of a priority mask register, these functions and macros
+globally enable and disable interrupts. */
+#define portENTER_CRITICAL()		vPortEnterCritical();
+#define portEXIT_CRITICAL()			vPortExitCritical();
+#define portENABLE_INTERRUPTS()		__asm volatile ( "CPSIE i 	\n"	);
+#define portDISABLE_INTERRUPTS()	__asm volatile ( "CPSID i 	\n"		\
+													 "DSB		\n"		\
+													 "ISB		  " );
+
+__attribute__( ( always_inline ) ) static __inline uint32_t portINLINE_SET_INTERRUPT_MASK_FROM_ISR( void )
+{
+volatile uint32_t ulCPSR;
+
+	__asm volatile ( "MRS %0, CPSR" : "=r" (ulCPSR) );
+	ulCPSR &= portINTERRUPT_ENABLE_BIT;
+	portDISABLE_INTERRUPTS();
+	return ulCPSR;
+}
+
+#define portSET_INTERRUPT_MASK_FROM_ISR() portINLINE_SET_INTERRUPT_MASK_FROM_ISR()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)	if( x == 0 ) portENABLE_INTERRUPTS()
+
+/*-----------------------------------------------------------*/
+
+/* Task function macros as described on the FreeRTOS.org WEB site.  These are
+not required for this port but included in case common demo code that uses these
+macros is used. */
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )	void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )	void vFunction( void *pvParameters )
+
+/* Tickless idle/low power functionality. */
+#ifndef portSUPPRESS_TICKS_AND_SLEEP
+	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
+#endif
+
+/* Prototype of the FreeRTOS tick handler.  This must be installed as the
+handler for whichever peripheral is used to generate the RTOS tick. */
+void FreeRTOS_Tick_Handler( void );
+
+/* Any task that uses the floating point unit MUST call vPortTaskUsesFPU()
+before any floating point instructions are executed. */
+void vPortTaskUsesFPU( void );
+#define portTASK_USES_FLOATING_POINT() vPortTaskUsesFPU()
+
+#define portLOWEST_INTERRUPT_PRIORITY ( ( ( uint32_t ) configUNIQUE_INTERRUPT_PRIORITIES ) - 1UL )
+#define portLOWEST_USABLE_INTERRUPT_PRIORITY ( portLOWEST_INTERRUPT_PRIORITY - 1UL )
+
+/* Architecture specific optimisations. */
+#ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
+	#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
+#endif
+
+#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+
+	/* Store/clear the ready priorities in a bit map. */
+	#define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities ) ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+	#define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities ) ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+
+	/*-----------------------------------------------------------*/
+
+	#define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities ) uxTopPriority = ( 31UL - ( uint32_t ) __builtin_clz( uxReadyPriorities ) )
+
+#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+
+#define portNOP() __asm volatile( "NOP" )
+#define portINLINE __inline
+
+#ifdef __cplusplus
+	} /* extern C */
+#endif
+
+
+#endif /* PORTMACRO_H */
+


### PR DESCRIPTION
Description
-----------
In previous releases, we "accidentally" committed a kernel port in kernel third party directory. This is unnecessary since third party port is essentially the same as ```GCC/ARM_CRx_No_GIC```. In this kernel release, we removed the redundant third party ports. We attempted to switch over to ```GCC/ARM_CRx_No_GIC``` in https://github.com/aws/amazon-freertos/pull/1746. Given - we don't know whether this MCU indeed supports floating point (data sheet did not mention) and we are having issue with tool chain flashing, I'm temporarily making a copy to unblock. 

Moving forward, we should reach out Cypress to get some context on FPU. Also, IDE debug needs to work and getting started guide should be updated. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.