### PR TITLE
Release candidate

### DIFF
--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -183,7 +183,7 @@ uint32_t ulRand(void);
  * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
  * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
  * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
-#define ipconfigINCLUDE_FULL_INET_ADDR            0
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
 
 /* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
  * are available to the IP stack.  The total number of network buffers is limited

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -183,7 +183,7 @@ uint32_t ulRand(void);
  * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
  * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
  * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
-#define ipconfigINCLUDE_FULL_INET_ADDR            0
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
 
 /* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
  * are available to the IP stack.  The total number of network buffers is limited


### PR DESCRIPTION
Temporary Change required to get the Renesas tests/demos running

Description
-----------

There is an issue with the implementation of the FreeRTOS_gethostbyname. (FreeRTOS_DNS.c)
It is supposed to return the ipaddress converted long integer if the input is an IP address. The logic is there but there is a flag checking around the logic: if (ipconfigINCLUDE_FULL_INET_ADDR == 1).
Renesas happens to have that flag set to 0 in FreeRTOSIPConfig.h
So the GG Core address was correctly retrieved from the gg core json file, but was never able to connect. (The ip address was converted to 0).

As a short term fix, the #define ipconfigINCLUDE_FULL_INET_ADDR was changed from 0 to 1 in FreeRTOSIPConfig.h for Renesas. 
For long run, the issue with FreeRTOS_gethostbyname should be fixed. (including understanding why the flag checks the way it does)

Following Xueli's suggestion, I have made the temporary change required to the demo/tests in Renesas. The GGD Demos/Tests no longer remain failing.
https://amazon-freertos-ci.corp.amazon.com/job/im_202002_00/job/custom_ide/job/renesas/job/rx65n-rsk-ide/59/
https://amazon-freertos-ci.corp.amazon.com/job/im_202002_00/job/custom_ide/job/renesas/job/rx65n-rsk-ide/60/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.