### PR TITLE
ECC Fix

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_pkcs11_config.h
@@ -69,7 +69,7 @@
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED          1
+#define pkcs11configIMPORT_PRIVATE_KEYS_SUPPORTED          0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -74,7 +74,7 @@
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT  ( 1 )
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT  ( 0 )
 
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This commit disables importing credentials to the ecc608a secure element.

Checklist:

----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.