### PR TITLE
Test: Fix wrong no of bytes assert in spi assisted tests

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_spi.c
+++ b/libraries/abstractions/common_io/test/test_iot_spi.c
@@ -311,7 +311,7 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadSyncAssisted )
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetRxNoOfbytes, &xBytesRx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( xBytesRx, 4 );
+        TEST_ASSERT_EQUAL( xBytesRx, sizeof( ucRxBuf ) );
     }
 
     /* Restore the original configuration saved in the beginning of this test,
@@ -455,7 +455,7 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_ReadAsyncAssisted )
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetRxNoOfbytes, &xBytesRx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( xBytesRx, 4 );
+        TEST_ASSERT_EQUAL( xBytesRx, sizeof( ucRxBuf ) );
     }
 
     /* Restore the original configuration saved in the beginning of this test,
@@ -584,7 +584,7 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteSyncAssisted )
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetTxNoOfbytes, &xBytesTx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( xBytesTx, 4 );
+        TEST_ASSERT_EQUAL( xBytesTx, sizeof( ucTxBuf ) );
     }
 
     /* Restore the original configuration saved in the beginning of this test,
@@ -787,11 +787,11 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_TransferSyncAssisted )
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetRxNoOfbytes, &xBytesRx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( 4, xBytesRx );
+        TEST_ASSERT_EQUAL( sizeof( ucRxBuf ), xBytesRx );
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetTxNoOfbytes, &xBytesTx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( 4, xBytesTx );
+        TEST_ASSERT_EQUAL( sizeof( ucTxBuf ), xBytesTx );
     }
 
     /* Restore the original configuration saved in the beginning of this test,
@@ -1033,7 +1033,7 @@ TEST( TEST_IOT_SPI, AFQP_IotSPI_WriteAsyncAssisted )
 
         lRetVal = iot_spi_ioctl( xSPIHandle, eSPIGetTxNoOfbytes, &xBytesTx );
         TEST_ASSERT_EQUAL( IOT_SPI_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( xBytesTx, 4 );
+        TEST_ASSERT_EQUAL( xBytesTx, sizeof( ucTxBuf ) );
     }
 
     /* Restore the original configuration saved in the beginning of this test,


### PR DESCRIPTION


<!--- Title -->

Description
-----------
Why: The byte count in the no of bytes assertion is incorrect.
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.