### PR TITLE
Fix Nordic OTA PAL Tests

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
@@ -162,7 +162,7 @@ OTA_Err_t prvErasePages(size_t xFrom, size_t xTo)
         else
         {
             /**
-             * IF soft device is enabled, the result of sd_flash_page_erase() is posted via event, otherwise sd_flash_page_erase()
+             * If soft device is enabled, the result of sd_flash_page_erase() is posted via event, otherwise sd_flash_page_erase()
              * is a blocking operation.
              */
             if( nrf_sdh_is_enabled() )
@@ -554,10 +554,10 @@ ret_code_t prvWriteFlash( uint32_t ulOffset,
 
       if( xErrCode == NRF_SUCCESS )
       {
-            /**
-             * IF soft device is enabled, the result of sd_flash_write() is posted via event, otherwise sd_flash_write()
-             * is a blocking operation.
-             */
+          /**
+           * If soft device is enabled, the result of sd_flash_write() is posted via event, otherwise sd_flash_write()
+           * is a blocking operation.
+           */
           if( nrf_sdh_is_enabled() )
           {
               EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );

--- a/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
@@ -161,10 +161,13 @@ OTA_Err_t prvErasePages(size_t xFrom, size_t xTo)
         }
         else
         {
-            EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );
-            if( xFlashResult & otapalFLASH_FAILURE )
+            if( nrf_sdh_is_enabled() )
             {
-                xStatus = kOTA_Err_RxFileCreateFailed;
+                EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );
+                if( xFlashResult & otapalFLASH_FAILURE )
+                {
+                    xStatus = kOTA_Err_RxFileCreateFailed;
+                }
             }
         }
     }
@@ -547,12 +550,15 @@ ret_code_t prvWriteFlash( uint32_t ulOffset,
 
       if( xErrCode == NRF_SUCCESS )
       {
-          EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );
-
-          if( xFlashResult & otapalFLASH_FAILURE )
+          if( nrf_sdh_is_enabled() )
           {
-              xErrCode = NRF_ERROR_INTERNAL;
-              break;
+              EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );
+
+              if( xFlashResult & otapalFLASH_FAILURE )
+              {
+                  xErrCode = NRF_ERROR_INTERNAL;
+                  break;
+              }
           }
       }
 

--- a/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ota/aws_ota_pal.c
@@ -161,6 +161,10 @@ OTA_Err_t prvErasePages(size_t xFrom, size_t xTo)
         }
         else
         {
+            /**
+             * IF soft device is enabled, the result of sd_flash_page_erase() is posted via event, otherwise sd_flash_page_erase()
+             * is a blocking operation.
+             */
             if( nrf_sdh_is_enabled() )
             {
                 EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );
@@ -550,6 +554,10 @@ ret_code_t prvWriteFlash( uint32_t ulOffset,
 
       if( xErrCode == NRF_SUCCESS )
       {
+            /**
+             * IF soft device is enabled, the result of sd_flash_write() is posted via event, otherwise sd_flash_write()
+             * is a blocking operation.
+             */
           if( nrf_sdh_is_enabled() )
           {
               EventBits_t xFlashResult = xEventGroupWaitBits( xFlashEventGrp, otapalFLASH_SUCCESS | otapalFLASH_FAILURE, pdTRUE, pdFALSE, portMAX_DELAY );


### PR DESCRIPTION
Fix Nordic OTA PAL Tests

Description
-----------

OTA PAL for Nordic assumes soft device task to always post events, for flash APIS, for which the soft device task needs to be enabled beforehand.
As part of the commit# 893f09ee40f0f6ec46d0763dcb4e4c577b1405ba  enable soft device has been postponed to when BLE is enabled. 
Also, as per the [documentation](https://github.com/aws/amazon-freertos/blob/f33863740032c59307b1849629c736a416ea2687/vendors/nordic/nRF5_SDK_15.2.0/components/softdevice/s112/headers/nrf_soc.h#L830),  flash Apis for Nordic does not require soft device to be running.

Fix: Adding a check if soft device is enabled before waiting for events from soft device task.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.