### PR TITLE
Free mbedtls resources in TLS_Cleanup().

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -129,7 +129,8 @@ static void prvFreeContext( TLSContext_t * pxCtx )
             ( CK_INVALID_HANDLE != pxCtx->xP11Session ) )
         {
             pxCtx->pxP11FunctionList->C_CloseSession( pxCtx->xP11Session ); /*lint !e534 This function always return CKR_OK. */
-	}
+        }
+
         pxCtx->xTLSHandshakeSuccessful = pdFALSE;
     }
 }

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -127,7 +127,7 @@ static void prvFreeContext( TLSContext_t * pxCtx )
         mbedtls_ssl_config_free( &pxCtx->xMbedSslConfig );
 
         /* Cleanup PKCS11 only if the handshake was started. */
-        if( ( TLS_HANDSHAKE_NOT_STARTED != xTLSHandshakeState ) &&
+        if( ( TLS_HANDSHAKE_NOT_STARTED != pxCtx->xTLSHandshakeState ) &&
             ( NULL != pxCtx->pxP11FunctionList ) &&
             ( NULL != pxCtx->pxP11FunctionList->C_CloseSession ) &&
             ( CK_INVALID_HANDLE != pxCtx->xP11Session ) )

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -62,7 +62,7 @@
  * @param[in] xNetworkRecv Callback for receiving data on an open TCP socket.
  * @param[in] xNetworkSend Callback for sending data on an open TCP socket.
  * @param[in] pvCallerContext Opaque pointer provided by caller for above callbacks.
- * @param[out] xTLSCHandshakeSuccessful Indicates whether TLS handshake was successfully completed.
+ * @param[out] xTLSHandshakeState Indicates the state of the TLS handshake.
  * @param[out] xMbedSslCtx Connection context for mbedTLS.
  * @param[out] xMbedSslConfig Configuration context for mbedTLS.
  * @param[out] xMbedX509CA Server certificate context for mbedTLS.
@@ -83,7 +83,7 @@ typedef struct TLSContext
     NetworkRecv_t xNetworkRecv;
     NetworkSend_t xNetworkSend;
     void * pvCallerContext;
-    BaseType_t xTLSHandshakeSuccessful;
+    BaseType_t xTLSHandshakeState;
 
     /* mbedTLS. */
     mbedtls_ssl_context xMbedSslCtx;
@@ -99,6 +99,10 @@ typedef struct TLSContext
     CK_OBJECT_HANDLE xP11PrivateKey;
     CK_KEY_TYPE xKeyType;
 } TLSContext_t;
+
+#define TLS_HANDSHAKE_NOT_STARTED   ( 0 )       /* Must be 0 */
+#define TLS_HANDSHAKE_STARTED       ( 1 )
+#define TLS_HANDSHAKE_SUCCESSFUL    ( 2 )
 
 #define TLS_PRINT( X )    vLoggingPrintf X
 
@@ -122,8 +126,8 @@ static void prvFreeContext( TLSContext_t * pxCtx )
         mbedtls_ssl_free( &pxCtx->xMbedSslCtx );
         mbedtls_ssl_config_free( &pxCtx->xMbedSslConfig );
 
-        /* Cleanup PKCS11 only if the handshake succeeded. */
-        if( ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) &&
+        /* Cleanup PKCS11 only if the handshake was started. */
+        if( ( TLS_HANDSHAKE_NOT_STARTED != xTLSHandshakeState ) &&
             ( NULL != pxCtx->pxP11FunctionList ) &&
             ( NULL != pxCtx->pxP11FunctionList->C_CloseSession ) &&
             ( CK_INVALID_HANDLE != pxCtx->xP11Session ) )
@@ -131,7 +135,7 @@ static void prvFreeContext( TLSContext_t * pxCtx )
             pxCtx->pxP11FunctionList->C_CloseSession( pxCtx->xP11Session ); /*lint !e534 This function always return CKR_OK. */
         }
 
-        pxCtx->xTLSHandshakeSuccessful = pdFALSE;
+        pxCtx->xTLSHandshakeState = TLS_HANDSHAKE_NOT_STARTED;
     }
 }
 
@@ -535,6 +539,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     /* Put the module in authenticated mode. */
     if( CKR_OK == xResult )
     {
+        pxCtx->xTLSHandshakeState = TLS_HANDSHAKE_STARTED;
         xResult = ( BaseType_t ) pxCtx->pxP11FunctionList->C_Login( pxCtx->xP11Session,
                                                                     CKU_USER,
                                                                     ( CK_UTF8CHAR_PTR ) configPKCS11_DEFAULT_USER_PIN,
@@ -870,7 +875,7 @@ BaseType_t TLS_Connect( void * pvContext )
     /* Keep track of successful completion of the handshake. */
     if( 0 == xResult )
     {
-        pxCtx->xTLSHandshakeSuccessful = pdTRUE;
+        pxCtx->xTLSHandshakeState = TLS_HANDSHAKE_SUCCESSFUL;
     }
     else if( xResult > 0 )
     {
@@ -896,7 +901,7 @@ BaseType_t TLS_Recv( void * pvContext,
     TLSContext_t * pxCtx = ( TLSContext_t * ) pvContext; /*lint !e9087 !e9079 Allow casting void* to other types. */
     size_t xRead = 0;
 
-    if( ( NULL != pxCtx ) && ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) )
+    if( ( NULL != pxCtx ) && ( TLS_HANDSHAKE_SUCCESSFUL == pxCtx->xTLSHandshakeState ) )
     {
         /* This routine will return however many bytes are returned from from mbedtls_ssl_read
          * immediately unless MBEDTLS_ERR_SSL_WANT_READ is returned, in which case we try again. */
@@ -945,7 +950,7 @@ BaseType_t TLS_Send( void * pvContext,
     TLSContext_t * pxCtx = ( TLSContext_t * ) pvContext; /*lint !e9087 !e9079 Allow casting void* to other types. */
     size_t xWritten = 0;
 
-    if( ( NULL != pxCtx ) && ( pdTRUE == pxCtx->xTLSHandshakeSuccessful ) )
+    if( ( NULL != pxCtx ) && ( TLS_HANDSHAKE_SUCCESSFUL == pxCtx->xTLSHandshakeState ) )
     {
         while( xWritten < xMsgLength )
         {

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -100,9 +100,9 @@ typedef struct TLSContext
     CK_KEY_TYPE xKeyType;
 } TLSContext_t;
 
-#define TLS_HANDSHAKE_NOT_STARTED   ( 0 )       /* Must be 0 */
-#define TLS_HANDSHAKE_STARTED       ( 1 )
-#define TLS_HANDSHAKE_SUCCESSFUL    ( 2 )
+#define TLS_HANDSHAKE_NOT_STARTED    ( 0 )      /* Must be 0 */
+#define TLS_HANDSHAKE_STARTED        ( 1 )
+#define TLS_HANDSHAKE_SUCCESSFUL     ( 2 )
 
 #define TLS_PRINT( X )    vLoggingPrintf X
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
`TLS_Cleanup()` was not calling `prvFreeContext()` for unsuccessful TLS handshakes.  This can cause a memory leak if the necessary credentials [can't be loaded](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/standard/tls/src/iot_tls.c#L553).  This change ensures that mbedtls resources are freed on `TLS_Cleanup()` even if the handshake didn't complete.  Note that PKCS11 resources are freed independently in the case where [`C_OpenSession()` fails](https://github.com/aws/amazon-freertos/blob/master/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c#L1028).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests (tested on esp32 with Full_TCP)
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.