### PR TITLE
Explicit typecast of UL to (void*)

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
@@ -152,11 +152,11 @@ int timer_create( clockid_t clockid,
 
 int timer_delete( timer_t timerid )
 {
-    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when
      * this file is being compiled. There exists just a place-holder for the structure in
      * the header file timers.h */
     TimerHandle_t xTimerHandle = ( void * ) timerid;
-    
+
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
 
     /* The value of the timer ID, set in timer_create, should not be NULL. */
@@ -197,12 +197,12 @@ int timer_settime( timer_t timerid,
                    struct itimerspec * ovalue )
 {
     int iStatus = 0;
-    
-    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when
      * this file is being compiled. There exists just a place-holder for the structure in
      * the header file timers.h */
     TimerHandle_t xTimerHandle = ( void * ) timerid;
-    
+
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextTimerExpiration = 0, xTimerExpirationPeriod = 0;
 
@@ -304,11 +304,11 @@ int timer_settime( timer_t timerid,
 int timer_gettime( timer_t timerid,
                    struct itimerspec * value )
 {
-    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when
      * this file is being compiled. There exists just a place-holder for the structure in
      * the header file timers.h */
     TimerHandle_t xTimerHandle = ( void * ) timerid;
-    
+
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextExpirationTime = xTimerGetExpiryTime( xTimerHandle ) - xTaskGetTickCount(),
                xTimerExpirationPeriod = pxTimer->xTimerPeriod;

--- a/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
@@ -152,7 +152,11 @@ int timer_create( clockid_t clockid,
 
 int timer_delete( timer_t timerid )
 {
-    TimerHandle_t xTimerHandle = timerid;
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+     * this file is being compiled. There exists just a place-holder for the structure in
+     * the header file timers.h */
+    TimerHandle_t xTimerHandle = ( void * ) timerid;
+    
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
 
     /* The value of the timer ID, set in timer_create, should not be NULL. */
@@ -193,7 +197,12 @@ int timer_settime( timer_t timerid,
                    struct itimerspec * ovalue )
 {
     int iStatus = 0;
-    TimerHandle_t xTimerHandle = timerid;
+    
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+     * this file is being compiled. There exists just a place-holder for the structure in
+     * the header file timers.h */
+    TimerHandle_t xTimerHandle = ( void * ) timerid;
+    
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextTimerExpiration = 0, xTimerExpirationPeriod = 0;
 
@@ -295,7 +304,11 @@ int timer_settime( timer_t timerid,
 int timer_gettime( timer_t timerid,
                    struct itimerspec * value )
 {
-    TimerHandle_t xTimerHandle = timerid;
+    /* Cannot use TimerHandle_t for casting since the structure itself is not defined when 
+     * this file is being compiled. There exists just a place-holder for the structure in
+     * the header file timers.h */
+    TimerHandle_t xTimerHandle = ( void * ) timerid;
+    
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextExpirationTime = xTimerGetExpiryTime( xTimerHandle ) - xTaskGetTickCount(),
                xTimerExpirationPeriod = pxTimer->xTimerPeriod;


### PR DESCRIPTION
Explicit typecast of UL to (void*)

Description
-----------
NOTE: This is specific to Microchip (Not sure about others though). The timer_t defined in the library finally converges to unsigned long.
Initialization was making pointer from integer without any kind of typecasting. This makes the typecast ambiguous and dependent on the compiler.
* Explicitly casted the variables to ( void * )
* Cannot cast them directly to TimerHandle_t since during compile time the structure itself may not be defined. Just a placeholder for the structure exists in the header-file timer.h during compile time.
* Uncrustify

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.