### PR TITLE
Fixed macro error

### DIFF
--- a/vendors/nordic/nRF5_SDK_15.2.0/external/nrf_cc310/common/integration_test_ssi_defs.h
+++ b/vendors/nordic/nRF5_SDK_15.2.0/external/nrf_cc310/common/integration_test_ssi_defs.h
@@ -32,9 +32,9 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                        *
 **************************************************************************************/
 
-#define SHARED_SECRET_MAX_LENGHT         250
-#define ECC_KEY_MAX_LENGHT               0x256
-#define AES_KEY_MAX_LENGHT_IN_BYTES      0x10
+#define SHARED_SECRET_MAX_LENGTH         250
+#define ECC_KEY_MAX_LENGTH               0x256
+#define AES_KEY_MAX_LENGTH_IN_BYTES      0x10
 
 
 


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Note that some macros are wrong, lucky is nobody uses them now, 
so fixed them to avoid more errors in the future:
SHARED_SECRET_MAX_LENGHT ->  SHARED_SECRET_MAX_LENGTH    
ECC_KEY_MAX_LENGHT ->  ECC_KEY_MAX_LENGTH    
AES_KEY_MAX_LENGHT_IN_BYTES -> AES_KEY_MAX_LENGTH_IN_BYTES

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.