### PR TITLE
Fix async test by separating read and write semaphore

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -63,7 +63,7 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint8_t ustestIotUartPort = 0; /** Default UART port for testing */
+uint8_t uctestIotUartPort = 0; /** Default UART port for testing */
 uint32_t ultestIotUartFlowControl = 0;
 uint32_t ultestIotUartParity = 0;
 uint32_t ultestIotUartWordLength = 0;
@@ -182,7 +182,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteReadSync )
     IotUARTHandle_t xUartHandle;
     int32_t lRead, lWrite, lClose;
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -211,7 +211,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
     int32_t lIoctl, lClose, lTransferAmount;
     IotUARTConfig_t xgetConfigBuffer, xConfigBuffer, xOriginalConfig;
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -301,7 +301,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTBaudChange )
 
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_STRING, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -386,7 +386,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -435,7 +435,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
 
     cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE - 1 ] = '\n';
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -480,7 +480,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     int32_t lRead, lWrite, lClose;
     BaseType_t xCallbackReturn;
-    uint8_t ucPort = ustestIotUartPort;
+    uint8_t ucPort = uctestIotUartPort;
 
     xUartHandle = iot_uart_open( ucPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
@@ -527,7 +527,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -578,7 +578,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncFuzzing )
     lWrite = iot_uart_write_async( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -612,7 +612,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteSyncFuzzing )
     lWrite = iot_uart_write_sync( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -642,7 +642,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadAsyncFuzzing )
     lRead = iot_uart_read_async( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -674,7 +674,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadSyncFuzzing )
     lRead = iot_uart_read_sync( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -705,7 +705,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlFuzzing )
     lIoctl = iot_uart_ioctl( NULL, eUartSetConfig, &xUartConfigTest );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -751,7 +751,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     IotUARTConfig_t xUartConfig = { .ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT };
 
-    xUartHandle = iot_uart_open( ustestIotUartPort );
+    xUartHandle = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -782,10 +782,10 @@ TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
     lClose = iot_uart_close( NULL );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lClose );
 
-    xUartHandle_2 = iot_uart_open( ustestIotUartPort );
+    xUartHandle_2 = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle_2 );
 
-    xUartHandle_3 = iot_uart_open( ustestIotUartPort );
+    xUartHandle_3 = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
 
     lCancel = iot_uart_cancel( NULL );

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -1,6 +1,6 @@
 /*
- * Amazon FreeRTOS Common IO V0.1.0
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Common IO V0.1.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -63,7 +63,7 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint8_t uctestIotUartPort = 0; /** Default UART port for testing */
+uint8_t ustestIotUartPort = 0; /** Default UART port for testing */
 uint32_t ultestIotUartFlowControl = 0;
 uint32_t ultestIotUartParity = 0;
 uint32_t ultestIotUartWordLength = 0;
@@ -72,8 +72,10 @@ uint32_t ultestIotUartStopBits = 0;
 /*-----------------------------------------------------------*/
 /* Static Globals */
 /*-----------------------------------------------------------*/
-static SemaphoreHandle_t xtestIotUARTSemaphore = NULL;
-static StaticSemaphore_t xtestIotUARTCompleted;
+static SemaphoreHandle_t xReadCompleteSemaphore = NULL;
+static SemaphoreHandle_t xWriteCompleteSemaphore = NULL;
+static StaticSemaphore_t xReadSemaphoreBuffer;
+static StaticSemaphore_t xWriteSemaphoreBuffer;
 
 /* note:  config1 is different in each field from config2 */
 static IotUARTConfig_t xSampleConfig1 =
@@ -102,11 +104,17 @@ static IotUARTConfig_t xSampleConfig2 =
 static void prvReadWriteCallback( IotUARTOperationStatus_t xOpStatus,
                                   void * pvParams )
 {
-    IotUARTOperationStatus_t * xCallbackStatus = ( IotUARTOperationStatus_t * ) pvParams;
     BaseType_t xHigherPriorityTaskWoken;
 
-    *xCallbackStatus = xOpStatus;
-    xSemaphoreGiveFromISR( xtestIotUARTSemaphore, &xHigherPriorityTaskWoken );
+    if( xOpStatus == eUartReadCompleted )
+    {
+        xSemaphoreGiveFromISR( xReadCompleteSemaphore, &xHigherPriorityTaskWoken );
+    }
+    else if( xOpStatus == eUartWriteCompleted )
+    {
+        xSemaphoreGiveFromISR( xWriteCompleteSemaphore, &xHigherPriorityTaskWoken );
+    }
+
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
@@ -123,8 +131,10 @@ TEST_GROUP( TEST_IOT_UART );
  */
 TEST_SETUP( TEST_IOT_UART )
 {
-    xtestIotUARTSemaphore = xSemaphoreCreateCountingStatic( 10, 0, &xtestIotUARTCompleted );
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotUARTSemaphore );
+    xReadCompleteSemaphore = xSemaphoreCreateBinaryStatic( &xReadSemaphoreBuffer );
+    TEST_ASSERT_NOT_EQUAL( NULL, xReadCompleteSemaphore );
+    xWriteCompleteSemaphore = xSemaphoreCreateBinaryStatic( &xWriteSemaphoreBuffer );
+    TEST_ASSERT_NOT_EQUAL( NULL, xWriteCompleteSemaphore );
 }
 
 /*-----------------------------------------------------------*/
@@ -172,7 +182,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteReadSync )
     IotUARTHandle_t xUartHandle;
     int32_t lRead, lWrite, lClose;
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -201,7 +211,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
     int32_t lIoctl, lClose, lTransferAmount;
     IotUARTConfig_t xgetConfigBuffer, xConfigBuffer, xOriginalConfig;
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -291,7 +301,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTBaudChange )
 
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BAUD_RATE_STRING, testIotUART_BAUD_RATE_BUFFER_TEST_LENGTH );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -376,7 +386,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -425,7 +435,7 @@ TEST( TEST_IOT_UART, AFQP_AssistedIotUARTWriteAsync )
 
     cpBufferLarge[ testIotUART_BUFFER_LENGTH_LARGE - 1 ] = '\n';
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -470,31 +480,26 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteReadAsyncWithCallback )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     int32_t lRead, lWrite, lClose;
     BaseType_t xCallbackReturn;
-    uint8_t ucPort = uctestIotUartPort;
-    volatile IotUARTOperationStatus_t xCallbackStatus = eUartLastWriteFailed;
+    uint8_t ucPort = ustestIotUartPort;
 
     xUartHandle = iot_uart_open( ucPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
     {
-        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, ( void * ) &xCallbackStatus );
+        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
 
         lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
-        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
-
-        TEST_ASSERT_EQUAL( eUartWriteCompleted, xCallbackStatus );
-
         lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
 
-        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        xCallbackReturn = xSemaphoreTake( xWriteCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
         TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
-        TEST_ASSERT_EQUAL( eUartReadCompleted, xCallbackStatus );
+        xCallbackReturn = xSemaphoreTake( xReadCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
         TEST_ASSERT_EQUAL( 0, strncmp( ( char * ) cpBuffer, ( char * ) cpBufferRead, testIotUART_BUFFER_LENGTH ) );
     }
@@ -515,7 +520,6 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
     IotUARTHandle_t xUartHandle;
     int32_t lWrite, lClose, lCancel;
     BaseType_t xCallbackReturn;
-    volatile IotUARTOperationStatus_t xCallbackStatus = eUartLastWriteFailed;
 
     uint8_t cSmallBuf[ 2 ] = { 'H', 'I' };
     uint8_t cpBuffer[ testIotUARTBUFFERSIZE ] = { 0 };
@@ -523,12 +527,12 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
 
     strncpy( ( char * ) cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
     {
-        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, ( void * ) &xCallbackStatus );
+        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
 
         lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
@@ -537,7 +541,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lCancel );
 
         /* Wait to make sure operation was really canceled. */
-        xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        xCallbackReturn = xSemaphoreTake( xWriteCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
         TEST_ASSERT_EQUAL( pdFALSE, xCallbackReturn );
     }
 
@@ -545,7 +549,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTCancel )
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
     /* Wait to make sure operation has completed. */
-    xCallbackReturn = xSemaphoreTake( ( SemaphoreHandle_t ) &xtestIotUARTCompleted, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+    xCallbackReturn = xSemaphoreTake( xWriteCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
     TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
 
     /* Since  cSmallBuf is small buffer, write is already complete. Hence nothing to cancel */
@@ -574,7 +578,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncFuzzing )
     lWrite = iot_uart_write_async( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -608,7 +612,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteSyncFuzzing )
     lWrite = iot_uart_write_sync( NULL, cpBuffer, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lWrite );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -638,7 +642,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadAsyncFuzzing )
     lRead = iot_uart_read_async( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -670,7 +674,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTReadSyncFuzzing )
     lRead = iot_uart_read_sync( NULL, cpBufferRead, testIotUART_BUFFER_LENGTH );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lRead );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -701,7 +705,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlFuzzing )
     lIoctl = iot_uart_ioctl( NULL, eUartSetConfig, &xUartConfigTest );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lIoctl );
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -747,7 +751,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlWhenBusy )
     strncpy( ( char * ) cpBuffer, ( char * ) testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
     IotUARTConfig_t xUartConfig = { .ulBaudrate = testIotUART_TEST_BAUD_RATE_DEFAULT };
 
-    xUartHandle = iot_uart_open( uctestIotUartPort );
+    xUartHandle = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle );
 
     if( TEST_PROTECT() )
@@ -778,10 +782,10 @@ TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
     lClose = iot_uart_close( NULL );
     TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lClose );
 
-    xUartHandle_2 = iot_uart_open( uctestIotUartPort );
+    xUartHandle_2 = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle_2 );
 
-    xUartHandle_3 = iot_uart_open( uctestIotUartPort );
+    xUartHandle_3 = iot_uart_open( ustestIotUartPort );
     TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
 
     lCancel = iot_uart_cancel( NULL );

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -131,10 +131,9 @@ TEST_GROUP( TEST_IOT_UART );
  */
 TEST_SETUP( TEST_IOT_UART )
 {
+    /* xSemaphoreCreateBinaryStatic succeeds as long as buffer parameter is not NULL. */
     xReadCompleteSemaphore = xSemaphoreCreateBinaryStatic( &xReadSemaphoreBuffer );
-    TEST_ASSERT_NOT_EQUAL( NULL, xReadCompleteSemaphore );
     xWriteCompleteSemaphore = xSemaphoreCreateBinaryStatic( &xWriteSemaphoreBuffer );
-    TEST_ASSERT_NOT_EQUAL( NULL, xWriteCompleteSemaphore );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fix async test by separating read and write semaphore.

Test case AFQP_IotUARTWriteReadAsyncWithCallback failed on ST board because it waits for write to complete before making a read call. That incurred UART overrun error. 

So the right way is to start async write and async read at the same time and verify each of them completes. I solve this problem by separating it to two semaphores.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.