### PR TITLE
Update BLE HAL

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
@@ -92,20 +92,20 @@ typedef struct
 /* BT GATT client error codes */
 typedef enum
 {
-    eBTGattcCommandSuccess = 0,      /* 0  Command succeeded                 */
-    eBTGattcCommandStarted,          /* 1  Command started OK.               */
-    eBTGattcCommandBusy,             /* 2  Device busy with another command  */
-    eBTGattcCommandStored,           /* 3 request is stored in control block */
-    eBTGattcNoResources,             /* 4  No resources to issue command     */
-    eBTGattcModeUnsupported,         /* 5  Request for 1 or more unsupported modes */
-    eBTGattcIllegalValue,            /* 6  Illegal command /parameter value  */
-    eBTGattcIncorrectState,          /* 7  Device in wrong state for request  */
-    eBTGattcUnknownAddr,             /* 8  Unknown remote BD address         */
-    eBTGattcDeviceTimeout,           /* 9  Device timeout                    */
-    eBTGattcInvalidControllerOutput, /* 10  An incorrect value was received from HCI */
-    eBTGattcSecurityError,           /* 11 Authorization or security failure or not authorized  */
-    eBTGattcDelayedEncryptionCheck,  /* 12 Delayed encryption check */
-    eBTGattcErrProcessing            /* 13 Generic error                     */
+    eBTGattcCommandSuccess = 0,           /* Command succeeded                 */
+    eBTGattcCommandStarted = 1,           /* Command started OK.               */
+    eBTGattcCommandBusy = 2,              /* Device busy with another command  */
+    eBTGattcCommandStored = 3,            /* equest is stored in control block */
+    eBTGattcNoResources = 4,              /* No resources to issue command     */
+    eBTGattcModeUnsupported = 5,          /* Request for 1 or more unsupported modes */
+    eBTGattcIllegalValue = 6,             /* Illegal command /parameter value  */
+    eBTGattcIncorrectState = 7,           /* Device in wrong state for request  */
+    eBTGattcUnknownAddr = 8,              /* Unknown remote BD address         */
+    eBTGattcDeviceTimeout = 9,            /* Device timeout                    */
+    eBTGattcInvalidControllerOutput = 10, /*  An incorrect value was received from HCI */
+    eBTGattcSecurityError = 11,           /* Authorization or security failure or not authorized  */
+    eBTGattcDelayedEncryptionCheck = 12,  /* Delayed encryption check */
+    eBTGattcErrProcessing = 13            /* Generic error                     */
 } BTGattcError_t;
 
 /** BT-GATT Client callback structure. */

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
@@ -95,14 +95,14 @@ typedef enum
     eBTGattcCommandSuccess = 0,           /* Command succeeded                 */
     eBTGattcCommandStarted = 1,           /* Command started OK.               */
     eBTGattcCommandBusy = 2,              /* Device busy with another command  */
-    eBTGattcCommandStored = 3,            /* equest is stored in control block */
+    eBTGattcCommandStored = 3,            /* Request is stored in control block */
     eBTGattcNoResources = 4,              /* No resources to issue command     */
     eBTGattcModeUnsupported = 5,          /* Request for 1 or more unsupported modes */
     eBTGattcIllegalValue = 6,             /* Illegal command /parameter value  */
     eBTGattcIncorrectState = 7,           /* Device in wrong state for request  */
     eBTGattcUnknownAddr = 8,              /* Unknown remote BD address         */
     eBTGattcDeviceTimeout = 9,            /* Device timeout                    */
-    eBTGattcInvalidControllerOutput = 10, /*  An incorrect value was received from HCI */
+    eBTGattcInvalidControllerOutput = 10, /* An incorrect value was received from HCI */
     eBTGattcSecurityError = 11,           /* Authorization or security failure or not authorized  */
     eBTGattcDelayedEncryptionCheck = 12,  /* Delayed encryption check */
     eBTGattcErrProcessing = 13            /* Generic error                     */

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -104,14 +104,14 @@ typedef enum
     eBTGattcDeviceTimeout,           /* 9  Device timeout                    */
     eBTGattcInvalidControllerOutput, /* 10  An incorrect value was received from HCI */
     eBTGattcSecurityError,           /* 11 Authorization or security failure or not authorized  */
-    eBTGattcDelayedEncryptionCheck,  /*12 Delayed encryption check */
-    eBTGattcErrProcessing            /* 12 Generic error                     */
+    eBTGattcDelayedEncryptionCheck,  /* 12 Delayed encryption check */
+    eBTGattcErrProcessing            /* 13 Generic error                     */
 } BTGattcError_t;
 
 /** BT-GATT Client callback structure. */
 
 /** Callback invoked in response to registerClient */
-typedef void ( * BTRegisterClientCallback_t)( BTStatus_t xStatus,
+typedef void ( * BTRegisterClientCallback_t)( BTGattStatus_t xStatus,
                                               uint8_t ucClientIf,
                                               BTUuid_t * pxAppUuid );
 
@@ -120,12 +120,12 @@ typedef void ( * BTRegisterClientCallback_t)( BTStatus_t xStatus,
  * has been completed.
  */
 typedef void ( * BTSearchCompleteCallback_t)( uint16_t usConnId,
-                                              BTStatus_t xStatus );
+                                              BTGattStatus_t xStatus );
 
 /** Callback invoked in response to [de]registerForNotification */
 typedef void ( * BTRegisterForNotificationCallback_t)( uint16_t usConnId,
                                                        bool bRegistered,
-                                                       BTStatus_t xStatus,
+                                                       BTGattStatus_t xStatus,
                                                        uint16_t usHandle );
 
 /**
@@ -137,37 +137,37 @@ typedef void ( * BTNotifyCallback_t)( uint16_t usConnId,
 
 /** Reports result of a GATT read operation */
 typedef void ( * BTReadCharacteristicCallback_t)( uint16_t usConnId,
-                                                  BTStatus_t xStatus,
+                                                  BTGattStatus_t xStatus,
                                                   BTGattReadParams_t * pxData );
 
 /** GATT write characteristic operation callback */
 typedef void ( * BTWriteCharacteristicCallback_t)( uint16_t usConnId,
-                                                   BTStatus_t xStatus,
+                                                   BTGattStatus_t xStatus,
                                                    uint16_t usHandle );
 
 /** GATT execute prepared write callback */
 typedef void ( * BTExecuteWriteCallback_t)( uint16_t usConnId,
-                                            BTStatus_t xStatus );
+                                            BTGattStatus_t xStatus );
 
 /** Callback invoked in response to readDescriptor */
 typedef void ( * BTReadDescriptorCallback_t)( uint16_t usConnId,
-                                              BTStatus_t xStatus,
+                                              BTGattStatus_t xStatus,
                                               BTGattReadParams_t * pxData );
 
 /** Callback invoked in response to writeDescriptor */
 typedef void ( * BTWriteDescriptorCallback_t)( uint16_t usConnId,
-                                               BTStatus_t xStatus,
+                                               BTGattStatus_t xStatus,
                                                uint16_t usHandle );
 
 /**
  * Callback indicating the status of a listen() operation
  */
-typedef void ( * BTListenCallback_t)( BTStatus_t xStatus,
+typedef void ( * BTListenCallback_t)( BTGattStatus_t xStatus,
                                       uint32_t ulServerIf );
 
 /** Callback invoked when the MTU for a given connection changes */
 typedef void ( * BTConfigureMtuCallback_t)( uint16_t usConnId,
-                                            BTStatus_t xStatus,
+                                            BTGattStatus_t xStatus,
                                             uint32_t ulMtu );
 
 /** GATT get database callback */

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_server.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_server.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_types.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_types.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -50,21 +50,35 @@
 
 /**
  * @brief GATT Status Codes
+ * @see BLUETOOTH SPECIFICATION Version 5.0 | Vol 3, Part F, 3.4.1.1 Error Response
+ *
  */
 typedef enum
 {
-    eBTGattStatusSuccess,                    /**< Success */
-    eBTGattStatusReadNotPermitted,           /**< Characteristic does not support read */
-    eBTGattStatusWriteNotPermitted,          /**< Characteristic does not support write */
-    eBTGattStatusInsufficientAuthentication, /**< Link is not properly Authenticated */
-    eBTGattStatusRequestNotSupported,        /**< Operation not supported */
-    eBTGattStatusInvalidOffset,              /**< Invalid offset (long writes/reads) */
-    eBTGattStatusErrorConnTimeout,           /**< Connection Timed out */
-    eBTGattStatusInvalidAttributeLength,     /**< Bad Attribute Length */
-    eBTGattStatusInsufficientEncryption,     /**< Link is not properly Encrypted */
-    eBTGattStatusError,                      /**< Generic GATT Error */
-    eBTGattStatusConnectionCongested,        /**< Congested connection */
-    eBTGattStatusErrorConnEstFail,           /**< Failed to establish gatt connection */
+    eBTGattStatusSuccess = 0x00,                      /**< Success */
+    eBTInvalidHandle = 0x01,                          /**< Invalid handle */
+    eBTGattStatusReadNotPermitted = 0x02,             /**< Characteristic does not support read */
+    eBTGattStatusWriteNotPermitted = 0x03,            /**< Characteristic does not support write */
+    eBTGattStatusInvalidPDU = 0x04,                   /**< Invalid PDU */
+    eBTGattStatusInsufficientAuthentication = 0x05,   /**< Link is not properly Authenticated */
+    eBTGattStatusRequestNotSupported = 0x06,          /**< Operation not supported */
+    eBTGattStatusInvalidOffset = 0x07,                /**< Invalid offset (long writes/reads) */
+    eBTGattStatusInsufficientAuthorization = 0x08,    /**< Link is not properly authorized */
+    eBTGattStatusPrepareQueueFull = 0x09,             /**< Too many prepare writes queued */
+    eBTGattStatusAttributeNotFound = 0x0A,            /**< No attribute found within handle range */
+    eBTGattStatusAttributeNotLong = 0x0B,             /**< Cannot be read with Read Blob Request */
+    eBTGattStatusInsufficientKeySize = 0x0C,          /**< Link is not properly Encrypted */
+    eBTGattStatusInvalidAttributeLength = 0x0D,       /**< Bad Attribute Length */
+    eBTGattStatusUnlikelyError = 0x0E,                /**< Encountered an unlikeley error */
+    eBTGattStatusInsufficientEncryption = 0x0F,       /**< Link is not properly Encrypted */
+    eBTGattStatusUnsupportedGroupType = 0x10,         /**< Unsupported grouping attribute */
+    eBTGattStatusInsufficientResources = 0x11,        /**< Insufficient Resources */
+    eBTGattStatusInternalError = 0x81,                /**< Internal GATT Error */
+    eBTGattStatusError = 0x85,                        /**< Generic GATT Error */
+    eBTGattStatusConnectionCongested = 0x8f,          /**< Congested connection */
+    eBTGattStatusErrorConnEstFail = 0x93,             /**< Failed to establish gatt connection */
+    eBTGattStatusErrorConnTimeout = 0x94,             /**< Connection Timed out */
+    eBTGattStatusLocalHostTerminatedConnection = 0x99 /**< Disconnect from Local Host */
 } BTGattStatus_t;
 
 /**

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -47,7 +47,7 @@
 /**
  * @brief  Incompatible API changes without backward compatibility.
  */
-#define btMAJOR_VERSION    4
+#define btMAJOR_VERSION    5
 
 /**
  * @brief Add new functionality with backward compatibility.
@@ -521,6 +521,7 @@ typedef struct
     BTPinRequestCallback_t pxPinRequestCb;
     BTSspRequestCallback_t pxSspRequestCb;
     BTPairingStateChangedCallback_t pxPairingStateChangedCb;
+    BTBondedCallback_t pxBondedCb; /** This is deprecated */
     BTDutModeRecvCallback_t pxDutModeRecvCb;
     BTLeTestModeCallback_t pxleTestModeCb;
     BTEnergyInfoCallback_t pxEnergyInfoCb;

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -108,6 +108,7 @@ typedef struct
                                 *   If set to 0, stack specific default values will be used. */
     uint8_t ucChannelMap;
     uint8_t ucTxPower;
+    uint8_t ucTimeout;                 /**< This is deprecated. Use usTimeout for advertisement duration value*/
     uint16_t usTimeout;                /**< Advertisement duration value in units of 10ms. Set to 0 for infinite timeout for advertisements. */
     uint8_t ucPrimaryAdvertisingPhy;   /* 5.0 Specific interface */
     uint8_t ucSecondaryAdvertisingPhy; /* 5.0 Specific interface */
@@ -307,7 +308,7 @@ typedef void (* BTMultiAdvUpdateCallback_t)( uint8_t ucAdapterIf,
 
 /**
  *
- * @brief Callback invoked on pxMultiAdvSetInstData.
+ * @brief Callback invoked on pxMultiAdvSetInstData and pxMultiAdvSetInstRawData.
  *
  * @param[in] ucAdapterIf Adapter interface ID. Returned from BTRegisterBleAdapterCallback_t after calling pxRegisterBleApp
  * @param[in] xStatus Returns eBTStatusSuccess if operation succeeded.
@@ -911,6 +912,23 @@ typedef struct
      * @brief returns the GATT server interface, see bt_hal_gatt_server.h
      */
     const void * ( *ppvGetGattServerInterface )( );
+
+    /**
+     *
+     * @brief Setup the raw data for the specified instance.
+     *
+     * Triggers BTMultiAdvDataCallback_t.
+     *
+     * @param[in] ucAdapterIf Adapter interface ID. Returned from BTRegisterBleAdapterCallback_t after calling pxRegisterBleApp
+     * @param[in] pucData raw data serialized
+     * @param[in] xDataLen serialized data length
+     * @param[in] bSetScanRsp
+     * @return Returns eBTStatusSuccess on successful call.
+     */
+    BTStatus_t ( * pxMultiAdvSetInstRawData )( uint8_t ucAdapterIf,
+                                               bool bSetScanRsp,
+                                               uint8_t * pucData,
+                                               size_t xDataLen );
 } BTBleAdapter_t;
 
 #endif /* #ifndef _BT_HAL_MANAGER_ADAPTER_BLE_H_ */

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_classic.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_classic.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_types.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_types.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V4.0.1
+ * FreeRTOS BLE HAL V5.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Update BLE HAL

Description
-----------
* Update BTGattStatus_t to match BT 5.0
* Change BTStatus_t to BTGattStatus_t for GATT Client callbacks
* Add pxMultiAdvSetInstRawData in bt_hal_manager_adapter_ble
* Add back pxBondedCb and ucTimeout and mark as deprecated

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.