### PR TITLE
Microchip Specific changes to remove possible bugs

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
@@ -58,9 +58,9 @@ typedef struct timer_internal
 
 /*-----------------------------------------------------------*/
 
-void prvTimerCallback( TimerHandle_t xTimerHandle )
+void prvTimerCallback( TimerHandle_t xTimerHandler )
 {
-    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
+    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandler );
     pthread_t xTimerNotificationThread;
 
     /* The value of the timer ID, set in timer_create, should not be NULL. */
@@ -74,7 +74,7 @@ void prvTimerCallback( TimerHandle_t xTimerHandle )
      * argument. This call should not block. */
     if( pxTimer->xTimerPeriod > 0 )
     {
-        xTimerChangePeriod( xTimerHandle, pxTimer->xTimerPeriod, 0 );
+        xTimerChangePeriod( xTimerHandler, pxTimer->xTimerPeriod, 0 );
     }
 
     /* Create the timer notification thread if requested. */
@@ -301,7 +301,7 @@ int timer_gettime( timer_t timerid,
                xTimerExpirationPeriod = pxTimer->xTimerPeriod;
 
     /* Set it_value only if the timer is armed. Otherwise, set it to 0. */
-    if( xTimerIsTimerActive( xTimerHandler) != pdFALSE )
+    if( xTimerIsTimerActive( xTimerHandler ) != pdFALSE )
     {
         value->it_value.tv_sec = ( time_t ) ( xNextExpirationTime / configTICK_RATE_HZ );
         value->it_value.tv_nsec = ( long ) ( ( xNextExpirationTime % configTICK_RATE_HZ ) * NANOSECONDS_PER_TICK );

--- a/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
@@ -152,7 +152,7 @@ int timer_create( clockid_t clockid,
 
 int timer_delete( timer_t timerid )
 {
-    TimerHandle_t xTimerHandle = timerid;
+    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
 
     /* The value of the timer ID, set in timer_create, should not be NULL. */
@@ -193,7 +193,7 @@ int timer_settime( timer_t timerid,
                    struct itimerspec * ovalue )
 {
     int iStatus = 0;
-    TimerHandle_t xTimerHandle = timerid;
+    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextTimerExpiration = 0, xTimerExpirationPeriod = 0;
 
@@ -295,7 +295,7 @@ int timer_settime( timer_t timerid,
 int timer_gettime( timer_t timerid,
                    struct itimerspec * value )
 {
-    TimerHandle_t xTimerHandle = timerid;
+    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
     timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
     TickType_t xNextExpirationTime = xTimerGetExpiryTime( xTimerHandle ) - xTaskGetTickCount(),
                xTimerExpirationPeriod = pxTimer->xTimerPeriod;

--- a/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c
@@ -152,8 +152,8 @@ int timer_create( clockid_t clockid,
 
 int timer_delete( timer_t timerid )
 {
-    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
-    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
+    TimerHandle_t xTimerHandler = ( TimerHandle_t ) timerid;
+    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandler );
 
     /* The value of the timer ID, set in timer_create, should not be NULL. */
     configASSERT( pxTimer != NULL );
@@ -161,10 +161,10 @@ int timer_delete( timer_t timerid )
     /* Stop the FreeRTOS timer. Because the timer is statically allocated, no call
      * to xTimerDelete is necessary. The timer is stopped so that it's not referenced
      * anywhere. xTimerStop will not fail when it has unlimited block time. */
-    ( void ) xTimerStop( xTimerHandle, portMAX_DELAY );
+    ( void ) xTimerStop( xTimerHandler, portMAX_DELAY );
 
     /* Wait until the timer stop command is processed. */
-    while( xTimerIsTimerActive( xTimerHandle ) == pdTRUE )
+    while( xTimerIsTimerActive( xTimerHandler ) == pdTRUE )
     {
         vTaskDelay( 1 );
     }
@@ -193,8 +193,8 @@ int timer_settime( timer_t timerid,
                    struct itimerspec * ovalue )
 {
     int iStatus = 0;
-    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
-    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
+    TimerHandle_t xTimerHandler = ( TimerHandle_t ) timerid;
+    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandler );
     TickType_t xNextTimerExpiration = 0, xTimerExpirationPeriod = 0;
 
     /* Validate the value argument, but only if the timer isn't being disarmed. */
@@ -215,9 +215,9 @@ int timer_settime( timer_t timerid,
     }
 
     /* Stop the timer if it's currently active. */
-    if( ( iStatus == 0 ) && xTimerIsTimerActive( xTimerHandle ) )
+    if( ( iStatus == 0 ) && xTimerIsTimerActive( xTimerHandler ) )
     {
-        ( void ) xTimerStop( xTimerHandle, portMAX_DELAY );
+        ( void ) xTimerStop( xTimerHandler, portMAX_DELAY );
     }
 
     /* Only restart the timer if it_value is not zero. */
@@ -277,13 +277,13 @@ int timer_settime( timer_t timerid,
          * triggered immediately. */
         if( xNextTimerExpiration == 0 )
         {
-            prvTimerCallback( xTimerHandle );
+            prvTimerCallback( xTimerHandler );
         }
         else
         {
             /* Set the timer to expire at the it_value, then start it. */
-            ( void ) xTimerChangePeriod( xTimerHandle, xNextTimerExpiration, portMAX_DELAY );
-            ( void ) xTimerStart( xTimerHandle, xNextTimerExpiration );
+            ( void ) xTimerChangePeriod( xTimerHandler, xNextTimerExpiration, portMAX_DELAY );
+            ( void ) xTimerStart( xTimerHandler, xNextTimerExpiration );
         }
     }
 
@@ -295,13 +295,13 @@ int timer_settime( timer_t timerid,
 int timer_gettime( timer_t timerid,
                    struct itimerspec * value )
 {
-    TimerHandle_t xTimerHandle = ( TimerHandle_t ) timerid;
-    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandle );
-    TickType_t xNextExpirationTime = xTimerGetExpiryTime( xTimerHandle ) - xTaskGetTickCount(),
+    TimerHandle_t xTimerHandler = ( TimerHandle_t ) timerid;
+    timer_internal_t * pxTimer = ( timer_internal_t * ) pvTimerGetTimerID( xTimerHandler );
+    TickType_t xNextExpirationTime = xTimerGetExpiryTime( xTimerHandler ) - xTaskGetTickCount(),
                xTimerExpirationPeriod = pxTimer->xTimerPeriod;
 
     /* Set it_value only if the timer is armed. Otherwise, set it to 0. */
-    if( xTimerIsTimerActive( xTimerHandle ) != pdFALSE )
+    if( xTimerIsTimerActive( xTimerHandler) != pdFALSE )
     {
         value->it_value.tv_sec = ( time_t ) ( xNextExpirationTime / configTICK_RATE_HZ );
         value->it_value.tv_nsec = ( long ) ( ( xNextExpirationTime % configTICK_RATE_HZ ) * NANOSECONDS_PER_TICK );

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
@@ -69,7 +69,7 @@
 #define configUSE_QUEUE_SETS                       0
 #define configUSE_TIME_SLICING                     0
 #define configUSE_NEWLIB_REENTRANT                 0
-#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configENABLE_BACKWARD_COMPATIBILITY        0
 #define configUSE_TASK_FPU_SUPPORT                 0
 #define configUSE_POSIX_ERRNO                      1
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
@@ -71,7 +71,7 @@
 #define configUSE_QUEUE_SETS                       0
 #define configUSE_TIME_SLICING                     0
 #define configUSE_NEWLIB_REENTRANT                 0
-#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configENABLE_BACKWARD_COMPATIBILITY        0
 #define configUSE_TASK_FPU_SUPPORT                 0
 #define configUSE_POSIX_ERRNO                      1
 


### PR DESCRIPTION
Microchip Specific changes to remove possible bugs

Description
-----------
`#define configENABLE_BACKWARD_COMPATIBILITY` flag was enabling a `#define xTimerHandle TimerHandle_t`. This was causing an issue in the functions `timer_delete`, `timer_settime` and `timer_gettime` defined in `FreeRTOS_POSIX_timer.c` since these functions were using variables named `xTimerHandle`.
The timer_t type when expanded results in an unsigned long (since the compiler uses its own version of POSIX library which is included in its toolchain and we cannot change that) in some Microchip compilers. The compiler does an implicit typecast (which is also bad) which we cannot get around, thus to suppress the warnings, we explicitly typecast the unsigned long to TimerHandle_t. TimerHandle_t is a struct pointer.
- #define configENABLE_BACKWARD_COMPATIBILITY changed to 0
- Explicitly typecasted the unsigned long to TimerHandle_t
- all instances of xTimerHandle changed to xOpaqueTimerhandle just to make this code full proof in case a user tries to enable backward compatibility. It would break the code since all instances of xTimerHandle would be replaced by TimerHandle_t.
- uncrustify

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.