### PR TITLE
Fix ST I2C bug by adding break in switch block

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_i2c.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_i2c.c
@@ -685,15 +685,19 @@ static int32_t _toI2cStatus( HAL_StatusTypeDef halStatus,
     {
         case HAL_OK:
             status = IOT_I2C_SUCCESS;
+            break;
 
         case HAL_ERROR:
             status = operation == _I2C_READ_OP ? IOT_I2C_READ_FAILED : IOT_I2C_WRITE_FAILED;
+            break;
 
         case HAL_BUSY:
             status = IOT_I2C_BUSY;
+            break;
 
         case HAL_TIMEOUT:
             status = IOT_I2C_BUS_TIMEOUT;
+            break;
     }
 
     return status;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fix ST I2C bug by adding break in switch block

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.