### PR TITLE
Changes in WinSim OTA config to use 1block/request

### DIFF
--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
@@ -54,7 +54,7 @@
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send
  * the request message after being idle for this amount of time.
  */
-#define otaconfigFILE_REQUEST_WAIT_MS           60000U
+#define otaconfigFILE_REQUEST_WAIT_MS           10000U
 
 /**
  * @brief The OTA agents task priority. Normally it runs at a low priority.

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
@@ -54,7 +54,7 @@
  * The wait timer is reset whenever a data block is received from the OTA service so we will only send
  * the request message after being idle for this amount of time.
  */
-#define otaconfigFILE_REQUEST_WAIT_MS           10000U
+#define otaconfigFILE_REQUEST_WAIT_MS           60000U
 
 /**
  * @brief The OTA agents task priority. Normally it runs at a low priority.
@@ -84,7 +84,7 @@
   *  Please note that this must be set larger than zero.
   *
   */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        32U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        1U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
@@ -41,7 +41,7 @@
  *
  * 10 bits yields a data block size of 1KB.
  */
-#define otaconfigLOG2_FILE_BLOCK_SIZE           12UL
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
 
 /**
  * @brief Milliseconds to wait for the self test phase to succeed before we force reset.

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
@@ -41,7 +41,7 @@
  *
  * 10 bits yields a data block size of 1KB.
  */
-#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
+#define otaconfigLOG2_FILE_BLOCK_SIZE           12UL
 
 /**
  * @brief Milliseconds to wait for the self test phase to succeed before we force reset.


### PR DESCRIPTION
WinSim OTA e2e test had issue to keep the file transfer connection open.  
Changed the request to 1 block at a time.  The block size will remain as 4K.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.