### PR TITLE
Removed Unused Struct Members Related to Find_Objects.

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -196,8 +196,6 @@ typedef struct P11Session
     CK_MECHANISM_TYPE xOperationDigestMechanism; /**< @brief Indicates if a digest operation is in progress. */
     CK_BYTE * pxFindObjectLabel;                 /**< @brief Pointer to the label for the search in progress. Should be NULL if no search in progress. */
     uint8_t xFindObjectLabelLength;              /**< @brief Find object length flag. */
-    CK_BBOOL xFindObjectInit;                    /**< @brief Unused and to be removed. */
-    CK_BBOOL xFindObjectComplete;                /**< @brief Unused and to be removed. */
     CK_MECHANISM_TYPE xOperationVerifyMechanism; /**< @brief The mechanism of verify operation in progress. Set during C_VerifyInit. */
     SemaphoreHandle_t xVerifyMutex;              /**< @brief Protects the verification key from being modified while in use. */
     mbedtls_pk_context xVerifyKey;               /**< @brief Verification key.  Set during C_VerifyInit. */
@@ -2874,13 +2872,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
         if( 1u != ulMaxObjectCount )
         {
             PKCS11_WARNING_PRINT( ( "WARN: Searching for more than 1 object not supported. \r\n" ) );
-        }
-
-        if( ( pdFALSE == xDone ) && ( ( CK_BBOOL ) CK_TRUE == pxSession->xFindObjectComplete ) )
-        {
-            *pulObjectCount = 0;
-            xResult = CKR_OK;
-            xDone = pdTRUE;
         }
     }
 

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -113,8 +113,6 @@ typedef struct P11Session
     CK_ULONG ulState;
     CK_BBOOL xOpened;
     CK_MECHANISM_TYPE xOperationInProgress;
-    CK_BBOOL xFindObjectInit;
-    CK_BBOOL xFindObjectComplete;
     CK_BYTE * pxFindObjectLabel; /* Pointer to the label for the search in progress. Should be NULL if no search in progress. */
     uint8_t xFindObjectLabelLength;
     CK_MECHANISM_TYPE xVerifyMechanism;
@@ -2255,13 +2253,6 @@ CK_DEFINE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
     if( 1u != ulMaxObjectCount )
     {
         PKCS11_WARNING_PRINT( ( "WARN: Searching for more than 1 object not supported. \r\n" ) );
-    }
-
-    if( ( pdFALSE == xDone ) && ( ( CK_BBOOL ) CK_TRUE == pxSession->xFindObjectComplete ) )
-    {
-        *pulObjectCount = 0;
-        xResult = CKR_OK;
-        xDone = pdTRUE;
     }
 
     if( ( pdFALSE == xDone ) )


### PR DESCRIPTION
These two struct members, xFindObjectInit, and xFindObjectComplete, are undocumented and unused. There is no reference in the code to xFindObjectInit being used.
xFindObjectComplete is actually used, but the code path it is used in is either impossible, or a bug. Since the P11SessionPtr_t struct is memset to 0
immediately after being malloc'd the line of code using xFindObjectComplete will always evaluate to false, as it is comparing it to CK_TRUE,
as CK_TRUE is equal to 1, and xFindObjectComplete is never explicitly set to 1.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.