### PR TITLE
Add back stddef.h

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -37,6 +37,7 @@
 #ifndef _BT_HAL_AVSRC_PROFILE_H
 #define _BT_HAL_AVSRC_PROFILE_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include "bt_hal_manager_types.h"
 

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_client.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_server.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_server.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_gatt_types.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_gatt_types.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -57,7 +57,7 @@
 /**
  * @brief Make changes in the API with backward compatibility.
  */
-#define btPATCH_VERSION    0
+#define btPATCH_VERSION    1
 
 /**
  * @brief  Help functions to convert version to string.

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_classic.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_classic.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_types.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_types.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS BLE HAL V5.0.0
+ * FreeRTOS BLE HAL V5.0.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Add back stddef.h

Description
-----------
* Need to add back stddef.h in bt_hal_avsrc_profile.h

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.