### PR TITLE
[BLE] Add set device name API

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -649,7 +649,7 @@ BTStatus_t IotBle_ConfirmNumericComparisonKeys( BTBdaddr_t * pBdAddr,
  * API can be used to set the device name before turning on BLE by calling IotBle_On(),
  * or when BLE is running. When BLE is advertising mode, setting device name should take into effect
  * immediately for the current advertisement. The device name needs to be set only once and
- * is available across BLE turn off-turn on cylces. API should be called only after IotBle_Init().
+ * is available across BLE turn off-turn on cycles. API should be called only after IotBle_Init().
  *
  * @param[in] pName Pointer to the device name string.
  * @param[in] length Length of the device name string without null terminator.

--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -642,4 +642,22 @@ BTStatus_t IotBle_ConfirmNumericComparisonKeys( BTBdaddr_t * pBdAddr,
                                                 bool keyAccepted );
 /* @[declare_iotble_confirmnumericcomparisonkeys] */
 
+
+/**
+ * @brief Set device name for BLE.
+ *
+ * API can be used to set the device name before turning on BLE by calling IotBle_On(),
+ * or when BLE is running. When BLE is advertising mode, setting device name should take into effect
+ * immediately for the current advertisement. The device name needs to be set only once and
+ * is available across BLE turn off-turn on cylces. API should be called only after IotBle_Init().
+ *
+ * @param[in] pName Pointer to the device name string.
+ * @param[in] length Length of the device name string without null terminator.
+ * @return Returns eBTStatusSuccess on successful call or error code otherwise.
+ */
+/* @[declare_iotble_setdevicename] */
+BTStatus_t IotBle_SetDeviceName( const char * pName,
+                                 size_t length );
+/* @[declare_iotble_setdevicename] */
+
 #endif /* _AWS_BLE_H_*/

--- a/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
@@ -365,8 +365,15 @@
 #endif
 
 
-#define IOT_BLE_MESG_ENCODER    ( _IotSerializerCborEncoder )
-#define IOT_BLE_MESG_DECODER    ( _IotSerializerCborDecoder )
+/**
+ * @brief As per BLE4.2 SPEC, device name length can be between 0 and 248 octet in length.
+ * This should not be modified.
+ *
+ */
+#define IOT_BLE_MAX_DEVICE_NAME_LENGTH    ( 248 )
+
+#define IOT_BLE_MESG_ENCODER              ( _IotSerializerCborEncoder )
+#define IOT_BLE_MESG_DECODER              ( _IotSerializerCborDecoder )
 
 /**
  * @brief Default configuration for memory allocation of data transfer service buffers.

--- a/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
@@ -373,8 +373,8 @@
     #define IOT_BLE_DATA_TRANSFER_TIMEOUT_MS    ( 2000 )
 #endif
 
-#define IOT_BLE_MESG_ENCODER              ( _IotSerializerCborEncoder )
-#define IOT_BLE_MESG_DECODER              ( _IotSerializerCborDecoder )
+#define IOT_BLE_MESG_ENCODER                    ( _IotSerializerCborEncoder )
+#define IOT_BLE_MESG_DECODER                    ( _IotSerializerCborDecoder )
 
 /**
  * @brief Default configuration for memory allocation of data transfer service buffers.

--- a/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_config_defaults.h
@@ -144,6 +144,15 @@
 #endif
 
 /**
+ * @brief Max length BLE local device name.
+ * As per BLE4.2 SPEC, device name length can be between 0 and 248 octet in length.
+ *
+ */
+#ifndef IOT_BLE_DEVICE_LOCAL_NAME_MAX_LENGTH
+    #define IOT_BLE_DEVICE_LOCAL_NAME_MAX_LENGTH    ( 248 )
+#endif
+
+/**
  * @brief Preferred MTU size for the device for a BLE connection.
  *
  * Upon new BLE connection both peers will negotiate their preferred MTU size. MTU size for the ble connection will be set to minimum
@@ -363,14 +372,6 @@
 #ifndef IOT_BLE_DATA_TRANSFER_TIMEOUT_MS
     #define IOT_BLE_DATA_TRANSFER_TIMEOUT_MS    ( 2000 )
 #endif
-
-
-/**
- * @brief As per BLE4.2 SPEC, device name length can be between 0 and 248 octet in length.
- * This should not be modified.
- *
- */
-#define IOT_BLE_MAX_DEVICE_NAME_LENGTH    ( 248 )
 
 #define IOT_BLE_MESG_ENCODER              ( _IotSerializerCborEncoder )
 #define IOT_BLE_MESG_DECODER              ( _IotSerializerCborDecoder )

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -130,7 +130,7 @@ static const BTIOtypes_t xIO = IOT_BLE_INPUT_OUTPUT;
 static const bool bIsBondable = IOT_BLE_ENABLE_BONDING;
 static const bool bSecureConnection = IOT_BLE_ENABLE_SECURE_CONNECTION;
 
-static char bleDeviceName[ IOT_BLE_MAX_DEVICE_NAME_LENGTH + 1 ] = { 0 };
+static char bleDeviceName[ IOT_BLE_DEVICE_LOCAL_NAME_MAX_LENGTH + 1 ] = { 0 };
 
 static bool isBLEOn = false;
 
@@ -917,7 +917,7 @@ BTStatus_t IotBle_SetDeviceName( const char * pName,
 {
     BTStatus_t status;
 
-    if( length <= IOT_BLE_MAX_DEVICE_NAME_LENGTH )
+    if( length <= IOT_BLE_DEVICE_LOCAL_NAME_MAX_LENGTH )
     {
         /* Copy the device name to a buffer, so that device name does not change between
          * stack disable-enable cycles.

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -125,39 +125,14 @@ static IotBleAdvertisementParams_t _advParams =
 };
 
 
-const uint32_t usMtu = IOT_BLE_PREFERRED_MTU_SIZE;
-const BTIOtypes_t xIO = IOT_BLE_INPUT_OUTPUT;
-const bool bIsBondable = IOT_BLE_ENABLE_BONDING;
-const bool bSecureConnection = IOT_BLE_ENABLE_SECURE_CONNECTION;
+static const uint32_t usMtu = IOT_BLE_PREFERRED_MTU_SIZE;
+static const BTIOtypes_t xIO = IOT_BLE_INPUT_OUTPUT;
+static const bool bIsBondable = IOT_BLE_ENABLE_BONDING;
+static const bool bSecureConnection = IOT_BLE_ENABLE_SECURE_CONNECTION;
 
-const BTProperty_t _deviceProperties[] =
-{
-    {
-        .xType = eBTpropertyBdname,
-        .xLen = sizeof( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) - 1,
-        .pvVal = ( void * ) IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME
-    },
-    {
-        .xType = eBTpropertyBondable,
-        .xLen = 1,
-        .pvVal = ( void * ) &bIsBondable
-    },
-    {
-        .xType = eBTpropertySecureConnectionOnly,
-        .xLen = 1,
-        .pvVal = ( void * ) &bSecureConnection
-    },
-    {
-        .xType = eBTpropertyIO,
-        .xLen = 1,
-        .pvVal = ( void * ) &xIO
-    },
-    {
-        .xType = eBTpropertyLocalMTUSize,
-        .xLen = 1,
-        .pvVal = ( void * ) &usMtu
-    }
-};
+static char bleDeviceName[ IOT_BLE_MAX_DEVICE_NAME_LENGTH + 1 ] = { 0 };
+
+static bool isBLEOn = false;
 
 /* 2 is the Maximum number of UUID that can be advertised in the same advertisement message */
 #define _BLE_MAX_UUID_PER_ADV_MESSAGE    2
@@ -186,6 +161,10 @@ static void _advStatusCb( BTStatus_t status,
                           uint8_t adapterIf,
                           bool bStart );
 static void _setAdvDataCb( BTStatus_t status );
+
+static BTStatus_t _setDeviceProperty( BTPropertyType_t type,
+                                      const void * pValue,
+                                      size_t length );
 
 static const BTCallbacks_t _BTManagerCb =
 {
@@ -466,6 +445,44 @@ BTStatus_t _setAdvData( IotBleAdvertisementParams_t * pAdvParams )
                                                                pServiceUuide,
                                                                countService );
 
+    if( status == eBTStatusSuccess )
+    {
+        IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+        status = _BTInterface.cbStatus;
+    }
+
+    return status;
+}
+
+static BTStatus_t _setDeviceProperty( BTPropertyType_t type,
+                                      const void * pValue,
+                                      size_t length )
+{
+    BTStatus_t status;
+    BTProperty_t property =
+    {
+        .xType = type,
+        .xLen  = length,
+        .pvVal = ( void * ) pValue
+    };
+
+    status = _BTInterface.pBTInterface->pxSetDeviceProperty( &property );
+
+    if( status == eBTStatusSuccess )
+    {
+        IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
+        status = _BTInterface.cbStatus;
+
+        if( status != eBTStatusSuccess )
+        {
+            IotLogError( "Callback error in stting property type %d , error returned %d.", type, status );
+        }
+    }
+    else
+    {
+        IotLogError( "Failed to set property type %d, error returned %d.", type, status );
+    }
+
     return status;
 }
 
@@ -510,8 +527,6 @@ BTStatus_t IotBle_ConnParameterUpdateRequest( const BTBdaddr_t * pBdAddr,
 BTStatus_t IotBle_On( void )
 {
     BTStatus_t status = eBTStatusSuccess;
-    uint16_t index;
-    uint32_t nbProperties = sizeof( _deviceProperties ) / sizeof( _deviceProperties[ 0 ] );
 
     status = _BTInterface.pBTInterface->pxBtManagerInit( &_BTManagerCb );
 
@@ -542,29 +557,29 @@ BTStatus_t IotBle_On( void )
         }
     }
 
-    /* Set GAP properties. */
     if( status == eBTStatusSuccess )
     {
-        for( index = 0; index < nbProperties; index++ )
-        {
-            status = _BTInterface.pBTInterface->pxSetDeviceProperty( &_deviceProperties[ index ] );
+        status = _setDeviceProperty( eBTpropertyBdname, &bleDeviceName, strlen( bleDeviceName ) );
+    }
 
-            if( status == eBTStatusSuccess )
-            {
-                IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
-                status = _BTInterface.cbStatus;
+    if( status == eBTStatusSuccess )
+    {
+        status = _setDeviceProperty( eBTpropertySecureConnectionOnly, &bSecureConnection, sizeof( bool ) );
+    }
 
-                if( status != eBTStatusSuccess )
-                {
-                    IotLogError( "Callback error in property %d, error returned %d.", index, status );
-                }
-            }
-            else
-            {
-                IotLogError( "Unable to set device property %d, error returned %d.", index, status );
-                break;
-            }
-        }
+    if( status == eBTStatusSuccess )
+    {
+        status = _setDeviceProperty( eBTpropertyBondable, &bIsBondable, sizeof( bool ) );
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        status = _setDeviceProperty( eBTpropertyIO, &xIO, sizeof( BTIOtypes_t ) );
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        status = _setDeviceProperty( eBTpropertyLocalMTUSize, &usMtu, sizeof( uint32_t ) );
     }
 
     /* Initialize the GATT server. */
@@ -601,12 +616,10 @@ BTStatus_t IotBle_On( void )
         #endif
 
         status = _setAdvData( &_advParams );
-        IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
 
         if( status == eBTStatusSuccess )
         {
             status = _setAdvData( &_scanRespParams );
-            IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
         }
     }
 
@@ -620,6 +633,11 @@ BTStatus_t IotBle_On( void )
             IotSemaphore_Wait( &_BTInterface.callbackSemaphore );
             status = _BTInterface.cbStatus;
         }
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        isBLEOn = true;
     }
 
     return status;
@@ -753,6 +771,8 @@ BTStatus_t IotBle_Off( void )
         status = _BTInterface.pBTInterface->pxBtManagerCleanup();
     }
 
+    isBLEOn = false;
+
     return status;
 }
 
@@ -836,11 +856,15 @@ void _initializeLists( void )
     }
 }
 
+
+
 /*-----------------------------------------------------------*/
 
 BTStatus_t IotBle_Init( void )
 {
     BTStatus_t status = eBTStatusSuccess;
+    char * pDeviceName = IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME;
+
 
     _initializeLists();
 
@@ -876,8 +900,62 @@ BTStatus_t IotBle_Init( void )
         }
     }
 
+    /*
+     * If a BLE device name is provided in the config, use it to set the local BLE device name.
+     */
+
+    if( ( pDeviceName != NULL ) && ( strcmp( pDeviceName, "" ) != 0 ) )
+    {
+        status = IotBle_SetDeviceName( pDeviceName, strlen( pDeviceName ) );
+    }
+
     return status;
 }
+
+BTStatus_t IotBle_SetDeviceName( const char * pName,
+                                 size_t length )
+{
+    BTStatus_t status;
+
+    if( length <= IOT_BLE_MAX_DEVICE_NAME_LENGTH )
+    {
+        /* Copy the device name to a buffer, so that device name does not change between
+         * stack disable-enable cycles.
+         */
+        strncpy( bleDeviceName, pName, length );
+        bleDeviceName[ length + 1 ] = '\0';
+        status = eBTStatusSuccess;
+    }
+    else
+    {
+        status = eBTStatusNoMem;
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        if( isBLEOn )
+        {
+            /* If BLE is running, set the device property and advertisement data to propagate the
+             * name change immediately in the advertisement.
+             */
+
+            status = _setDeviceProperty( eBTpropertyBdname, bleDeviceName, strlen( bleDeviceName ) );
+
+            if( status == eBTStatusSuccess )
+            {
+                status = _setAdvData( &_advParams );
+            }
+
+            if( status == eBTStatusSuccess )
+            {
+                status = _setAdvData( &_scanRespParams );
+            }
+        }
+    }
+
+    return status;
+}
+
 
 /*-----------------------------------------------------------*/
 

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -923,7 +923,7 @@ BTStatus_t IotBle_SetDeviceName( const char * pName,
          * stack disable-enable cycles.
          */
         strncpy( bleDeviceName, pName, length );
-        bleDeviceName[ length + 1 ] = '\0';
+        bleDeviceName[ length ] = '\0';
         status = eBTStatusSuccess;
     }
     else

--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
@@ -47,7 +47,7 @@
 #include "unity.h"
 
 
-#define BLE_TEST_CONNECTION_TIMEOUT_MS  ( 15000 )
+#define BLE_TEST_CONNECTION_TIMEOUT_MS    ( 15000 )
 
 /*-----------------------------------------------------------*/
 
@@ -101,10 +101,9 @@ static BTStatus_t _BLEInit( void )
 
 static void _BLEConnectionCallback( BTStatus_t status,
                                     uint16_t connId,
-                                       bool connected,
-                                       BTBdaddr_t * pBa )
+                                    bool connected,
+                                    BTBdaddr_t * pBa )
 {
-
     if( connected == true )
     {
         IotBle_StopAdv( NULL );
@@ -113,9 +112,9 @@ static void _BLEConnectionCallback( BTStatus_t status,
     {
         ( void ) IotBle_StartAdv( NULL );
     }
+
     bBLEConnected = connected;
     IotSemaphore_Post( &bleConnectionSem );
-
 }
 
 
@@ -126,7 +125,6 @@ static BTStatus_t _BLEEnable( void )
 
     if( !bBLEEnabled )
     {
-
         TEST_ASSERT_EQUAL_INT( true, IotSemaphore_Create( &bleConnectionSem, 0, 1 ) );
 
         eventCb.pConnectionCb = _BLEConnectionCallback;
@@ -139,7 +137,7 @@ static BTStatus_t _BLEEnable( void )
 
         TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
 
-        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ));
+        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ) );
 
         TEST_ASSERT_TRUE( bBLEConnected );
 
@@ -157,12 +155,11 @@ static BTStatus_t _BLEDisable( void )
 
     if( bBLEEnabled )
     {
-
         status = IotBle_Off();
 
         TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
 
-        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ));
+        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ) );
 
         TEST_ASSERT_FALSE( bBLEConnected );
 
@@ -186,7 +183,6 @@ TEST_GROUP( Full_BLE_END_TO_END_CONNECTIVITY );
 
 TEST_SETUP( Full_BLE_END_TO_END_CONNECTIVITY )
 {
-
 }
 
 /*-----------------------------------------------------------*/
@@ -274,9 +270,8 @@ TEST( Full_BLE_END_TO_END_CONNECTIVITY, EnableBLE )
 
 TEST( Full_BLE_END_TO_END_CONNECTIVITY, SetDeviceName )
 {
-
     TEST_ASSERT_EQUAL( eBTStatusSuccess,
-            IotBle_SetDeviceName( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME, strlen( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) ) );
+                       IotBle_SetDeviceName( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME, strlen( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) ) );
 }
 
 TEST( Full_BLE_END_TO_END_MQTT, SubscribePublishWaitQoS0 )

--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
@@ -27,24 +27,37 @@
  * @file iot_test_ble_end_to_end.c
  * @brief Tests for ble.
  */
+
+#include <string.h>
+
 /* The config header is always included first. */
 #include "iot_config.h"
 
 /* C standard library includes. */
 #include <stdbool.h>
 
+#include "iot_ble.h"
 /* Network interface includes. */
 #include "platform/iot_network_ble.h"
 #include "iot_mqtt.h"
+#include "platform/iot_threads.h"
 
 /* Test framework includes. */
 #include "unity_fixture.h"
 #include "unity.h"
 
+
+#define BLE_TEST_CONNECTION_TIMEOUT_MS  ( 15000 )
+
 /*-----------------------------------------------------------*/
 
 extern bool IotTestNetwork_SelectNetworkType( uint16_t networkType );
 static bool bBLEInitialized = pdFALSE;
+static bool bBLEEnabled = false;
+static bool bBLEConnected = false;
+
+static IotSemaphore_t bleConnectionSem;
+
 
 /**
  * @brief Declares and runs an MQTT system test.
@@ -62,6 +75,136 @@ static bool bBLEInitialized = pdFALSE;
     TEST_ASSERT_MESSAGE( bBLEInitialized, "BLE Not initialized" ); \
     TEST_Shadow_System_ ## name ## _();
 /*-----------------------------------------------------------*/
+
+BTStatus_t bleStackInit( void );
+
+static BTStatus_t _BLEInit( void )
+{
+    BTStatus_t status = eBTStatusSuccess;
+
+    /** Only do one time initialization of stack and Middleware **/
+    if( !bBLEInitialized )
+    {
+        status = bleStackInit();
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        status = IotBle_Init();
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        bBLEInitialized = true;
+    }
+
+    return status;
+}
+
+static void _BLEConnectionCallback( BTStatus_t status,
+                                    uint16_t connId,
+                                       bool connected,
+                                       BTBdaddr_t * pBa )
+{
+
+    if( connected == true )
+    {
+        IotBle_StopAdv( NULL );
+    }
+    else
+    {
+        ( void ) IotBle_StartAdv( NULL );
+    }
+    bBLEConnected = connected;
+    IotSemaphore_Post( &bleConnectionSem );
+
+}
+
+
+static BTStatus_t _BLEEnable( void )
+{
+    IotBleEventsCallbacks_t eventCb;
+    BTStatus_t status = eBTStatusSuccess;
+
+    if( !bBLEEnabled )
+    {
+
+        TEST_ASSERT_EQUAL_INT( true, IotSemaphore_Create( &bleConnectionSem, 0, 1 ) );
+
+        eventCb.pConnectionCb = _BLEConnectionCallback;
+
+        status = IotBle_RegisterEventCb( eBLEConnection, eventCb );
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        status = IotBle_On();
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ));
+
+        TEST_ASSERT_TRUE( bBLEConnected );
+
+        bBLEEnabled = true;
+    }
+
+    return status;
+}
+
+
+static BTStatus_t _BLEDisable( void )
+{
+    BTStatus_t status;
+    IotBleEventsCallbacks_t eventCb;
+
+    if( bBLEEnabled )
+    {
+
+        status = IotBle_Off();
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        TEST_ASSERT_TRUE( IotSemaphore_TimedWait( &bleConnectionSem, BLE_TEST_CONNECTION_TIMEOUT_MS ));
+
+        TEST_ASSERT_FALSE( bBLEConnected );
+
+
+        eventCb.pConnectionCb = _BLEConnectionCallback;
+        status = IotBle_UnRegisterEventCb( eBLEConnection, eventCb );
+
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, status );
+
+        IotSemaphore_Destroy( &bleConnectionSem );
+
+        bBLEEnabled = false;
+    }
+
+    return status;
+}
+
+TEST_GROUP( Full_BLE_END_TO_END_CONNECTIVITY );
+
+/*-----------------------------------------------------------*/
+
+TEST_SETUP( Full_BLE_END_TO_END_CONNECTIVITY )
+{
+
+}
+
+/*-----------------------------------------------------------*/
+
+TEST_TEAR_DOWN( Full_BLE_END_TO_END_CONNECTIVITY )
+{
+}
+
+/*-----------------------------------------------------------*/
+
+TEST_GROUP_RUNNER( Full_BLE_END_TO_END_CONNECTIVITY )
+{
+    RUN_TEST_CASE( Full_BLE_END_TO_END_CONNECTIVITY, InitializeBLE );
+    RUN_TEST_CASE( Full_BLE_END_TO_END_CONNECTIVITY, SetDeviceName );
+    RUN_TEST_CASE( Full_BLE_END_TO_END_CONNECTIVITY, EnableBLE );
+}
+
+
 
 TEST_GROUP( Full_BLE_END_TO_END_MQTT );
 
@@ -90,6 +233,10 @@ TEST_TEAR_DOWN( Full_BLE_END_TO_END_MQTT )
 TEST_GROUP_RUNNER( Full_BLE_END_TO_END_MQTT )
 {
     /* For these tests, use the BLE network interface. */
+
+    _BLEInit();
+    _BLEEnable();
+
     bBLEInitialized = IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
 
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, SubscribePublishWaitQoS0 );
@@ -107,6 +254,7 @@ TEST_GROUP_RUNNER( Full_BLE_END_TO_END_MQTT )
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, SubscribeCompleteReentrancy );
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, IncomingPublishReentrancy );
 
+
     /* Revert to sockets network interface after this test is finished. */
     IotTestNetwork_SelectNetworkType( DEFAULT_NETWORK );
 }
@@ -114,6 +262,22 @@ TEST_GROUP_RUNNER( Full_BLE_END_TO_END_MQTT )
 
 /*-----------------------------------------------------------*/
 
+TEST( Full_BLE_END_TO_END_CONNECTIVITY, InitializeBLE )
+{
+    _BLEInit();
+}
+
+TEST( Full_BLE_END_TO_END_CONNECTIVITY, EnableBLE )
+{
+    _BLEEnable();
+}
+
+TEST( Full_BLE_END_TO_END_CONNECTIVITY, SetDeviceName )
+{
+
+    TEST_ASSERT_EQUAL( eBTStatusSuccess,
+            IotBle_SetDeviceName( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME, strlen( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) ) );
+}
 
 TEST( Full_BLE_END_TO_END_MQTT, SubscribePublishWaitQoS0 )
 {
@@ -180,6 +344,9 @@ TEST_TEAR_DOWN( Full_BLE_END_TO_END_SHADOW )
 
 TEST_GROUP_RUNNER( Full_BLE_END_TO_END_SHADOW )
 {
+    _BLEInit();
+    _BLEEnable();
+
     /* For these tests, use the BLE network interface. */
     bBLEInitialized = IotTestNetwork_SelectNetworkType( AWSIOT_NETWORK_TYPE_BLE );
 

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -200,6 +200,7 @@ static void RunTests( void )
 
     #if ( testrunnerFULL_BLE_END_TO_END_TEST_ENABLED == 1 )
         RUN_TEST_GROUP( MQTT_Unit_BLE_Serialize );
+        RUN_TEST_GROUP( Full_BLE_END_TO_END_CONNECTIVITY );
         RUN_TEST_GROUP( Full_BLE_END_TO_END_MQTT );
         RUN_TEST_GROUP( Full_BLE_END_TO_END_SHADOW );
     #endif

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -36,10 +36,6 @@
 
 static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 
-#if ( BLE_SUPPORTED == 1 )
-    static bool bleEnabled = false;
-#endif
-
 /*-----------------------------------------------------------*/
 
 
@@ -76,100 +72,10 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 #endif /* if ( WIFI_SUPPORTED == 1 ) */
 
 #if ( BLE_SUPPORTED == 1 )
-    #include "iot_ble.h"
     #include "platform/iot_network_ble.h"
     #include "iot_mqtt.h"
     extern const IotMqttSerializer_t IotBleMqttSerializer;
-    /*-----------------------------------------------------------*/
 
-    static void _BLEConnectionCallback( BTStatus_t status,
-                                        uint16_t connId,
-                                        bool connected,
-                                        BTBdaddr_t * pBa )
-    {
-        if( connected == true )
-        {
-            IotBle_StopAdv( NULL );
-        }
-        else
-        {
-            ( void ) IotBle_StartAdv( NULL );
-        }
-    }
-    /*-----------------------------------------------------------*/
-    extern BTStatus_t bleStackInit( void );
-
-    static BaseType_t _BLEEnable( void )
-    {
-        IotBleEventsCallbacks_t xEventCb;
-        BaseType_t xRet = pdTRUE;
-        static bool bInitBLE = false;
-        BTStatus_t xStatus = eBTStatusSuccess;
-
-        if( bInitBLE == false )
-        {
-            /* Initialize low level drivers for BLE */
-            xStatus = bleStackInit();
-
-            if( xStatus == eBTStatusSuccess )
-            {
-                xStatus = IotBle_Init();
-
-                if( xStatus == eBTStatusSuccess )
-                {
-                    bInitBLE = true;
-                }
-            }
-        }
-
-        if( xStatus == eBTStatusSuccess )
-        {
-            xStatus = IotBle_On();
-        }
-
-        /* Register BLE Connection callback */
-        if( xStatus == eBTStatusSuccess )
-        {
-            xEventCb.pConnectionCb = _BLEConnectionCallback;
-
-            if( IotBle_RegisterEventCb( eBLEConnection, xEventCb ) != eBTStatusSuccess )
-            {
-                xStatus = eBTStatusFail;
-            }
-        }
-
-        if( xStatus != eBTStatusSuccess )
-        {
-            xRet = pdFALSE;
-        }
-
-        return xRet;
-    }
-
-/*-----------------------------------------------------------*/
-
-    static BaseType_t _BLEDisable( void )
-    {
-        bool ret = true;
-        IotBleEventsCallbacks_t xEventCb;
-
-        xEventCb.pConnectionCb = _BLEConnectionCallback;
-
-        if( IotBle_UnRegisterEventCb( eBLEConnection, xEventCb ) != eBTStatusSuccess )
-        {
-            ret = false;
-        }
-
-        if( ret == true )
-        {
-            if( IotBle_Off() != eBTStatusSuccess )
-            {
-                ret = false;
-            }
-        }
-
-        return ret;
-    }
 #endif /* if ( BLE_SUPPORTED == 1 ) */
 
 
@@ -202,32 +108,8 @@ const IotNetworkInterface_t * IotTestNetwork_GetNetworkInterface( void )
 
 bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
 {
-    bool bInitializeSucceeded = pdFALSE;
-
-    switch( networkType )
-    {
-        #if ( BLE_SUPPORTED == 1 )
-            case AWSIOT_NETWORK_TYPE_BLE:
-
-                if( bleEnabled == false )
-                {
-                    bleEnabled = _BLEEnable();
-                }
-
-                bInitializeSucceeded = bleEnabled;
-                break;
-        #endif
-        #if !defined( WIFI_SUPPORTED ) || ( WIFI_SUPPORTED != 0 )
-            case AWSIOT_NETWORK_TYPE_WIFI:
-                bInitializeSucceeded = pdTRUE;
-                break;
-        #endif
-        default:
-            break;
-    }
-
     _IotTestNetworkType = networkType;
-    return bInitializeSucceeded;
+    return true;
 }
 
 /*-----------------------------------------------------------*/

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_gap.c
@@ -708,14 +708,20 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
     uint8_t ucFlags;
     uint8_t ucTxPower;
     esp_err_t xESPErr = ESP_OK;
+    char *pDeviceName;
+    size_t deviceNameLength;
 
-    if( ( pxParams->ucName.xType == BTGattAdvNameComplete ) || ( IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE >= sizeof( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) - 1 ) )
+
+    pDeviceName = prxESPGetBLEDeviceName();
+    deviceNameLength = strlen( pDeviceName );
+
+    if( ( pxParams->ucName.xType == BTGattAdvNameComplete ) || ( IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE >= deviceNameLength ) )
     {
-        prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_NAME_CMPL, ( uint8_t * ) IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME, sizeof( IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME ) - 1 );
+        prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_NAME_CMPL, ( uint8_t * ) pDeviceName, deviceNameLength );
     }
     else if( pxParams->ucName.xType == BTGattAdvNameShort )
     {
-        prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_NAME_SHORT, ( uint8_t * ) IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME, pxParams->ucName.ucShortNameLen );
+        prvAddToAdvertisementMessage( ucMessageRaw, &ucMessageIndex, ESP_BLE_AD_TYPE_NAME_SHORT, ( uint8_t * ) pDeviceName, IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE );
     }
 
     if( ( pxParams->bIncludeTxPower == true ) && ( xStatus == eBTStatusSuccess ) )

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_internals.h
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_internals.h
@@ -55,5 +55,6 @@ void prvCopytoESPUUID( esp_bt_uuid_t * pxESPuuid,
 BTStatus_t prvSetIOs( BTIOtypes_t xPropertyIO );
 BTStatus_t prvToggleBondableFlag( bool bEnable );
 BTStatus_t prvToggleSecureConnectionOnlyMode( bool bEnable );
+char * prxESPGetBLEDeviceName( void );
 
 #endif /* ifndef _AWS_BLE_INTERNALS_H_ */


### PR DESCRIPTION
Add set device name API 

Description
-----------

Add a new API to set device name for BLE at run time. This facilitates reading the device name from a storage example flash and configuring different names for different devices without changing code.

Minor - Replaced some static variables (used only once) to functions to save RAM.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.