### PR TITLE
Remove unused function prototype vApplicationInit

### DIFF
--- a/demos/include/aws_demo.h
+++ b/demos/include/aws_demo.h
@@ -53,8 +53,6 @@ void runDemoTask( void * pArgument );
 
 void DEMO_RUNNER_RunDemos( void );
 
-void vApplicationInit( void );
-
 typedef struct demoContext
 {
     /* Network types for the demo */


### PR DESCRIPTION
Description
-----------
Remove unused function prototype vApplicationInit in aws_demo.h. This was brought to our attention by a customer through github issues. https://github.com/aws/amazon-freertos/issues/1821

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.