### PR TITLE
Logging function use cleaned up

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -34,7 +34,7 @@
 #include "esp_log.h"
 #include "esp_wifi.h"
 #include "esp_wifi_internal.h"
-prvMonitorResources();#include "tcpip_adapter.h"
+#include "tcpip_adapter.h"
 
 enum if_state_t {
     INTERFACE_DOWN = 0,

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -34,7 +34,7 @@
 #include "esp_log.h"
 #include "esp_wifi.h"
 #include "esp_wifi_internal.h"
-#include "tcpip_adapter.h"
+prvMonitorResources();#include "tcpip_adapter.h"
 
 enum if_state_t {
     INTERFACE_DOWN = 0,
@@ -47,10 +47,9 @@ volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 /* protect the function declaration itself instead of using
    #if everywhere.                                        */
 #if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources();
-    #define PRINT_RESOURCE_LOGS prvMonitorResources();
+    static void prvMonitorResources();    
 #else
-    #define PRINT_RESOURCE_LOGS
+    #define prvMonitorResources()
 #endif
 
 BaseType_t xNetworkInterfaceInitialise( void )
@@ -88,7 +87,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
     }
 
     /* Print the necessary debugging logs */
-    PRINT_RESOURCE_LOGS;
+    prvMonitorResources();
     
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
@@ -117,7 +116,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-    PRINT_RESOURCE_LOGS;
+    prvMonitorResources();
 
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -47,9 +47,9 @@ volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 /* protect the function declaration itself instead of using
    #if everywhere.                                        */
 #if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources();    
+    static void prvPrintResourceStats();    
 #else
-    #define prvMonitorResources()
+    #define prvPrintResourceStats()
 #endif
 
 BaseType_t xNetworkInterfaceInitialise( void )
@@ -86,8 +86,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
         }
     }
 
-    /* Print the necessary debugging logs */
-    prvMonitorResources();
+    prvPrintResourceStats();
     
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
@@ -116,7 +115,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-    prvMonitorResources();
+    prvPrintResourceStats();
 
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");
@@ -148,7 +147,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
 }
 
 #if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources()
+    static void prvPrintResourceStats()
     {
         static UBaseType_t uxLastMinBufferCount = 0u;
         static UBaseType_t uxCurrentBufferCount = 0u;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -44,8 +44,13 @@ enum if_state_t {
 static const char *TAG = "NetInterface";
 volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 
+/* protect the function declaration itself instead of using
+   #if everywhere.                                        */
 #if ( ipconfigHAS_PRINTF != 0 )
     static void prvMonitorResources();
+    #define PRINT_RESOURCE_LOGS prvMonitorResources();
+#else
+    #define PRINT_RESOURCE_LOGS
 #endif
 
 BaseType_t xNetworkInterfaceInitialise( void )
@@ -82,9 +87,9 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
         }
     }
 
-#if ( ipconfigHAS_PRINTF != 0 )
-    prvMonitorResources();
-#endif
+    /* Print the necessary debugging logs */
+    PRINT_RESOURCE_LOGS;
+    
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
     }
@@ -112,9 +117,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-#if ( ipconfigHAS_PRINTF != 0 )
-    prvMonitorResources();
-#endif
+    PRINT_RESOURCE_LOGS;
 
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -37,7 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    1
+#define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -37,7 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    0
+#define ipconfigHAS_DEBUG_PRINTF    1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif


### PR DESCRIPTION
Logging function use cleaned up

Description
-----------
The logging function was being guarded by multiple #ifs all over the code. Instead of doing that at every single place, a #define was used to guard the declaration and definition itself. It makes the code look cleaner and might help future users avoid mistakes.

Code tests:
- Custom Cmake (#define ipconfigHAS_PRINTF = 1). The tests show that shadow did not pass, but since that doesn't have anything to do with this change I have assumed that the code works. (Also other tests passed)
- Custom Cmake (#define ipconfigHAS_PRINTF = 0). The tests show that OTA did not pass, but since that doesn't have anything to do with this change I have assumed that the code works. (Also other tests passed)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.