### PR TITLE
Enable IotLog override and fix format specifier warnings.

### DIFF
--- a/demos/defender/aws_iot_demo_defender.c
+++ b/demos/defender/aws_iot_demo_defender.c
@@ -275,7 +275,7 @@ int RunDefenderDemo( bool awsIotMqttMode,
 
         if( mqttStatus != IOT_MQTT_SUCCESS )
         {
-            IotLogError( "Failed to Create MQTT Connection:%d", IotMqtt_strerror( mqttStatus ) );
+            IotLogError( "Failed to Create MQTT Connection, error: %s", IotMqtt_strerror( mqttStatus ) );
             IotMqtt_Cleanup();
             defenderResult = AWS_IOT_DEFENDER_INTERNAL_FAILURE;
         }

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -680,12 +680,12 @@ static void _readReadyCallback( void * pPrivData,
             return;
         }
 
-        IotLogDebug( "Reading the content length for response %d.", respHandle );
+        IotLogDebug( "Reading the content length for response %p.", respHandle );
         returnStatus = IotHttpsClient_ReadContentLength( respHandle, &contentLength );
 
         if( ( returnStatus != IOT_HTTPS_OK ) || ( contentLength == 0 ) )
         {
-            IotLogError( "Failed to retrieve the Content-Length from the response. ",
+            IotLogError( "Failed to retrieve the Content-Length from the response. "
                          "Please try increasing the size of IOT_DEMO_HTTPS_RESP_USER_BUFFER_SIZE." );
             IotHttpsClient_CancelResponseAsync( respHandle );
             return;
@@ -695,8 +695,8 @@ static void _readReadyCallback( void * pPrivData,
          * cancel the request. In this demo cancelling the request is an error condition that ends the demo. */
         if( contentLength != pRequestContext->numReqBytes )
         {
-            IotLogError( "The Content-Length found in this file does not equal the number of bytes requested. So we may ",
-                         "not have download the file completely. The content length is %d and the requested number of bytes for ",
+            IotLogError( "The Content-Length found in this file does not equal the number of bytes requested. So we may "
+                         "not have download the file completely. The content length is %d and the requested number of bytes for "
                          "this request is %d", contentLength, pRequestContext->numReqBytes );
             IotHttpsClient_CancelResponseAsync( respHandle );
             return;
@@ -759,7 +759,7 @@ static void _readReadyCallback( void * pPrivData,
          * at the same time a request is being sent, a reconnection needs to be made before the next request sends and
          * gets a network error ending the demo. Please see the design flow for more information:
          * https://docs.aws.amazon.com/freertos/latest/lib-ref/https/https_design.html#Asynchronous_Design */
-        IotLogDebug( "Looking for the \"Connection\" header in response %d.", respHandle );
+        IotLogDebug( "Looking for the \"Connection\" header in response %p.", respHandle );
         returnStatus = IotHttpsClient_ReadHeader( respHandle,
                                                   CONNECTION_HEADER_FIELD,
                                                   CONNECTION_HEADER_FILED_LENGTH,
@@ -839,7 +839,7 @@ static void _responseCompleteCallback( void * pPrivData,
      * end the demo. */
     if( rc != IOT_HTTPS_OK )
     {
-        IotLogError( "There was a problem with the current response %d. Error code: %d. ", respHandle, rc );
+        IotLogError( "There was a problem with the current response %p. Error code: %d. ", respHandle, rc );
         IotSemaphore_Post( &( _fileFinishedSem ) );
     }
     else if( pRequestContext->currDownloaded != pRequestContext->numReqBytes )
@@ -991,7 +991,7 @@ static int _scheduleAsyncRequest( int reqIndex,
 
     /* Send the request and receive the response asynchronously. This will schedule the async request. This function
      * will return immediately after scheduling. */
-    IotLogDebug( "Sending asynchronously %s, req num: %d", _requestPool.pRequestContexts[ reqIndex ].pRangeValueStr, _requestPool.pReqHandles[ reqIndex ] );
+    IotLogDebug( "Sending asynchronously %s, req num: %p", _requestPool.pRequestContexts[ reqIndex ].pRangeValueStr, _requestPool.pReqHandles[ reqIndex ] );
     httpsClientStatus = IotHttpsClient_SendAsync( _connHandle,
                                                   _requestPool.pReqHandles[ reqIndex ],
                                                   &( _requestPool.pRespHandles[ reqIndex ] ),

--- a/demos/mqtt/iot_demo_mqtt.c
+++ b/demos/mqtt/iot_demo_mqtt.c
@@ -294,7 +294,7 @@ static void _mqttSubscriptionCallback( void * param1,
         /* Check for errors from snprintf. */
         if( acknowledgementLength < 0 )
         {
-            IotLogWarn( "Failed to generate acknowledgement message for PUBLISH *.*s.",
+            IotLogWarn( "Failed to generate acknowledgement message for PUBLISH %.*s.",
                         ( int ) messageNumberLength,
                         pPayload + messageNumberIndex );
         }

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -629,7 +629,7 @@ static void _onNetworkStateChangeCallback( uint32_t networkType,
                 }
                 else
                 {
-                    IotLogError( "Failed to invoke subscription task for network: %d, state: %d, error:",
+                    IotLogError( "Failed to invoke subscription task for network: %d, state: %d, error: %d",
                                  pNetwork->type,
                                  newState,
                                  error );
@@ -641,7 +641,7 @@ static void _onNetworkStateChangeCallback( uint32_t networkType,
         }
         else
         {
-            IotLogError( "Failed to create subscription task for network: %d, state: %d, error:",
+            IotLogError( "Failed to create subscription task for network: %d, state: %d, error: %d",
                          pNetwork->type,
                          newState,
                          error );

--- a/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c
+++ b/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c
@@ -260,7 +260,7 @@ static AwsIotShadowError_t _validateDocumentInfo( _shadowOperationType_t type,
     {
         if( pDocumentInfo->qos != IOT_MQTT_QOS_1 )
         {
-            IotLogError( "QoS for Shadow %d must be 0 or 1.",
+            IotLogError( "QoS for Shadow %s must be 0 or 1.",
                          _pAwsIotShadowOperationNames[ type ] );
 
             return AWS_IOT_SHADOW_BAD_PARAMETER;

--- a/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c
+++ b/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c
@@ -727,7 +727,7 @@ AwsIotShadowError_t _AwsIotShadow_ProcessOperation( IotMqttConnection_t mqttConn
             publishInfo.retryMs = pDocumentInfo->retryMs;
 
             IotLogDebug( "Shadow %s message will be published at QoS %d with "
-                         "retryLimit %d and retryMs %llu.",
+                         "retryLimit %d and retryMs %u.",
                          _pAwsIotShadowOperationNames[ pOperation->type ],
                          publishInfo.qos,
                          publishInfo.retryLimit,

--- a/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c
+++ b/libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c
@@ -227,14 +227,14 @@ AwsIotShadowError_t _AwsIotShadow_ParseErrorDocument( const char * pErrorDocumen
                                     &pMessage,
                                     &messageLength ) == true )
     {
-        IotLogWarn( "Code %lu: %.*s.",
+        IotLogWarn( "Code %u: %.*s.",
                     code,
                     messageLength,
                     pMessage );
     }
     else
     {
-        IotLogWarn( "Code %lu; failed to parse message from error document.\n%.*s",
+        IotLogWarn( "Code %u; failed to parse message from error document.\n%.*s",
                     code,
                     errorDocumentLength,
                     pErrorDocument );

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -29,6 +29,7 @@
  */
 
 #include <string.h>
+#include <inttypes.h>
 
 #include "iot_config.h"
 #include "iot_ble_config.h"
@@ -592,7 +593,7 @@ static bool _deserializeAddNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter ( %d ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -719,7 +720,7 @@ static bool _deserializeEditNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter ( %d ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -744,7 +745,7 @@ static bool _deserializeEditNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "New Network index parameter ( %d ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "New Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -848,7 +849,7 @@ static bool _deserializeDeleteNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter ( %d ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter %" PRId64 " is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -29,7 +29,6 @@
  */
 
 #include <string.h>
-#include <inttypes.h>
 
 #include "iot_config.h"
 #include "iot_ble_config.h"
@@ -593,7 +592,7 @@ static bool _deserializeAddNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -720,7 +719,7 @@ static bool _deserializeEditNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -745,7 +744,7 @@ static bool _deserializeEditNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "New Network index parameter ( %" PRId64 " ) is out of range", value.u.value.u.signedInt );
+                IotLogError( "New Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }
@@ -849,7 +848,7 @@ static bool _deserializeDeleteNetworkRequest( const uint8_t * pData,
             }
             else
             {
-                IotLogError( "Network index parameter %" PRId64 " is out of range", value.u.value.u.signedInt );
+                IotLogError( "Network index parameter %lld is out of range", value.u.value.u.signedInt );
                 result = false;
             }
         }

--- a/libraries/c_sdk/standard/common/include/iot_logging_setup.h
+++ b/libraries/c_sdk/standard/common/include/iot_logging_setup.h
@@ -186,13 +186,14 @@
 #else
     /* Define IotLog if the log level is greater than "none". */
     #if LIBRARY_LOG_LEVEL > IOT_LOG_NONE
-        #define IotLog( messageLevel, pLogConfig, ... ) \
-    IotLog_Generic( LIBRARY_LOG_LEVEL,                  \
-                    LIBRARY_LOG_NAME,                   \
-                    messageLevel,                       \
-                    pLogConfig,                         \
-                    __VA_ARGS__ )
-
+        #ifndef IotLog
+            #define IotLog( messageLevel, pLogConfig, ... ) \
+        IotLog_Generic( LIBRARY_LOG_LEVEL,                  \
+                        LIBRARY_LOG_NAME,                   \
+                        messageLevel,                       \
+                        pLogConfig,                         \
+                        __VA_ARGS__ )
+        #endif
 /* Define the abbreviated logging macros. */
         #define IotLogError( ... )    IotLog( IOT_LOG_ERROR, NULL, __VA_ARGS__ )
         #define IotLogWarn( ... )     IotLog( IOT_LOG_WARN, NULL, __VA_ARGS__ )
@@ -201,16 +202,21 @@
 
 /* If log level is DEBUG, enable the function to print buffers. */
         #if LIBRARY_LOG_LEVEL >= IOT_LOG_DEBUG
-            #define IotLog_PrintBuffer( pHeader, pBuffer, bufferSize ) \
-    IotLog_GenericPrintBuffer( LIBRARY_LOG_NAME,                       \
-                               pHeader,                                \
-                               pBuffer,                                \
-                               bufferSize )
+            #ifndef IotLog_PrintBuffer
+                #define IotLog_PrintBuffer( pHeader, pBuffer, bufferSize ) \
+        IotLog_GenericPrintBuffer( LIBRARY_LOG_NAME,                       \
+                                   pHeader,                                \
+                                   pBuffer,                                \
+                                   bufferSize )
+            #endif
         #else
+            #undef IotLog_PrintBuffer
             #define IotLog_PrintBuffer( pHeader, pBuffer, bufferSize )
         #endif
         /* Remove references to IotLog from the source code if logging is disabled. */
     #else /* if LIBRARY_LOG_LEVEL > IOT_LOG_NONE */
+        #undef IotLog
+        #undef IotLog_PrintBuffer
         /* @[declare_logging_log] */
         #define IotLog( messageLevel, pLogConfig, ... )
         /* @[declare_logging_log] */

--- a/libraries/c_sdk/standard/common/include/iot_logging_setup.h
+++ b/libraries/c_sdk/standard/common/include/iot_logging_setup.h
@@ -188,11 +188,11 @@
     #if LIBRARY_LOG_LEVEL > IOT_LOG_NONE
         #ifndef IotLog
             #define IotLog( messageLevel, pLogConfig, ... ) \
-        IotLog_Generic( LIBRARY_LOG_LEVEL,                  \
-                        LIBRARY_LOG_NAME,                   \
-                        messageLevel,                       \
-                        pLogConfig,                         \
-                        __VA_ARGS__ )
+    IotLog_Generic( LIBRARY_LOG_LEVEL,                      \
+                    LIBRARY_LOG_NAME,                       \
+                    messageLevel,                           \
+                    pLogConfig,                             \
+                    __VA_ARGS__ )
         #endif
 /* Define the abbreviated logging macros. */
         #define IotLogError( ... )    IotLog( IOT_LOG_ERROR, NULL, __VA_ARGS__ )
@@ -204,10 +204,10 @@
         #if LIBRARY_LOG_LEVEL >= IOT_LOG_DEBUG
             #ifndef IotLog_PrintBuffer
                 #define IotLog_PrintBuffer( pHeader, pBuffer, bufferSize ) \
-        IotLog_GenericPrintBuffer( LIBRARY_LOG_NAME,                       \
-                                   pHeader,                                \
-                                   pBuffer,                                \
-                                   bufferSize )
+    IotLog_GenericPrintBuffer( LIBRARY_LOG_NAME,                           \
+                               pHeader,                                    \
+                               pBuffer,                                    \
+                               bufferSize )
             #endif
         #else
             #undef IotLog_PrintBuffer

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -28,8 +28,6 @@
  * @brief Implementation of the user-facing functions of the FreeRTOS HTTPS Client library.
  */
 
-#include <inttypes.h>
-
 /* The config header is always included first. */
 #include "iot_config.h"
 
@@ -2000,7 +1998,7 @@ static IotHttpsReturnCode_t _receiveHttpsBody( _httpsConnection_t * pHttpsConnec
 
     HTTPS_FUNCTION_CLEANUP_BEGIN();
 
-    IotLogDebug( "The remaining content length on the network is %" PRIu64 ".",
+    IotLogDebug( "The remaining content length on the network is %llu.",
                  pHttpsResponse->httpParserInfo.responseParser.content_length );
 
     HTTPS_FUNCTION_CLEANUP_END();

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -28,6 +28,8 @@
  * @brief Implementation of the user-facing functions of the FreeRTOS HTTPS Client library.
  */
 
+#include <inttypes.h>
+
 /* The config header is always included first. */
 #include "iot_config.h"
 
@@ -943,7 +945,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
         /* If there is still more body that has not been passed back to the user, then this callback is invoked again. */
         do
         {
-            IotLogDebug( "Invoking the readReadyCallback for response %d.", pHttpsResponse );
+            IotLogDebug( "Invoking the readReadyCallback for response %p.", pHttpsResponse );
             pHttpsResponse->pCallbacks->readReadyCallback( pHttpsResponse->pUserPrivData,
                                                            pHttpsResponse,
                                                            pHttpsResponse->bodyRxStatus,
@@ -951,7 +953,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
 
             if( pHttpsResponse->cancelled == true )
             {
-                IotLogDebug( "Cancelled HTTP response %d.", pHttpsResponse );
+                IotLogDebug( "Cancelled HTTP response %p.", pHttpsResponse );
                 status = IOT_HTTPS_RECEIVE_ABORT;
 
                 /* We break out of the loop and do not goto clean up because we want to print debugging logs for
@@ -962,7 +964,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
 
         if( HTTPS_FAILED( pHttpsResponse->bodyRxStatus ) )
         {
-            IotLogError( "Error receiving the HTTP response body for response %d. Error code: %d",
+            IotLogError( "Error receiving the HTTP response body for response %p. Error code: %d",
                          pHttpsResponse,
                          pHttpsResponse->bodyRxStatus );
             /* An error in the network or the parser takes precedence  */
@@ -971,7 +973,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
 
         if( pHttpsResponse->parserState < PARSER_STATE_BODY_COMPLETE )
         {
-            IotLogDebug( "Did not receive all of the HTTP response body for response %d.",
+            IotLogDebug( "Did not receive all of the HTTP response body for response %p.",
                          pHttpsResponse );
         }
     }
@@ -1004,7 +1006,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
 
             if( HTTPS_FAILED( status ) )
             {
-                IotLogError( "Error receiving the HTTPS response body for response %d. Error code: %d.",
+                IotLogError( "Error receiving the HTTPS response body for response %p. Error code: %d.",
                              pHttpsResponse,
                              status );
                 HTTPS_GOTO_CLEANUP();
@@ -1012,7 +1014,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
         }
         else
         {
-            IotLogDebug( "Received the maximum amount of HTTP body when filling the header buffer for response %d.",
+            IotLogDebug( "Received the maximum amount of HTTP body when filling the header buffer for response %p.",
                          pHttpsResponse );
         }
 
@@ -1020,7 +1022,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
          *  The rest of body will be on the network socket. */
         if( HTTPS_SUCCEEDED( status ) && ( pHttpsResponse->parserState < PARSER_STATE_BODY_COMPLETE ) )
         {
-            IotLogError( "HTTPS response body does not fit into application provided response buffer at location 0x%x "
+            IotLogError( "HTTPS response body does not fit into application provided response buffer at location %p "
                          "with length: %d",
                          pHttpsResponse->pBody,
                          pHttpsResponse->pBodyEnd - pHttpsResponse->pBody );
@@ -1029,7 +1031,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
     }
     else
     {
-        IotLogDebug( "No response body was configure for response %d.", pHttpsResponse );
+        IotLogDebug( "No response body was configure for response %p.", pHttpsResponse );
     }
 
     HTTPS_FUNCTION_EXIT_NO_CLEANUP();
@@ -1083,7 +1085,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
     /* If the current response was cancelled, then don't bother receiving the headers and body. */
     if( pCurrentHttpsResponse->cancelled )
     {
-        IotLogDebug( "Response ID: %d was cancelled.", pCurrentHttpsResponse );
+        IotLogDebug( "Response ID: %p was cancelled.", pCurrentHttpsResponse );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_RECEIVE_ABORT );
     }
 
@@ -1101,7 +1103,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
         {
             /* There was an error parsing the HTTPS response body. This may be an indication of a server that does
              *  not adhere to protocol correctly. We should disconnect. */
-            IotLogError( "Failed to parse the HTTPS headers for response %d, Error code: %d.",
+            IotLogError( "Failed to parse the HTTPS headers for response %p, Error code: %d.",
                          pCurrentHttpsResponse,
                          status );
             fatalDisconnect = true;
@@ -1114,14 +1116,14 @@ static void _networkReceiveCallback( void * pNetworkConnection,
              * the headers or body is a timeout. We always disconnect from the network when there is a timeout because the
              * server may be slow to respond. If the server happens to send the response later at the same time another response
              * is waiting in the queue, then the workflow is corrupted. Pipelining is not current supported in this library. */
-            IotLogError( "Network error receiving the HTTPS headers for response %d. Error code: %d",
+            IotLogError( "Network error receiving the HTTPS headers for response %p. Error code: %d",
                          pCurrentHttpsResponse,
                          status );
             fatalDisconnect = true;
         }
         else /* Any other error. */
         {
-            IotLogError( "Failed to retrive the HTTPS body for response %d. Error code: %d", pCurrentHttpsResponse, status );
+            IotLogError( "Failed to retrive the HTTPS body for response %p. Error code: %d", pCurrentHttpsResponse, status );
         }
 
         HTTPS_GOTO_CLEANUP();
@@ -1130,7 +1132,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
     /* Check if we received all of the headers into the header buffer. */
     if( pCurrentHttpsResponse->parserState < PARSER_STATE_HEADERS_COMPLETE )
     {
-        IotLogDebug( "Headers received on the network did not all fit into the configured header buffer for response %d."
+        IotLogDebug( "Headers received on the network did not all fit into the configured header buffer for response %p."
                      " The length of the headers buffer is: %d",
                      pCurrentHttpsResponse,
                      pCurrentHttpsResponse->pHeadersEnd - pCurrentHttpsResponse->pHeaders );
@@ -1153,14 +1155,14 @@ static void _networkReceiveCallback( void * pNetworkConnection,
         if( status == IOT_HTTPS_RECEIVE_ABORT )
         {
             /* If the request was cancelled, this is logged, but does not close the connection. */
-            IotLogDebug( "User cancelled during the async readReadyCallback() for response %d.",
+            IotLogDebug( "User cancelled during the async readReadyCallback() for response %p.",
                          pCurrentHttpsResponse );
         }
         else if( status == IOT_HTTPS_PARSING_ERROR )
         {
             /* There was an error parsing the HTTPS response body. This may be an indication of a server that does
              *  not adhere to protocol correctly. We should disconnect. */
-            IotLogError( "Failed to parse the HTTPS body for response %d, Error code: %d.",
+            IotLogError( "Failed to parse the HTTPS body for response %p, Error code: %d.",
                          pCurrentHttpsResponse,
                          status );
             fatalDisconnect = true;
@@ -1169,14 +1171,14 @@ static void _networkReceiveCallback( void * pNetworkConnection,
         {
             /* We always disconnect for a network error because failure to receive the HTTPS body will result in a
              * corruption of the workflow. */
-            IotLogError( "Network error receiving the HTTPS body for response %d. Error code: %d",
+            IotLogError( "Network error receiving the HTTPS body for response %p. Error code: %d",
                          pCurrentHttpsResponse,
                          status );
             fatalDisconnect = true;
         }
         else /* Any other error. */
         {
-            IotLogError( "Failed to retrive the HTTPS body for response %d. Error code: %d", pCurrentHttpsResponse, status );
+            IotLogError( "Failed to retrive the HTTPS body for response %p. Error code: %d", pCurrentHttpsResponse, status );
         }
 
         HTTPS_GOTO_CLEANUP();
@@ -1217,7 +1219,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
      * flushing the network. If the network is being disconnected we also do not schedule any pending requests. */
     if( fatalDisconnect || pCurrentHttpsResponse->isNonPersistent )
     {
-        IotLogDebug( "Disconnecting response %d.", pCurrentHttpsResponse );
+        IotLogDebug( "Disconnecting response %p.", pCurrentHttpsResponse );
         disconnectStatus = IotHttpsClient_Disconnect( pHttpsConnection );
 
         if( ( pCurrentHttpsResponse != NULL ) && pCurrentHttpsResponse->isAsync && pCurrentHttpsResponse->pCallbacks->connectionClosedCallback )
@@ -1227,7 +1229,7 @@ static void _networkReceiveCallback( void * pNetworkConnection,
 
         if( HTTPS_FAILED( disconnectStatus ) )
         {
-            IotLogWarn( "Failed to disconnect response %d. Error code: %d.", pCurrentHttpsResponse, disconnectStatus );
+            IotLogWarn( "Failed to disconnect response %p. Error code: %d.", pCurrentHttpsResponse, disconnectStatus );
         }
 
         /* If we disconnect, we do not process anymore requests. */
@@ -1271,13 +1273,13 @@ static void _networkReceiveCallback( void * pNetworkConnection,
 
             if( pNextHttpsRequest->scheduled == false )
             {
-                IotLogDebug( "Request %d is next in the queue. Now scheduling a task to send the request.", pNextHttpsRequest );
+                IotLogDebug( "Request %p is next in the queue. Now scheduling a task to send the request.", pNextHttpsRequest );
                 scheduleStatus = _scheduleHttpsRequestSend( pNextHttpsRequest );
 
                 /* If there was an error with scheduling the new task, then report it. */
                 if( HTTPS_FAILED( scheduleStatus ) )
                 {
-                    IotLogError( "Error scheduling HTTPS request %d. Error code: %d", pNextHttpsRequest, scheduleStatus );
+                    IotLogError( "Error scheduling HTTPS request %p. Error code: %d", pNextHttpsRequest, scheduleStatus );
 
                     if( pNextHttpsRequest->isAsync && pNextHttpsRequest->pCallbacks->errorCallback )
                     {
@@ -1649,7 +1651,7 @@ static IotHttpsReturnCode_t _networkRecv( _httpsConnection_t * pHttpsConnection,
                                                                       pBuf,
                                                                       bufLen );
 
-    IotLogDebug( "The network interface receive returned %d.", numBytesRecv );
+    IotLogDebug( "The network interface receive returned %d.", *numBytesRecv );
 
     /* We return IOT_HTTPS_NETWORK_ERROR only if we receive nothing. Receiving less
      * data than requested is okay because it is not known in advance how much data
@@ -1761,7 +1763,7 @@ static IotHttpsReturnCode_t _sendHttpsBody( _httpsConnection_t * pHttpsConnectio
 
     if( HTTPS_FAILED( status ) )
     {
-        IotLogError( "Error sending final HTTPS body at location 0x%x. Error code: %d", pBodyBuf, status );
+        IotLogError( "Error sending final HTTPS body at location %p. Error code: %d", pBodyBuf, status );
         HTTPS_GOTO_CLEANUP();
     }
 
@@ -1998,7 +2000,7 @@ static IotHttpsReturnCode_t _receiveHttpsBody( _httpsConnection_t * pHttpsConnec
 
     HTTPS_FUNCTION_CLEANUP_BEGIN();
 
-    IotLogDebug( "The remaining content length on the network is %d.",
+    IotLogDebug( "The remaining content length on the network is %" PRIu64 ".",
                  pHttpsResponse->httpParserInfo.responseParser.content_length );
 
     HTTPS_FUNCTION_CLEANUP_END();
@@ -2080,7 +2082,7 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
         HTTPS_GOTO_CLEANUP();
     }
 
-    IotLogDebug( "Sent HTTPS headers for request %d.", pHttpsRequest );
+    IotLogDebug( "Sent HTTPS headers for request %p.", pHttpsRequest );
 
     if( ( pHttpsRequest->pBody != NULL ) && ( pHttpsRequest->bodyLength > 0 ) )
     {
@@ -2092,7 +2094,7 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
             HTTPS_GOTO_CLEANUP();
         }
 
-        IotLogDebug( "Sent HTTPS body for request %d.", pHttpsRequest );
+        IotLogDebug( "Sent HTTPS body for request %p.", pHttpsRequest );
     }
 
     HTTPS_FUNCTION_EXIT_NO_CLEANUP();
@@ -2117,11 +2119,11 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
     ( void ) pTaskPool;
     ( void ) pJob;
 
-    IotLogDebug( "Task with request ID: %d started.", pHttpsRequest );
+    IotLogDebug( "Task with request ID: %p started.", pHttpsRequest );
 
     if( pHttpsRequest->cancelled == true )
     {
-        IotLogDebug( "Request ID: %d was cancelled.", pHttpsRequest );
+        IotLogDebug( "Request ID: %p was cancelled.", pHttpsRequest );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_SEND_ABORT );
     }
 
@@ -2143,7 +2145,7 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
 
     if( pHttpsRequest->cancelled == true )
     {
-        IotLogDebug( "Request ID: %d was cancelled.", pHttpsRequest );
+        IotLogDebug( "Request ID: %p was cancelled.", pHttpsRequest );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_SEND_ABORT );
     }
 
@@ -2165,7 +2167,7 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
 
     if( pHttpsRequest->cancelled == true )
     {
-        IotLogDebug( "Request ID: %d was cancelled.", pHttpsRequest );
+        IotLogDebug( "Request ID: %p was cancelled.", pHttpsRequest );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_SEND_ABORT );
     }
 
@@ -2221,7 +2223,7 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
          * closed. */
         if( status == IOT_HTTPS_NETWORK_ERROR )
         {
-            IotLogDebug( "Disconnecting request %d.", pHttpsRequest );
+            IotLogDebug( "Disconnecting request %p.", pHttpsRequest );
             disconnectStatus = IotHttpsClient_Disconnect( pHttpsConnection );
 
             if( pHttpsRequest->isAsync && pHttpsRequest->pCallbacks->connectionClosedCallback )
@@ -2233,7 +2235,7 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
 
             if( HTTPS_FAILED( disconnectStatus ) )
             {
-                IotLogWarn( "Failed to disconnect request %d. Error code: %d.", pHttpsRequest, disconnectStatus );
+                IotLogWarn( "Failed to disconnect request %p. Error code: %d.", pHttpsRequest, disconnectStatus );
             }
         }
         else
@@ -2258,13 +2260,13 @@ static void _sendHttpsRequest( IotTaskPool_t pTaskPool,
 
                 if( pNextHttpsRequest->scheduled == false )
                 {
-                    IotLogDebug( "Request %d is next in the queue. Now scheduling a task to send the request.", pNextHttpsRequest );
+                    IotLogDebug( "Request %p is next in the queue. Now scheduling a task to send the request.", pNextHttpsRequest );
                     scheduleStatus = _scheduleHttpsRequestSend( pNextHttpsRequest );
 
                     /* If there was an error with scheduling the new task, then report it. */
                     if( HTTPS_FAILED( scheduleStatus ) )
                     {
-                        IotLogError( "Error scheduling HTTPS request %d. Error code: %d", pNextHttpsRequest, scheduleStatus );
+                        IotLogError( "Error scheduling HTTPS request %p. Error code: %d", pNextHttpsRequest, scheduleStatus );
 
                         if( pNextHttpsRequest->isAsync && pNextHttpsRequest->pCallbacks->errorCallback )
                         {
@@ -2345,24 +2347,24 @@ IotHttpsReturnCode_t _addRequestToConnectionReqQ( _httpsRequest_t * pHttpsReques
     bool scheduleRequest = false;
 
     /* Log information about the request*/
-    IotLogDebug( "Now queueing request %d.", pHttpsRequest );
+    IotLogDebug( "Now queueing request %p.", pHttpsRequest );
 
     if( pHttpsRequest->isNonPersistent )
     {
-        IotLogDebug( "Request %d is non-persistent.", pHttpsRequest );
+        IotLogDebug( "Request %p is non-persistent.", pHttpsRequest );
     }
     else
     {
-        IotLogDebug( "Request %d is persistent. ", pHttpsRequest );
+        IotLogDebug( "Request %p is persistent. ", pHttpsRequest );
     }
 
     if( pHttpsRequest->isAsync )
     {
-        IotLogDebug( " Request %d is asynchronous.", pHttpsRequest );
+        IotLogDebug( " Request %p is asynchronous.", pHttpsRequest );
     }
     else
     {
-        IotLogDebug( " Request %d is synchronous.", pHttpsRequest );
+        IotLogDebug( " Request %p is synchronous.", pHttpsRequest );
     }
 
     /* This is a new request and has not been scheduled if this routine is called. */
@@ -2396,7 +2398,7 @@ IotHttpsReturnCode_t _addRequestToConnectionReqQ( _httpsRequest_t * pHttpsReques
 
         if( HTTPS_FAILED( status ) )
         {
-            IotLogError( "Failed to schedule the request in the queue for request %d. Error code: %d", pHttpsRequest, status );
+            IotLogError( "Failed to schedule the request in the queue for request %p. Error code: %d", pHttpsRequest, status );
 
             /* If we fail to schedule the only request in the queue we should remove it. */
             IotMutex_Lock( &( pHttpsConnection->connectionMutex ) );
@@ -2641,7 +2643,7 @@ IotHttpsReturnCode_t IotHttpsClient_Disconnect( IotHttpsConnectionHandle_t connH
     if( pRespItem != NULL )
     {
         pHttpsResponse = IotLink_Container( _httpsResponse_t, pRespItem, link );
-        IotLogDebug( "Response %d found in the queue during disconnect.", pHttpsResponse );
+        IotLogDebug( "Response %p found in the queue during disconnect.", pHttpsResponse );
 
         if( pHttpsResponse->reqFinishedSending == false )
         {
@@ -2878,13 +2880,13 @@ IotHttpsReturnCode_t IotHttpsClient_AddHeader( IotHttpsRequestHandle_t reqHandle
     /* Check for name long enough for header length calculation to overflow */
     HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP( nameLen <= ( UINT32_MAX >> 2 ),
                                          IOT_HTTPS_INVALID_PARAMETER,
-                                         "Attempting to generate headers with name length %d > %d. This is not allowed.",
+                                         "Attempting to generate headers with name length %u > %lu. This is not allowed.",
                                          nameLen, UINT32_MAX >> 2 );
 
     /* Check for value long enough for header length calculation to overflow */
     HTTPS_ON_ARG_ERROR_MSG_GOTO_CLEANUP( valueLen <= ( UINT32_MAX >> 2 ),
                                          IOT_HTTPS_INVALID_PARAMETER,
-                                         "Attempting to generate headers with value length %d > %d. This is not allowed.",
+                                         "Attempting to generate headers with value length %u > %lu. This is not allowed.",
                                          valueLen, UINT32_MAX >> 2 );
 
     /* Check for auto-generated header "Content-Length". This header is created and send automatically when right before
@@ -2960,7 +2962,7 @@ IotHttpsReturnCode_t IotHttpsClient_SendSync( IotHttpsConnectionHandle_t connHan
 
     if( HTTPS_FAILED( status ) )
     {
-        IotLogError( "Failed to initialize the response on the synchronous request %d.", reqHandle );
+        IotLogError( "Failed to initialize the response on the synchronous request %p.", reqHandle );
         HTTPS_GOTO_CLEANUP();
     }
 
@@ -3196,7 +3198,7 @@ IotHttpsReturnCode_t IotHttpsClient_SendAsync( IotHttpsConnectionHandle_t connHa
 
     if( HTTPS_FAILED( status ) )
     {
-        IotLogError( "Failed to initialize the response on the synchronous request %d.", reqHandle );
+        IotLogError( "Failed to initialize the response on the synchronous request %p.", reqHandle );
         HTTPS_GOTO_CLEANUP();
     }
 
@@ -3214,7 +3216,7 @@ IotHttpsReturnCode_t IotHttpsClient_SendAsync( IotHttpsConnectionHandle_t connHa
 
     if( HTTPS_FAILED( status ) )
     {
-        IotLogError( "Failed to add request %d to the connection's request queue. Error code: %d.", reqHandle, status );
+        IotLogError( "Failed to add request %p to the connection's request queue. Error code: %d.", reqHandle, status );
         HTTPS_GOTO_CLEANUP();
     }
 

--- a/libraries/c_sdk/standard/mqtt/src/iot_ble_mqtt_serialize.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_ble_mqtt_serialize.c
@@ -27,6 +27,9 @@
  * @file iot_ble_mqtt_serialize.c
  * @brief MQTT library for BLE.
  */
+
+#include <inttypes.h>
+
 /* The config header is always included first. */
 #include "iot_config.h"
 
@@ -1208,7 +1211,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 case 0x02:
                     IotLog( IOT_LOG_DEBUG,
                             &_logHideAll,
-                            "Topic accepted, max QoS %hhu.", subscriptionStatus );
+                            "Topic accepted, max QoS %" PRId64 ".", subscriptionStatus );
                     ret = IOT_MQTT_SUCCESS;
                     break;
 
@@ -1228,7 +1231,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 default:
                     IotLog( IOT_LOG_DEBUG,
                             &_logHideAll,
-                            "Bad SUBSCRIBE status %hhu.", subscriptionStatus );
+                            "Bad SUBSCRIBE status %" PRId64 ".", subscriptionStatus );
 
                     ret = IOT_MQTT_BAD_RESPONSE;
                     break;

--- a/libraries/c_sdk/standard/mqtt/src/iot_ble_mqtt_serialize.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_ble_mqtt_serialize.c
@@ -28,8 +28,6 @@
  * @brief MQTT library for BLE.
  */
 
-#include <inttypes.h>
-
 /* The config header is always included first. */
 #include "iot_config.h"
 
@@ -1162,7 +1160,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
 {
     IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
     IotSerializerError_t error;
-    int64_t subscriptionStatus;
+    uint8_t subscriptionStatus;
     IotMqttError_t ret = IOT_MQTT_SUCCESS;
 
     error = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pSuback->pRemainingData, pSuback->remainingLength );
@@ -1202,7 +1200,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
         }
         else
         {
-            subscriptionStatus = ( uint16_t ) decoderValue.u.value.u.signedInt;
+            subscriptionStatus = ( uint8_t ) decoderValue.u.value.u.signedInt;
 
             switch( subscriptionStatus )
             {
@@ -1211,7 +1209,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 case 0x02:
                     IotLog( IOT_LOG_DEBUG,
                             &_logHideAll,
-                            "Topic accepted, max QoS %" PRId64 ".", subscriptionStatus );
+                            "Topic accepted, max QoS %hhu.", subscriptionStatus );
                     ret = IOT_MQTT_SUCCESS;
                     break;
 
@@ -1231,7 +1229,7 @@ IotMqttError_t IotBleMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 default:
                     IotLog( IOT_LOG_DEBUG,
                             &_logHideAll,
-                            "Bad SUBSCRIBE status %" PRId64 ".", subscriptionStatus );
+                            "Bad SUBSCRIBE status %hhu.", subscriptionStatus );
 
                     ret = IOT_MQTT_BAD_RESPONSE;
                     break;

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -168,7 +168,7 @@ static bool _checkRetryLimit( _mqttOperation_t * pOperation )
          * accounts for the final check for a PUBACK. */
         IotMqtt_Assert( pOperation->u.operation.retry.count == pOperation->u.operation.retry.limit + 1 );
 
-        IotLogDebug( "(MQTT connection %p, PUBLISH operation %p) No response received after %lu retries.",
+        IotLogDebug( "(MQTT connection %p, PUBLISH operation %p) No response received after %u retries.",
                      pMqttConnection,
                      pOperation,
                      pOperation->u.operation.retry.limit );
@@ -505,7 +505,7 @@ bool _IotMqtt_DecrementOperationReferences( _mqttOperation_t * pOperation,
         pOperation->u.operation.jobReference--;
 
         IotLogDebug( "(MQTT connection %p, %s operation %p) Job reference changed"
-                     " from %ld to %ld.",
+                     " from %d to %d.",
                      pMqttConnection,
                      IotMqtt_OperationType( pOperation->u.operation.type ),
                      pOperation,
@@ -563,8 +563,7 @@ void _IotMqtt_DestroyOperation( _mqttOperation_t * pOperation )
         IotLogDebug( "(MQTT connection %p, %s operation %p) Removed operation from connection lists.",
                      pMqttConnection,
                      IotMqtt_OperationType( pOperation->u.operation.type ),
-                     pOperation,
-                     pMqttConnection );
+                     pOperation );
 
         IotListDouble_Remove( &( pOperation->link ) );
     }


### PR DESCRIPTION
Fix Format specifier warnings
Allow logging override for log library.

Description
-----------

This PR contains changes enable overriding IotLog macro with a custom logging function by defining it in `iot_config.h`.
Also the PR aims to fix format specifier warnings like:

- Incorrect number of arguments to logger.
- Incorrect format specifier types

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.