### PR TITLE
Support OTA data over HTTP together with BLE on ESP32 when SPIRAM is enabled

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ota/aws_ota_pal.c
+++ b/vendors/espressif/boards/esp32/ports/ota/aws_ota_pal.c
@@ -47,9 +47,12 @@
 #define kOTA_HalfSecondDelay    pdMS_TO_TICKS( 500UL )
 #define ECDSA_INTEGER_LEN       32
 
+/* Check configuration for memory constraints provided SPIRAM is not enabled */
+#if !CONFIG_SPIRAM_SUPPORT
 #if (configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP) && (configENABLED_NETWORKS & AWSIOT_NETWORK_TYPE_BLE)
     #error "Cannot enable OTA data over HTTP together with BLE because of not enough heap."
 #endif
+#endif // !CONFIG_SPIRAM_SUPPORT
 
 /*
  * Includes 4 bytes of version field, followed by 64 bytes of signature


### PR DESCRIPTION


<!--- Title -->

Description
-----------
When SPIRAM is enabled, available heap is enough to support OTA data over HTTP along with BLE.

Hence, memory constraints should be checked only when SPIRAM is disabled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.