### PR TITLE
Change Default Winsim Test Port to 0

### DIFF
--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSConfig.h
@@ -171,7 +171,7 @@ extern void vLoggingPrint( const char * pcMessage );
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE       ( 3L )
+#define configNETWORK_INTERFACE_TO_USE       ( 0L )
 
 /* The address of an echo server that will be used by the two demo echo client
  * tasks:


### PR DESCRIPTION
Currently the winsim test project is configured to network adapter 3. If this adapter is incorrect for your windows PC, the project will seemingly
get stuck after successfully opening the network port. This issue is very hard to debug, as the project appears to just be frozen. If we configure this
network port to 0, the test project will be unable to open the network adapter, and print a helpful error message that helps the user configure it to the right
network adapter.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.