### PR TITLE
Separate old shadow unit test

### DIFF
--- a/libraries/c_sdk/aws/shadow/test/aws_test_shadow.c
+++ b/libraries/c_sdk/aws/shadow/test/aws_test_shadow.c
@@ -84,23 +84,37 @@ BaseType_t prvTestDeleteCallback( const char * const pcThingName,
                                   MQTTBufferHandle_t xBuffer );
 
 
+TEST_GROUP( Full_Shadow_Unit );
 TEST_GROUP( Full_Shadow );
 
+TEST_SETUP( Full_Shadow_Unit )
+{
+    TEST_ASSERT_EQUAL( true, IotSdk_Init() );
+    TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, IotMqtt_Init() );
+}
 TEST_SETUP( Full_Shadow )
 {
     TEST_ASSERT_EQUAL( true, IotSdk_Init() );
     TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, IotMqtt_Init() );
 }
 
+TEST_TEAR_DOWN( Full_Shadow_Unit )
+{
+    IotMqtt_Cleanup();
+    IotSdk_Cleanup();
+}
 TEST_TEAR_DOWN( Full_Shadow )
 {
     IotMqtt_Cleanup();
     IotSdk_Cleanup();
 }
 
+TEST_GROUP_RUNNER( Full_Shadow_Unit )
+{
+    RUN_TEST_CASE( Full_Shadow_Unit, ClientCreateDelete );
+}
 TEST_GROUP_RUNNER( Full_Shadow )
 {
-    RUN_TEST_CASE( Full_Shadow, ClientCreateDelete );
     RUN_TEST_CASE( Full_Shadow, ClientConnectDisconnect );
     RUN_TEST_CASE( Full_Shadow, CreateShadowDocument );
     RUN_TEST_CASE( Full_Shadow, DeleteShadowDocument );
@@ -196,7 +210,7 @@ void TEST_SHADOW_Connect_Helper( MQTTAgentConnectParams_t * xConnectParams,
 }
 
 /* Test for shadow client create and delete api */
-TEST( Full_Shadow, ClientCreateDelete )
+TEST( Full_Shadow_Unit, ClientCreateDelete )
 {
     /*Init required params and shadow library for test.*/
     ShadowClientHandle_t xShadowClientHandle;

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -92,6 +92,7 @@ static void RunTests( void )
     #endif
 
     #if ( testrunnerFULL_SHADOW_ENABLED == 1 )
+        RUN_TEST_GROUP( Full_Shadow_Unit );
         RUN_TEST_GROUP( Full_Shadow );
     #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Creates a new unit test group for the Shadow `ClientCreateDelete` test, which is part of the old Shadow API. The tests were kept in the same file to follow the same pattern as [MQTT](https://github.com/aws/amazon-freertos/blob/master/libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c), where all test groups for the v1 API are in a single file. The `Shadow_Unit_` prefix was not used for the test groups to avoid confusion with the v4 Shadow API, which uses those group names.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.