### PR TITLE
BLE data transfer: Remove read permission on RX char

### DIFF
--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -102,8 +102,8 @@
             .xCharacteristic =                                                        \
             {                                                                         \
                 .xUuid        = _UUID128( _RX_CHAR_UUID( identifier ) ),              \
-                .xPermissions = ( IOT_BLE_CHAR_READ_PERM | IOT_BLE_CHAR_WRITE_PERM ), \
-                .xProperties  = ( eBTPropRead | eBTPropWrite )                        \
+                .xPermissions = ( IOT_BLE_CHAR_WRITE_PERM ),                          \
+                .xProperties  = ( eBTPropWrite )                                      \
             }                                                                         \
         },                                                                            \
         {                                                                             \
@@ -128,8 +128,8 @@
             .xCharacteristic =                                                        \
             {                                                                         \
                 .xUuid        = _UUID128( _RX_LARGE_UUID( identifier ) ),             \
-                .xPermissions = ( IOT_BLE_CHAR_READ_PERM | IOT_BLE_CHAR_WRITE_PERM ), \
-                .xProperties  = ( eBTPropRead | eBTPropWrite )                        \
+                .xPermissions = ( IOT_BLE_CHAR_WRITE_PERM ),                          \
+                .xProperties  = ( eBTPropWrite )                                      \
             }                                                                         \
         }                                                                             \
     }

--- a/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
+++ b/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
@@ -499,7 +499,7 @@ void setUp( void )
     IotBle_RegisterEventCb_Stub( IotBle_RegisterEventCb_Callback );
     IotBle_UnRegisterEventCb_Stub( IotBle_UnregisterEventCb_Callback );
 
-      n_ble_response_calls = 0;
+    n_ble_send_response_calls = 0;
 
     IotLog_Generic_Ignore();
 }
@@ -1280,8 +1280,7 @@ void test_RXMesgCharCallback_Read( void )
     IotBleDataTransferChannel_t * pChannel = get_open_channel( service_variant );
     IotBleDataTransfer_SetCallback( pChannel, channel_callback, NULL );
 
-    IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
-    uint8_t msg[] = "Invalid read on RX characteristic";
+    IotBle_SendResponse_Stub( IotBle_SendResponse_Callback );
     generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR );
     TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }
@@ -1394,9 +1393,7 @@ void test_RXLargeMesgCharCallback_Read( void )
     IotBleDataTransferChannel_t * pChannel = get_open_channel( service_variant );
     IotBleDataTransfer_SetCallback( pChannel, channel_callback, NULL );
 
-    IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
-    uint8_t msg[ get_max_data_len() / 2 ];
-    memset( msg, 0xDC, sizeof( msg ) );
+    IotBle_SendResponse_Stub( IotBle_SendResponse_Callback );
     generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_LARGE_CHAR );
     TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }

--- a/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
+++ b/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
@@ -33,7 +33,7 @@ void initCallbacks();
  ******************************************************************************/
 static int32_t malloc_free_calls = 0;
 static uint32_t n_dummy_callback_calls = 0;
-
+static uint32_t n_ble_send_response_calls = 0;
 
 
 /*******************************************************************************
@@ -469,6 +469,16 @@ static BTStatus_t IotBle_UnregisterEventCb_Callback( IotBleEvents_t event,
     return eBTStatusSuccess;
 }
 
+static BTStatus_t IotBle_SendResponse_Callback( IotBleEventResponse_t * pResp,
+                                                uint16_t connId,
+                                                uint32_t transId,
+                                                int numCalls )
+{
+
+    n_ble_send_response_calls++;
+    return eBTStatusSuccess;
+}
+
 /*******************************************************************************
  * Unity fixtures
  ******************************************************************************/
@@ -488,6 +498,8 @@ void setUp( void )
 
     IotBle_RegisterEventCb_Stub( IotBle_RegisterEventCb_Callback );
     IotBle_UnRegisterEventCb_Stub( IotBle_UnregisterEventCb_Callback );
+
+      n_ble_response_calls = 0;
 
     IotLog_Generic_Ignore();
 }
@@ -1223,7 +1235,6 @@ void test_RXMesgCharCallback_HappyPath( void )
     generate_client_write_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR, msg, sizeof( msg ), true );
 }
 
-
 /**
  * @brief Client sends message that was couldn't fit within current MTU.
  */
@@ -1254,6 +1265,25 @@ void test_RXMesgCharCallback_WithCloseChannel( void )
 
     uint8_t msg[] = "This is test data";
     generate_client_write_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR, msg, sizeof( msg ), false );
+}
+
+
+/**
+ * @brief Read request on RX characteristic is invalid and should not
+ * trigger a response from datatransfer service.
+ */
+void test_RXMesgCharCallback_Read( void )
+{
+    const uint8_t service_variant = IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT;
+
+    init_transfers();
+    IotBleDataTransferChannel_t * pChannel = get_open_channel( service_variant );
+    IotBleDataTransfer_SetCallback( pChannel, channel_callback, NULL );
+
+    IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
+    uint8_t msg[] = "Invalid read on RX characteristic";
+    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR, msg, sizeof( msg ), true );
+    TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }
 
 /**
@@ -1350,6 +1380,25 @@ void test_RXLargeMesgCharCallback_WithServiceDNE( void )
 
     init_transfers();
     generate_client_write_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_LARGE_CHAR, NULL, 0, false );
+}
+
+/**
+ * @brief Read request on RX Large characteristic is invalid and should not
+ * trigger a response from datatransfer service.
+ */
+void test_RXLargeMesgCharCallback_Read( void )
+{
+     const uint8_t service_variant = IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT;
+
+    init_transfers();
+    IotBleDataTransferChannel_t * pChannel = get_open_channel( service_variant );
+    IotBleDataTransfer_SetCallback( pChannel, channel_callback, NULL );
+
+    IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
+    uint8_t msg[ get_max_data_len() / 2 ];
+    memset( msg, 0xDC, sizeof( msg ) );
+    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_LARGE_CHAR, msg, sizeof( msg ), true );
+    TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }
 
 /**

--- a/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
+++ b/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
@@ -474,7 +474,6 @@ static BTStatus_t IotBle_SendResponse_Callback( IotBleEventResponse_t * pResp,
                                                 uint32_t transId,
                                                 int numCalls )
 {
-
     n_ble_send_response_calls++;
     return eBTStatusSuccess;
 }
@@ -1387,7 +1386,7 @@ void test_RXLargeMesgCharCallback_WithServiceDNE( void )
  */
 void test_RXLargeMesgCharCallback_Read( void )
 {
-     const uint8_t service_variant = IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT;
+    const uint8_t service_variant = IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT;
 
     init_transfers();
     IotBleDataTransferChannel_t * pChannel = get_open_channel( service_variant );

--- a/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
+++ b/libraries/c_sdk/standard/ble/utest/iot_ble_data_transfer_utest.c
@@ -1282,7 +1282,7 @@ void test_RXMesgCharCallback_Read( void )
 
     IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
     uint8_t msg[] = "Invalid read on RX characteristic";
-    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR, msg, sizeof( msg ), true );
+    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_CHAR );
     TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }
 
@@ -1397,7 +1397,7 @@ void test_RXLargeMesgCharCallback_Read( void )
     IotBle_SendResponse_StubAndCallback( IotBle_SendResponse_Callback );
     uint8_t msg[ get_max_data_len() / 2 ];
     memset( msg, 0xDC, sizeof( msg ) );
-    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_LARGE_CHAR, msg, sizeof( msg ), true );
+    generate_client_read_event( service_variant, IOT_BLE_DATA_TRANSFER_RX_LARGE_CHAR );
     TEST_ASSERT_EQUAL( 0, n_ble_send_response_calls );
 }
 


### PR DESCRIPTION
Remove read permission on RX char.
PR Fixes #1845 

Description
-----------
Read permission is not required for RX characteristics as its used to write data to the device.

Added unit tests to catch this behavior.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.