### PR TITLE
TEST: fix race condition in Unit test

### DIFF
--- a/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
+++ b/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
@@ -1118,7 +1118,7 @@ static void vTaskDelete_cb( TaskHandle_t task_handle,
                             int num_calls )
 {
     free_cb( handle, 1 );
-    task_kill( tsk );
+    /*task_kill( tsk ); */
 }
 
 /* helper function to create a fake implementation of xTaskCreate */
@@ -1175,7 +1175,6 @@ void test_SecureSockets_SetSockOpt_wakeup_callback_socket_close( void )
     event_wait( callback_event );
     deinitSocket( s_so );
     task_join( tsk );
-
     event_delete( callback_event );
 }
 
@@ -1224,8 +1223,6 @@ void test_SecureSockets_SetSockOpt_wakeup_callback( void )
     int32_t ret;
     void * option = &taskComplete_cb; /* user callback for socket event */
 
-    callback_event = event_create();
-
     xTaskCreate_Stub( xTaskCreate_cb );
     so = initSocket();
 
@@ -1236,7 +1233,6 @@ void test_SecureSockets_SetSockOpt_wakeup_callback( void )
     deinitSocket( so );
     TEST_ASSERT_TRUE( userCallback_called );
     userCallback_called = false;
-    event_delete( callback_event );
     free_cb( handle, 1 );
 }
 

--- a/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
+++ b/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
@@ -1118,7 +1118,7 @@ static void vTaskDelete_cb( TaskHandle_t task_handle,
                             int num_calls )
 {
     free_cb( handle, 1 );
-    /*task_kill( tsk ); */
+    task_kill( tsk );
 }
 
 /* helper function to create a fake implementation of xTaskCreate */

--- a/tests/unit_test/linux/CMakeLists.txt
+++ b/tests/unit_test/linux/CMakeLists.txt
@@ -46,8 +46,8 @@
                 )
     set_target_properties(utils PROPERTIES
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-            COMPILE_FLAGS "-Wall -Og -pthread"
-            LINK_FLAGS "-Wall -Og -pthread -lpthread"
+            COMPILE_FLAGS "-Wall -Og -pthread -ggdb3"
+            LINK_FLAGS "-Wall -Og -pthread -lpthread -ggdb3"
         )
 
     # add unit test subdirectories here

--- a/tests/unit_test/linux/CMakeLists.txt
+++ b/tests/unit_test/linux/CMakeLists.txt
@@ -23,7 +23,6 @@
     set_target_properties(cmock PROPERTIES
             ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
             POSITION_INDEPENDENT_CODE ON
-            COMPILE_FLAGS "-Og"
         )
 
     add_library(unity STATIC
@@ -32,7 +31,6 @@
     set_target_properties(unity PROPERTIES
             ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
             POSITION_INDEPENDENT_CODE ON
-            COMPILE_FLAGS "-Og"
         )
 
     target_include_directories(cmock PUBLIC
@@ -44,10 +42,12 @@
                 ${CMAKE_CURRENT_LIST_DIR}/utils/wait_for_event.c
                 ${CMAKE_CURRENT_LIST_DIR}/utils/task_control.c
                 )
+    message ( "debug flags are ${CMAKE_C_FLAGS}")
+    message ( "c flags are ${CFLAGS}")
+    message ( "debug flags debug  are ${CMAKE_C_FLAGS_DEBUG}")
     set_target_properties(utils PROPERTIES
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-            COMPILE_FLAGS "-Wall -Og -pthread -ggdb3"
-            LINK_FLAGS "-Wall -Og -pthread -lpthread -ggdb3"
+            LINK_FLAGS " -pthread"
         )
 
     # add unit test subdirectories here

--- a/tests/unit_test/linux/CMakeLists.txt
+++ b/tests/unit_test/linux/CMakeLists.txt
@@ -23,6 +23,7 @@
     set_target_properties(cmock PROPERTIES
             ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
             POSITION_INDEPENDENT_CODE ON
+            COMPILE_FLAGS "-Og"
         )
 
     add_library(unity STATIC
@@ -42,13 +43,15 @@
                 ${CMAKE_CURRENT_LIST_DIR}/utils/wait_for_event.c
                 ${CMAKE_CURRENT_LIST_DIR}/utils/task_control.c
                 )
-    message ( "debug flags are ${CMAKE_C_FLAGS}")
-    message ( "c flags are ${CFLAGS}")
-    message ( "debug flags debug  are ${CMAKE_C_FLAGS_DEBUG}")
     set_target_properties(utils PROPERTIES
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
             LINK_FLAGS " -pthread"
         )
+#set_target_properties(utils PROPERTIES
+#            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+#            COMPILE_FLAGS "-Wall -Og -pthread -ggdb3"
+#            LINK_FLAGS "-Wall -Og -pthread -lpthread -ggdb3"
+#        )
 
     # add unit test subdirectories here
     add_subdirectory(../../../libraries libraries)

--- a/tests/unit_test/linux/CMakeLists.txt
+++ b/tests/unit_test/linux/CMakeLists.txt
@@ -47,11 +47,6 @@
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
             LINK_FLAGS " -pthread"
         )
-#set_target_properties(utils PROPERTIES
-#            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-#            COMPILE_FLAGS "-Wall -Og -pthread -ggdb3"
-#            LINK_FLAGS "-Wall -Og -pthread -lpthread -ggdb3"
-#        )
 
     # add unit test subdirectories here
     add_subdirectory(../../../libraries libraries)

--- a/tests/unit_test/linux/utils/task_control.c
+++ b/tests/unit_test/linux/utils/task_control.c
@@ -12,12 +12,15 @@ struct task * task_create( task_callback tc,
     int ret;
     struct task * t = malloc( sizeof( struct task ) );
 
-    ret = pthread_create( &t->tid, NULL, ( void *( * )( void * ) )tc, arg );
-
-    if( ret != 0 )
+    if( t != NULL )
     {
-        free( t );
-        return NULL;
+        ret = pthread_create( &t->tid, NULL, ( void *( * )( void * ) )tc, arg );
+
+        if( ret != 0 )
+        {
+            free( t );
+            t = NULL;
+        }
     }
 
     return t;
@@ -26,10 +29,10 @@ struct task * task_create( task_callback tc,
 void task_join( struct task * t )
 {
     pthread_join( t->tid, NULL );
+    free( t );
 }
 
 void task_kill( struct task * t )
 {
-    free( t );
     pthread_exit( NULL );
 }

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -83,7 +83,6 @@ function(create_mock_list mock_name mock_list)
                                ${mocks_dir}
             )
     set_target_properties(${mock_name} PROPERTIES
-                        LINK_FLAGS "-fPIC"
                         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                         POSITION_INDEPENDENT_CODE ON
             )

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -16,7 +16,7 @@ function(create_test test_name test_src link_list dep_list)
     set_target_properties(${test_name} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
             INSTALL_RPATH_USE_LINK_PATH TRUE
-            LINK_FLAGS "-Og -ggdb3 \
+            LINK_FLAGS " \
                 -Wl,-rpath,${CMAKE_BINARY_DIR}/lib \
                 -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}/lib"
         )
@@ -83,7 +83,7 @@ function(create_mock_list mock_name mock_list)
                                ${mocks_dir}
             )
     set_target_properties(${mock_name} PROPERTIES
-                        LINK_FLAGS "-ggdb3 -fPIC -Og"
+                        LINK_FLAGS "-fPIC"
                         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                         POSITION_INDEPENDENT_CODE ON
             )

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -14,7 +14,6 @@ function(create_test test_name test_src link_list dep_list)
         )
     add_executable(${test_name} ${test_src} ${test_name}_runner.c)
     set_target_properties(${test_name} PROPERTIES
-            COMPILE_FLAGS "-ggdb3 -Og -Wall"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
             INSTALL_RPATH_USE_LINK_PATH TRUE
             LINK_FLAGS "-Og -ggdb3 \
@@ -84,7 +83,6 @@ function(create_mock_list mock_name mock_list)
                                ${mocks_dir}
             )
     set_target_properties(${mock_name} PROPERTIES
-                        COMPILE_FLAGS "-ggdb3 -Og -fPIC"
                         LINK_FLAGS "-ggdb3 -fPIC -Og"
                         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                         POSITION_INDEPENDENT_CODE ON

--- a/vendors/pc/boards/linux/CMakeLists.txt
+++ b/vendors/pc/boards/linux/CMakeLists.txt
@@ -1,4 +1,7 @@
 if (AFR_ENABLE_UNIT_TESTS)
+    set (CMAKE_C_FLAGS_DEBUG "-ggdb3 -Og")
+    set (CMAKE_C_FLAGS_RELEASE "-O3")
+    set(CMAKE_C_FLAGS "-Wall")
     enable_testing()
     add_subdirectory("tests/unit_test/linux")
 endif ()

--- a/vendors/pc/boards/linux/CMakeLists.txt
+++ b/vendors/pc/boards/linux/CMakeLists.txt
@@ -1,7 +1,11 @@
 if (AFR_ENABLE_UNIT_TESTS)
-    set (CMAKE_C_FLAGS_DEBUG "-ggdb3 -Og")
-    set (CMAKE_C_FLAGS_RELEASE "-O3")
+
+    set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -Og")
+    set(CMAKE_C_FLAGS_RELEASE "-O3")
     set(CMAKE_C_FLAGS "-Wall")
+
+    set(CMAKE_SHARED_LINKER_FLAGS "-fPIC")
+
     enable_testing()
     add_subdirectory("tests/unit_test/linux")
 endif ()


### PR DESCRIPTION
Fix Race Condition In Unit Test

Description
-----------
A race condition could occur in UT where a thread frees a shared variable, then it is used by the main thread which could cause a core dump

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.