### PR TITLE
Remove specific target platform version from VS project file

### DIFF
--- a/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
+++ b/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
@@ -16,7 +16,6 @@
 		<Keyword>Win32Proj</Keyword>
 		<RootNamespace>aws_IoT_MCU_Full_Tests</RootNamespace>
 		<ProjectName>aws_tests</ProjectName>
-		<WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
 	</PropertyGroup>
 	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
 	<PropertyGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;" Label="Configuration">


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Line initially put in #1854.
Specifying WindowsTargetPlatformVersion in the project file makes it specific to an SDK version which fails to build in our tests. 
After fix: https://amazon-freertos-ci.corp.amazon.com/job/im_v1_master/job/custom_ide/job/pc/job/windows-ide/768/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.