### PR TITLE
Reinclude multiple-sockets metrics test from pre-separation as a system test

### DIFF
--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -824,9 +824,9 @@ static Socket_t _createSocketToEchoServer()
 
     /* Set a time out so a missing reply does not cause the task to block indefinitely. */
     error = SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_RCVTIMEO, &xReceiveTimeOut, sizeof( xReceiveTimeOut ) );
-    TEST_ASSERT_EQUAL(SOCKETS_ERROR_NONE, error);
+    TEST_ASSERT_EQUAL( SOCKETS_ERROR_NONE, error );
     error = SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_SNDTIMEO, &xSendTimeOut, sizeof( xSendTimeOut ) );
-    TEST_ASSERT_EQUAL(SOCKETS_ERROR_NONE, error);
+    TEST_ASSERT_EQUAL( SOCKETS_ERROR_NONE, error );
 
     error = SOCKETS_Connect( socket, &echoServerAddress, sizeof( echoServerAddress ) );
     TEST_ASSERT_EQUAL( SOCKETS_ERROR_NONE, error );

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -267,7 +267,7 @@ TEST( Defender_System, Metrics_empty_are_published )
     /* Set test callback to verify report. */
     _startInfo.callback = _testCallback;
 
-    /* start actual MQTT connection */
+    /* Start actual MQTT connection. */
     mqttError = _startMqttConnection();
     TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, mqttError );
     _startInfo.mqttConnection = _mqttConnection;
@@ -823,11 +823,13 @@ static Socket_t _createSocketToEchoServer()
     TEST_ASSERT_NOT_EQUAL( SOCKETS_INVALID_SOCKET, socket );
 
     /* Set a time out so a missing reply does not cause the task to block indefinitely. */
-    SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_RCVTIMEO, &xReceiveTimeOut, sizeof( xReceiveTimeOut ) );
-    SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_SNDTIMEO, &xSendTimeOut, sizeof( xSendTimeOut ) );
+    error = SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_RCVTIMEO, &xReceiveTimeOut, sizeof( xReceiveTimeOut ) );
+    TEST_ASSERT_EQUAL(SOCKETS_ERROR_NONE, error);
+    error = SOCKETS_SetSockOpt( socket, 0, SOCKETS_SO_SNDTIMEO, &xSendTimeOut, sizeof( xSendTimeOut ) );
+    TEST_ASSERT_EQUAL(SOCKETS_ERROR_NONE, error);
 
     error = SOCKETS_Connect( socket, &echoServerAddress, sizeof( echoServerAddress ) );
-    TEST_ASSERT_EQUAL( 0, error );
+    TEST_ASSERT_EQUAL( SOCKETS_ERROR_NONE, error );
 
     return socket;
 }

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -809,8 +809,8 @@ static void _verifyTcpConnections( int total )
 
 static Socket_t _createSocketToEchoServer()
 {
-    static const TickType_t xReceiveTimeOut = pdMS_TO_TICKS( 2000 );
-    static const TickType_t xSendTimeOut = pdMS_TO_TICKS( 2000 );
+    const TickType_t xReceiveTimeOut = pdMS_TO_TICKS( 2000 );
+    const TickType_t xSendTimeOut = pdMS_TO_TICKS( 2000 );
 
     Socket_t socket;
     SocketsSockaddr_t echoServerAddress;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This PR re-includes Metrics_TCP_connections_all_are_published_multiple_sockets as a system test. 
This test was last included [here](https://github.com/aws/amazon-freertos/blob/a6a459b5e498f92db5ab16d6bf69f8d449d8c8e9/libraries/c_sdk/aws/defender/test/aws_iot_tests_defender_api.c) but was removed after transferring tests from C SDK: #1854 

Note that _verifyTcpConnections( int total ) is not changed back to _verifyTcpConnections( int total, ... ) due to lack of platform-specific tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.