### PR TITLE
common-io: Refactoring and updates to UART test cases

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -234,7 +234,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTIoctlGetSet )
         TEST_ASSERT_EQUAL( xSampleConfig2.ulBaudrate, xgetConfigBuffer.ulBaudrate );
 
         /* Test changing control flow config if specified by the test framework */
-        if (ultestIotUartFlowControl)
+        if( ultestIotUartFlowControl )
         {
             xConfigBuffer.ucFlowControl = xSampleConfig2.ucFlowControl;
             lIoctl = iot_uart_ioctl( xUartHandle, eUartSetConfig, &xConfigBuffer );
@@ -795,7 +795,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
         lCancel = iot_uart_cancel( NULL );
         TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lCancel );
     }
-    
+
     lClose = iot_uart_close( xUartHandle_2 );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -787,12 +787,15 @@ TEST( TEST_IOT_UART, AFQP_IotUARTOpenCloseCancelFuzzing )
     xUartHandle_2 = iot_uart_open( uctestIotUartPort );
     TEST_ASSERT_NOT_EQUAL( NULL, xUartHandle_2 );
 
-    xUartHandle_3 = iot_uart_open( uctestIotUartPort );
-    TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
+    if( TEST_PROTECT() )
+    {
+        xUartHandle_3 = iot_uart_open( uctestIotUartPort );
+        TEST_ASSERT_EQUAL( NULL, xUartHandle_3 );
 
-    lCancel = iot_uart_cancel( NULL );
-    TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lCancel );
-
+        lCancel = iot_uart_cancel( NULL );
+        TEST_ASSERT_EQUAL( IOT_UART_INVALID_VALUE, lCancel );
+    }
+    
     lClose = iot_uart_close( xUartHandle_2 );
     TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lClose );
 


### PR DESCRIPTION
Description
-----------
Refactored open/close to be done in setup/tear-down stages. 

Updated word length defines to number of bits.

Added checks for optional features such as flow-control support. 

Refactored loopback tests to perform read->write instead of write->read.

This is part of the work related to the following issue:

https://github.com/aws/amazon-freertos/issues/1859

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.