### PR TITLE
common-io: Refactoring ADC test cases

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -49,10 +49,7 @@ typedef struct IotAdcTestUserContext_s
 } testIotAdcTestUserContext_t;
 
 #define testIotADC_CH_DATA_BUF_LEN    5
-
-/* static global variables */
 static SemaphoreHandle_t xtestIotAdcTestSemaphore = NULL;
-static IotAdcHandle_t xAdcHandle;
 
 /* global variables for channel test control */
 /* ADC module instance, default to 0 */
@@ -63,10 +60,9 @@ uint8_t uctestIotAdcChListLen = 1;
 uint8_t * puctestIotAdcChList = NULL;
 /* ADC module instance for assisted test, need to be configured to the channel with external access */
 uint8_t ucAssistedTestIotAdcChannel = 0;
+
 /* ADC Channel Scan Wait time in ms */
 uint32_t ltestIotAdcTestChWaitTime = 1000;
-
-
 
 /* Define Test Group. */
 TEST_GROUP( TEST_IOT_ADC );
@@ -77,9 +73,6 @@ TEST_GROUP( TEST_IOT_ADC );
  */
 TEST_SETUP( TEST_IOT_ADC )
 {
-    /* Allocate the ADC peripheral during setup phase */
-    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 }
 
 /*-----------------------------------------------------------*/
@@ -89,17 +82,6 @@ TEST_SETUP( TEST_IOT_ADC )
  */
 TEST_TEAR_DOWN( TEST_IOT_ADC )
 {
-    /* Release the ADC hardware during teardown */
-    int32_t lRetVal;
-
-    lRetVal = iot_adc_close( xAdcHandle );
-
-    if (lRetVal == IOT_ADC_NOT_OPEN)
-    {
-        return;
-    }
-
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -150,7 +132,14 @@ static void prvAdcChCallback( uint16_t * pusConvertedData,
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcOpenClose )
 {
-    /* No content, test is covered by setup / teardown */
+    IotAdcHandle_t xAdcHandle;
+    int32_t lRetVal;
+
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
+
+    lRetVal = iot_adc_close( xAdcHandle );
+    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 
@@ -161,20 +150,30 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOpenClose )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcConfig )
 {
+    IotAdcHandle_t xAdcHandle;
     IotAdcConfig_t xAdcConfig;
     int32_t lRetVal;
 
-    xAdcConfig.ulAdcSampleTime = 100;
-    xAdcConfig.ucAdcResolution = 12;
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
-    xAdcConfig.ulAdcSampleTime = 0;
-    xAdcConfig.ucAdcResolution = 0;
-    lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
+    if( TEST_PROTECT() )
+    {
+        xAdcConfig.ulAdcSampleTime = 100;
+        xAdcConfig.ucAdcResolution = 12;
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+        xAdcConfig.ulAdcSampleTime = 0;
+        xAdcConfig.ucAdcResolution = 0;
+        lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        TEST_ASSERT_GREATER_THAN( 0, xAdcConfig.ulAdcSampleTime );
+        TEST_ASSERT_GREATER_THAN( 0, xAdcConfig.ucAdcResolution );
+    }
+
+    lRetVal = iot_adc_close( xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    TEST_ASSERT_GREATER_THAN( 0, xAdcConfig.ulAdcSampleTime );
-    TEST_ASSERT_GREATER_THAN( 0, xAdcConfig.ucAdcResolution );
 }
 
 /*-----------------------------------------------------------*/
@@ -194,49 +193,56 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcGetChStatus )
     ucChX = puctestIotAdcChList[ 0 ];
     ucChY = puctestIotAdcChList[ 1 ];
 
-    xUserCntx.xAdcHandle = xAdcHandle;
-    xUserCntx.ucAdcChannel = ucChX;
-    xUserCntx.ucDataSize = 1;
+    xUserCntx.xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
-    /* set channel callback */
-    iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
-
-    /* start channel data scan on channel x */
-    lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-
-    /* query channel state for channel x */
-    xAdcChStatus.ucAdcChannel = ucChX;
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    /* since channel x is used, expected to return busy */
-    TEST_ASSERT_EQUAL( ucChX, xAdcChStatus.ucAdcChannel );
-    TEST_ASSERT_EQUAL( eChStateBusy, xAdcChStatus.xAdcChState );
-
-    /* query channel state for channel y */
-    xAdcChStatus.ucAdcChannel = ucChY;
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    /* since channel y is not used, expected to return idle */
-    TEST_ASSERT_EQUAL( ucChY, xAdcChStatus.ucAdcChannel );
-    TEST_ASSERT_EQUAL( eChStateIdle, xAdcChStatus.xAdcChState );
-
-    /* stop channel data scan on channel x */
-    lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-
-    /* consume all semaphores given due to Async read callbacks which the test didn't care about */
-    while( pdTRUE == xSemaphoreTake( xtestIotAdcTestSemaphore, 0 ) )
+    if( TEST_PROTECT() )
     {
-    }
+        xUserCntx.ucAdcChannel = ucChX;
+        xUserCntx.ucDataSize = 1;
+        /* set channel callback */
+        iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
 
-    /* query channel state for channel x */
-    xAdcChStatus.ucAdcChannel = ucChX;
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
+        /* start channel data scan on channel x */
+        lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+        /* query channel state for channel x */
+        xAdcChStatus.ucAdcChannel = ucChX;
+        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        /* since channel x is used, expected to return busy */
+        TEST_ASSERT_EQUAL( ucChX, xAdcChStatus.ucAdcChannel );
+        TEST_ASSERT_EQUAL( eChStateBusy, xAdcChStatus.xAdcChState );
+
+        /* query channel state for channel y */
+        xAdcChStatus.ucAdcChannel = ucChY;
+        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        /* since channel y is not used, expected to return idle */
+        TEST_ASSERT_EQUAL( ucChY, xAdcChStatus.ucAdcChannel );
+        TEST_ASSERT_EQUAL( eChStateIdle, xAdcChStatus.xAdcChState );
+
+        /* stop channel data scan on channel x */
+        lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+        /* consume all semaphores given due to Async read callbacks which the test didn't care about */
+        while( pdTRUE == xSemaphoreTake( xtestIotAdcTestSemaphore, 0 ) )
+        {
+        }
+
+        /* query channel state for channel x */
+        xAdcChStatus.ucAdcChannel = ucChX;
+        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eGetChStatus, &xAdcChStatus );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        /* since channel x is stop, expected to return idle */
+        TEST_ASSERT_EQUAL( ucChX, xAdcChStatus.ucAdcChannel );
+        TEST_ASSERT_EQUAL( eChStateIdle, xAdcChStatus.xAdcChState );
+    }   
+
+    lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    /* since channel x is stop, expected to return idle */
-    TEST_ASSERT_EQUAL( ucChX, xAdcChStatus.ucAdcChannel );
-    TEST_ASSERT_EQUAL( eChStateIdle, xAdcChStatus.xAdcChState );
 }
 
 /*-----------------------------------------------------------*/
@@ -246,19 +252,29 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcGetChStatus )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcReadSample )
 {
+    IotAdcHandle_t xAdcHandle;
     int32_t lRetVal;
     uint16_t usSample;
 
     /* make sure ADC channel list has been configured */
     TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
 
-    /* read sample from ADC channels */
-    for( int i = 0; i < uctestIotAdcChListLen; i++ )
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
+
+    if( TEST_PROTECT() )
     {
-        lRetVal = iot_adc_read_sample( xAdcHandle, puctestIotAdcChList[ i ], &usSample );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-        TEST_ASSERT_GREATER_THAN( 0, usSample );
+        /* read sample from ADC channels */
+        for( int i = 0; i < uctestIotAdcChListLen; i++ )
+        {
+            lRetVal = iot_adc_read_sample( xAdcHandle, puctestIotAdcChList[ i ], &usSample );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            TEST_ASSERT_GREATER_THAN( 0, usSample );
+        }
     }
+
+    lRetVal = iot_adc_close( xAdcHandle );
+    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -268,14 +284,24 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcReadSample )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcPrintReadSample )
 {
+    IotAdcHandle_t xAdcHandle;
     int32_t lRetVal;
     uint16_t usSample;
 
     /* make sure ADC channel list has been configured */
     TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
 
-    /* read sample from ADC channels */
-    lRetVal = iot_adc_read_sample( xAdcHandle, ucAssistedTestIotAdcChannel, &usSample );
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
+
+    if( TEST_PROTECT() )
+    {
+        /* read sample from ADC channels */
+        lRetVal = iot_adc_read_sample( xAdcHandle, ucAssistedTestIotAdcChannel, &usSample );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+    }
+
+    lRetVal = iot_adc_close( xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 
     /* print ADC sample with an assert failure */
@@ -292,45 +318,53 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcChBuffer )
     uint8_t ucCh;
     int32_t lRetVal;
 
-    /* use global handle */
-    xUserCntx.xAdcHandle = xAdcHandle;
-
     TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
 
-    for( int i = 0; i < uctestIotAdcChListLen; i++ )
-    {
-        ucCh = puctestIotAdcChList[ i ];
+    /* open ADC module for operation */
+    xUserCntx.xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
-        /* configure channel buffer */
-        xChBuf.ucAdcChannel = ucCh;
-        xChBuf.pvBuffer = usChDataBuf;
-        xChBuf.ucBufLen = sizeof( usChDataBuf );
-        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetChBuffer, &xChBuf );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+    if( TEST_PROTECT() )
+    {   
+        for( int i = 0; i < uctestIotAdcChListLen; i++ )
+        {
+            ucCh = puctestIotAdcChList[ i ];
 
-        /* set channel callback */
-        xUserCntx.ucAdcChannel = ucCh;
-        xUserCntx.ucDataSize = testIotADC_CH_DATA_BUF_LEN;
-        iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
+            /* configure channel buffer */
+            xChBuf.ucAdcChannel = ucCh;
+            xChBuf.pvBuffer = usChDataBuf;
+            xChBuf.ucBufLen = sizeof( usChDataBuf );
+            lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetChBuffer, &xChBuf );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 
-        /* start channel data scan on channel */
-        memset( usChDataBuf, 0, sizeof( usChDataBuf ) );
-        lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-        lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            /* set channel callback */
+            xUserCntx.ucAdcChannel = ucCh;
+            xUserCntx.ucDataSize = testIotADC_CH_DATA_BUF_LEN;
+            iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
 
-        /* start channel data scan on channel again to make sure we can sample repeatedly */
-        memset( usChDataBuf, 0, sizeof( usChDataBuf ) );
-        lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-        lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            /* start channel data scan on channel */
+            memset( usChDataBuf, 0, sizeof( usChDataBuf ) );
+            lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
 
-        /* stop channel data scan */
-        lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            /* start channel data scan on channel again to make sure we can sample repeatedly */
+            memset( usChDataBuf, 0, sizeof( usChDataBuf ) );
+            lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+            /* stop channel data scan */
+            lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        }
     }
+
+    /* close ADC module */
+    lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
+    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -343,58 +377,64 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChain )
     uint8_t ucCh;
     int32_t lRetVal;
 
-    /* use global handle */
-    xUserCntx.xAdcHandle = xAdcHandle;
+    /* open ADC module for operation */
+    xUserCntx.xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
-    /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
-    TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
-    TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
-    ucCh = puctestIotAdcChList[ 0 ];
+    if( TEST_PROTECT() )
+    {  
+        /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
+        TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
+        TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
+        ucCh = puctestIotAdcChList[ 0 ];
 
-    /* configure ADC chain */
-    xAdcChain.ucAdcChannel = ucCh;
-    xAdcChain.pvBuffer = usChainBuf;
-    /* TODO: need better solution. expect uctestIotAdcChListLen samples, each sample takes 2 bytes */
-    xAdcChain.ucBufLen = uctestIotAdcChListLen * 2;
-    xAdcChain.usChainMask = 0;
+        /* configure ADC chain */
+        xAdcChain.ucAdcChannel = ucCh;
+        xAdcChain.pvBuffer = usChainBuf;
+        /* TODO: need better solution. expect uctestIotAdcChListLen samples, each sample takes 2 bytes */
+        xAdcChain.ucBufLen = uctestIotAdcChListLen * 2;
+        xAdcChain.usChainMask = 0;
 
-    for( int i = 0; i < uctestIotAdcChListLen; i++ )
-    {
-        xAdcChain.usChainMask |= 1 << puctestIotAdcChList[ i ];
+        for( int i = 0; i < uctestIotAdcChListLen; i++ )
+        {
+            xAdcChain.usChainMask |= 1 << puctestIotAdcChList[ i ];
+        }
+
+        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
+
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+            /* set chain callback */
+            xUserCntx.ucAdcChannel = ucCh;
+            xUserCntx.ucDataSize = uctestIotAdcChListLen;
+            iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
+
+            /* start chain scan */
+            memset( usChainBuf, 0, sizeof( usChainBuf ) );
+            lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+            /* start chain scan to make sure we can sample repeatedly */
+            memset( usChainBuf, 0, sizeof( usChainBuf ) );
+            lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+            /* stop chain scan */
+            lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        }
     }
 
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
-
-    if( lRetVal == IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        return;
-    }
-
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-
-    /* set chain callback */
-    xUserCntx.ucAdcChannel = ucCh;
-    xUserCntx.ucDataSize = uctestIotAdcChListLen;
-    iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
-
-    /* start chain scan */
-    memset( usChainBuf, 0, sizeof( usChainBuf ) );
-    lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
-    TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-
-    /* start chain scan to make sure we can sample repeatedly */
-    memset( usChainBuf, 0, sizeof( usChainBuf ) );
-    lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
-    TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-
-    /* stop chain scan */
-    lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+    /* close ADC module */
+    lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
@@ -408,28 +448,36 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOperation )
 
     TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
 
-    /* use global handle */
-    xUserCntx.xAdcHandle = xAdcHandle;
+    /* open ADC module for operation */
+    xUserCntx.xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
-    for( int i = 0; i < uctestIotAdcChListLen; i++ )
-    {
-        ucCh = puctestIotAdcChList[ i ];
+    if( TEST_PROTECT() )
+    {  
+        for( int i = 0; i < uctestIotAdcChListLen; i++ )
+        {
+            ucCh = puctestIotAdcChList[ i ];
 
-        /* set channel callback */
-        xUserCntx.ucAdcChannel = ucCh;
-        xUserCntx.ucDataSize = 1;
-        iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
+            /* set channel callback */
+            xUserCntx.ucAdcChannel = ucCh;
+            xUserCntx.ucDataSize = 1;
+            iot_adc_set_callback( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel, prvAdcChCallback, &xUserCntx );
 
-        /* start channel data scan on channel */
-        lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-        lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            /* start channel data scan on channel */
+            lRetVal = iot_adc_start( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            lRetVal = xSemaphoreTake( xtestIotAdcTestSemaphore, ltestIotAdcTestChWaitTime );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
 
-        /* stop channel data scan */
-        lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
-        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+            /* stop channel data scan */
+            lRetVal = iot_adc_stop( xUserCntx.xAdcHandle, xUserCntx.ucAdcChannel );
+            TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        }
     }
+
+    /* close ADC module */
+    lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
+    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -439,23 +487,29 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOperation )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcOpenCloseFuzzy )
 {
-    IotAdcHandle_t xAdcHandleFuzz;
+    IotAdcHandle_t xAdcHandle, xAdcHandleTmp;
     int32_t lRetVal;
 
     /* invliad ADC instance number */
-    xAdcHandleFuzz = iot_adc_open( 0xFFFFFFFF );
-    TEST_ASSERT_EQUAL( NULL, xAdcHandleFuzz );
+    xAdcHandle = iot_adc_open( 0xFFFFFFFF );
+    TEST_ASSERT_EQUAL( NULL, xAdcHandle );
 
-    xAdcHandleFuzz = iot_adc_open( -1 );
-    TEST_ASSERT_EQUAL( NULL, xAdcHandleFuzz );
+    xAdcHandle = iot_adc_open( -1 );
+    TEST_ASSERT_EQUAL( NULL, xAdcHandle );
 
-    /* open same ADC instance twice (already open during setup) */
-    xAdcHandleFuzz = iot_adc_open( uctestIotAdcInstance );
-    TEST_ASSERT_EQUAL( NULL, xAdcHandleFuzz );
+    /* open same ADC instance twice */
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
-    /* close ADC instance with NULL handle */
-    lRetVal = iot_adc_close( NULL );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+    if( TEST_PROTECT() )
+    {  
+        xAdcHandleTmp = iot_adc_open( uctestIotAdcInstance );
+        TEST_ASSERT_EQUAL( NULL, xAdcHandleTmp );
+
+        /* close ADC instance with NULL handle */
+        lRetVal = iot_adc_close( NULL );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+    }
 
     /* close same ADC instance twice */
     lRetVal = iot_adc_close( xAdcHandle );
@@ -472,27 +526,37 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOpenCloseFuzzy )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcIoctlSetConfigFuzzy )
 {
+    IotAdcHandle_t xAdcHandle;
     IotAdcConfig_t xAdcConfig;
     int32_t lRetVal;
 
-    xAdcConfig.ucAdcResolution = 100; /* no such resolution */
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+    xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
-    xAdcConfig.ulAdcSampleTime = 0xFFFFFFFF; /* not expecting such large value for sample time */
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+    if( TEST_PROTECT() )
+    {  
+        xAdcConfig.ucAdcResolution = 100; /* no such resolution */
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
 
-    /* use a set of valid sample time and resolution */
-    xAdcConfig.ulAdcSampleTime = 3;
-    xAdcConfig.ucAdcResolution = 12;
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
+        xAdcConfig.ulAdcSampleTime = 0xFFFFFFFF; /* not expecting such large value for sample time */
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        /* use a set of valid sample time and resolution */
+        xAdcConfig.ulAdcSampleTime = 3;
+        xAdcConfig.ucAdcResolution = 12;
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( 3, xAdcConfig.ulAdcSampleTime );
+        TEST_ASSERT_EQUAL( 12, xAdcConfig.ucAdcResolution );
+    }
+
+    lRetVal = iot_adc_close( xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( 3, xAdcConfig.ulAdcSampleTime );
-    TEST_ASSERT_EQUAL( 12, xAdcConfig.ucAdcResolution );
 }
 
 /*-----------------------------------------------------------*/
@@ -508,46 +572,50 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChainFuzzy )
     uint8_t ucCh;
     int32_t lRetVal;
 
-    /* use global handle */
-    xUserCntx.xAdcHandle = xAdcHandle;
+    /* open ADC module for operation */
+    xUserCntx.xAdcHandle = iot_adc_open( uctestIotAdcInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
-    /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
-    TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
-    TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
-    ucCh = puctestIotAdcChList[ 0 ];
+    if( TEST_PROTECT() )
+    { 
+        /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
+        TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
+        TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
+        ucCh = puctestIotAdcChList[ 0 ];
 
-    /* configure ADC chain */
-    xAdcChain.ucAdcChannel = ucCh;
-    xAdcChain.pvBuffer = usChainBuf;
-    xAdcChain.ucBufLen = sizeof( usChainBuf );
-    xAdcChain.usChainMask = 0;
+        /* configure ADC chain */
+        xAdcChain.ucAdcChannel = ucCh;
+        xAdcChain.pvBuffer = usChainBuf;
+        xAdcChain.ucBufLen = sizeof( usChainBuf );
+        xAdcChain.usChainMask = 0;
 
-    /* ChainMask invalid */
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
+        /* ChainMask invalid */
+        lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
 
-    if( lRetVal == IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        return;
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+            for( int i = 0; i < uctestIotAdcChListLen; i++ )
+            {
+                xAdcChain.usChainMask |= 1 << puctestIotAdcChList[ i ];
+            }
+
+            /* chain's logical channel has to be marked with lsb, below match msb */
+            xAdcChain.ucAdcChannel = puctestIotAdcChList[ uctestIotAdcChListLen - 1 ];
+
+            lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
+
+            if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+            {
+                TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+            }
+        }
     }
 
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    for( int i = 0; i < uctestIotAdcChListLen; i++ )
-    {
-        xAdcChain.usChainMask |= 1 << puctestIotAdcChList[ i ];
-    }
-
-    /* chain's logical channel has to be marked with lsb, below match msb */
-    xAdcChain.ucAdcChannel = puctestIotAdcChList[ uctestIotAdcChListLen - 1 ];
-
-    lRetVal = iot_adc_ioctl( xUserCntx.xAdcHandle, eSetAdcChain, &xAdcChain );
-
-    if( lRetVal == IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        return;
-    }
-
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+    /* close ADC module */
+    lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
+    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -557,18 +625,13 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChainFuzzy )
  */
 TEST( TEST_IOT_ADC, AFQP_IotAdcOperationFuzzy )
 {
+    IotAdcHandle_t xAdcHandle = NULL;
     uint8_t ucAdcChannel = 0xFF; /* fake channel number */
     IotAdcConfig_t xAdcConfig;
     IotAdcChBuffer_t xAdcChBuffer = { ucAdcChannel, NULL, 0 };
     IotAdcChain_t xAdcChain = { ucAdcChannel, NULL, 0, 0x0 };
     uint16_t usDataBuf[ 5 ];
     int32_t lRetVal;
-
-    /* Start by closing the global handle allcoated during setup */
-    lRetVal = iot_adc_close( xAdcHandle );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-    /* Set handle to NULL */
-    xAdcHandle = NULL;
 
     lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
     TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
@@ -586,93 +649,99 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOperationFuzzy )
     xAdcHandle = iot_adc_open( uctestIotAdcInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
-    lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_stop( xAdcHandle, ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_read_sample( xAdcHandle, ucAdcChannel, usDataBuf );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
-    TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-
-    /* NULL pointer for ioctl */
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, NULL );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, NULL );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eGetChStatus, NULL );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, NULL );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, NULL );
-
-    if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
+    if( TEST_PROTECT() )
+    { 
+        lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
         TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_stop( xAdcHandle, ucAdcChannel );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_read_sample( xAdcHandle, ucAdcChannel, usDataBuf );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
+
+        /* NULL pointer for ioctl */
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, NULL );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, NULL );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eGetChStatus, NULL );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, NULL );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, NULL );
+
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+        }
+
+        /* pick a valid ucAdcChannel from a global ADC channel list which is configured by the test based on board */
+        TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
+        ucAdcChannel = puctestIotAdcChList[ 0 ];
+
+        /* NULL pointer for data buffer */
+        /* assign a valid channel number to xAdcChBuffer while keep xAdcChBuffer.pvBuffer = NULL */
+        xAdcChBuffer.ucAdcChannel = ucAdcChannel;
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, &xAdcChBuffer );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        /* assign a valid channel number to xAdcChain while keep xAdcChain.pvBuffer = NULL */
+        xAdcChain.ucAdcChannel = ucAdcChannel;
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
+
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+        }
+
+        /* zero data buffer length */
+        /* assign a valid data buffer pointer to  xAdcChBuffer while keep xAdcChBuffer.ucBufLen = 0 */
+        xAdcChBuffer.pvBuffer = ( void * ) usDataBuf;
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, &xAdcChBuffer );
+        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+
+        /* assign a valid data buffer pointer to xAdcChain while keep xAdcChain.ucBufLen = 0 */
+        xAdcChain.pvBuffer = ( void * ) usDataBuf;
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
+
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+        }
+
+        /* invalid ADC chain mask */
+        /* assign valid data buffer length while keep xAdcChain.usChainMask = 0x0 */
+        xAdcChain.ucBufLen = sizeof( usDataBuf );
+
+        lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
+
+        if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
+        }
+
+        /* start shall fail without setting callback successfully */
+        lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
+        TEST_ASSERT_EQUAL( IOT_ADC_FAILED, lRetVal );
+
+        /* stop shall succeed unless handle is not valid */
+        lRetVal = iot_adc_stop( xAdcHandle, ucAdcChannel );
+        TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
     }
 
-    /* pick a valid ucAdcChannel from a global ADC channel list which is configured by the test based on board */
-    TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
-    ucAdcChannel = puctestIotAdcChList[ 0 ];
-
-    /* NULL pointer for data buffer */
-    /* assign a valid channel number to xAdcChBuffer while keep xAdcChBuffer.pvBuffer = NULL */
-    xAdcChBuffer.ucAdcChannel = ucAdcChannel;
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, &xAdcChBuffer );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    /* assign a valid channel number to xAdcChain while keep xAdcChain.pvBuffer = NULL */
-    xAdcChain.ucAdcChannel = ucAdcChannel;
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
-
-    if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-    }
-
-    /* zero data buffer length */
-    /* assign a valid data buffer pointer to  xAdcChBuffer while keep xAdcChBuffer.ucBufLen = 0 */
-    xAdcChBuffer.pvBuffer = ( void * ) usDataBuf;
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetChBuffer, &xAdcChBuffer );
-    TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-
-    /* assign a valid data buffer pointer to xAdcChain while keep xAdcChain.ucBufLen = 0 */
-    xAdcChain.pvBuffer = ( void * ) usDataBuf;
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
-
-    if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-    }
-
-    /* invalid ADC chain mask */
-    /* assign valid data buffer length while keep xAdcChain.usChainMask = 0x0 */
-    xAdcChain.ucBufLen = sizeof( usDataBuf );
-
-    lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcChain, &xAdcChain );
-
-    if( lRetVal != IOT_ADC_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
-    }
-
-    /* start shall fail without setting callback successfully */
-    lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
-    TEST_ASSERT_EQUAL( IOT_ADC_FAILED, lRetVal );
-
-    /* stop shall succeed unless handle is not valid */
-    lRetVal = iot_adc_stop( xAdcHandle, ucAdcChannel );
+    lRetVal = iot_adc_close( xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
 }
 

--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -239,7 +239,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcGetChStatus )
         /* since channel x is stop, expected to return idle */
         TEST_ASSERT_EQUAL( ucChX, xAdcChStatus.ucAdcChannel );
         TEST_ASSERT_EQUAL( eChStateIdle, xAdcChStatus.xAdcChState );
-    }   
+    }
 
     lRetVal = iot_adc_close( xUserCntx.xAdcHandle );
     TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
@@ -325,7 +325,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcChBuffer )
     TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
     if( TEST_PROTECT() )
-    {   
+    {
         for( int i = 0; i < uctestIotAdcChListLen; i++ )
         {
             ucCh = puctestIotAdcChList[ i ];
@@ -382,7 +382,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChain )
     TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
     if( TEST_PROTECT() )
-    {  
+    {
         /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
         TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
         TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
@@ -453,7 +453,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOperation )
     TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
     if( TEST_PROTECT() )
-    {  
+    {
         for( int i = 0; i < uctestIotAdcChListLen; i++ )
         {
             ucCh = puctestIotAdcChList[ i ];
@@ -502,7 +502,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOpenCloseFuzzy )
     TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
     if( TEST_PROTECT() )
-    {  
+    {
         xAdcHandleTmp = iot_adc_open( uctestIotAdcInstance );
         TEST_ASSERT_EQUAL( NULL, xAdcHandleTmp );
 
@@ -534,7 +534,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcIoctlSetConfigFuzzy )
     TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
     if( TEST_PROTECT() )
-    {  
+    {
         xAdcConfig.ucAdcResolution = 100; /* no such resolution */
         lRetVal = iot_adc_ioctl( xAdcHandle, eSetAdcConfig, &xAdcConfig );
         TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
@@ -577,7 +577,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcSetChainFuzzy )
     TEST_ASSERT_NOT_EQUAL( NULL, xUserCntx.xAdcHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Chain size has to be greater than 1, otherwise no need to use Chain operation */
         TEST_ASSERT_GREATER_THAN( 1, uctestIotAdcChListLen );
         TEST_ASSERT_NOT_EQUAL( NULL, puctestIotAdcChList );
@@ -650,7 +650,7 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcOperationFuzzy )
     TEST_ASSERT_NOT_EQUAL( NULL, xAdcHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         lRetVal = iot_adc_start( xAdcHandle, ucAdcChannel );
         TEST_ASSERT_EQUAL( IOT_ADC_INVALID_VALUE, lRetVal );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Refactored tests to perform open/close during setup/tear-down phases.

This is part of the work related to the following issue: https://github.com/aws/amazon-freertos/issues/1859

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.