### PR TITLE
common-io: Refactoring FLASH test cases

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -90,7 +90,7 @@ TEST_SETUP( TEST_IOT_FLASH )
  * @brief Tear down function called after each test in this group is executed.
  */
 TEST_TEAR_DOWN( TEST_IOT_FLASH )
-{ 
+{
 }
 
 /*-----------------------------------------------------------*/
@@ -129,7 +129,9 @@ static void prvIotTimerCallback( void * pvUserContext )
 
 /*-----------------------------------------------------------*/
 
-static void prvIotFlashWriteDummyData(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+static void prvIotFlashWriteDummyData( IotFlashHandle_t xFlashHandle,
+                                       uint32_t offset,
+                                       uint32_t size )
 {
     uint32_t lRetVal;
 
@@ -137,11 +139,11 @@ static void prvIotFlashWriteDummyData(IotFlashHandle_t xFlashHandle, uint32_t of
     for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
     {
         /* Less the a full buffer left? */
-        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        uint32_t remaining_size = ( ( i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE ) > size ) ? ( size - i ) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
 
-        if (remaining_size > 0)
+        if( remaining_size > 0 )
         {
-            for ( uint32_t j = 0; j < remaining_size; j++)
+            for( uint32_t j = 0; j < remaining_size; j++ )
             {
                 uctestIotFlashWriteBuffer[ j ] = j;
             }
@@ -158,16 +160,18 @@ static void prvIotFlashWriteDummyData(IotFlashHandle_t xFlashHandle, uint32_t of
 
 /*-----------------------------------------------------------*/
 
-static void prvIotFlashReadVerifyDummyData(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+static void prvIotFlashReadVerifyDummyData( IotFlashHandle_t xFlashHandle,
+                                            uint32_t offset,
+                                            uint32_t size )
 {
     uint32_t lRetVal;
 
     for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
     {
         /* Less the a full buffer left? */
-        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        uint32_t remaining_size = ( ( i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE ) > size ) ? ( size - i ) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
 
-        if (remaining_size > 0)
+        if( remaining_size > 0 )
         {
             /* Read back the data written */
             lRetVal = iot_flash_read_sync( xFlashHandle,
@@ -179,7 +183,7 @@ static void prvIotFlashReadVerifyDummyData(IotFlashHandle_t xFlashHandle, uint32
             /* Verify the data is erased. */
             for( uint32_t i = 0; i < remaining_size; i++ )
             {
-                if( uctestIotFlashReadBuffer[ i ] != (i & 0xFF) )
+                if( uctestIotFlashReadBuffer[ i ] != ( i & 0xFF ) )
                 {
                     TEST_ASSERT_MESSAGE( 0, "Data was NOT erased" );
                 }
@@ -190,16 +194,18 @@ static void prvIotFlashReadVerifyDummyData(IotFlashHandle_t xFlashHandle, uint32
 
 /*-----------------------------------------------------------*/
 
-static void prvIotFlashReadVerifyErased(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+static void prvIotFlashReadVerifyErased( IotFlashHandle_t xFlashHandle,
+                                         uint32_t offset,
+                                         uint32_t size )
 {
     uint32_t lRetVal;
 
     for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
     {
         /* Less the a full buffer left? */
-        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        uint32_t remaining_size = ( ( i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE ) > size ) ? ( size - i ) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
 
-        if (remaining_size > 0)
+        if( remaining_size > 0 )
         {
             /* Read back the data written */
             lRetVal = iot_flash_read_sync( xFlashHandle,
@@ -222,13 +228,15 @@ static void prvIotFlashReadVerifyErased(IotFlashHandle_t xFlashHandle, uint32_t 
 
 /*-----------------------------------------------------------*/
 
-static void prvIotFlashWriteReadVerify(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+static void prvIotFlashWriteReadVerify( IotFlashHandle_t xFlashHandle,
+                                        uint32_t offset,
+                                        uint32_t size )
 {
     /* Fill out a buffer of pageSize to be written */
-    prvIotFlashWriteDummyData(xFlashHandle, offset, size);
+    prvIotFlashWriteDummyData( xFlashHandle, offset, size );
 
     /* Read back the data written */
-    prvIotFlashReadVerifyDummyData(xFlashHandle, offset, size);
+    prvIotFlashReadVerifyDummyData( xFlashHandle, offset, size );
 }
 
 /*-----------------------------------------------------------*/
@@ -379,7 +387,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSector )
         }
 
         /* Fill a sector with dummy data and verify it */
-        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize );
 
         /* Erase one sector */
         lRetVal = iot_flash_erase_sectors( xFlashHandle,
@@ -396,7 +404,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSector )
 
         /* Read back the whole sector to make sure the contents are erased.
          */
-        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize );
     }
 
     /* Close flash handle */
@@ -449,7 +457,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseMultipleSectors )
 
         /* Read back the two sectors to make sure the contents are erased.
          */
-        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2);
+        prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2 );
     }
 
     /* Close flash handle */
@@ -482,7 +490,6 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
         /* Make sure the offset is aligned to BlockSize */
         if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
         {
-
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
             {
@@ -510,7 +517,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
              * Write dummy data starting at the middle of the sector to half of next sector
              * and read it back to verify the data.
              */
-            prvIotFlashWriteReadVerify(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize );
 
             /* Erase a Block */
             lRetVal = iot_flash_erase_sectors( xFlashHandle,
@@ -527,11 +534,11 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
 
             /* Read back the block to make sure the contents are erased.
              */
-            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulBlockSize);
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulBlockSize );
         }
         else
         {
-            TEST_MESSAGE("Start offset is not aligned with blockSize");
+            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
         }
     }
 
@@ -593,7 +600,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
              * Write dummy data starting at the middle of the sector to half of next sector
              * and read it back to verify the data.
              */
-            prvIotFlashWriteReadVerify(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize );
 
             /* Erase a Block minus sector size starting at block boundry plus sector size */
             lRetVal = iot_flash_erase_sectors( xFlashHandle,
@@ -609,18 +616,18 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
             }
 
             /* Read back the block to make sure the contents are erased.
-            */
-            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize, 
-                                        pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize);
+             */
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize,
+                                         pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
 
             /* Read and make sure that the first sector written is not erased */
             ulMiddleOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
 
-            prvIotFlashReadVerifyDummyData(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize / 2);
+            prvIotFlashReadVerifyDummyData( xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize / 2 );
         }
         else
         {
-            TEST_MESSAGE("Start offset is not aligned with blockSize");
+            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
         }
     }
 
@@ -647,7 +654,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -682,7 +689,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
              * Write dummy data starting at the middle of the sector to half of next sector
              * and read it back to verify the data.
              */
-            prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize );
 
             /* Also write the last sector in the block to make sure its not erased */
             lRetVal = iot_flash_erase_sectors( xFlashHandle,
@@ -692,7 +699,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
 
             ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
 
-            prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize );
 
             /* Erase a Block minus sector size starting at block boundry */
             lRetVal = iot_flash_erase_sectors( xFlashHandle,
@@ -707,25 +714,24 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
                 TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
             }
 
-
             /* Read back the block to make sure the contents are erased.
-            */
-            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, 
-                                        pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize);
+             */
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset,
+                                         pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
 
             /* Read and make sure that the last sector written is not erased */
             ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
-            prvIotFlashReadVerifyDummyData(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+            prvIotFlashReadVerifyDummyData( xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize );
         }
         else
         {
-            TEST_MESSAGE("Start offset is not aligned with blockSize");
+            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
         }
     }
 
     /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal ); 
+    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
 
 /*-----------------------------------------------------------*/
@@ -746,7 +752,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseUnAlignedAddress )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -781,7 +787,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseUnAlignedSize )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -816,7 +822,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePartialPage )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -903,7 +909,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePage )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -930,7 +936,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePage )
         }
 
         /* Write the a full page and verify the data by reading it back */
-        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+        prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
     }
 
     /* Close flash handle */
@@ -956,7 +962,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSector )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -983,7 +989,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSector )
         }
 
         /* Write the a full sector and verify the data by reading it back */
-        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize );
     }
 
     /* Close flash handle */
@@ -1009,7 +1015,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteAcrossSectors )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1040,7 +1046,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteAcrossSectors )
         /*
          * Try to write dummy data across twi sectors and read it back to verify the data.
          */
-        prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashWriteReadVerify( xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize );
     }
 
     /* Close flash handle */
@@ -1066,7 +1072,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseInProgressRead )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1181,7 +1187,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectWriteFailure )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1229,7 +1235,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectWriteFailure )
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
             /* Write the a full page and verify the data by reading it back */
-            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
 
         /* Now make the sector writeable */
@@ -1252,7 +1258,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectWriteFailure )
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
             /* Write the a full page and verify the data by reading it back */
-            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
     }
 
@@ -1279,7 +1285,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1306,10 +1312,10 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
         }
 
         /* Verify that the page was erased */
-        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+        prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
 
         /* Fill out a buffer of sectorSize to be written */
-        prvIotFlashWriteDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+        prvIotFlashWriteDummyData( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
 
         /* Make the sector as read only. */
         xFlashProtect.ulAddress = ultestIotFlashStartOffset;
@@ -1344,7 +1350,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
             }
 
             /* Read back the data written */
-            prvIotFlashReadVerifyDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashReadVerifyDummyData( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
 
         /* Now make the sector as writeable. */
@@ -1380,7 +1386,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
             }
 
             /* Read back the data written and verify that it is erased */
-            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
     }
 
@@ -1407,7 +1413,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteEraseReadCycle )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1419,12 +1425,12 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteEraseReadCycle )
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
         /* Read back the data and make sure that data is erased first */
-        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+        prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
 
         for( uint32_t idx = 0; idx < 5; idx++ )
         {
             /* Write to this sector and veirfy */
-            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
 
             /* Get the flash information. */
             pxFlashInfo = iot_flash_getinfo( xFlashHandle );
@@ -1437,7 +1443,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteEraseReadCycle )
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
             /* Read back the data and make sure that data is erased */
-            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
     }
 
@@ -1464,7 +1470,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSuspendResume )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Setup a timer to suspend the write */
         xTimerHandle = iot_timer_open( ltestIotTimerInstance );
         TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
@@ -1509,7 +1515,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSuspendResume )
         TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
         /* Fill out a sector with data */
-        prvIotFlashWriteDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashWriteDummyData( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize );
 
         /* Wait for the Delay callback to be called. */
         lRetVal = xSemaphoreTake( xtestIotFlashTimerSemaphore, portMAX_DELAY );
@@ -1542,7 +1548,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSuspendResume )
         TEST_ASSERT_EQUAL( eFlashIdle, lStatus );
 
         /* Read the data back to make sure Resume succeded and data is written */
-        prvIotFlashReadVerifyDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+        prvIotFlashReadVerifyDummyData( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize );
 
         lRetVal = iot_timer_close( xTimerHandle );
         TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
@@ -1570,7 +1576,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSuspendResume )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Setup a timer to suspend the write */
         xTimerHandle = iot_timer_open( ltestIotTimerInstance );
         TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
@@ -1645,7 +1651,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSuspendResume )
         }
 
         /* Read the data back to make sure Resume succeded and data is erased */
-        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2);
+        prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2 );
 
         lRetVal = iot_timer_close( xTimerHandle );
         TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
@@ -1673,7 +1679,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
@@ -1703,11 +1709,11 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
         for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
         {
             /* Less the a full buffer left? */
-            uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > pxFlashInfo->ulPageSize) ? (pxFlashInfo->ulPageSize - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+            uint32_t remaining_size = ( ( i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE ) > pxFlashInfo->ulPageSize ) ? ( pxFlashInfo->ulPageSize - i ) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
 
-            if (remaining_size > 0)
+            if( remaining_size > 0 )
             {
-                for ( uint32_t j = 0; j < remaining_size; j++)
+                for( uint32_t j = 0; j < remaining_size; j++ )
                 {
                     uctestIotFlashWriteBuffer[ j ] = j;
                 }
@@ -1724,9 +1730,9 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
         for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
         {
             /* Less the a full buffer left? */
-            uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > pxFlashInfo->ulPageSize) ? (pxFlashInfo->ulPageSize - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+            uint32_t remaining_size = ( ( i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE ) > pxFlashInfo->ulPageSize ) ? ( pxFlashInfo->ulPageSize - i ) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
 
-            if (remaining_size > 0)
+            if( remaining_size > 0 )
             {
                 /* Read back the data written */
                 lRetVal = iot_flash_read_sync( xFlashHandle,
@@ -1758,7 +1764,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
  *
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashOpenCloseFuzz )
-{   
+{
     IotFlashHandle_t xFlashHandle, xFlashHandleTmp;
     int32_t lRetVal;
 
@@ -1767,7 +1773,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashOpenCloseFuzz )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    {   
+    {
         /* open the same intance twice */
         xFlashHandleTmp = iot_flash_open( ltestIotFlashInstance );
         TEST_ASSERT_EQUAL( NULL, xFlashHandleTmp );
@@ -1808,7 +1814,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashGetInfoFuzz )
  *
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashIoctlFuzz )
-{   
+{
     IotFlashHandle_t xFlashHandle;
     int32_t lRetVal;
     uint32_t lStatus;
@@ -1822,7 +1828,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashIoctlFuzz )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Call ioctl with handle, but invalid enum */
         lRetVal = iot_flash_ioctl( xFlashHandle, -1, NULL );
         TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
@@ -1855,7 +1861,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFuzz )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Erase one sector with invalid start address*/
         lRetVal = iot_flash_erase_sectors( xFlashHandle,
                                            -1,
@@ -1897,7 +1903,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteFuzz )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Write partial page with invalid start address */
         lRetVal = iot_flash_write_sync( xFlashHandle,
                                         -1,
@@ -1941,7 +1947,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashReadFuzz )
     TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
     if( TEST_PROTECT() )
-    { 
+    {
         /* Read partial page with invalid start address */
         lRetVal = iot_flash_read_sync( xFlashHandle,
                                        -1,

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -53,12 +53,13 @@
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-extern IotFlashHandle_t gIotFlashHandle;
+extern int32_t ltestIotTimerInstance;
+
+uint8_t ltestIotFlashInstance = 0; /** Default Flash instance for testing */
 
 /* This offset is used for testing the flash test-cases
  * The data from offset to offset + 2 sectors will be corrupted */
-uint32_t ultestIotFlashStartOffset;
-extern int32_t ltestIotTimerInstance;
+uint32_t ultestIotFlashStartOffset = 0;
 
 /*-----------------------------------------------------------*/
 /** Static globals */
@@ -89,7 +90,7 @@ TEST_SETUP( TEST_IOT_FLASH )
  * @brief Tear down function called after each test in this group is executed.
  */
 TEST_TEAR_DOWN( TEST_IOT_FLASH )
-{
+{ 
 }
 
 /*-----------------------------------------------------------*/
@@ -124,6 +125,110 @@ static void prvIotTimerCallback( void * pvUserContext )
 
     xSemaphoreGiveFromISR( xtestIotFlashTimerSemaphore, &xHigherPriorityTaskWoken );
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIotFlashWriteDummyData(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+{
+    uint32_t lRetVal;
+
+    /* Fill out a buffer of pageSize to be written */
+    for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
+    {
+        /* Less the a full buffer left? */
+        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+
+        if (remaining_size > 0)
+        {
+            for ( uint32_t j = 0; j < remaining_size; j++)
+            {
+                uctestIotFlashWriteBuffer[ j ] = j;
+            }
+
+            /* Write full page of data */
+            lRetVal = iot_flash_write_sync( xFlashHandle,
+                                            offset + i,
+                                            &uctestIotFlashWriteBuffer[ 0 ],
+                                            remaining_size );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIotFlashReadVerifyDummyData(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+{
+    uint32_t lRetVal;
+
+    for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
+    {
+        /* Less the a full buffer left? */
+        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+
+        if (remaining_size > 0)
+        {
+            /* Read back the data written */
+            lRetVal = iot_flash_read_sync( xFlashHandle,
+                                           offset + i,
+                                           &uctestIotFlashReadBuffer[ 0 ],
+                                           remaining_size );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Verify the data is erased. */
+            for( uint32_t i = 0; i < remaining_size; i++ )
+            {
+                if( uctestIotFlashReadBuffer[ i ] != (i & 0xFF) )
+                {
+                    TEST_ASSERT_MESSAGE( 0, "Data was NOT erased" );
+                }
+            }
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIotFlashReadVerifyErased(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+{
+    uint32_t lRetVal;
+
+    for( uint32_t i = 0; i < size; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
+    {
+        /* Less the a full buffer left? */
+        uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > size) ? (size - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+
+        if (remaining_size > 0)
+        {
+            /* Read back the data written */
+            lRetVal = iot_flash_read_sync( xFlashHandle,
+                                           offset + i,
+                                           &uctestIotFlashReadBuffer[ 0 ],
+                                           remaining_size );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Verify the data is erased. */
+            for( uint32_t i = 0; i < remaining_size; i++ )
+            {
+                if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
+                {
+                    TEST_ASSERT_MESSAGE( 0, "Data was NOT erased" );
+                }
+            }
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIotFlashWriteReadVerify(IotFlashHandle_t xFlashHandle, uint32_t offset, uint32_t size)
+{
+    /* Fill out a buffer of pageSize to be written */
+    prvIotFlashWriteDummyData(xFlashHandle, offset, size);
+
+    /* Read back the data written */
+    prvIotFlashReadVerifyDummyData(xFlashHandle, offset, size);
 }
 
 /*-----------------------------------------------------------*/
@@ -180,25 +285,16 @@ TEST_GROUP_RUNNER( TEST_IOT_FLASH )
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashOpenClose )
 {
-    int32_t lRetVal;
     IotFlashHandle_t xFlashHandle;
+    int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Set the global TimerHandle to NULL as we closed the handle */
-    gIotFlashHandle = NULL;
 }
 
 /*-----------------------------------------------------------*/
@@ -210,33 +306,30 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashOpenClose )
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashReadInfo )
 {
-    int32_t lRetVal;
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
+    int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+
+        /*
+         * Check the flash size, block size, sector size and flash size
+         */
+        TEST_ASSERT_NOT_EQUAL( 0, pxFlashInfo->ulPageSize );
+        TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulPageSize, pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulSectorSize, pxFlashInfo->ulBlockSize );
+        TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulBlockSize, pxFlashInfo->ulFlashSize );
     }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /*
-     * Check the flash size, block size, sector size and flash size
-     */
-    TEST_ASSERT_NOT_EQUAL( 0, pxFlashInfo->ulPageSize );
-    TEST_ASSERT_GREATER_THAN_UINT32( pxFlashInfo->ulPageSize, pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_GREATER_THAN_UINT32( pxFlashInfo->ulSectorSize, pxFlashInfo->ulBlockSize );
-    TEST_ASSERT_GREATER_THAN_UINT32( pxFlashInfo->ulBlockSize, pxFlashInfo->ulFlashSize );
-
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -253,132 +346,60 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSector )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the sector before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of MAX_BUFFER_SIZE to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Write the sector in ulChunks */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in pages. */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Erase one sector */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the whole sector in ulChunks of MAX_BUFFER_SIZE
-     * to make sure the contents are erased.
-     */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
+        /* Erase the sector before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Fill a sector with dummy data and verify it */
+        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+
+        /* Erase one sector */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Read back the whole sector to make sure the contents are erased.
+         */
+        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -394,72 +415,44 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseMultipleSectors )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase 2 sectors */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the data from 2 sectors in ulChunks of MAX_BUFFER_SIZE
-     * to make sure the contents are erased.
-     */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( pxFlashInfo->ulSectorSize * 2 ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Erase 2 sectors */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize * 2 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Read back the two sectors to make sure the contents are erased.
+         */
+        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2);
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -474,140 +467,75 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
+    uint32_t ulMiddleOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Make sure the offset is aligned to BlockSize */
-    if( !( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
-    {
-        return;
-    }
-
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /*
-     * Write starting at the middle of the sector to half of next sector.
-     */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in ulChunks of pxFlashInfo->ulSectorSize/16 */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* Make sure the offset is aligned to BlockSize */
+        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+
+            /* If Erase asyc is supported, register a callback */
+            if( pxFlashInfo->ucAsyncSupported )
             {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                iot_flash_set_callback( xFlashHandle,
+                                        prvIotFlashEraseCallback,
+                                        NULL );
             }
+
+            /* Erase the 2 sectors before writing to it. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize * 2 );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            ulMiddleOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
+
+            /*
+             * Write dummy data starting at the middle of the sector to half of next sector
+             * and read it back to verify the data.
+             */
+            prvIotFlashWriteReadVerify(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize);
+
+            /* Erase a Block */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulBlockSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            /* Read back the block to make sure the contents are erased.
+             */
+            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulBlockSize);
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Erase a Block */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulBlockSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the data from the Block in ulChunks of MAX_BUFFER_SIZE
-     * to make sure the contents are erased.
-     */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( pxFlashInfo->ulBlockSize ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        else
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            TEST_MESSAGE("Start offset is not aligned with blockSize");
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -623,165 +551,80 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
+    uint32_t ulMiddleOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Make sure the offset is aligned to BlockSize */
-    if( !( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
-    {
-        return;
-    }
-
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /*
-     * Write starting at the middle of the sector to half of next sector.
-     */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in ulChunks of pxFlashInfo->ulSectorSize/16 */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* Make sure the offset is aligned to BlockSize */
+        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+            /* If Erase asyc is supported, register a callback */
+            if( pxFlashInfo->ucAsyncSupported )
             {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                iot_flash_set_callback( xFlashHandle,
+                                        prvIotFlashEraseCallback,
+                                        NULL );
             }
+
+            /* Erase the 2 sectors before writing to it. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize * 2 );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            ulMiddleOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
+
+            /*
+             * Write dummy data starting at the middle of the sector to half of next sector
+             * and read it back to verify the data.
+             */
+            prvIotFlashWriteReadVerify(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize);
+
+            /* Erase a Block minus sector size starting at block boundry plus sector size */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize,
+                                               pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            /* Read back the block to make sure the contents are erased.
+            */
+            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize, 
+                                        pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize);
+
+            /* Read and make sure that the first sector written is not erased */
+            ulMiddleOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
+
+            prvIotFlashReadVerifyDummyData(xFlashHandle, ulMiddleOffset, pxFlashInfo->ulSectorSize / 2);
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Erase a Block minus sector size starting at block boundry plus sector size */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize,
-                                       pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the data from the Block in ulChunks of MAX_BUFFER_SIZE
-     * to make sure the contents are erased.
-     */
-    ulChunkOffset = ultestIotFlashStartOffset + pxFlashInfo->ulSectorSize;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        else
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            TEST_MESSAGE("Start offset is not aligned with blockSize");
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
     }
 
-    /* Read and make sure that the first sector written is not erased */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( ( pxFlashInfo->ulSectorSize / 2 ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
-        }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -797,213 +640,92 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
+    uint32_t ulOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Make sure the offset is aligned to BlockSize */
-    if( !( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
-    {
-        return;
-    }
-
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /*
-     * Write starting at the middle of the sector to half of next sector.
-     */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in ulChunks of pxFlashInfo->ulSectorSize/16 */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* Make sure the offset is aligned to BlockSize */
+        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+            /* If Erase asyc is supported, register a callback */
+            if( pxFlashInfo->ucAsyncSupported )
             {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                iot_flash_set_callback( xFlashHandle,
+                                        prvIotFlashEraseCallback,
+                                        NULL );
             }
+
+            /* Erase the 2 sectors before writing to it. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize * 2 );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
+
+            /*
+             * Write dummy data starting at the middle of the sector to half of next sector
+             * and read it back to verify the data.
+             */
+            prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+
+            /* Also write the last sector in the block to make sure its not erased */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ),
+                                               pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
+
+            prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
+
+            /* Erase a Block minus sector size starting at block boundry */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+
+            /* Read back the block to make sure the contents are erased.
+            */
+            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, 
+                                        pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize);
+
+            /* Read and make sure that the last sector written is not erased */
+            ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
+            prvIotFlashReadVerifyDummyData(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Also write the last sector in the block to make sure its not erased */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ),
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read and make sure that the last sector written is not erased */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( ( pxFlashInfo->ulSectorSize ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        else
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            TEST_MESSAGE("Start offset is not aligned with blockSize");
         }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
     }
 
-    /* Erase a Block minus sector size starting at block boundry */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the data from the Block in ulChunks of MAX_BUFFER_SIZE
-     * to make sure the contents are erased.
-     */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
-        }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read and make sure that the last sector written is not erased */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulBlockSize - pxFlashInfo->ulSectorSize ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < ( ( pxFlashInfo->ulSectorSize ) / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
-        }
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal ); 
 }
 
 /*-----------------------------------------------------------*/
@@ -1019,28 +741,24 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseUnAlignedAddress )
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+
+        /* Try erasing sector where offset is not aligned. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset + 1,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
     }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Try erasing sector where offset is not aligned. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset + 1,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1058,28 +776,24 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseUnAlignedSize )
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+
+        /* Try erasing sector where offset is not aligned. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize + 1 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
     }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Try erasing sector where offset is not aligned. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize + 1 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1097,81 +811,77 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePartialPage )
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the sector before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* fill out a buffer (Partial page) to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Write partial page (< page size) */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    &uctestIotFlashWriteBuffer[ 0 ],
-                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Write partial page starting from the end of previous
-     * write and make sure the second write does not overwrite the first
-     */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset + testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE,
-                                    &uctestIotFlashWriteBuffer[ testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE ],
-                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Read back the data written */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Verify the data written. */
-    for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2; i++ )
-    {
-        if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
+        }
+
+        /* Erase the sector before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* fill out a buffer (Partial page) to be written */
+        for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2; i++ )
+        {
+            uctestIotFlashWriteBuffer[ i ] = i;
+        }
+
+        /* Write partial page (< page size) */
+        lRetVal = iot_flash_write_sync( xFlashHandle,
+                                        ultestIotFlashStartOffset,
+                                        &uctestIotFlashWriteBuffer[ 0 ],
+                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        /* Write partial page starting from the end of previous
+         * write and make sure the second write does not overwrite the first
+         */
+        lRetVal = iot_flash_write_sync( xFlashHandle,
+                                        ultestIotFlashStartOffset + testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE,
+                                        &uctestIotFlashWriteBuffer[ testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE ],
+                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        /* Read back the data written */
+        lRetVal = iot_flash_read_sync( xFlashHandle,
+                                       ultestIotFlashStartOffset,
+                                       &uctestIotFlashReadBuffer[ 0 ],
+                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        /* Verify the data written. */
+        for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE * 2; i++ )
+        {
+            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+            {
+                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+            }
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1188,72 +898,42 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePage )
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the sector before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of pageSize to be written */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Write full page of data */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    &uctestIotFlashWriteBuffer[ 0 ],
-                                    pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Read back the data written */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Verify the data written. */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
+
+        /* Erase the sector before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Write the a full page and verify the data by reading it back */
+        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1270,92 +950,43 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSector )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the sector before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of MAX_BUFFER_SIZE to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Write the sector in ulChunks */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in pages. */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Erase the sector before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Write the a full sector and verify the data by reading it back */
+        prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1371,94 +1002,48 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteAcrossSectors )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
+    uint32_t ulOffset;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Try writing across 2 sectors.
-     * Write starting at the middle of the sector to half of next sector.
-     */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Read back the data written in ulChunks of pxFlashInfo->ulSectorSize/16 */
-    ulChunkOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Erase the 2 sectors before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize * 2 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        ulOffset = ( ultestIotFlashStartOffset + ( pxFlashInfo->ulSectorSize / 2 ) );
+
+        /*
+         * Try to write dummy data across twi sectors and read it back to verify the data.
+         */
+        prvIotFlashWriteReadVerify(xFlashHandle, ulOffset, pxFlashInfo->ulSectorSize);
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1476,40 +1061,36 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseInProgressRead )
     int32_t lRetVal;
     uint32_t ulSize;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Erase multiple sectors to get some time for read while erase. */
-    ulSize = pxFlashInfo->ulSectorSize * 2;
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       ulSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Try reading the data from the same sector(s) being erased. */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-
-    if( lRetVal != IOT_FLASH_DEVICE_BUSY )
-    {
+        /* Erase multiple sectors to get some time for read while erase. */
+        ulSize = pxFlashInfo->ulSectorSize * 2;
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           ulSize );
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        /* Try reading the data from the same sector(s) being erased. */
+        lRetVal = iot_flash_read_sync( xFlashHandle,
+                                       ultestIotFlashStartOffset,
+                                       &uctestIotFlashReadBuffer[ 0 ],
+                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+
+        if( lRetVal != IOT_FLASH_DEVICE_BUSY )
+        {
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1527,61 +1108,57 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseInProgressWrite )
     int32_t lRetVal;
     uint32_t ulSize;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
+
+    if( TEST_PROTECT() )
     {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Erase multiple sectors to get some time for read while erase. */
-    ulSize = pxFlashInfo->ulSectorSize * 2;
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       ulSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Try writing the the same sector when erase is in progress. */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    &uctestIotFlashWriteBuffer[ 0 ],
-                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-
-    if( lRetVal != IOT_FLASH_DEVICE_BUSY )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        /* Erase multiple sectors to get some time for read while erase. */
+        ulSize = pxFlashInfo->ulSectorSize * 2;
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           ulSize );
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Verify the data written. */
+        /* Fill out a buffer of sectorSize to be written */
         for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE; i++ )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+            uctestIotFlashWriteBuffer[ i ] = i;
+        }
+
+        /* Try writing the the same sector when erase is in progress. */
+        lRetVal = iot_flash_write_sync( xFlashHandle,
+                                        ultestIotFlashStartOffset,
+                                        &uctestIotFlashWriteBuffer[ 0 ],
+                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+
+        if( lRetVal != IOT_FLASH_DEVICE_BUSY )
+        {
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+            /* Read back the data written */
+            lRetVal = iot_flash_read_sync( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           &uctestIotFlashReadBuffer[ 0 ],
+                                           testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Verify the data written. */
+            for( int i = 0; i < testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE; i++ )
             {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
+                {
+                    TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                }
             }
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1597,146 +1174,89 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectWriteFailure )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulSize;
     IotFlashWriteProtectConfig_t xFlashProtect;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
+        }
 
-    /* Erase a sector before trying to write to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Make the sector as read only. */
-    xFlashProtect.ulAddress = ultestIotFlashStartOffset;
-    xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
-    xFlashProtect.xProtectionLevel = eFlashReadOnly;
-
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eSetFlashBlockProtection,
-                               ( void * const ) &xFlashProtect );
-
-    /* Check if block protection is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
+        /* Erase a sector before trying to write to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Read back the block protection */
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Make the sector as read only. */
+        xFlashProtect.ulAddress = ultestIotFlashStartOffset;
+        xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
+        xFlashProtect.xProtectionLevel = eFlashReadOnly;
+
         lRetVal = iot_flash_ioctl( xFlashHandle,
-                                   eGetFlashBlockProtection,
+                                   eSetFlashBlockProtection,
                                    ( void * const ) &xFlashProtect );
 
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Fill out a buffer of sectorSize to be written */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
+        /* Check if block protection is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
         {
-            uctestIotFlashWriteBuffer[ i ] = i;
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Read back the block protection */
+            lRetVal = iot_flash_ioctl( xFlashHandle,
+                                       eGetFlashBlockProtection,
+                                       ( void * const ) &xFlashProtect );
+
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Write the a full page and verify the data by reading it back */
+            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
         }
 
-        /* Try writing to this sector */
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ultestIotFlashStartOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify that the data is not written to the flash */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
-        }
-    }
-
-    /* Now make the sector writeable */
-    xFlashProtect.ulAddress = ultestIotFlashStartOffset;
-    xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
-    xFlashProtect.xProtectionLevel = eFlashReadWrite;
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eSetFlashBlockProtection,
-                               ( void * const ) &xFlashProtect );
-
-    /* Check if block protection is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Read back the block protection */
+        /* Now make the sector writeable */
+        xFlashProtect.ulAddress = ultestIotFlashStartOffset;
+        xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
+        xFlashProtect.xProtectionLevel = eFlashReadWrite;
         lRetVal = iot_flash_ioctl( xFlashHandle,
-                                   eGetFlashBlockProtection,
+                                   eSetFlashBlockProtection,
                                    ( void * const ) &xFlashProtect );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Fill out a buffer of sectorSize to be written */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
+        /* Check if block protection is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
         {
-            uctestIotFlashWriteBuffer[ i ] = i;
-        }
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Try writing to this sector */
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ultestIotFlashStartOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+            /* Read back the block protection */
+            lRetVal = iot_flash_ioctl( xFlashHandle,
+                                       eGetFlashBlockProtection,
+                                       ( void * const ) &xFlashProtect );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify that the data is not written to the flash */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            /* Write the a full page and verify the data by reading it back */
+            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1752,95 +1272,27 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
-    uint32_t ulSize;
     IotFlashWriteProtectConfig_t xFlashProtect;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase a sector before trying to write to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read back the data and make sure that data is erased first */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Verify that the data is erased */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
-    }
 
-    /* Fill out a buffer of sectorSize to be written */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Try writing to this sector */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    &uctestIotFlashWriteBuffer[ 0 ],
-                                    pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Make the sector as read only. */
-    xFlashProtect.ulAddress = ultestIotFlashStartOffset;
-    xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
-    xFlashProtect.xProtectionLevel = eFlashReadOnly;
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eSetFlashBlockProtection,
-                               ( void * const ) &xFlashProtect );
-
-    /* Check if block protection is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Read back the block protection */
-        lRetVal = iot_flash_ioctl( xFlashHandle,
-                                   eGetFlashBlockProtection,
-                                   ( void * const ) &xFlashProtect );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Try erasing the sector. */
+        /* Erase a sector before trying to write to it. */
         lRetVal = iot_flash_erase_sectors( xFlashHandle,
                                            ultestIotFlashStartOffset,
                                            pxFlashInfo->ulSectorSize );
@@ -1853,73 +1305,86 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectEraseFailure )
             TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
         }
 
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        /* Verify that the page was erased */
+        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
 
-        /* Verify that the data is not erased */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
-        }
-    }
+        /* Fill out a buffer of sectorSize to be written */
+        prvIotFlashWriteDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
 
-    /* Now make the sector as writeable. */
-    xFlashProtect.ulAddress = ultestIotFlashStartOffset;
-    xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
-    xFlashProtect.xProtectionLevel = eFlashReadWrite;
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eSetFlashBlockProtection,
-                               ( void * const ) &xFlashProtect );
-
-    /* Check if block protection is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Read back the block protection */
+        /* Make the sector as read only. */
+        xFlashProtect.ulAddress = ultestIotFlashStartOffset;
+        xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
+        xFlashProtect.xProtectionLevel = eFlashReadOnly;
         lRetVal = iot_flash_ioctl( xFlashHandle,
-                                   eGetFlashBlockProtection,
+                                   eSetFlashBlockProtection,
                                    ( void * const ) &xFlashProtect );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Try erasing the sector. */
-        lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                           ultestIotFlashStartOffset,
-                                           pxFlashInfo->ulSectorSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        if( pxFlashInfo->ucAsyncSupported )
+        /* Check if block protection is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
         {
-            /* Wait for the Erase to be completed and callback is called. */
-            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Read back the block protection */
+            lRetVal = iot_flash_ioctl( xFlashHandle,
+                                       eGetFlashBlockProtection,
+                                       ( void * const ) &xFlashProtect );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Try erasing the sector. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
+            {
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+            }
+
+            /* Read back the data written */
+            prvIotFlashReadVerifyDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
         }
 
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        /* Now make the sector as writeable. */
+        xFlashProtect.ulAddress = ultestIotFlashStartOffset;
+        xFlashProtect.ulSize = pxFlashInfo->ulLockSupportSize;
+        xFlashProtect.xProtectionLevel = eFlashReadWrite;
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eSetFlashBlockProtection,
+                                   ( void * const ) &xFlashProtect );
 
-        /* Verify that the data is erased */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
+        /* Check if block protection is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Read back the block protection */
+            lRetVal = iot_flash_ioctl( xFlashHandle,
+                                       eGetFlashBlockProtection,
+                                       ( void * const ) &xFlashProtect );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Try erasing the sector. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            if( pxFlashInfo->ucAsyncSupported )
             {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+                /* Wait for the Erase to be completed and callback is called. */
+                lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+                TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
             }
+
+            /* Read back the data written and verify that it is erased */
+            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -1936,106 +1401,47 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteEraseReadCycle )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
-    uint32_t ulChunkOffset;
-    uint32_t ulSize;
-    IotFlashWriteProtectConfig_t xFlashProtect;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
-
-    /* Erase a sector before trying to write to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Read back the data and make sure that data is erased first */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Verify that the data is erased */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-        {
-            TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-        }
-    }
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    for( uint32_t idx = 0; idx < 5; idx++ )
-    {
-        /* Write to this sector */
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ultestIotFlashStartOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data read-back */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-        {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback After Write" );
-            }
-        }
-
+    if( TEST_PROTECT() )
+    { 
         /* Get the flash information. */
         pxFlashInfo = iot_flash_getinfo( xFlashHandle );
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-        /* Erase the sector. */
+        /* Erase a sector before trying to write to it. */
         lRetVal = iot_flash_erase_sectors( xFlashHandle,
                                            ultestIotFlashStartOffset,
                                            pxFlashInfo->ulSectorSize );
         TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-        /* Read back the data written */
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       pxFlashInfo->ulPageSize );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        /* Read back the data and make sure that data is erased first */
+        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
 
-        /* Verify that the data is erased */
-        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
+        for( uint32_t idx = 0; idx < 5; idx++ )
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback after Erase" );
-            }
+            /* Write to this sector and veirfy */
+            prvIotFlashWriteReadVerify(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
+
+            /* Get the flash information. */
+            pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+            TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+
+            /* Erase the sector. */
+            lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                               ultestIotFlashStartOffset,
+                                               pxFlashInfo->ulSectorSize );
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+            /* Read back the data and make sure that data is erased */
+            prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize);
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2050,146 +1456,99 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteSuspendResume )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     IotTimerHandle_t xTimerHandle;
-    uint64_t ulMicroSeconds;
-    uint32_t ulChunkOffset;
     int32_t lRetVal;
     uint32_t lStatus;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Setup a timer to suspend the write */
-    xTimerHandle = iot_timer_open( ltestIotTimerInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
+    if( TEST_PROTECT() )
+    { 
+        /* Setup a timer to suspend the write */
+        xTimerHandle = iot_timer_open( ltestIotTimerInstance );
+        TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Set up the timer callback */
-    iot_timer_set_callback( xTimerHandle,
-                            prvIotTimerCallback,
-                            xFlashHandle );
-
-    /* Set up the timer delay */
-    lRetVal = iot_timer_delay( xTimerHandle,
-                               testIotFLASH_DEFAULT_DELAY_US );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
-
-    /* Start the timer */
-    lRetVal = iot_timer_start( xTimerHandle );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
-
-    /* Fill out a buffer of sectorSize to be written */
-    for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
-    {
-        uctestIotFlashWriteBuffer[ i ] = i;
-    }
-
-    /* Write 2 sectors. */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_write_sync( xFlashHandle,
-                                        ulChunkOffset,
-                                        &uctestIotFlashWriteBuffer[ 0 ],
-                                        testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-    }
-
-    /* Wait for the Delay callback to be called. */
-    lRetVal = xSemaphoreTake( xtestIotFlashTimerSemaphore, portMAX_DELAY );
-    TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-
-    /* Verify that current write is suspended */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eGetFlashStatus,
-                               ( void * const ) &lStatus );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eFlashProgramSuspended, lStatus );
-
-    /* Resume the current write operation */
-    /* Suspend the flash write/erase */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eResumeFlashProgramErase,
-                               NULL );
-
-    /* Check if suspend/resume is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    }
-
-    /* Verify that current write is resumed */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eGetFlashStatus,
-                               ( void * const ) &lStatus );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eFlashIdle, lStatus );
-
-    /* Read the data back to make sure Resume succeded and data is written */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteBuffer[ i ] )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Erase the 2 sectors before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize * 2 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Set up the timer callback */
+        iot_timer_set_callback( xTimerHandle,
+                                prvIotTimerCallback,
+                                xFlashHandle );
+
+        /* Set up the timer delay */
+        lRetVal = iot_timer_delay( xTimerHandle,
+                                   testIotFLASH_DEFAULT_DELAY_US );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
+
+        /* Start the timer */
+        lRetVal = iot_timer_start( xTimerHandle );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
+
+        /* Fill out a sector with data */
+        prvIotFlashWriteDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+
+        /* Wait for the Delay callback to be called. */
+        lRetVal = xSemaphoreTake( xtestIotFlashTimerSemaphore, portMAX_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+        /* Verify that current write is suspended */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eGetFlashStatus,
+                                   ( void * const ) &lStatus );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( eFlashProgramSuspended, lStatus );
+
+        /* Resume the current write operation */
+        /* Suspend the flash write/erase */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eResumeFlashProgramErase,
+                                   NULL );
+
+        /* Check if suspend/resume is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        }
+
+        /* Verify that current write is resumed */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eGetFlashStatus,
+                                   ( void * const ) &lStatus );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( eFlashIdle, lStatus );
+
+        /* Read the data back to make sure Resume succeded and data is written */
+        prvIotFlashReadVerifyDummyData(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize);
+
+        lRetVal = iot_timer_close( xTimerHandle );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
     }
 
-    lRetVal = iot_timer_close( xTimerHandle );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2203,124 +1562,96 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseSuspendResume )
     IotFlashHandle_t xFlashHandle;
     IotFlashInfo_t * pxFlashInfo;
     IotTimerHandle_t xTimerHandle;
-    uint64_t ulMicroSeconds;
-    uint32_t ulChunkOffset;
     int32_t lRetVal;
     uint32_t lStatus;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Setup a timer to suspend the write */
-    xTimerHandle = iot_timer_open( ltestIotTimerInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
+    if( TEST_PROTECT() )
+    { 
+        /* Setup a timer to suspend the write */
+        xTimerHandle = iot_timer_open( ltestIotTimerInstance );
+        TEST_ASSERT_NOT_EQUAL( NULL, xTimerHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* Set up the timer callback */
-    iot_timer_set_callback( xTimerHandle,
-                            prvIotTimerCallback,
-                            xFlashHandle );
+        /* Set up the timer callback */
+        iot_timer_set_callback( xTimerHandle,
+                                prvIotTimerCallback,
+                                xFlashHandle );
 
-    /* Set up the timer delay */
-    lRetVal = iot_timer_delay( xTimerHandle,
-                               testIotFLASH_DEFAULT_DELAY_US );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
+        /* Set up the timer delay */
+        lRetVal = iot_timer_delay( xTimerHandle,
+                                   testIotFLASH_DEFAULT_DELAY_US );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
-    /* Start the timer */
-    lRetVal = iot_timer_start( xTimerHandle );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
+        /* Start the timer */
+        lRetVal = iot_timer_start( xTimerHandle );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the 2 sectors before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize * 2 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-
-    /* Wait for the Delay callback to be called. */
-    lRetVal = xSemaphoreTake( xtestIotFlashTimerSemaphore, portMAX_DELAY );
-    TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-
-    /* Verify that current erase is suspended */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eGetFlashStatus,
-                               ( void * const ) &lStatus );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eFlashEraseSuspended, lStatus );
-
-    /* Resume the current erase operation */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eResumeFlashProgramErase,
-                               NULL );
-
-    /* Check if suspend/resume is supported */
-    if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
-    {
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    }
-
-    /* Verify that current erase is resumed */
-    lRetVal = iot_flash_ioctl( xFlashHandle,
-                               eGetFlashStatus,
-                               ( void * const ) &lStatus );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-    TEST_ASSERT_EQUAL( eFlashIdle, lStatus );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Read the data back to make sure Resume succeded and data is erased */
-    ulChunkOffset = ultestIotFlashStartOffset;
-
-    for( uint32_t ulChunks = 0;
-         ulChunks < pxFlashInfo->ulSectorSize / testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
-         ulChunks++ )
-    {
-        lRetVal = iot_flash_read_sync( xFlashHandle,
-                                       ulChunkOffset,
-                                       &uctestIotFlashReadBuffer[ 0 ],
-                                       testIotFLASH_DEFAULT_MAX_BUFFER_SIZE );
-        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-        /* Verify the data written. */
-        for( int i = 0; i < testIotFLASH_DEFAULT_MAX_BUFFER_SIZE; i++ )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
-            {
-                TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
-            }
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
         }
 
-        ulChunkOffset += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+        /* Erase the 2 sectors before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize * 2 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+
+        /* Wait for the Delay callback to be called. */
+        lRetVal = xSemaphoreTake( xtestIotFlashTimerSemaphore, portMAX_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+
+        /* Verify that current erase is suspended */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eGetFlashStatus,
+                                   ( void * const ) &lStatus );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( eFlashEraseSuspended, lStatus );
+
+        /* Resume the current erase operation */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eResumeFlashProgramErase,
+                                   NULL );
+
+        /* Check if suspend/resume is supported */
+        if( lRetVal != IOT_FLASH_FUNCTION_NOT_SUPPORTED )
+        {
+            TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        }
+
+        /* Verify that current erase is resumed */
+        lRetVal = iot_flash_ioctl( xFlashHandle,
+                                   eGetFlashStatus,
+                                   ( void * const ) &lStatus );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+        TEST_ASSERT_EQUAL( eFlashIdle, lStatus );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Read the data back to make sure Resume succeded and data is erased */
+        prvIotFlashReadVerifyErased(xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulSectorSize * 2);
+
+        lRetVal = iot_timer_close( xTimerHandle );
+        TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
     }
 
-    lRetVal = iot_timer_close( xTimerHandle );
-    TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
-
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2337,66 +1668,86 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
     IotFlashInfo_t * pxFlashInfo;
     int32_t lRetVal;
 
-    /* Open flash to initialize hardware. */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Get the flash information. */
-    pxFlashInfo = iot_flash_getinfo( xFlashHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
+    if( TEST_PROTECT() )
+    { 
+        /* Get the flash information. */
+        pxFlashInfo = iot_flash_getinfo( xFlashHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
-    /* If Erase asyc is supported, register a callback */
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        iot_flash_set_callback( xFlashHandle,
-                                prvIotFlashEraseCallback,
-                                NULL );
-    }
-
-    /* Erase the sector before writing to it. */
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       pxFlashInfo->ulSectorSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    if( pxFlashInfo->ucAsyncSupported )
-    {
-        /* Wait for the Erase to be completed and callback is called. */
-        lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
-        TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
-    }
-
-    /* Write full page of data */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    uctestIotFlashWriteROBuffer,
-                                    pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Read back the data written */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   pxFlashInfo->ulPageSize );
-    TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
-
-    /* Verify the data written. */
-    for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i++ )
-    {
-        if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteROBuffer[ i ] )
+        /* If Erase asyc is supported, register a callback */
+        if( pxFlashInfo->ucAsyncSupported )
         {
-            TEST_ASSERT_MESSAGE( 0, "Contents do NOT match when readback" );
+            iot_flash_set_callback( xFlashHandle,
+                                    prvIotFlashEraseCallback,
+                                    NULL );
+        }
+
+        /* Erase the sector before writing to it. */
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           pxFlashInfo->ulSectorSize );
+        TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+        if( pxFlashInfo->ucAsyncSupported )
+        {
+            /* Wait for the Erase to be completed and callback is called. */
+            lRetVal = xSemaphoreTake( xtestIotFlashSemaphore, portMAX_DELAY );
+            TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
+        }
+
+        /* Write full page of data */
+        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
+        {
+            /* Less the a full buffer left? */
+            uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > pxFlashInfo->ulPageSize) ? (pxFlashInfo->ulPageSize - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+
+            if (remaining_size > 0)
+            {
+                for ( uint32_t j = 0; j < remaining_size; j++)
+                {
+                    uctestIotFlashWriteBuffer[ j ] = j;
+                }
+
+                /* Write full page of data */
+                lRetVal = iot_flash_write_sync( xFlashHandle,
+                                                ultestIotFlashStartOffset + i,
+                                                uctestIotFlashWriteROBuffer,
+                                                remaining_size );
+                TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+            }
+        }
+
+        for( uint32_t i = 0; i < pxFlashInfo->ulPageSize; i += testIotFLASH_DEFAULT_MAX_BUFFER_SIZE )
+        {
+            /* Less the a full buffer left? */
+            uint32_t remaining_size = ((i + testIotFLASH_DEFAULT_MAX_BUFFER_SIZE) > pxFlashInfo->ulPageSize) ? (pxFlashInfo->ulPageSize - i) : testIotFLASH_DEFAULT_MAX_BUFFER_SIZE;
+
+            if (remaining_size > 0)
+            {
+                /* Read back the data written */
+                lRetVal = iot_flash_read_sync( xFlashHandle,
+                                               ultestIotFlashStartOffset + i,
+                                               &uctestIotFlashReadBuffer[ 0 ],
+                                               remaining_size );
+                TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
+
+                /* Verify the data is erased. */
+                for( uint32_t i = 0; i < remaining_size; i++ )
+                {
+                    if( uctestIotFlashReadBuffer[ i ] != uctestIotFlashWriteROBuffer[ i ] )
+                    {
+                        TEST_ASSERT_MESSAGE( 0, "Data was NOT erased" );
+                    }
+                }
+            }
         }
     }
 
-    /* Close the flash handle. */
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2407,23 +1758,23 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWritePageFromFlash )
  *
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashOpenCloseFuzz )
-{
+{   
+    IotFlashHandle_t xFlashHandle, xFlashHandleTmp;
     int32_t lRetVal;
-    IotFlashHandle_t xFlashHandle;
 
-    /* Open flash to initialize hardware with invalid handle. */
-    xFlashHandle = iot_flash_open( testIotFLASH_INVALID_HANDLE );
-    TEST_ASSERT_EQUAL( NULL, xFlashHandle );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Open with valid handle */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
+    if( TEST_PROTECT() )
+    {   
+        /* open the same intance twice */
+        xFlashHandleTmp = iot_flash_open( ltestIotFlashInstance );
+        TEST_ASSERT_EQUAL( NULL, xFlashHandleTmp );
+
+        /* Open flash to initialize hardware with invalid handle. */
+        xFlashHandleTmp = iot_flash_open( testIotFLASH_INVALID_HANDLE );
+        TEST_ASSERT_EQUAL( NULL, xFlashHandleTmp );
     }
 
     /* Close with valid handle */
@@ -2457,31 +1808,27 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashGetInfoFuzz )
  *
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashIoctlFuzz )
-{
+{   
+    IotFlashHandle_t xFlashHandle;
     int32_t lRetVal;
     uint32_t lStatus;
-    IotFlashHandle_t xFlashHandle;
-
-    /* Open with valid handle */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
 
     /* Call ioctl with null handle */
     lRetVal = iot_flash_ioctl( NULL, eGetFlashStatus, ( void * const ) &lStatus );
     TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Call ioctl with handle, but invalid enum */
-    lRetVal = iot_flash_ioctl( xFlashHandle, -1, NULL );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Close with valid handle */
+    if( TEST_PROTECT() )
+    { 
+        /* Call ioctl with handle, but invalid enum */
+        lRetVal = iot_flash_ioctl( xFlashHandle, -1, NULL );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    }
+
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2494,19 +1841,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashIoctlFuzz )
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFuzz )
 {
-    int32_t lRetVal;
     IotFlashHandle_t xFlashHandle;
-
-    /* Open with valid handle */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    int32_t lRetVal;
 
     /* Erase one sector with NULL handle*/
     lRetVal = iot_flash_erase_sectors( NULL,
@@ -2514,19 +1850,26 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFuzz )
                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
     TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Erase one sector with invalid start address*/
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       -1,
-                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Erase one sector with invalid length*/
-    lRetVal = iot_flash_erase_sectors( xFlashHandle,
-                                       ultestIotFlashStartOffset,
-                                       -1 );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    if( TEST_PROTECT() )
+    { 
+        /* Erase one sector with invalid start address*/
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           -1,
+                                           testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Close with valid handle */
+        /* Erase one sector with invalid length*/
+        lRetVal = iot_flash_erase_sectors( xFlashHandle,
+                                           ultestIotFlashStartOffset,
+                                           -1 );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    }
+
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2539,19 +1882,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFuzz )
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteFuzz )
 {
-    int32_t lRetVal;
     IotFlashHandle_t xFlashHandle;
-
-    /* Open with valid handle */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    int32_t lRetVal;
 
     /* Write partial page with invalid handle */
     lRetVal = iot_flash_write_sync( NULL,
@@ -2560,21 +1892,28 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteFuzz )
                                     testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
     TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Write partial page with invalid start address */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    -1,
-                                    &uctestIotFlashWriteBuffer[ 0 ],
-                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Write partial page with invalid buffer */
-    lRetVal = iot_flash_write_sync( xFlashHandle,
-                                    ultestIotFlashStartOffset,
-                                    NULL,
-                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    if( TEST_PROTECT() )
+    { 
+        /* Write partial page with invalid start address */
+        lRetVal = iot_flash_write_sync( xFlashHandle,
+                                        -1,
+                                        &uctestIotFlashWriteBuffer[ 0 ],
+                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Close with valid handle */
+        /* Write partial page with invalid buffer */
+        lRetVal = iot_flash_write_sync( xFlashHandle,
+                                        ultestIotFlashStartOffset,
+                                        NULL,
+                                        testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    }
+
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }
@@ -2587,19 +1926,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteFuzz )
  */
 TEST( TEST_IOT_FLASH, AFQP_IotFlashReadFuzz )
 {
-    int32_t lRetVal;
     IotFlashHandle_t xFlashHandle;
-
-    /* Open with valid handle */
-    if( gIotFlashHandle == NULL )
-    {
-        xFlashHandle = iot_flash_open( 0 );
-        TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
-    }
-    else
-    {
-        xFlashHandle = gIotFlashHandle;
-    }
+    int32_t lRetVal;
 
     /* Read partial page with invalid handle */
     lRetVal = iot_flash_read_sync( NULL,
@@ -2608,21 +1936,28 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashReadFuzz )
                                    testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
     TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Read partial page with invalid start address */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   -1,
-                                   &uctestIotFlashReadBuffer[ 0 ],
-                                   testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    /* Open the flash instance */
+    xFlashHandle = iot_flash_open( ltestIotFlashInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xFlashHandle );
 
-    /* Read partial page with invalid buffer */
-    lRetVal = iot_flash_read_sync( xFlashHandle,
-                                   ultestIotFlashStartOffset,
-                                   NULL,
-                                   testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
-    TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    if( TEST_PROTECT() )
+    { 
+        /* Read partial page with invalid start address */
+        lRetVal = iot_flash_read_sync( xFlashHandle,
+                                       -1,
+                                       &uctestIotFlashReadBuffer[ 0 ],
+                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
 
-    /* Close with valid handle */
+        /* Read partial page with invalid buffer */
+        lRetVal = iot_flash_read_sync( xFlashHandle,
+                                       ultestIotFlashStartOffset,
+                                       NULL,
+                                       testIotFLASH_DEFAULT_PARTIAL_PAGE_SIZE );
+        TEST_ASSERT_EQUAL( IOT_FLASH_INVALID_VALUE, lRetVal );
+    }
+
+    /* Close flash handle */
     lRetVal = iot_flash_close( xFlashHandle );
     TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 }

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -180,12 +180,12 @@ static void prvIotFlashReadVerifyDummyData( IotFlashHandle_t xFlashHandle,
                                            remaining_size );
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-            /* Verify the data is erased. */
+            /* Verify that  the data was written. */
             for( uint32_t i = 0; i < remaining_size; i++ )
             {
                 if( uctestIotFlashReadBuffer[ i ] != ( i & 0xFF ) )
                 {
-                    TEST_ASSERT_MESSAGE( 0, "Data was NOT erased" );
+                    TEST_ASSERT_MESSAGE( 0, "Data was NOT written" );
                 }
             }
         }
@@ -207,14 +207,14 @@ static void prvIotFlashReadVerifyErased( IotFlashHandle_t xFlashHandle,
 
         if( remaining_size > 0 )
         {
-            /* Read back the data written */
+            /* Read the data */
             lRetVal = iot_flash_read_sync( xFlashHandle,
                                            offset + i,
                                            &uctestIotFlashReadBuffer[ 0 ],
                                            remaining_size );
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-            /* Verify the data is erased. */
+            /* Verify that the data was erased. */
             for( uint32_t i = 0; i < remaining_size; i++ )
             {
                 if( uctestIotFlashReadBuffer[ i ] != testIotFLASH_DEFAULT_FLASH_BYTE )
@@ -1234,8 +1234,9 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashWriteProtectWriteFailure )
 
             TEST_ASSERT_EQUAL( IOT_FLASH_SUCCESS, lRetVal );
 
-            /* Write the a full page and verify the data by reading it back */
-            prvIotFlashWriteReadVerify( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
+            /* Write the a full page and verify the data is not written reading it back */
+            prvIotFlashWriteDummyData( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
+            prvIotFlashReadVerifyErased( xFlashHandle, ultestIotFlashStartOffset, pxFlashInfo->ulPageSize );
         }
 
         /* Now make the sector writeable */

--- a/libraries/abstractions/pkcs11/ecc608a/atca_cert_chain.h
+++ b/libraries/abstractions/pkcs11/ecc608a/atca_cert_chain.h
@@ -15,4 +15,4 @@
         }
     #endif
 
-#endif // CERT_DEF_2_DEVICE_H
+#endif /* ifndef CERT_DEF_2_DEVICE_H */


### PR DESCRIPTION
Description
-----------
This pull request is rather large (sorry for this), the main contributions is the following:

* Refactored flash test cases to use TEST_PROTECT sections to guard against cascading failures.
* Refactored flash test cases, moving common code for writing, reading, verifying dummy data out of each test case into global privates. This should simplify maintaining the tests as.
* Updated AFQP_IotFlashReadInfo to allow block >= sector >= page >= flash (in other words, moved from "greater than" to "greater than or equal") as this is a valid scenario. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.