### PR TITLE
Fix doc typos

### DIFF
--- a/libraries/3rdparty/mbedtls_utils/README.md
+++ b/libraries/3rdparty/mbedtls_utils/README.md
@@ -1,6 +1,14 @@
 ## Background
-This folder contains the mbedtls_utils.c file. 
+This folder contains two files:
+
+### mbedtls_utils.c
 
 The convert_pem_to_der() function defined in mbedtls_utils.c is used by the PKCS #11 tests and the dev_mode_key_provisioning demo. This function is copied from the pem2der.c file that can be found in the mbedtls/programs/util/ directory of the mbedTLS library. Copying this function is required since the pem2der.c file has a main function and could not be used.
 
 The PKI_RSA_RSASSA_PKCS1_v15_Encode() function defined in mbedtls_utils.c is used in the PKCS #11 tests. It's a  modified version of the rsa_rsassa_pkcs1_v15_encode() function that is defined in the mbedTLS library file rsa.c that can be found in the mbedtls/library/ directory. Copying and modifying this function is required because the test code needs changes that are specific to this repo and should not be moved upstream.
+
+### mbedtls_error.h/.c files
+
+These provide 2 utility functions, `mbedtls_strerror_highlevel` and `mbedtls_strerror_lowlevel`, to convert the high-level and low-level codes embedded in a mbed TLS return codes, respectively. 
+
+The difference between these utilities and the mbedTLS provided `mbedtls_strerror` utility is that the former enable string-conversion of error codes with constant strings (that is efficient for resource-constrained microcontroller platforms), while the latter involves a string-copy operation in a caller-provided buffer.

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -66,13 +66,13 @@
 #include <string.h>
 
 /**
- * @brief Represents string to be loggedwhen mbed TLS returned error
+ * @brief Represents string to be logged when mbed TLS returned error
  * does not contain a high-level code.
  */
 static const char * pNoHighLevelMbedTlsCodeStr = "<No-High-Level-Code>";
 
 /**
- * @brief Represents string to be loggedwhen mbed TLS returned error
+ * @brief Represents string to be logged when mbed TLS returned error
  * does not contain a low-level code.
  */
 static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";


### PR DESCRIPTION
Fix documentation typos in `iot_pkcs11_mbetls.c`

Description
-----------
Resolves documentation typos pointed in #1875 
Update `mbedtls_utils/README.md` about the new `mbedtls_strerror_highlevel` and `mbedtls_strerror_lowlevel` utilities

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.