### PR TITLE
Retry using exponential backoff upon connection failure with GGD system tests

### DIFF
--- a/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
@@ -104,14 +104,6 @@
 #define ggdLOOP_BACK_IP            "127.0.0.1"
 
 /**
- * @brief Retry count for GGD_JSONRequestStart
- *
- * Used to retry GGD_JSONRequestStart method in GGD_GetGGCIPandCertificate
- */
-#define ggdSTART_RETRY_COUNT       3
-
-
-/**
  * @brief JSON parsing helper functions.
  *
  * The functions declared below are used to make parsing of JSON file a bit easier.
@@ -179,28 +171,7 @@ BaseType_t GGD_GetGGCIPandCertificate( const char * pcHostAddress,
     configASSERT( pxHostAddressData != NULL );
     configASSERT( pcBuffer != NULL );
 
-    /* Retry GGD_JSONRequestStart in case of failure */
-    int32_t retryCount = 0;
-
-    /* Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
-
-    for (; retryCount < ggdSTART_RETRY_COUNT; retryCount++)
-    {
-        xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, &xSocket );
-
-        #if ( ggdSTART_RETRY_COUNT > 1 )
-                if (xStatus != pdPASS)
-                {
-                    IotClock_SleepMs(periodMs);
-                    periodMs *= 2;
-                }
-                else
-                {
-                    break;
-                }
-        #endif
-    }
+    xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, &xSocket );
 
     if( xStatus == pdPASS )
     {

--- a/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c
@@ -104,6 +104,14 @@
 #define ggdLOOP_BACK_IP            "127.0.0.1"
 
 /**
+ * @brief Retry count for GGD_JSONRequestStart
+ *
+ * Used to retry GGD_JSONRequestStart method in GGD_GetGGCIPandCertificate
+ */
+#define ggdSTART_RETRY_COUNT       3
+
+
+/**
  * @brief JSON parsing helper functions.
  *
  * The functions declared below are used to make parsing of JSON file a bit easier.
@@ -171,7 +179,28 @@ BaseType_t GGD_GetGGCIPandCertificate( const char * pcHostAddress,
     configASSERT( pxHostAddressData != NULL );
     configASSERT( pcBuffer != NULL );
 
-    xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, &xSocket );
+    /* Retry GGD_JSONRequestStart in case of failure */
+    int32_t retryCount = 0;
+
+    /* Wait until 1100 ms have elapsed since the last connection. */
+    uint32_t periodMs = 1100;
+
+    for (; retryCount < ggdSTART_RETRY_COUNT; retryCount++)
+    {
+        xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, &xSocket );
+
+        #if ( ggdSTART_RETRY_COUNT > 1 )
+                if (xStatus != pdPASS)
+                {
+                    IotClock_SleepMs(periodMs);
+                    periodMs *= 2;
+                }
+                else
+                {
+                    break;
+                }
+        #endif
+    }
 
     if( xStatus == pdPASS )
     {

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -79,7 +79,7 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
 static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
                                            uint16_t usGGDPort,
                                            const char * pcThingName,
-                                           Socket_t * pxSocket)
+                                           Socket_t * pxSocket);
 
 TEST_GROUP( GGD_System );
 
@@ -135,9 +135,9 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
 }
 
 static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
-                                        uint16_t usGGDPort,
-                                        const char * pcThingName,
-                                        Socket_t * pxSocket )
+                                           uint16_t usGGDPort,
+                                           const char * pcThingName,
+                                           Socket_t * pxSocket )
 {
     BaseType_t xStatus;
 
@@ -162,9 +162,9 @@ TEST( GGD_System, JSONRequestAbort )
         GGD_JSONRequestAbort( &xSocket );
 
         prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                              clientcredentialGREENGRASS_DISCOVERY_PORT,
-                              clientcredentialIOT_THING_NAME,
-                              &xSocket );
+                                 clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                 clientcredentialIOT_THING_NAME,
+                                 &xSocket );
         GGD_JSONRequestAbort( &xSocket );
     }
     else
@@ -326,9 +326,9 @@ TEST( GGD_System, GetIPandCertificateFromJSON )
 
         xAutoSearchFlag = pdTRUE;
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
 
         if( xStatus == pdPASS )
         {
@@ -458,9 +458,9 @@ TEST( GGD_System, JSONRequestGetFile )
          *  @{
          */
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
 
         if( xStatus == pdPASS )
         {
@@ -487,9 +487,9 @@ TEST( GGD_System, JSONRequestGetFile )
          *  @{
          */
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
 
         if( xStatus == pdPASS )
         {
@@ -525,9 +525,9 @@ TEST( GGD_System, JSONRequestGetFile )
          *  @{
          */
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
 
         if( xStatus == pdPASS )
         {
@@ -605,9 +605,9 @@ TEST( GGD_System, JSONRequestGetSize )
          *  @{
          */
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
         TEST_ASSERT_EQUAL_INT32( pdPASS, xStatus );
 
         xStatus = GGD_JSONRequestGetSize( &xSocket, &ulJSONFileSize );
@@ -644,9 +644,9 @@ TEST( GGD_System, JSONRequestStart )
          *  @{
          */
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           &xSocket );
         TEST_ASSERT_EQUAL_INT32( pdPASS, xStatus );
         GGD_SecureConnect_Disconnect( &xSocket );
         /** @}*/
@@ -662,18 +662,18 @@ TEST( GGD_System, JSONRequestStart )
     if( TEST_PROTECT() )
     {
         xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        clientcredentialIOT_THING_NAME,
-                                        NULL );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           clientcredentialIOT_THING_NAME,
+                                           NULL );
         TEST_FAIL();
     }
 
     if( TEST_PROTECT() )
     {
         xStatus = prvGGD_JSONRequestStart( NULL,
-                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                        NULL,
-                                        &xSocket );
+                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                           NULL,
+                                           &xSocket );
         TEST_FAIL();
     }
 

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -75,7 +75,7 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
                                                  BaseType_t * pxJSONFileRetrieveCompleted,
                                                  uint32_t ulJSONFileSize );
 
-/* Wrapper function to retry request in case of failure with exponential backoff */
+/* Wrapper function to retry request in case of failure with exponential backoff. */
 static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
                                            uint16_t usGGDPort,
                                            const char * pcThingName,

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -185,7 +185,6 @@ TEST( GGD_System, GetGGCIPandCertificate )
 {
     BaseType_t xStatus;
     GGD_HostAddressData_t xHostAddressData;
-    int16_t nBufferLength = 128;
     uint32_t ulBufferSize = testrunnerBUFFER_SIZE;
 
     if( TEST_PROTECT() )

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -38,7 +38,6 @@
 #include "iot_init.h"
 
 #define ggdJSON_FILE                     "{\"GGGroups\":[{\"GGGroupId\":\"myGroupID\",\"Cores\":[{\"thingArn\":\"myGreenGrassCoreArn\",\"Connectivity\":[{\"Id\":\"AUTOIP_10.60.212.138_0\",\"HostAddress\":\"44.44.44.44\",\"PortNumber\":1234,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_127.0.0.1_1\",\"HostAddress\":\"127.0.0.1\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_192.168.2.2_2\",\"HostAddress\":\"01.23.456.789\",\"PortNumber\":4321,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_::1_3\",\"HostAddress\":\"::1\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_fe80::bfda:8f62:7b4b:f358_4\",\"HostAddress\":\"fe80::bfda:8f62:7b4b:f358\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_fe80::e234:cff9:f53f:6216_5\",\"HostAddress\":\"fe80::e234:cff9:f53f:6216\",\"PortNumber\":8883,\"Metadata\":\"\"}]}],\"CAs\":[\"-----BEGIN CERTIFICATE-----\\nMIIEFTCCAv2gAwIBAgIVAPRru+NqCDr0r6oD6PnTG05rWuY+MA0GCSqGSIb3DQEB\\nCwUAMIGoMQswCQYDVQQGEwJVUzEYMBYGA1UECgwPQW1hem9uLmNvbSBJbmMuMRww\\nGgYDVQQLDBNBbWF6b24gV2ViIFNlcnZpY2VzMRMwEQYDVQQIDApXYXNoaW5ndG9u\\nMRAwDgYDVQQHDAdTZWF0dGxlMTowOAYDVQQDDDE5NDI5MjczNzY5NjU6ZDk3ZmZl\\nZmUtNTI4MS00ZWM5LTk4NDYtYjNlZTQxMDRjMjAxMCAXDTE3MDcwNjIwMDczOFoY\\nDzIwOTcwNzA2MjAwNzM3WjCBqDELMAkGA1UEBhMCVVMxGDAWBgNVBAoMD0FtYXpv\\nbi5jb20gSW5jLjEcMBoGA1UECwwTQW1hem9uIFdlYiBTZXJ2aWNlczETMBEGA1UE\\nCAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTE6MDgGA1UEAwwxOTQyOTI3\\nMzc2OTY1OmQ5N2ZmZWZlLTUyODEtNGVjOS05ODQ2LWIzZWU0MTA0YzIwMTCCASIw\\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKxzJpXU2DZDEglh/FT01epAWby6\\np4Ymw76icyMzBUJzafibABJ3cTyjDQE6ZqbSl1ryBxGwQBsveIgj8SVVtv927wk7\\nlncgD+EghfTZgSfscND653AJeVFQlCeHipZI32wzXyPmwglFrWp9vsrY/8BO1Kjk\\nSAs4o8fDVVMAaZCJDMuc5csc3CQ2OJYLOl+SZisGNM1h0xHpWieM38KDDrp99x8Q\\nTwDmgaMjtdIJR7Y9Nzm0N78gTf3gTazEO9iUKojVCNubxK/lQ6KjJ0JcvsljPpVp\\nuzjOmn91xmNoHEQCboa7YoYNNbdAbftGeUl16wFdTgbuUS9vakk5idVoC2ECAwEA\\nAaMyMDAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUmcz4OlH9+mlpnTKG3taI\\nw+6FSk0wDQYJKoZIhvcNAQELBQADggEBACeiQ6MxiktsU0sLNmP1cNbiuBuutjoq\\nymk476Bhr4E2WSE0B9W1TFOSLIYx9oN63T3lXzsGHP/MznueIbqbwFf/o5aXI7th\\n+J+i9LgBrViNvzkze7G0GiPuEQ7ox4XnPBJAFtTZxa8gXL95QfcypERpQs28lg7W\\nQpdNhiBN+c4o1aSOzJ474sjXnjtI1G2jRTKucm0buYYeAeVT7kpBq9YL7gGfOcyj\\nsPxQEgyQV2Mk+b1q7lYDS4tnzoRkUfNLgAtDKSh8S8iVhAR6wRR2G3aMySKrOxbg\\nalghO3OqfeuTwIj9w17JTAyYAME22RJQ6oxEJ8rHp/9PaYnOmiSkP7M=\\n-----END CERTIFICATE-----\\n\"]}]}"
-#define ggdTestLOOP_NUMBER               10
 #define ggdTestMAX_REQUEST_LOOP_COUNT    3
 
 /**
@@ -198,20 +197,20 @@ TEST( GGD_System, GetGGCIPandCertificate )
          * Check with auto-search flag set to false and true
          *  @{
          */
-        for( i = 0; i < ggdTestLOOP_NUMBER; i++ )
-        {
-            xStatus = GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
-                                                  clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                                  clientcredentialIOT_THING_NAME,
-                                                  cBuffer, /*lint !e971 can use char without signed/unsigned. */
-                                                  ulBufferSize,
-                                                  &xHostAddressData );
+        RETRY_EXPONENTIAL( xStatus - GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
+                                                                 clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                                                 clientcredentialIOT_THING_NAME,
+                                                                 cBuffer, /*lint !e971 can use char without signed/unsigned. */
+                                                                 ulBufferSize,
+                                                                 &xHostAddressData ),
+                           pdPASS,
+                           IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
+                           IOT_TEST_GGD_CONNECT_RETRY_COUNT );
 
-            snprintf( cMsgBuffer, nBufferLength,
-                      "GGD_GetGGCIPandCertificate returned %d on iteration %d",
-                      ( int ) xStatus, ( int ) i );
-            TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xStatus, cBuffer );
-        }
+        snprintf( cMsgBuffer, nBufferLength,
+                  "GGD_GetGGCIPandCertificate returned %d on iteration %d",
+                  ( int ) xStatus, ( int ) i );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xStatus, cBuffer );
 
         /** @}*/
 

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -79,7 +79,7 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
 static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
                                            uint16_t usGGDPort,
                                            const char * pcThingName,
-                                           Socket_t * pxSocket);
+                                           Socket_t * pxSocket );
 
 TEST_GROUP( GGD_System );
 
@@ -670,19 +670,19 @@ TEST( GGD_System, JSONRequestStart )
      */
     if( TEST_PROTECT() )
     {
-        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
-                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                           clientcredentialIOT_THING_NAME,
-                                           NULL );
+        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                        clientcredentialIOT_THING_NAME,
+                                        NULL );
         TEST_FAIL();
     }
 
     if( TEST_PROTECT() )
     {
-        xStatus = prvGGD_JSONRequestStart( NULL,
-                                           clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                           NULL,
-                                           &xSocket );
+        xStatus = GGD_JSONRequestStart( NULL,
+                                        clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                        NULL,
+                                        &xSocket );
         TEST_FAIL();
     }
 

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -54,7 +54,7 @@
 #ifndef IOT_TEST_GGD_REQUEST_RETRY_COUNT
     #define IOT_TEST_GGD_REQUEST_RETRY_COUNT    ( 1 )
 #endif
- /** @endcond */
+/** @endcond */
 
 #if IOT_TEST_GGD_REQUEST_RETRY_COUNT < 1
     #error "IOT_TEST_GGD_REQUEST_RETRY_COUNT must be at least 1."
@@ -74,6 +74,12 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
                                                  uint32_t * pulByteRead,
                                                  BaseType_t * pxJSONFileRetrieveCompleted,
                                                  uint32_t ulJSONFileSize );
+
+/* Wrapper function to retry request in case of failure with exponential backoff */
+static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
+                                           uint16_t usGGDPort,
+                                           const char * pcThingName,
+                                           Socket_t * pxSocket)
 
 TEST_GROUP( GGD_System );
 
@@ -128,16 +134,17 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
     return xStatus;
 }
 
-static BaseType_t _ggdJSONRequestStart( const char * pcHostAddress,
-                                         uint16_t usGGDPort,
-                                         const char * pcThingName,
-                                         Socket_t * pxSocket )
+static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
+                                        uint16_t usGGDPort,
+                                        const char * pcThingName,
+                                        Socket_t * pxSocket )
 {
     BaseType_t xStatus;
+
     RETRY_EXPONENTIAL( xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, pxSocket ),
                        pdPASS,
                        IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
-                       IOT_TEST_GGD_REQUEST_RETRY_COUNT);
+                       IOT_TEST_GGD_REQUEST_RETRY_COUNT );
     return xStatus;
 }
 
@@ -154,7 +161,7 @@ TEST( GGD_System, JSONRequestAbort )
         xSocket = SOCKETS_INVALID_SOCKET;
         GGD_JSONRequestAbort( &xSocket );
 
-        _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                               clientcredentialGREENGRASS_DISCOVERY_PORT,
                               clientcredentialIOT_THING_NAME,
                               &xSocket );
@@ -318,7 +325,7 @@ TEST( GGD_System, GetIPandCertificateFromJSON )
         TEST_ASSERT_EQUAL_INT32( strlen( cCERTIFICATE ) + 1, xHostAddressData.ulCertificateSize );
 
         xAutoSearchFlag = pdTRUE;
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -450,7 +457,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Check return status and value in ideal case.
          *  @{
          */
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -479,7 +486,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Retrieve the JSON file in separate chunks.
          *  @{
          */
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -517,7 +524,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Check fail if we receive more bytes than expected.
          *  @{
          */
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -597,7 +604,7 @@ TEST( GGD_System, JSONRequestGetSize )
         /** @brief Check return status and value in ideal case
          *  @{
          */
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -636,7 +643,7 @@ TEST( GGD_System, JSONRequestStart )
         /** @brief Check return status and value in ideal case
          *  @{
          */
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -654,7 +661,7 @@ TEST( GGD_System, JSONRequestStart )
      */
     if( TEST_PROTECT() )
     {
-        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = prvGGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         NULL );
@@ -663,7 +670,7 @@ TEST( GGD_System, JSONRequestStart )
 
     if( TEST_PROTECT() )
     {
-        xStatus = _ggdJSONRequestStart( NULL,
+        xStatus = prvGGD_JSONRequestStart( NULL,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         NULL,
                                         &xSocket );

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -31,6 +31,7 @@
 #include "jsmn.h"
 #include "unity_fixture.h"
 #include "unity.h"
+#include "aws_test_utils.h"
 #include "aws_greengrass_discovery_test_access_declare.h"
 #include "aws_test_runner.h"
 #include "iot_mqtt.h"
@@ -39,6 +40,25 @@
 #define ggdJSON_FILE                     "{\"GGGroups\":[{\"GGGroupId\":\"myGroupID\",\"Cores\":[{\"thingArn\":\"myGreenGrassCoreArn\",\"Connectivity\":[{\"Id\":\"AUTOIP_10.60.212.138_0\",\"HostAddress\":\"44.44.44.44\",\"PortNumber\":1234,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_127.0.0.1_1\",\"HostAddress\":\"127.0.0.1\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_192.168.2.2_2\",\"HostAddress\":\"01.23.456.789\",\"PortNumber\":4321,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_::1_3\",\"HostAddress\":\"::1\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_fe80::bfda:8f62:7b4b:f358_4\",\"HostAddress\":\"fe80::bfda:8f62:7b4b:f358\",\"PortNumber\":8883,\"Metadata\":\"\"},{\"Id\":\"AUTOIP_fe80::e234:cff9:f53f:6216_5\",\"HostAddress\":\"fe80::e234:cff9:f53f:6216\",\"PortNumber\":8883,\"Metadata\":\"\"}]}],\"CAs\":[\"-----BEGIN CERTIFICATE-----\\nMIIEFTCCAv2gAwIBAgIVAPRru+NqCDr0r6oD6PnTG05rWuY+MA0GCSqGSIb3DQEB\\nCwUAMIGoMQswCQYDVQQGEwJVUzEYMBYGA1UECgwPQW1hem9uLmNvbSBJbmMuMRww\\nGgYDVQQLDBNBbWF6b24gV2ViIFNlcnZpY2VzMRMwEQYDVQQIDApXYXNoaW5ndG9u\\nMRAwDgYDVQQHDAdTZWF0dGxlMTowOAYDVQQDDDE5NDI5MjczNzY5NjU6ZDk3ZmZl\\nZmUtNTI4MS00ZWM5LTk4NDYtYjNlZTQxMDRjMjAxMCAXDTE3MDcwNjIwMDczOFoY\\nDzIwOTcwNzA2MjAwNzM3WjCBqDELMAkGA1UEBhMCVVMxGDAWBgNVBAoMD0FtYXpv\\nbi5jb20gSW5jLjEcMBoGA1UECwwTQW1hem9uIFdlYiBTZXJ2aWNlczETMBEGA1UE\\nCAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTE6MDgGA1UEAwwxOTQyOTI3\\nMzc2OTY1OmQ5N2ZmZWZlLTUyODEtNGVjOS05ODQ2LWIzZWU0MTA0YzIwMTCCASIw\\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKxzJpXU2DZDEglh/FT01epAWby6\\np4Ymw76icyMzBUJzafibABJ3cTyjDQE6ZqbSl1ryBxGwQBsveIgj8SVVtv927wk7\\nlncgD+EghfTZgSfscND653AJeVFQlCeHipZI32wzXyPmwglFrWp9vsrY/8BO1Kjk\\nSAs4o8fDVVMAaZCJDMuc5csc3CQ2OJYLOl+SZisGNM1h0xHpWieM38KDDrp99x8Q\\nTwDmgaMjtdIJR7Y9Nzm0N78gTf3gTazEO9iUKojVCNubxK/lQ6KjJ0JcvsljPpVp\\nuzjOmn91xmNoHEQCboa7YoYNNbdAbftGeUl16wFdTgbuUS9vakk5idVoC2ECAwEA\\nAaMyMDAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUmcz4OlH9+mlpnTKG3taI\\nw+6FSk0wDQYJKoZIhvcNAQELBQADggEBACeiQ6MxiktsU0sLNmP1cNbiuBuutjoq\\nymk476Bhr4E2WSE0B9W1TFOSLIYx9oN63T3lXzsGHP/MznueIbqbwFf/o5aXI7th\\n+J+i9LgBrViNvzkze7G0GiPuEQ7ox4XnPBJAFtTZxa8gXL95QfcypERpQs28lg7W\\nQpdNhiBN+c4o1aSOzJ474sjXnjtI1G2jRTKucm0buYYeAeVT7kpBq9YL7gGfOcyj\\nsPxQEgyQV2Mk+b1q7lYDS4tnzoRkUfNLgAtDKSh8S8iVhAR6wRR2G3aMySKrOxbg\\nalghO3OqfeuTwIj9w17JTAyYAME22RJQ6oxEJ8rHp/9PaYnOmiSkP7M=\\n-----END CERTIFICATE-----\\n\"]}]}"
 #define ggdTestLOOP_NUMBER               10
 #define ggdTestMAX_REQUEST_LOOP_COUNT    3
+
+/**
+ * @brief The initial delay in milliseconds that is doubled each retry of request.
+ */
+#ifndef IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY
+    #define IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY    ( ( uint32_t ) 300 )
+#endif
+
+/**
+ * @brief The amount of times to retry a request if it fails.
+ */
+#ifndef IOT_TEST_GGD_REQUEST_RETRY_COUNT
+    #define IOT_TEST_GGD_REQUEST_RETRY_COUNT    ( 1 )
+#endif
+ /** @endcond */
+
+#if IOT_TEST_GGD_REQUEST_RETRY_COUNT < 1
+    #error "IOT_TEST_GGD_REQUEST_RETRY_COUNT must be at least 1."
+#endif
 
 static const char cJSON_FILE[] = ggdJSON_FILE;
 static const char cCERTIFICATE[] = "-----BEGIN CERTIFICATE-----\nMIIEFTCCAv2gAwIBAgIVAPRru+NqCDr0r6oD6PnTG05rWuY+MA0GCSqGSIb3DQEB\nCwUAMIGoMQswCQYDVQQGEwJVUzEYMBYGA1UECgwPQW1hem9uLmNvbSBJbmMuMRww\nGgYDVQQLDBNBbWF6b24gV2ViIFNlcnZpY2VzMRMwEQYDVQQIDApXYXNoaW5ndG9u\nMRAwDgYDVQQHDAdTZWF0dGxlMTowOAYDVQQDDDE5NDI5MjczNzY5NjU6ZDk3ZmZl\nZmUtNTI4MS00ZWM5LTk4NDYtYjNlZTQxMDRjMjAxMCAXDTE3MDcwNjIwMDczOFoY\nDzIwOTcwNzA2MjAwNzM3WjCBqDELMAkGA1UEBhMCVVMxGDAWBgNVBAoMD0FtYXpv\nbi5jb20gSW5jLjEcMBoGA1UECwwTQW1hem9uIFdlYiBTZXJ2aWNlczETMBEGA1UE\nCAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTE6MDgGA1UEAwwxOTQyOTI3\nMzc2OTY1OmQ5N2ZmZWZlLTUyODEtNGVjOS05ODQ2LWIzZWU0MTA0YzIwMTCCASIw\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKxzJpXU2DZDEglh/FT01epAWby6\np4Ymw76icyMzBUJzafibABJ3cTyjDQE6ZqbSl1ryBxGwQBsveIgj8SVVtv927wk7\nlncgD+EghfTZgSfscND653AJeVFQlCeHipZI32wzXyPmwglFrWp9vsrY/8BO1Kjk\nSAs4o8fDVVMAaZCJDMuc5csc3CQ2OJYLOl+SZisGNM1h0xHpWieM38KDDrp99x8Q\nTwDmgaMjtdIJR7Y9Nzm0N78gTf3gTazEO9iUKojVCNubxK/lQ6KjJ0JcvsljPpVp\nuzjOmn91xmNoHEQCboa7YoYNNbdAbftGeUl16wFdTgbuUS9vakk5idVoC2ECAwEA\nAaMyMDAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUmcz4OlH9+mlpnTKG3taI\nw+6FSk0wDQYJKoZIhvcNAQELBQADggEBACeiQ6MxiktsU0sLNmP1cNbiuBuutjoq\nymk476Bhr4E2WSE0B9W1TFOSLIYx9oN63T3lXzsGHP/MznueIbqbwFf/o5aXI7th\n+J+i9LgBrViNvzkze7G0GiPuEQ7ox4XnPBJAFtTZxa8gXL95QfcypERpQs28lg7W\nQpdNhiBN+c4o1aSOzJ474sjXnjtI1G2jRTKucm0buYYeAeVT7kpBq9YL7gGfOcyj\nsPxQEgyQV2Mk+b1q7lYDS4tnzoRkUfNLgAtDKSh8S8iVhAR6wRR2G3aMySKrOxbg\nalghO3OqfeuTwIj9w17JTAyYAME22RJQ6oxEJ8rHp/9PaYnOmiSkP7M=\n-----END CERTIFICATE-----\n";
@@ -108,6 +128,19 @@ static BaseType_t prvGGD_JSONRequestGetFileLoop( uint32_t ulBufferSize,
     return xStatus;
 }
 
+static BaseType_t _ggdJSONRequestStart( const char * pcHostAddress,
+                                         uint16_t usGGDPort,
+                                         const char * pcThingName,
+                                         Socket_t * pxSocket )
+{
+    BaseType_t xStatus;
+    RETRY_EXPONENTIAL( xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, pxSocket ),
+                       pdPASS,
+                       IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
+                       IOT_TEST_GGD_REQUEST_RETRY_COUNT);
+    return xStatus;
+}
+
 TEST( GGD_System, JSONRequestAbort )
 {
     /** @brief check for stability for all meaningfull values of socket.
@@ -121,7 +154,7 @@ TEST( GGD_System, JSONRequestAbort )
         xSocket = SOCKETS_INVALID_SOCKET;
         GGD_JSONRequestAbort( &xSocket );
 
-        GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                               clientcredentialGREENGRASS_DISCOVERY_PORT,
                               clientcredentialIOT_THING_NAME,
                               &xSocket );
@@ -285,7 +318,7 @@ TEST( GGD_System, GetIPandCertificateFromJSON )
         TEST_ASSERT_EQUAL_INT32( strlen( cCERTIFICATE ) + 1, xHostAddressData.ulCertificateSize );
 
         xAutoSearchFlag = pdTRUE;
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -417,7 +450,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Check return status and value in ideal case.
          *  @{
          */
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -446,7 +479,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Retrieve the JSON file in separate chunks.
          *  @{
          */
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -484,7 +517,7 @@ TEST( GGD_System, JSONRequestGetFile )
         /** @brief Check fail if we receive more bytes than expected.
          *  @{
          */
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -564,7 +597,7 @@ TEST( GGD_System, JSONRequestGetSize )
         /** @brief Check return status and value in ideal case
          *  @{
          */
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -603,7 +636,7 @@ TEST( GGD_System, JSONRequestStart )
         /** @brief Check return status and value in ideal case
          *  @{
          */
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         &xSocket );
@@ -621,7 +654,7 @@ TEST( GGD_System, JSONRequestStart )
      */
     if( TEST_PROTECT() )
     {
-        xStatus = GGD_JSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
+        xStatus = _ggdJSONRequestStart( clientcredentialMQTT_BROKER_ENDPOINT,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         clientcredentialIOT_THING_NAME,
                                         NULL );
@@ -630,7 +663,7 @@ TEST( GGD_System, JSONRequestStart )
 
     if( TEST_PROTECT() )
     {
-        xStatus = GGD_JSONRequestStart( NULL,
+        xStatus = _ggdJSONRequestStart( NULL,
                                         clientcredentialGREENGRASS_DISCOVERY_PORT,
                                         NULL,
                                         &xSocket );

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -48,7 +48,7 @@
 #endif
 
 /**
- * @brief The amount of times to retry a request if it fails.
+ * @brief The amount of times to retry a connection if it fails with 1 being a single attempt.
  */
 #ifndef IOT_TEST_GGD_CONNECT_RETRY_COUNT
     #define IOT_TEST_GGD_CONNECT_RETRY_COUNT    ( 1 )

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -183,9 +183,7 @@ TEST( GGD_System, JSONRequestAbort )
 
 TEST( GGD_System, GetGGCIPandCertificate )
 {
-    BaseType_t i;
     BaseType_t xStatus;
-    char cMsgBuffer[ 128 ];
     GGD_HostAddressData_t xHostAddressData;
     int16_t nBufferLength = 128;
     uint32_t ulBufferSize = testrunnerBUFFER_SIZE;
@@ -197,7 +195,7 @@ TEST( GGD_System, GetGGCIPandCertificate )
          * Check with auto-search flag set to false and true
          *  @{
          */
-        RETRY_EXPONENTIAL( xStatus - GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
+        RETRY_EXPONENTIAL( xStatus = GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
                                                                  clientcredentialGREENGRASS_DISCOVERY_PORT,
                                                                  clientcredentialIOT_THING_NAME,
                                                                  cBuffer, /*lint !e971 can use char without signed/unsigned. */
@@ -207,9 +205,6 @@ TEST( GGD_System, GetGGCIPandCertificate )
                            IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
                            IOT_TEST_GGD_CONNECT_RETRY_COUNT );
 
-        snprintf( cMsgBuffer, nBufferLength,
-                  "GGD_GetGGCIPandCertificate returned %d on iteration %d",
-                  ( int ) xStatus, ( int ) i );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xStatus, cBuffer );
 
         /** @}*/

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -206,15 +206,6 @@ TEST( GGD_System, GetGGCIPandCertificate )
                                                   cBuffer, /*lint !e971 can use char without signed/unsigned. */
                                                   ulBufferSize,
                                                   &xHostAddressData );
-            RETRY_EXPONENTIAL( xStatus - GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
-                                                                     clientcredentialGREENGRASS_DISCOVERY_PORT,
-                                                                     clientcredentialIOT_THING_NAME,
-                                                                     cBuffer, /*lint !e971 can use char without signed/unsigned. */
-                                                                     ulBufferSize,
-                                                                     &xHostAddressData ),
-                               pdPASS,
-                               IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
-                               IOT_TEST_GGD_CONNECT_RETRY_COUNT );
 
             snprintf( cMsgBuffer, nBufferLength,
                       "GGD_GetGGCIPandCertificate returned %d on iteration %d",

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -51,13 +51,13 @@
 /**
  * @brief The amount of times to retry a request if it fails.
  */
-#ifndef IOT_TEST_GGD_REQUEST_RETRY_COUNT
-    #define IOT_TEST_GGD_REQUEST_RETRY_COUNT    ( 1 )
+#ifndef IOT_TEST_GGD_CONNECT_RETRY_COUNT
+    #define IOT_TEST_GGD_CONNECT_RETRY_COUNT    ( 1 )
 #endif
 /** @endcond */
 
-#if IOT_TEST_GGD_REQUEST_RETRY_COUNT < 1
-    #error "IOT_TEST_GGD_REQUEST_RETRY_COUNT must be at least 1."
+#if IOT_TEST_GGD_CONNECT_RETRY_COUNT < 1
+    #error "IOT_TEST_GGD_CONNECT_RETRY_COUNT must be at least 1."
 #endif
 
 static const char cJSON_FILE[] = ggdJSON_FILE;
@@ -144,7 +144,7 @@ static BaseType_t prvGGD_JSONRequestStart( const char * pcHostAddress,
     RETRY_EXPONENTIAL( xStatus = GGD_JSONRequestStart( pcHostAddress, usGGDPort, pcThingName, pxSocket ),
                        pdPASS,
                        IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
-                       IOT_TEST_GGD_REQUEST_RETRY_COUNT );
+                       IOT_TEST_GGD_CONNECT_RETRY_COUNT );
     return xStatus;
 }
 
@@ -206,6 +206,15 @@ TEST( GGD_System, GetGGCIPandCertificate )
                                                   cBuffer, /*lint !e971 can use char without signed/unsigned. */
                                                   ulBufferSize,
                                                   &xHostAddressData );
+            RETRY_EXPONENTIAL( xStatus - GGD_GetGGCIPandCertificate( clientcredentialMQTT_BROKER_ENDPOINT,
+                                                                     clientcredentialGREENGRASS_DISCOVERY_PORT,
+                                                                     clientcredentialIOT_THING_NAME,
+                                                                     cBuffer, /*lint !e971 can use char without signed/unsigned. */
+                                                                     ulBufferSize,
+                                                                     &xHostAddressData ),
+                               pdPASS,
+                               IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY,
+                               IOT_TEST_GGD_CONNECT_RETRY_COUNT );
 
             snprintf( cMsgBuffer, nBufferLength,
                       "GGD_GetGGCIPandCertificate returned %d on iteration %d",

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -48,7 +48,7 @@
 #endif
 
 /**
- * @brief The amount of times to retry a connection if it fails with 1 being a single attempt.
+ * @brief The number of times to try a connection. Values greater than 1 will retry on failure with an exponential backoff.
  */
 #ifndef IOT_TEST_GGD_CONNECT_RETRY_COUNT
     #define IOT_TEST_GGD_CONNECT_RETRY_COUNT    ( 1 )

--- a/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
+++ b/libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c
@@ -45,7 +45,7 @@
  * @brief The initial delay in milliseconds that is doubled each retry of request.
  */
 #ifndef IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY
-    #define IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY    ( ( uint32_t ) 300 )
+    #define IOT_TEST_GGD_INITIAL_CONNECTION_RETRY_DELAY    ( ( uint32_t ) 1100 )
 #endif
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
GGD_JSONRequestStart method creates a connection to a specified host and port by using the Sockets API. If that connection fails, then the test completely fails. This PR addresses this issue by wrapping the method around RETRY_EXPONENTIAL, which retries the method with exponential backoff if the expected status is not returned. 

Also considered retries for the library function instead but this masks the problem that really needs to be handled in the network layer.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.