### PR TITLE
Retry using exponential backoff upon connection failure with Defender system tests

### DIFF
--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -517,6 +517,9 @@ static IotMqttError_t _startMqttConnection( void )
     IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
     IotMqttNetworkInfo_t mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
     IotMqttConnectInfo_t mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
+    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+     * Wait until 1100 ms have elapsed since the last connection. */
+    uint32_t periodMs = 1100;
 
     if( !_mqttConnectionStarted )
     {
@@ -533,9 +536,6 @@ static IotMqttError_t _startMqttConnection( void )
         mqttConnectionInfo.pClientIdentifier = AWS_IOT_TEST_DEFENDER_THING_NAME;
         mqttConnectionInfo.clientIdentifierLength = ( uint16_t ) strlen( AWS_IOT_TEST_DEFENDER_THING_NAME );
 
-        /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-         * Wait until 1100 ms have elapsed since the last connection. */
-        uint32_t periodMs = 1100;
         RETRY_EXPONENTIAL( mqttError = IotMqtt_Connect( &mqttNetworkInfo,
                                                         &mqttConnectionInfo,
                                                         1000,

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -520,7 +520,7 @@ static IotMqttError_t _startMqttConnection( void )
 
     /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
      * Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
+    const uint32_t periodMs = 1100;
 
     if( !_mqttConnectionStarted )
     {

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -55,7 +55,10 @@
 
 #include "cbor.h"
 
+/* Test framework includes. */
 #include "unity_fixture.h"
+#include "aws_test_utils.h"
+
 
 /* Total time to wait for a state to be true. */
 #define WAIT_STATE_TOTAL_SECONDS    10
@@ -75,6 +78,20 @@
 
 /* Use a big number to represent no event happened in defender. */
 #define NO_EVENT                             10000
+
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section.
+ *
+ * Provide default values of test configuration constants.
+ */
+#ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
+#endif
+#if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
+    #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
+#endif
+ /** @endcond */
 
 static const uint32_t _ECHO_SERVER_IP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                  tcptestECHO_SERVER_ADDR1,
@@ -516,10 +533,16 @@ static IotMqttError_t _startMqttConnection( void )
         mqttConnectionInfo.pClientIdentifier = AWS_IOT_TEST_DEFENDER_THING_NAME;
         mqttConnectionInfo.clientIdentifierLength = ( uint16_t ) strlen( AWS_IOT_TEST_DEFENDER_THING_NAME );
 
-        mqttError = IotMqtt_Connect( &mqttNetworkInfo,
-                                     &mqttConnectionInfo,
-                                     1000,
-                                     &_mqttConnection );
+        /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+         * Wait until 1100 ms have elapsed since the last connection. */
+        uint32_t periodMs = 1100;
+        RETRY_EXPONENTIAL( mqttError = IotMqtt_Connect( &mqttNetworkInfo,
+                                                        &mqttConnectionInfo,
+                                                        1000,
+                                                        &_mqttConnection ),
+                           IOT_MQTT_SUCCESS,
+                           periodMs,
+                           IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
         if( mqttError == IOT_MQTT_SUCCESS )
         {

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -85,11 +85,11 @@
  *
  * Provide default values of test configuration constants.
  */
-#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
-    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
+#ifndef IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS
+    #define IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS    ( 1100 )
 #endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 6 )
 #endif
 #if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
@@ -541,7 +541,7 @@ static IotMqttError_t _startMqttConnection( void )
                                                         1000,
                                                         &_mqttConnection ),
                            IOT_MQTT_SUCCESS,
-                           IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY,
+                           IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS,
                            IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
         if( mqttError == IOT_MQTT_SUCCESS )

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -85,8 +85,8 @@
  *
  * Provide default values of test configuration constants.
  */
-#ifndef IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY
-    #define IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY    ( 1100 )
+#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
+    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
 #endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
     #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
@@ -541,7 +541,7 @@ static IotMqttError_t _startMqttConnection( void )
                                                         1000,
                                                         &_mqttConnection ),
                            IOT_MQTT_SUCCESS,
-                           IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY,
+                           IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY,
                            IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
         if( mqttError == IOT_MQTT_SUCCESS )

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -517,6 +517,7 @@ static IotMqttError_t _startMqttConnection( void )
     IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
     IotMqttNetworkInfo_t mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
     IotMqttConnectInfo_t mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
+
     /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
      * Wait until 1100 ms have elapsed since the last connection. */
     uint32_t periodMs = 1100;

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -86,12 +86,12 @@
  * Provide default values of test configuration constants.
  */
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    ( 1 )
 #endif
 #if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
 #endif
- /** @endcond */
+/** @endcond */
 
 static const uint32_t _ECHO_SERVER_IP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                  tcptestECHO_SERVER_ADDR1,

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -85,8 +85,11 @@
  *
  * Provide default values of test configuration constants.
  */
+#ifndef IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY
+    #define IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY    ( 1100 )
+#endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
 #endif
 #if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
@@ -518,10 +521,6 @@ static IotMqttError_t _startMqttConnection( void )
     IotMqttNetworkInfo_t mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
     IotMqttConnectInfo_t mqttConnectionInfo = ( IotMqttConnectInfo_t ) IOT_MQTT_CONNECT_INFO_INITIALIZER;
 
-    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-     * Wait until 1100 ms have elapsed since the last connection. */
-    const uint32_t periodMs = 1100;
-
     if( !_mqttConnectionStarted )
     {
         mqttNetworkInfo = ( IotMqttNetworkInfo_t ) IOT_MQTT_NETWORK_INFO_INITIALIZER;
@@ -542,7 +541,7 @@ static IotMqttError_t _startMqttConnection( void )
                                                         1000,
                                                         &_mqttConnection ),
                            IOT_MQTT_SUCCESS,
-                           periodMs,
+                           IOT_TEST_MQTT_INITIAL_CONNECT_RETRY_DELAY,
                            IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
         if( mqttError == IOT_MQTT_SUCCESS )

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -55,7 +55,6 @@
 
 /* Test framework includes. */
 #include "unity_fixture.h"
-#include "aws_test_utils.h"
 
 /* Require Shadow library asserts to be enabled for these tests. The Shadow
  * assert function is used to abort the tests on failure from the Shadow operation
@@ -75,14 +74,8 @@
 #ifndef IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S
     #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S    ( 30 )
 #endif
-#ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
-#endif
-#if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
-    #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
-#endif
 #ifndef AWS_IOT_TEST_SHADOW_TIMEOUT
-    #define AWS_IOT_TEST_SHADOW_TIMEOUT    ( 5000 )
+    #define AWS_IOT_TEST_SHADOW_TIMEOUT                 ( 5000 )
 #endif
 /** @endcond */
 
@@ -430,30 +423,6 @@ static void _updateGetDeleteBlocking( IotMqttQos_t qos )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Establish an MQTT connection. Retry if enabled.
- */
-static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
-                                    const IotMqttConnectInfo_t * pConnectInfo,
-                                    uint32_t timeoutMs,
-                                    IotMqttConnection_t * const pMqttConnection )
-{
-    IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
-
-    int32_t retryCount = 0;
-
-    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-     * Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
-
-    RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
-                       IOT_MQTT_SUCCESS,
-                       periodMs,
-                       IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
-
-    return status;
-}
-
-/**
  * @brief Test group for Shadow system tests.
  */
 TEST_GROUP( Shadow_System );
@@ -514,10 +483,10 @@ TEST_SETUP( Shadow_System )
     connectInfo.keepAliveSeconds = IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S;
 
     /* Establish an MQTT connection. */
-    if( _mqttConnect( &_networkInfo,
-                      &connectInfo,
-                      AWS_IOT_TEST_SHADOW_TIMEOUT,
-                      &_mqttConnection ) != IOT_MQTT_SUCCESS )
+    if( IotMqtt_Connect( &_networkInfo,
+                         &connectInfo,
+                         AWS_IOT_TEST_SHADOW_TIMEOUT,
+                         &_mqttConnection ) != IOT_MQTT_SUCCESS )
     {
         TEST_FAIL_MESSAGE( "Failed to establish MQTT connection for Shadow tests." );
     }

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -55,6 +55,7 @@
 
 /* Test framework includes. */
 #include "unity_fixture.h"
+#include "aws_test_utils.h"
 
 /* Require Shadow library asserts to be enabled for these tests. The Shadow
  * assert function is used to abort the tests on failure from the Shadow operation
@@ -73,6 +74,12 @@
  */
 #ifndef IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S
     #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S    ( 30 )
+#endif
+#ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
+#endif
+#if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
+    #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
 #endif
 #ifndef AWS_IOT_TEST_SHADOW_TIMEOUT
     #define AWS_IOT_TEST_SHADOW_TIMEOUT                 ( 5000 )
@@ -423,6 +430,30 @@ static void _updateGetDeleteBlocking( IotMqttQos_t qos )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Establish an MQTT connection. Retry if enabled.
+ */
+static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
+                                    const IotMqttConnectInfo_t * pConnectInfo,
+                                    uint32_t timeoutMs,
+                                    IotMqttConnection_t * const pMqttConnection)
+{
+    IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
+
+    int32_t retryCount = 0;
+
+    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+     * Wait until 1100 ms have elapsed since the last connection. */
+    uint32_t periodMs = 1100;
+
+    RETRY_EXPONENTIAL( status = IotMqtt_Connect(pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection),
+                       IOT_MQTT_SUCCESS,
+                       periodMs ,
+                       IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
+
+    return status;
+}
+
+/**
  * @brief Test group for Shadow system tests.
  */
 TEST_GROUP( Shadow_System );
@@ -483,7 +514,7 @@ TEST_SETUP( Shadow_System )
     connectInfo.keepAliveSeconds = IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S;
 
     /* Establish an MQTT connection. */
-    if( IotMqtt_Connect( &_networkInfo,
+    if( _mqttConnect( &_networkInfo,
                          &connectInfo,
                          AWS_IOT_TEST_SHADOW_TIMEOUT,
                          &_mqttConnection ) != IOT_MQTT_SUCCESS )

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -82,7 +82,7 @@
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
 #endif
 #ifndef AWS_IOT_TEST_SHADOW_TIMEOUT
-    #define AWS_IOT_TEST_SHADOW_TIMEOUT                 ( 5000 )
+    #define AWS_IOT_TEST_SHADOW_TIMEOUT    ( 5000 )
 #endif
 /** @endcond */
 
@@ -435,7 +435,7 @@ static void _updateGetDeleteBlocking( IotMqttQos_t qos )
 static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
                                     const IotMqttConnectInfo_t * pConnectInfo,
                                     uint32_t timeoutMs,
-                                    IotMqttConnection_t * const pMqttConnection)
+                                    IotMqttConnection_t * const pMqttConnection )
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
 
@@ -445,9 +445,9 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
      * Wait until 1100 ms have elapsed since the last connection. */
     uint32_t periodMs = 1100;
 
-    RETRY_EXPONENTIAL( status = IotMqtt_Connect(pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection),
+    RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
                        IOT_MQTT_SUCCESS,
-                       periodMs ,
+                       periodMs,
                        IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
     return status;
@@ -515,9 +515,9 @@ TEST_SETUP( Shadow_System )
 
     /* Establish an MQTT connection. */
     if( _mqttConnect( &_networkInfo,
-                         &connectInfo,
-                         AWS_IOT_TEST_SHADOW_TIMEOUT,
-                         &_mqttConnection ) != IOT_MQTT_SUCCESS )
+                      &connectInfo,
+                      AWS_IOT_TEST_SHADOW_TIMEOUT,
+                      &_mqttConnection ) != IOT_MQTT_SUCCESS )
     {
         TEST_FAIL_MESSAGE( "Failed to establish MQTT connection for Shadow tests." );
     }


### PR DESCRIPTION
<!--- Title -->
If IotMqtt_Connect connection fails, then the test completely fails. This PR addresses this issue by wrapping the method around RETRY_EXPONENTIAL, which retries the method with exponential backoff if the expected status is not returned.

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.