### PR TITLE
Retry using exponential backoff upon connection failure with Shadow system tests 

### DIFF
--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -73,10 +73,13 @@
  * Provide default values of test configuration constants.
  */
 #ifndef IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S
-    #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S    ( 30 )
+    #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S     ( 30 )
+#endif
+#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
+    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
 #endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
 #endif
 #if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
@@ -439,13 +442,9 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
 
-    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-     * Wait until 1100 ms have elapsed since the last connection. */
-    const uint32_t periodMs = 1100;
-
     RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
                        IOT_MQTT_SUCCESS,
-                       periodMs,
+                       IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY,
                        IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
     return status;

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -75,11 +75,11 @@
 #ifndef IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S
     #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S     ( 30 )
 #endif
-#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
-    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
+#ifndef IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS
+    #define IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS    ( 1100 )
 #endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 6 )
 #endif
 #if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
     #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
@@ -444,7 +444,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 
     RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
                        IOT_MQTT_SUCCESS,
-                       IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY,
+                       IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS,
                        IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
 
     return status;

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -441,7 +441,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 
     /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
      * Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
+    const uint32_t periodMs = 1100;
 
     RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
                        IOT_MQTT_SUCCESS,

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -55,6 +55,7 @@
 
 /* Test framework includes. */
 #include "unity_fixture.h"
+#include "aws_test_utils.h"
 
 /* Require Shadow library asserts to be enabled for these tests. The Shadow
  * assert function is used to abort the tests on failure from the Shadow operation
@@ -74,8 +75,14 @@
 #ifndef IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S
     #define IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S    ( 30 )
 #endif
+#ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT           ( 1 )
+#endif
+#if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
+    #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
+#endif
 #ifndef AWS_IOT_TEST_SHADOW_TIMEOUT
-    #define AWS_IOT_TEST_SHADOW_TIMEOUT                 ( 5000 )
+    #define AWS_IOT_TEST_SHADOW_TIMEOUT    ( 5000 )
 #endif
 /** @endcond */
 
@@ -423,6 +430,30 @@ static void _updateGetDeleteBlocking( IotMqttQos_t qos )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Establish an MQTT connection. Retry if enabled.
+ */
+static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
+                                    const IotMqttConnectInfo_t * pConnectInfo,
+                                    uint32_t timeoutMs,
+                                    IotMqttConnection_t * const pMqttConnection )
+{
+    IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
+
+    int32_t retryCount = 0;
+
+    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+     * Wait until 1100 ms have elapsed since the last connection. */
+    uint32_t periodMs = 1100;
+
+    RETRY_EXPONENTIAL( status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection ),
+                       IOT_MQTT_SUCCESS,
+                       periodMs,
+                       IOT_TEST_MQTT_CONNECT_RETRY_COUNT );
+
+    return status;
+}
+
+/**
  * @brief Test group for Shadow system tests.
  */
 TEST_GROUP( Shadow_System );
@@ -483,10 +514,10 @@ TEST_SETUP( Shadow_System )
     connectInfo.keepAliveSeconds = IOT_TEST_MQTT_SHORT_KEEPALIVE_INTERVAL_S;
 
     /* Establish an MQTT connection. */
-    if( IotMqtt_Connect( &_networkInfo,
-                         &connectInfo,
-                         AWS_IOT_TEST_SHADOW_TIMEOUT,
-                         &_mqttConnection ) != IOT_MQTT_SUCCESS )
+    if( _mqttConnect( &_networkInfo,
+                      &connectInfo,
+                      AWS_IOT_TEST_SHADOW_TIMEOUT,
+                      &_mqttConnection ) != IOT_MQTT_SUCCESS )
     {
         TEST_FAIL_MESSAGE( "Failed to establish MQTT connection for Shadow tests." );
     }

--- a/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
+++ b/libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c
@@ -439,8 +439,6 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
 
-    int32_t retryCount = 0;
-
     /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
      * Wait until 1100 ms have elapsed since the last connection. */
     uint32_t periodMs = 1100;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
If IotMqtt_Connect connection fails, then the test completely fails. This PR addresses this issue by wrapping the method around RETRY_EXPONENTIAL, which retries the method with exponential backoff if the expected status is not returned.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.