### PR TITLE
Add retries to MQTT connect in OTA agent tests

### DIFF
--- a/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c
@@ -46,12 +46,17 @@
 /* Test network header include. */
 #include IOT_TEST_NETWORK_HEADER
 
+/* Test framework includes. */
+#include "aws_test_utils.h"
+
 /* Configuration for this test. */
 #include "aws_test_ota_config.h"
 
 /**
  * @brief Configuration for this test group.
  */
+#define otatestMQTT_RETRIES_START_MS      ( 250 )
+#define otatestMQTT_RETRIES_MAX           ( 7 )
 #define otatestMAX_LOOP_MEM_LEAK_CHECK    ( 1 )
 #define otatestSHUTDOWN_WAIT              pdMS_TO_TICKS( 10000 )
 #define otatestAGENT_INIT_WAIT            10000
@@ -185,10 +190,13 @@ TEST_SETUP( Full_OTA_AGENT )
     connectInfo.clientIdentifierLength = sizeof( clientcredentialIOT_THING_NAME ) - 1;
 
     /* Connect to the broker. */
-    connectStatus = IotMqtt_Connect( &networkInfo,
-                                     &connectInfo,
-                                     otatestAGENT_INIT_WAIT,
-                                     &xMQTTClientHandle );
+    RETRY_EXPONENTIAL( connectStatus = IotMqtt_Connect( &networkInfo,
+                                                        &connectInfo,
+                                                        otatestAGENT_INIT_WAIT,
+                                                        &xMQTTClientHandle ),
+                       IOT_MQTT_SUCCESS,
+                       otatestMQTT_RETRIES_START_MS,
+                       otatestMQTT_RETRIES_MAX );
 
     TEST_ASSERT_EQUAL_INT_MESSAGE(
         IOT_MQTT_SUCCESS, connectStatus,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
MQTT connect in the OTA agent tests did not have retries before and could easily fail. This PR addresses the problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.