### PR TITLE
Make periodMs a config macro

### DIFF
--- a/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -233,7 +233,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 
     int32_t retryCount = 0;
 
-    uint32_t periodMs = IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY;
+    uint32_t periodMs = IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS;
 
     for( ; retryCount < IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
     {

--- a/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -65,6 +65,9 @@
 #ifndef IOT_TEST_MQTT_TOPIC_PREFIX
     #define IOT_TEST_MQTT_TOPIC_PREFIX           "iotmqtttest"
 #endif
+#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
+    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
+#endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
     #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    ( 1 )
 #endif
@@ -230,9 +233,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
 
     int32_t retryCount = 0;
 
-    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-     * Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
+    uint32_t periodMs = IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY;
 
     for( ; retryCount < IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
     {

--- a/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -60,16 +60,16 @@
  * Provide default values of test configuration constants.
  */
 #ifndef IOT_TEST_MQTT_TIMEOUT_MS
-    #define IOT_TEST_MQTT_TIMEOUT_MS             ( 5000 )
+    #define IOT_TEST_MQTT_TIMEOUT_MS                     ( 5000 )
 #endif
 #ifndef IOT_TEST_MQTT_TOPIC_PREFIX
-    #define IOT_TEST_MQTT_TOPIC_PREFIX           "iotmqtttest"
+    #define IOT_TEST_MQTT_TOPIC_PREFIX                   "iotmqtttest"
 #endif
-#ifndef IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY
-    #define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
+#ifndef IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS
+    #define IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS    ( 1100 )
 #endif
 #ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
-    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    ( 1 )
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 1 )
 #endif
 /** @endcond */
 

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -253,7 +253,7 @@ extern const struct IotNetworkInterface * IotTestNetwork_GetNetworkInterface( vo
 /* Allow the network serializer to be chosen by at runtime. */
 struct IotMqttSerializer;
 extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
-#define IOT_TEST_MQTT_SERIALIZER             IotTestNetwork_GetSerializer()
+#define IOT_TEST_MQTT_SERIALIZER                     IotTestNetwork_GetSerializer()
 
 /* Retry the MQTT Connections in the MQTT System unit tests for all hardware
  * platforms supported in FreeRTOS.
@@ -263,7 +263,7 @@ extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
 
 /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
  * Wait until 1100 ms have elapsed since the last connection. */
-#define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
+#define IOT_TEST_MQTT_CONNECT_INIT_RETRY_DELAY_MS    ( 1100 )
 
 /* Forward declarations of network types used in the tests. */
 typedef struct IotNetworkConnection    IotTestNetworkConnection_t;

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -259,7 +259,11 @@ extern const struct IotMqttSerializer * IotTestNetwork_GetSerializer( void );
  * platforms supported in FreeRTOS.
  * Set this to the number of connection attempts for the MQTT tests.
  * If undefined, it should default to 1. */
-#define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    3
+#define IOT_TEST_MQTT_CONNECT_RETRY_COUNT            ( 3 )
+
+/* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+ * Wait until 1100 ms have elapsed since the last connection. */
+#define IOT_TEST_MQTT_CONNECT_INITIAL_RETRY_DELAY    ( 1100 )
 
 /* Forward declarations of network types used in the tests. */
 typedef struct IotNetworkConnection    IotTestNetworkConnection_t;


### PR DESCRIPTION
<!--- Title -->
Because we are now using periodMs throughout all system tests, it makes sense to make it a config macro in iot_config_common.h. 

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.