### PR TITLE
Remove port specific portYIELD_FROM_ISR in I2C tests

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -143,12 +143,9 @@ TEST_TEAR_DOWN( TEST_IOT_I2C )
 void prvI2CCallback( IotI2COperationStatus_t xOpStatus,
                      void * pvParam )
 {
-    BaseType_t xHigherPriorityTaskWoken;
-
     if( xOpStatus == eI2CCompleted )
     {
-        xSemaphoreGiveFromISR( xtestIotI2CSemaphore, &xHigherPriorityTaskWoken );
-        portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+        xSemaphoreGiveFromISR( xtestIotI2CSemaphore, NULL );
     }
 }
 
@@ -156,8 +153,6 @@ static void prvChainToReadCallback( IotI2COperationStatus_t xOpStatus,
                                     void * pvParam )
 {
     static uint8_t ucOps = 0;
-
-    BaseType_t xHigherPriorityTaskWoken;
 
     CallbackParam_t * pxCallbackParam = ( CallbackParam_t * ) pvParam;
 
@@ -171,8 +166,7 @@ static void prvChainToReadCallback( IotI2COperationStatus_t xOpStatus,
         }
         else
         {
-            xSemaphoreGiveFromISR( xtestIotI2CSemaphore, &xHigherPriorityTaskWoken );
-            portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+            xSemaphoreGiveFromISR( xtestIotI2CSemaphore, NULL );
         }
     }
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Remove port specific portYIELD_FROM_ISR in I2C tests.

I2C tests is supposed to be platform independent. I didn't realize portYIELD_FROM_ISR is port-specific until the implementation of ESP: https://github.com/aws/amazon-freertos/pull/1850/files

After second thought, portYIELD_FROM_ISR should not be strictly required in Common IO tests. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.