### PR TITLE
Set mbedTLS version to 2.16.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,4 +26,4 @@
 [submodule "mbedtls"]
 	path = libraries/3rdparty/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git
-	branch = mbedtls-2.16.5
+	branch = mbedtls-2.16.6


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Security
   * Fix side channel in ECC code that allowed an adversary with access to
     precise enough timing and memory access information (typically an
     untrusted operating system attacking a secure enclave) to fully recover
     an ECDSA private key. Found and reported by Alejandro Cabrera Aldaya,
     Billy Brumley and Cesar Pereida Garcia. CVE-2020-10932
   * Fix a potentially remotely exploitable buffer overread in a
     DTLS client when parsing the Hello Verify Request message.

Bugfix
   * Fix compilation failure when both MBEDTLS_SSL_PROTO_DTLS and
     MBEDTLS_SSL_HW_RECORD_ACCEL are enabled.
   * Fix a function name in a debug message. Contributed by Ercan Ozturk in
     #3013.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.