### PR TITLE
common-io: Updates to I2C test cases

### DIFF
--- a/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
+++ b/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
@@ -232,12 +232,12 @@
 
 /* I2C */
 #if defined( IOT_TEST_COMMON_IO_I2C_SUPPORTED ) && ( IOT_TEST_COMMON_IO_I2C_SUPPORTED >= 1 )
-    extern uint8_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
-    extern uint8_t uctestIotI2CDeviceRegister;    /* Slave I2C register address used in read/write tests */
-    extern uint8_t uctestIotI2CWriteVal;          /* Write value that will be used in the register write test */
-    extern uint8_t uctestIotI2CInstanceIdx;       /* I2C instance used in the test */
-    extern uint8_t uctestIotI2CInstanceNum;       /* The total number of I2C instances on the device */
-    extern uint8_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
+    extern uint16_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
+    extern uint8_t uctestIotI2CDeviceRegister;     /* Slave I2C register address used in read/write tests */
+    extern uint8_t uctestIotI2CWriteVal;           /* Write value that will be used in the register write test */
+    extern uint8_t uctestIotI2CInstanceIdx;        /* I2C instance used in the test */
+    extern uint8_t uctestIotI2CInstanceNum;        /* The total number of I2C instances on the device */
+    extern uint16_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
 
 /**
  * Board specific I2C config set

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -128,7 +128,7 @@ void prvI2CCallback( IotI2COperationStatus_t xOpStatus,
 {
     if( xOpStatus == eI2CCompleted )
     {
-        xSemaphoreGiveFromISR( xtestIotI2CSemaphore, &xHigherPriorityTaskWoken );
+        xSemaphoreGiveFromISR( xtestIotI2CSemaphore, NULL );
     }
 }
 
@@ -149,7 +149,7 @@ static void prvChainToReadCallback( IotI2COperationStatus_t xOpStatus,
         }
         else
         {
-            xSemaphoreGiveFromISR( xtestIotI2CSemaphore, &xHigherPriorityTaskWoken );
+            xSemaphoreGiveFromISR( xtestIotI2CSemaphore, NULL );
         }
     }
 }

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -74,7 +74,7 @@ uint8_t uctestIotI2CDeviceRegister = 0;         /**< The device register to be s
 uint8_t uctestIotI2CWriteVal = 0;               /**< The write value to write to device. */
 uint8_t uctestIotI2CInstanceIdx = 0;            /**< The current I2C test instance index */
 uint8_t uctestIotI2CInstanceNum = 1;            /**< The total I2C test instance number */
-uint8_t ucAssistedTestIotI2CSlaveAddr = 0;      /**< The slave address to be set for the assisted test. */
+uint16_t ucAssistedTestIotI2CSlaveAddr = 0;     /**< The slave address to be set for the assisted test. */
 
 /*-----------------------------------------------------------*/
 /* Static Globals */


### PR DESCRIPTION
Description
-----------
Removed reference to global handles and closing them during setup. This based on the assumption that other tests using the I2C and possibly these handles should me responsible for cleaning up.

Updated to use variable directly in code instead of a define replacement, this to align with how other tests look. 

Added a TEST_PROTECT section to AFQP_IotI2COpenCloseFail.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.