### PR TITLE
common-io: Refactoring and updates to PWM test cases

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_pwm.c
+++ b/libraries/abstractions/common_io/test/test_iot_pwm.c
@@ -36,41 +36,28 @@
 /* Driver includes */
 #include "FreeRTOS.h"
 #include "semphr.h"
-#include "task.h"
-#include <time.h>
-#include <sys/time.h>
+
 #include "iot_pwm.h"
-#include "iot_board_gpio.h"
 #include "iot_gpio.h"
-#include "test_iot_config.h"
+#include "iot_test_common_io_internal.h"
 
+/*-----------------------------------------------------------*/
 
+#define PWM_TEST_DURATION_MSEC    5000
 
 /*-----------------------------------------------------------*/
 
 /* Globals values which can be overwritten by the test
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
-uint32_t ultestIotPwmGpioOutputPin = 14;
 uint32_t ultestIotPwmGpioInputPin = 18;
-uint32_t ultestIotPwmGpioFunction = 0x4U; /*IOPCTL_PIO_FUNC4; */
-uint32_t ulAssistedTestIotPwmGpioInputPin = 23;
 
 uint32_t ultestIotPwmInstance = 2;            /* Use PWM instance 2 */
 uint32_t ultestIotPwmFrequency = 2000UL;      /* 2KHz frequency */
 uint32_t ultestIotPwmDutyCycle = 20;          /* Default duty cycle */
 uint32_t ultestIotPwmChannel = 0;             /* Default PWM Channel */
-uint32_t ulAssistedTestIotPwmInstance = 2;    /* Use PWM instance 2 for assisted test */
-uint32_t ulAssistedTestIotPwmChannel = 0;     /* Default PWM Channel for assisted test */
 
 volatile uint32_t ultestIotPwmIrqCounter = 0; /* Count how many pulses we've had */
-#define PWM_TEST_DURATION_MSEC    5000
-
-
-/*-----------------------------------------------------------*/
-/* Static Globals */
-/*-----------------------------------------------------------*/
-static SemaphoreHandle_t xtestIotPwmGpioSemaphore = NULL;
 
 /*-----------------------------------------------------------*/
 
@@ -102,8 +89,6 @@ TEST_TEAR_DOWN( TEST_IOT_PWM )
  */
 TEST_GROUP_RUNNER( TEST_IOT_PWM )
 {
-    xtestIotPwmGpioSemaphore = xSemaphoreCreateBinary();
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotPwmGpioSemaphore );
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_OpenClose );
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_SetGetConfig );
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_Start );
@@ -113,20 +98,10 @@ TEST_GROUP_RUNNER( TEST_IOT_PWM )
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_CloseFuzzing );
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_SetConfigFuzzing );
     RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_GetConfigFuzzing );
+    RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwm_StartFuzzing );
+    RUN_TEST_CASE( TEST_IOT_PWM, AFQP_IotPwmAccuracy );
 }
 
-
-/**
- * @brief Function for testing iot_gpio_set_callback.
- */
-static void prvGpioCallback( uint8_t ucPinState,
-                             void * pvPosixParam )
-{
-    BaseType_t xHigherPriorityTaskWoken;
-
-    xSemaphoreGiveFromISR( xtestIotPwmGpioSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-}
 
 /*-----------------------------------------------------------*/
 
@@ -163,23 +138,26 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_SetGetConfig )
     xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Settup the pwm configuration */
+    /* Setup the pwm configuration */
     xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
     xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
     xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
 
-    /* Set the pwm configuration */
-    lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        /* Set the pwm configuration */
+        lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Get the pwm configuration */
-    xGetPwmConfig = iot_pwm_get_config( xPwmHandle );
-    TEST_ASSERT_NOT_EQUAL( NULL, xGetPwmConfig );
+        /* Get the pwm configuration */
+        xGetPwmConfig = iot_pwm_get_config( xPwmHandle );
+        TEST_ASSERT_NOT_EQUAL( NULL, xGetPwmConfig );
 
-    /* Confim Set and Get are the same */
-    TEST_ASSERT_EQUAL( xSetPwmConfig.ulPwmFrequency, xGetPwmConfig->ulPwmFrequency );
-    TEST_ASSERT_EQUAL( xSetPwmConfig.ucPwmDutyCycle, xGetPwmConfig->ucPwmDutyCycle );
-    TEST_ASSERT_EQUAL( xSetPwmConfig.ucPwmChannel, xGetPwmConfig->ucPwmChannel );
+        /* Confim Set and Get are the same */
+        TEST_ASSERT_EQUAL( xSetPwmConfig.ulPwmFrequency, xGetPwmConfig->ulPwmFrequency );
+        TEST_ASSERT_EQUAL( xSetPwmConfig.ucPwmDutyCycle, xGetPwmConfig->ucPwmDutyCycle );
+        TEST_ASSERT_EQUAL( xSetPwmConfig.ucPwmChannel, xGetPwmConfig->ucPwmChannel );
+    }
 
     /* Close PWM handle */
     lRetVal = iot_pwm_close( xPwmHandle );
@@ -200,18 +178,21 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_Start )
     xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Settup the pwm configuration */
+    /* Setup the pwm configuration */
     xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
     xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
     xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
 
-    /* Set the pwm configuration */
-    lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        /* Set the pwm configuration */
+        lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+        /* Start the PWM signal */
+        lRetVal = iot_pwm_start( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+    }
 
     /* Close PWM handle */
     lRetVal = iot_pwm_close( xPwmHandle );
@@ -232,22 +213,25 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_Stop )
     xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Settup the pwm configuration */
+    /* Setup the pwm configuration */
     xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
     xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
     xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
 
-    /* Set the pwm configuration */
-    lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        /* Set the pwm configuration */
+        lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+        /* Start the PWM signal */
+        lRetVal = iot_pwm_start( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Stop the PWM signal */
-    lRetVal = iot_pwm_stop( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+        /* Stop the PWM signal */
+        lRetVal = iot_pwm_stop( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+    }
 
     /* Close PWM handle */
     lRetVal = iot_pwm_close( xPwmHandle );
@@ -267,9 +251,12 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_NoConfig )
     xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_NOT_CONFIGURED, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        /* Start the PWM signal */
+        lRetVal = iot_pwm_start( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_NOT_CONFIGURED, lRetVal );
+    }
 
     /* Close PWM handle */
     lRetVal = iot_pwm_close( xPwmHandle );
@@ -277,17 +264,33 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_NoConfig )
 }
 
 /**
- * @brief Test Function to test pwm open with invalid instance
+ * @brief Test Function to test pwm open and open again to
+ * validate the failure condition
  *
  */
 TEST( TEST_IOT_PWM, AFQP_IotPwm_OpenFuzzing )
 {
-    IotPwmHandle_t xPwmHandle;
+    IotPwmHandle_t xPwmHandle1, xPwmHandle2;
     int32_t lRetVal;
 
-    /* Open PWM handle */
-    xPwmHandle = iot_pwm_open( -1 );
-    TEST_ASSERT_EQUAL( NULL, xPwmHandle );
+    /* Open pwm with invalid instance */
+    xPwmHandle1 = iot_pwm_open( -1 );
+    TEST_ASSERT_EQUAL( NULL, xPwmHandle1 );
+
+    /* Open pwm handle */
+    xPwmHandle1 = iot_pwm_open( ultestIotPwmInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle1 );
+
+    if( TEST_PROTECT() )
+    {
+        /* Open pwm handle again. */
+        xPwmHandle2 = iot_pwm_open( ultestIotPwmInstance );
+        TEST_ASSERT_EQUAL( NULL, xPwmHandle2 );
+    }
+
+    /* Close the pwm handle */
+    lRetVal = iot_pwm_close( xPwmHandle1 );
+    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 }
 
 /**
@@ -347,47 +350,24 @@ TEST( TEST_IOT_PWM, AFQP_IotPwm_GetConfigFuzzing )
  * the PWM configuration.
  *
  */
-TEST( TEST_IOT_PWM, AFQP_IotPwmStartFailure )
+TEST( TEST_IOT_PWM, AFQP_IotPwm_StartFuzzing )
 {
     IotPwmHandle_t xPwmHandle;
     int32_t lRetVal;
 
     /* Open pwm handle */
     xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
+    TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_NOT_CONFIGURED, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        /* Start the PWM signal */
+        lRetVal = iot_pwm_start( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_NOT_CONFIGURED, lRetVal );
+    }
 
     /* Close the pwm handle */
     lRetVal = iot_pwm_close( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
-}
-
-/**
- * @brief Test Function to test pwm open and open again to
- * validate the failure condition
- *
- */
-TEST( TEST_IOT_PWM, AFQP_IotPwmOpenFailure )
-{
-    IotPwmHandle_t xPwmHandle1, xPwmHandle2;
-    int32_t lRetVal;
-
-    /* Open pwm with invalid instance */
-    xPwmHandle1 = iot_pwm_open( -1 );
-    TEST_ASSERT_EQUAL( NULL, xPwmHandle1 );
-
-    /* Open pwm handle */
-    xPwmHandle1 = iot_pwm_open( ultestIotPwmInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle1 );
-
-    /* Open pwm handle again. */
-    xPwmHandle2 = iot_pwm_open( ultestIotPwmInstance );
-    TEST_ASSERT_EQUAL( NULL, xPwmHandle2 );
-
-    /* Close the pwm handle */
-    lRetVal = iot_pwm_close( xPwmHandle1 );
     TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 }
 
@@ -420,109 +400,42 @@ TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
     xtestIotGpioHandleB = iot_gpio_open( ultestIotPwmGpioInputPin );
     TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioHandleB );
 
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioDirection, &xGpioDirectionB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
+    if( TEST_PROTECT() )
+    {
+        lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioDirection, &xGpioDirectionB );
+        TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
 
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioPull, &xGpioPullB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
+        lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioPull, &xGpioPullB );
+        TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
 
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioInterrupt, &xGpioInterruptB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
+        lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioInterrupt, &xGpioInterruptB );
+        TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
 
-    iot_gpio_set_callback( xtestIotGpioHandleB, prvPwmGpioInterruptCallback, &xGpioInterruptB );
+        iot_gpio_set_callback( xtestIotGpioHandleB, prvPwmGpioInterruptCallback, &xGpioInterruptB );
 
-    /* Initialize our counter to 0 */
-    ultestIotPwmIrqCounter = 0;
+        /* Initialize our counter to 0 */
+        ultestIotPwmIrqCounter = 0;
 
-    /* Open PWM handle */
-    xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
+        /* Open PWM handle */
+        xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
+        TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
-    /* Settup the pwm configuration */
-    xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
-    xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
-    xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
+        /* Settup the pwm configuration */
+        xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
+        xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
+        xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
 
-    /* Set the pwm configuration */
-    lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+        /* Set the pwm configuration */
+        lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
+        /* Start the PWM signal */
+        lRetVal = iot_pwm_start( xPwmHandle );
+        TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
 
-    /* Delay for 5 sec. */
-    vTaskDelay( PWM_TEST_DURATION_MSEC / portTICK_PERIOD_MS );
-
-    /* Close PWM handle */
-    lRetVal = iot_pwm_close( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
-
-    /* Close the GPIO handle */
-    lRetVal = iot_gpio_close( xtestIotGpioHandleB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
-
-    expected_count = ultestIotPwmFrequency * ( PWM_TEST_DURATION_MSEC / 1000 );
-    TEST_ASSERT_GREATER_THAN( ( expected_count - 100 ), ultestIotPwmIrqCounter );
-    TEST_ASSERT_GREATER_THAN( ultestIotPwmIrqCounter, ( expected_count + 100 ) );
-}
-
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Assited Test Function to test pwm accuracy by running the
- * pwm signal for 5 seconds and also counting the number of pulses
- *
- */
-TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracyAssisted )
-{
-    int32_t lRetVal;
-    uint32_t expected_count = 0;
-    IotPwmHandle_t xPwmHandle = NULL;
-    IotPwmConfig_t xSetPwmConfig;
-
-    IotGpioHandle_t xtestIotGpioHandleB = NULL;
-    IotGpioDirection_t xGpioDirectionB = eGpioDirectionInput;
-    IotGpioPull_t xGpioPullB = eGpioPullNone;
-    IotGpioInterrupt_t xGpioInterruptB = eGpioInterruptRising;
-
-    /* set up port B for interrupt */
-    xtestIotGpioHandleB = iot_gpio_open( ulAssistedTestIotPwmGpioInputPin );
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioHandleB );
-
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioDirection, &xGpioDirectionB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
-
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioPull, &xGpioPullB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
-
-    lRetVal = iot_gpio_ioctl( xtestIotGpioHandleB, eSetGpioInterrupt, &xGpioInterruptB );
-    TEST_ASSERT_EQUAL( IOT_GPIO_SUCCESS, lRetVal );
-
-    iot_gpio_set_callback( xtestIotGpioHandleB, prvPwmGpioInterruptCallback, &xGpioInterruptB );
-
-    /* Initialize our counter to 0 */
-    ultestIotPwmIrqCounter = 0;
-
-    /* Open PWM handle */
-    xPwmHandle = iot_pwm_open( ulAssistedTestIotPwmInstance );
-    TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
-
-    /* Settup the pwm configuration */
-    xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
-    xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
-    xSetPwmConfig.ucPwmChannel = ulAssistedTestIotPwmChannel;
-
-    /* Set the pwm configuration */
-    lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
-
-    /* Start the PWM signal */
-    lRetVal = iot_pwm_start( xPwmHandle );
-    TEST_ASSERT_EQUAL( IOT_PWM_SUCCESS, lRetVal );
-
-    /* Delay for 5 sec. */
-    vTaskDelay( PWM_TEST_DURATION_MSEC / portTICK_PERIOD_MS );
+        /* Delay for 5 sec. */
+        vTaskDelay( PWM_TEST_DURATION_MSEC / portTICK_PERIOD_MS );
+    }
 
     /* Close PWM handle */
     lRetVal = iot_pwm_close( xPwmHandle );

--- a/libraries/abstractions/common_io/test/test_iot_pwm.c
+++ b/libraries/abstractions/common_io/test/test_iot_pwm.c
@@ -51,11 +51,14 @@
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
 uint32_t ultestIotPwmGpioInputPin = 18;
+uint32_t ulAssistedTestIotPwmGpioInputPin = 23;
 
 uint32_t ultestIotPwmInstance = 2;            /* Use PWM instance 2 */
 uint32_t ultestIotPwmFrequency = 2000UL;      /* 2KHz frequency */
 uint32_t ultestIotPwmDutyCycle = 20;          /* Default duty cycle */
 uint32_t ultestIotPwmChannel = 0;             /* Default PWM Channel */
+uint32_t ulAssistedTestIotPwmInstance = 2;    /* Use PWM instance 2 for assisted test */
+uint32_t ulAssistedTestIotPwmChannel = 0;     /* Default PWM Channel for assisted test */
 
 volatile uint32_t ultestIotPwmIrqCounter = 0; /* Count how many pulses we've had */
 
@@ -379,12 +382,9 @@ static void prvPwmGpioInterruptCallback( uint8_t ucPinState,
 }
 /*-----------------------------------------------------------*/
 
-/**
- * @brief Test Function to test pwm accuracy by running the
- * pwm signal for 5 seconds and then counting the number of pulses
- *
- */
-TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
+void prvTestPwmAccuracy( uint32_t ulGpioInstance,
+                         uint32_t ulPwmInstance,
+                         uint32_t ulPwmChannel )
 {
     int32_t lRetVal;
     uint32_t expected_count = 0;
@@ -397,7 +397,7 @@ TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
     IotGpioInterrupt_t xGpioInterruptB = eGpioInterruptRising;
 
     /* set up port B for interrupt */
-    xtestIotGpioHandleB = iot_gpio_open( ultestIotPwmGpioInputPin );
+    xtestIotGpioHandleB = iot_gpio_open( ulGpioInstance );
     TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioHandleB );
 
     if( TEST_PROTECT() )
@@ -417,13 +417,13 @@ TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
         ultestIotPwmIrqCounter = 0;
 
         /* Open PWM handle */
-        xPwmHandle = iot_pwm_open( ultestIotPwmInstance );
+        xPwmHandle = iot_pwm_open( ulPwmInstance );
         TEST_ASSERT_NOT_EQUAL( NULL, xPwmHandle );
 
         /* Settup the pwm configuration */
         xSetPwmConfig.ulPwmFrequency = ultestIotPwmFrequency;
         xSetPwmConfig.ucPwmDutyCycle = ultestIotPwmDutyCycle;
-        xSetPwmConfig.ucPwmChannel = ultestIotPwmChannel;
+        xSetPwmConfig.ucPwmChannel = ulPwmChannel;
 
         /* Set the pwm configuration */
         lRetVal = iot_pwm_set_config( xPwmHandle, xSetPwmConfig );
@@ -448,4 +448,26 @@ TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
     expected_count = ultestIotPwmFrequency * ( PWM_TEST_DURATION_MSEC / 1000 );
     TEST_ASSERT_GREATER_THAN( ( expected_count - 100 ), ultestIotPwmIrqCounter );
     TEST_ASSERT_GREATER_THAN( ultestIotPwmIrqCounter, ( expected_count + 100 ) );
+}
+
+/**
+ * @brief Test Function to test pwm accuracy by running the
+ * pwm signal for 5 seconds and then counting the number of pulses
+ *
+ */
+TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracy )
+{
+    prvTestPwmAccuracy( ultestIotPwmGpioInputPin, ultestIotPwmInstance, ultestIotPwmChannel );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Assited Test Function to test pwm accuracy by running the
+ * pwm signal for 5 seconds and also counting the number of pulses
+ *
+ */
+TEST( TEST_IOT_PWM, AFQP_IotPwmAccuracyAssisted )
+{
+    prvTestPwmAccuracy( ulAssistedTestIotPwmGpioInputPin, ulAssistedTestIotPwmInstance, ulAssistedTestIotPwmChannel );
 }


### PR DESCRIPTION
Description
-----------
* Added "TEST_PROTECT" sections where needed
* Removed stale includes, variables and code
* Added in "AFQP_IotPwm_StartFuzzing" and "AFQP_IotPwmAccuracy" test cases in the group.
* Removed "AFQP_IotPwmOpenFailure" as it was testing the same as "AFQP_IotPwmOpenFuzzing" 
* Refactored "AFQP_IotPwmAccuracy" and "AFQP_IotPwmAccuracyAssisted", moving common code out to shared private function. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.