### PR TITLE
Fix Linux Unit Test build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ endif()
 # Use include here because we need portable layer targets defined by vendor to be at
 # the same directory level as our library components.
 include("${AFR_BOARD_PATH}/CMakeLists.txt")
+if (AFR_ENABLE_UNIT_TESTS)
+    return()
+endif()
 
 # -------------------------------------------------------------------------------------------------
 # Conditionally set mbedtls config
@@ -77,9 +80,6 @@ endif()
 # Do not prefix the output library file.
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
-if (AFR_ENABLE_UNIT_TESTS)
-    return()
-endif()
 
 # Initialize all modules.
 add_subdirectory("libraries")


### PR DESCRIPTION
The Linux unit test was broken, because a library target was referenced before the unit test conditional statement.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.