### PR TITLE
ModusToolbox: Fix MTB builds

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
@@ -88,7 +88,8 @@ CY_IGNORE+=\
 	$(CY_EXTAPP_PATH)/common\
 	$(CY_EXTAPP_PATH)/lwip\
 	$(CY_EXTAPP_PATH)/libraries\
-	$(CY_EXTAPP_PATH)/WICED_SDK
+	$(CY_EXTAPP_PATH)/WICED_SDK\
+	$(CY_EXTAPP_PATH)/freertos_thirdparty_port
     
 CY_CONFIG_MODUS_FILE=./$(CY_AFR_BOARD_APP_PATH)/design.modus
 

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/ota/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/ota/afr.mk
@@ -137,7 +137,8 @@ CY_IGNORE+=\
 	$(CY_EXTAPP_PATH)/common\
 	$(CY_EXTAPP_PATH)/libraries\
 	$(CY_EXTAPP_PATH)/lwip\
-	$(CY_EXTAPP_PATH)/WICED_SDK
+	$(CY_EXTAPP_PATH)/WICED_SDK\
+	$(CY_EXTAPP_PATH)/freertos_thirdparty_port
     
 CY_CONFIG_MODUS_FILE=./$(CY_AFR_BOARD_APP_PATH)/design.modus
 

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/wifi_scanner/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/wifi_scanner/afr.mk
@@ -124,7 +124,8 @@ CY_IGNORE+=\
 	$(CY_EXTAPP_PATH)/common\
 	$(CY_EXTAPP_PATH)/libraries\
 	$(CY_EXTAPP_PATH)/lwip\
-	$(CY_EXTAPP_PATH)/WICED_SDK
+	$(CY_EXTAPP_PATH)/WICED_SDK\
+	$(CY_EXTAPP_PATH)/freertos_thirdparty_port
     
 CY_CONFIG_MODUS_FILE=./$(CY_AFR_BOARD_APP_PATH)/design.modus
 


### PR DESCRIPTION
ModusToolbox: Fix MTB builds

Description
-----------
Exclude freertos_thirdparty_port from being built in the projects.

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.