### PR TITLE
Remove port specific code in SPI and UART tests

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_spi.c
+++ b/libraries/abstractions/common_io/test/test_iot_spi.c
@@ -83,10 +83,7 @@ static void prvOutputMessage();
 static void prvSpiAsyncCallback( IotSPITransactionStatus_t xStatus,
                                  void * pvUserContext )
 {
-    BaseType_t xHigherPriorityTaskWoken;
-
-    xSemaphoreGiveFromISR( xtestIotSPISemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    xSemaphoreGiveFromISR( xtestIotSPISemaphore, NULL );
 }
 /*-----------------------------------------------------------*/
 

--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -104,18 +104,14 @@ static IotUARTConfig_t xSampleConfig2 =
 static void prvReadWriteCallback( IotUARTOperationStatus_t xOpStatus,
                                   void * pvParams )
 {
-    BaseType_t xHigherPriorityTaskWoken;
-
     if( xOpStatus == eUartReadCompleted )
     {
-        xSemaphoreGiveFromISR( xReadCompleteSemaphore, &xHigherPriorityTaskWoken );
+        xSemaphoreGiveFromISR( xReadCompleteSemaphore, NULL );
     }
     else if( xOpStatus == eUartWriteCompleted )
     {
-        xSemaphoreGiveFromISR( xWriteCompleteSemaphore, &xHigherPriorityTaskWoken );
+        xSemaphoreGiveFromISR( xWriteCompleteSemaphore, NULL );
     }
-
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Remove port specific code in SPI and UART tests

Common IO tests is supposed to be platform independent. I didn't realize portYIELD_FROM_ISR is port-specific until the implementation of ESP: https://github.com/aws/amazon-freertos/pull/1850/files

After second thought, portYIELD_FROM_ISR should not be strictly required in Common IO tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.