### PR TITLE
Fix OTA pal tests on windows simulator

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_ota_config.h
@@ -49,11 +49,11 @@
 #define otatestpalFIRMWARE_FILE  "dummy.bin"
 
 /**
- * @brief Some boards OTA PAL layers will use the file names passed into it for the 
+ * @brief Some boards OTA PAL layers will use the file names passed into it for the
  * image and the certificates because their non-volatile memory is abstracted by a
  * file system. Set this to 1 if that is the case for your device.
  */
-#define otatestpalUSE_FILE_SYSTEM     1
+#define otatestpalUSE_FILE_SYSTEM     0
 
 /**
  * @brief 1 if prvPAL_CheckFileSignature() is implemented in aws_ota_pal.c.

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_ota_config.h
@@ -49,11 +49,11 @@
 #define otatestpalFIRMWARE_FILE  "dummy.bin"
 
 /**
- * @brief Some boards OTA PAL layers will use the file names passed into it for the 
+ * @brief Some boards OTA PAL layers will use the file names passed into it for the
  * image and the certificates because their non-volatile memory is abstracted by a
  * file system. Set this to 1 if that is the case for your device.
  */
-#define otatestpalUSE_FILE_SYSTEM     1
+#define otatestpalUSE_FILE_SYSTEM     0
 
 /**
  * @brief 1 if prvPAL_CheckFileSignature() is implemented in aws_ota_pal.c.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Winsim now fallback to use the signing cert from the header file if it's not found on file system. This will resolve the OTA pal tests failures in our regression tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.