### PR TITLE
Remove warnings from PKCS11 and Defender files

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -461,6 +461,7 @@ void runDemoTask( void * pArgument )
 
         /* Unused Parameters */
         ( void ) xTask;
+        ( void ) pcTaskName;
 
         /* Loop forever */
         for( ; ; )

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -854,7 +854,7 @@ static CK_RV prvGetProvisionedState( CK_SESSION_HANDLE xSession,
     CK_SLOT_ID_PTR pxSlotId = NULL;
     CK_ULONG ulSlotCount = 0;
     CK_TOKEN_INFO xTokenInfo = { 0 };
-    int i = 0;
+    unsigned int i = 0;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -960,7 +960,7 @@ static int _scheduleAsyncRequest( int reqIndex,
                                ( unsigned int ) curByte,
                                ( unsigned int ) ( curByte + numReqBytes - 1 ) );
 
-    if( ( numWritten < 0 ) || ( numWritten >= sizeof( _requestPool.pRequestContexts[ reqIndex ].pRangeValueStr ) ) )
+    if( ( numWritten < 0 ) || ( numWritten >= ( ( int ) sizeof( _requestPool.pRequestContexts[ reqIndex ].pRangeValueStr ) ) ) )
     {
         IotLogError( "Failed to write the header value: \"bytes=%d-%d\" . Error code: %d",
                      curByte,

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -837,6 +837,9 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
                                           size_t xLength,
                                           uint8_t ** ppucCertData )
     {
+        /* Disable unused parameter warning. */
+        ( void ) xLength;
+
         BaseType_t xResult = CK_TRUE;
 
         if( 0 == memcmp( pucLabel, pkcs11configLABEL_JITP_CERTIFICATE, strlen( ( char * ) pkcs11configLABEL_JITP_CERTIFICATE ) ) )
@@ -1106,6 +1109,9 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetMechanismInfo )( CK_SLOT_ID xSlotID,
                                                   CK_MECHANISM_TYPE type,
                                                   CK_MECHANISM_INFO_PTR pInfo )
 {
+    /* Disable unused parameter warning. */
+    ( void ) xSlotID;
+
     CK_RV xResult = CKR_MECHANISM_INVALID;
     struct CryptoMechanisms
     {
@@ -1643,14 +1649,12 @@ CK_RV prvGetExistingKeyComponent( CK_OBJECT_HANDLE_PTR pxPalHandle,
  * @param[out] ppxLabel label of PKCS #11 object.
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
- * @param[in] pxObject PKCS #11 object handle.
  *
  */
 CK_RV prvCreateEcPrivateKey( mbedtls_pk_context * pxMbedContext,
                              CK_ATTRIBUTE_PTR * ppxLabel,
                              CK_ATTRIBUTE_PTR pxTemplate,
-                             CK_ULONG ulCount,
-                             CK_OBJECT_HANDLE_PTR pxObject )
+                             CK_ULONG ulCount )
 {
     CK_RV xResult = CKR_OK;
     int lMbedReturn;
@@ -1748,14 +1752,12 @@ CK_RV prvCreateEcPrivateKey( mbedtls_pk_context * pxMbedContext,
  * @param[out] ppxLabel label of PKCS #11 object.
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
- * @param[in] pxObject PKCS #11 object handle.
  *
  */
 CK_RV prvCreateRsaPrivateKey( mbedtls_pk_context * pxMbedContext,
                               CK_ATTRIBUTE_PTR * ppxLabel,
                               CK_ATTRIBUTE_PTR pxTemplate,
-                              CK_ULONG ulCount,
-                              CK_OBJECT_HANDLE_PTR pxObject )
+                              CK_ULONG ulCount )
 {
     CK_RV xResult = CKR_OK;
     mbedtls_rsa_context * pxRsaContext;
@@ -1912,7 +1914,6 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
     CK_ATTRIBUTE_PTR pxLabel = NULL;
     CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
     mbedtls_rsa_context * pxRsaCtx = NULL;
-    mbedtls_ecp_keypair * pxKeyPair = NULL;
 
     mbedtls_pk_init( &xMbedContext );
 
@@ -1931,8 +1932,7 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
             xResult = prvCreateRsaPrivateKey( &xMbedContext,
                                               &pxLabel,
                                               pxTemplate,
-                                              ulCount,
-                                              pxObject );
+                                              ulCount );
         }
         else
         {
@@ -1957,7 +1957,7 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
 
                 /* If a key had been found by prvGetExistingKeyComponent, the keypair context
                  * would have been malloc'ed. */
-                pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+                mbedtls_ecp_keypair * pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
 
                 if( pxKeyPair != NULL )
                 {
@@ -1980,8 +1980,7 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
             xResult = prvCreateEcPrivateKey( &xMbedContext,
                                              &pxLabel,
                                              pxTemplate,
-                                             ulCount,
-                                             pxObject );
+                                             ulCount );
         }
     #endif /* if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 ) */
     else
@@ -2076,14 +2075,12 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
  * @param[out] ppxLabel label of PKCS #11 object.
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
- * @param[in] pxObject PKCS #11 object handle.
  *
  */
 CK_RV prvCreateECPublicKey( mbedtls_pk_context * pxMbedContext,
                             CK_ATTRIBUTE_PTR * ppxLabel,
                             CK_ATTRIBUTE_PTR pxTemplate,
-                            CK_ULONG ulCount,
-                            CK_OBJECT_HANDLE_PTR pxObject )
+                            CK_ULONG ulCount )
 {
     CK_RV xResult = CKR_OK;
     int lMbedReturn;
@@ -2195,8 +2192,6 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
     CK_BBOOL xPrivateKeyFound = CK_FALSE;
 
     mbedtls_pk_init( &xMbedContext );
-    mbedtls_ecp_keypair * pxKeyPair;
-
 
     prvGetKeyType( &xKeyType, pxTemplate, ulCount );
 
@@ -2221,7 +2216,7 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
 
                 /* If a key had been found by prvGetExistingKeyComponent, the keypair context
                  * would have been malloc'ed. */
-                pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
+                mbedtls_ecp_keypair * pxKeyPair = pvPortMalloc( sizeof( mbedtls_ecp_keypair ) );
 
                 if( pxKeyPair != NULL )
                 {
@@ -2245,7 +2240,7 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
                 xPrivateKeyFound = CK_TRUE;
             }
 
-            xResult = prvCreateECPublicKey( &xMbedContext, &pxLabel, pxTemplate, ulCount, pxObject );
+            xResult = prvCreateECPublicKey( &xMbedContext, &pxLabel, pxTemplate, ulCount );
         }
     #endif /* if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 ) */
     else

--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c
@@ -463,7 +463,6 @@ static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
 
     IotMqttError_t mqttError = IOT_MQTT_SUCCESS;
     bool reportCreated = false;
-    IotTaskPoolError_t taskPoolError = IOT_TASKPOOL_SUCCESS;
 
     if( !IotSemaphore_TryWait( &_doneSem ) )
     {
@@ -509,7 +508,7 @@ static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
         else
         {
             /* Re-schedule metrics job with period as deferred interval. */
-            taskPoolError = IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, _periodMilliSecond );
+            ( void ) IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, _periodMilliSecond );
         }
 
         /* Give Done semaphore so AwsIotDefender_Stop() can proceed */

--- a/libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c
@@ -110,6 +110,9 @@ BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
 
 static void prvLoggingTask( void * pvParameters )
 {
+    /* Disable unused parameter warning. */
+    ( void ) pvParameters;
+
     char * pcReceivedString = NULL;
 
     for( ; ; )

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -101,7 +101,7 @@
  *
  * These are in order to the HTTP request method enums defined in IotHttpsMethod_t.
  */
-static const char * _pHttpsMethodStrings[] =
+static const char * const _pHttpsMethodStrings[] =
 {
     "GET",
     "HEAD",

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -95,6 +95,20 @@
 
 /*-----------------------------------------------------------*/
 
+
+/**
+ * @brief A map of the method enum to strings
+ *
+ * These are in order to the HTTP request method enums defined in IotHttpsMethod_t.
+ */
+static const char * _pHttpsMethodStrings[] =
+{
+    "GET",
+    "HEAD",
+    "PUT",
+    "POST"
+};
+
 /**
  * @brief Minimum size of the request user buffer.
  *
@@ -1712,7 +1726,7 @@ static IotHttpsReturnCode_t _sendHttpsHeaders( _httpsConnection_t * pHttpsConnec
                                ( unsigned int ) contentLength );
     }
 
-    if( ( numWritten < 0 ) || ( numWritten >= sizeof( contentLengthHeaderStr ) ) )
+    if( ( numWritten < 0 ) || ( numWritten >= ( ( int ) sizeof( contentLengthHeaderStr ) ) ) )
     {
         IotLogError( "Internal error in snprintf() in _sendHttpsHeaders(). Error code %d.", numWritten );
         HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_INTERNAL_ERROR );

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -97,11 +97,9 @@
 
 
 /**
- * @brief A map of the method enum to strings
- *
- * These are in order to the HTTP request method enums defined in IotHttpsMethod_t.
+ * @brief Definition of HTTP method enum to strings array.
  */
-static const char * const _pHttpsMethodStrings[] =
+const char * _pHttpsMethodStrings[] =
 {
     "GET",
     "HEAD",

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -481,4 +481,12 @@ typedef struct _httpsRequest
 } _httpsRequest_t;
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief A map of the method enum to strings
+ *
+ * These are in the same order as the HTTP request method enums defined in IotHttpsMethod_t.
+ */
+extern const char * _pHttpsMethodStrings[];
+
 #endif /* IOT_HTTPS_INTERNAL_H_ */

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -481,17 +481,4 @@ typedef struct _httpsRequest
 } _httpsRequest_t;
 
 /*-----------------------------------------------------------*/
-
-/**
- * @brief A map of the method enum to strings
- *
- * These are in order to the HTTP request method enums defined in IotHttpsMethod_t.
- */
-static const char * _pHttpsMethodStrings[] = {
-    "GET",
-    "HEAD",
-    "PUT",
-    "POST"
-};
-
 #endif /* IOT_HTTPS_INTERNAL_H_ */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Address some warnings flagged by ARM GCC from `-Wall -Wextra` build configuration

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.