### PR TITLE
Pre-provisioning: Use TLS certificates in sec_cert partition for TLS handshakes

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/partition-table-pre-prov.csv
+++ b/vendors/espressif/boards/esp32/aws_demos/partition-table-pre-prov.csv
@@ -1,0 +1,9 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
+sec_cert, 0x3F, ,        0xd000,   0x3000
+nvs,      data, nvs,     0x10000,  0x6000
+otadata,  data, ota,     0x16000,  0x2000
+phy_init, data, phy,     0x18000,  0x1000
+ota_0,    0,    ota_0,   0x20000,  1500K
+ota_1,    0,    ota_1,   ,         1500K
+storage,  data, nvs,     ,         0x10000

--- a/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_config.h
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_config.h
@@ -1,0 +1,45 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#pragma once
+#include <stdint.h>
+
+#define SECURE_CERT_OFFSET           4096        /* Secure certificate size allocated for each certificate in the partition */
+#define SECURE_CERT_PARTITION_TYPE   0x3F        /* Custom partition type */
+#define SECURE_CERT_PARTITION_NAME   "sec_cert"  /* Name of the custom secure cert partition */
+
+#define SECURE_CERT_CRC_BYTES         4
+#define SECURE_CERT_LEN_BYTES         4
+#define SECURE_CERT_LEN_MAGIC_BYTE    1
+
+#define SECURE_CERT_PKEY_MAGIC_BYTE   0xC1   /* Magic byte of the generated private key */
+#define SECURE_DEVICE_CERT_MAGIC_BYTE 0xC2   /* Magic byte of the generated device certificate */
+#define SECURE_CA_CERT_MAGIC_BYTE     0xC3   /* Magic byte of the CA certificate */
+
+#define METADATA_SIZE                 32     /* 32 bytes are reserved for the metadata (Must be a multiple of 32)*/
+
+typedef struct {
+    uint32_t secure_cert_crc;                   /* CRC of only the data of the certificate */
+    uint8_t magic_byte;                         /* The magic byte of the cert as mentioned above */
+    uint32_t secure_cert_len;                   /* The actual length of the cert[The length before the 32 byte alignment] */
+} secure_cert_metadata;                         /* The sizeof struct is 12 bytes, 3 bytes after magic_byte are unused because of struct packing */

--- a/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_operations.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_operations.c
@@ -1,0 +1,136 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <string.h>
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_partition.h"
+#include "rom/crc.h"
+#include "secure_cert_config.h"
+
+#define TAG "Sec Cert Ops"
+
+#define pkcs11palFILE_NAME_CLIENT_CERTIFICATE    "P11_Cert"
+#define pkcs11palFILE_NAME_KEY                   "P11_Key"
+#define pkcs11palFILE_CODE_SIGN_PUBLIC_KEY       "P11_CSK"
+#define pkcs11palFILE_JITP_CERTIFICATE           "P11_JITP"
+#define pkcs11palFILE_CA_CERTIFICATE             "P11_CA_Cert" // Pre-provisinoning specific option
+
+static esp_err_t secure_cert_read_raw_flash(const esp_partition_t* partition, uint32_t src_offset, void * dst, uint32_t size)
+{
+    /* Encrypted partitions need to be read via a cache mapping */
+    const void *buf;
+    spi_flash_mmap_handle_t handle;
+    esp_err_t err;
+
+    err = esp_partition_mmap(partition, src_offset, size, SPI_FLASH_MMAP_DATA, &buf, &handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+    memcpy(dst, buf, size);
+    spi_flash_munmap(handle);
+    return ESP_OK;
+}
+
+static esp_err_t secure_cert_read(size_t offset, unsigned char *buffer, uint32_t * len)
+{
+    esp_err_t err;
+    esp_partition_iterator_t it = esp_partition_find(SECURE_CERT_PARTITION_TYPE, ESP_PARTITION_SUBTYPE_ANY, SECURE_CERT_PARTITION_NAME);
+    if (it == NULL) {
+        ESP_LOGE(TAG, "Partition not found.");
+        return ESP_FAIL;
+    }
+
+    const esp_partition_t * part = esp_partition_get(it);
+    if (part == NULL) {
+        ESP_LOGE(TAG, "Could not get partition.");
+        return ESP_FAIL;
+    }
+
+    secure_cert_metadata metadata;
+    err = secure_cert_read_raw_flash(part, offset, &metadata, sizeof(metadata));
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read magic byte.");
+        return ESP_FAIL;
+    }
+
+    if (!(metadata.magic_byte == SECURE_CERT_PKEY_MAGIC_BYTE || metadata.magic_byte == SECURE_DEVICE_CERT_MAGIC_BYTE || metadata.magic_byte == SECURE_CA_CERT_MAGIC_BYTE)) {
+        ESP_LOGE(TAG, "Unrecognised Magic Byte. %x", metadata.magic_byte);
+        return ESP_FAIL;
+    }
+
+    if (buffer == NULL) {
+        *len = metadata.secure_cert_len;
+        return ESP_OK;
+    }
+
+    if (*len < metadata.secure_cert_len) {
+        ESP_LOGE(TAG, "Insufficient length of buffer");        
+        return ESP_FAIL;
+    }
+
+    err = secure_cert_read_raw_flash(part, offset + METADATA_SIZE, buffer, metadata.secure_cert_len);
+    if (err != ESP_OK) {    
+        ESP_LOGE(TAG, "Could not read data.");
+        return ESP_FAIL;
+    }
+
+    uint32_t read_crc = crc32_le(UINT32_MAX ,(const uint8_t * )buffer, metadata.secure_cert_len);
+    ESP_LOGE(TAG,"0x%x 0x%x 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x", buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[metadata.secure_cert_len-2], buffer[metadata.secure_cert_len-1]);
+    ESP_LOGE(TAG,"%d", metadata.secure_cert_len);
+    if (read_crc != metadata.secure_cert_crc) {
+        ESP_LOGE(TAG,"Data has been tampered");
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t secure_cert_get_priv_key(unsigned char * buffer, uint32_t *len)
+{
+    return secure_cert_read(0, buffer, len);
+}
+
+static esp_err_t secure_cert_get_device_cert(unsigned char * buffer, uint32_t *len)
+{
+    return secure_cert_read(SECURE_CERT_OFFSET, buffer, len);
+}
+
+static esp_err_t secure_cert_get_ca_cert(unsigned char * buffer, uint32_t *len)
+{
+    return secure_cert_read(2 * SECURE_CERT_OFFSET, buffer, len);
+}
+
+esp_err_t secure_cert_get_data(unsigned char * buffer, uint32_t *len, char * label) {
+    if (!memcmp(label, pkcs11palFILE_NAME_KEY, strlen(pkcs11palFILE_NAME_KEY))) {
+        return secure_cert_get_priv_key(buffer, len);
+    } else if (!memcmp(label, pkcs11palFILE_NAME_CLIENT_CERTIFICATE, strlen(pkcs11palFILE_NAME_CLIENT_CERTIFICATE)) || 
+                !memcmp(label, pkcs11palFILE_JITP_CERTIFICATE, strlen(pkcs11palFILE_JITP_CERTIFICATE))) {
+        return secure_cert_get_device_cert(buffer, len);
+    } else if (!memcmp(label, pkcs11palFILE_CA_CERTIFICATE, strlen(pkcs11palFILE_CA_CERTIFICATE))) {
+        return secure_cert_get_ca_cert(buffer, len);
+    } else {
+        ESP_LOGE(TAG, "Label %s not supported", label);
+    }
+    return ESP_ERR_INVALID_ARG;
+}

--- a/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_operations.h
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/secure_cert_operations.h
@@ -1,0 +1,83 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#pragma once
+#include "esp_err.h"
+
+// esp_err_t secure_cert_get_priv_key(unsigned char * buffer, size_t *len);
+// esp_err_t secure_cert_get_device_cert(unsigned char * buffer, size_t *len);
+// esp_err_t secure_cert_get_ca_cert(unsigned char * buffer, size_t *len);
+
+esp_err_t  secure_cert_get_data(unsigned char * buffer, size_t *len, char *label);
+
+/* Storage Format:
+0-4 Bytes: CRC of the secure cert
+5th Byte: Magic Bytes
+9-12 Bytes: Key/Cert Length
+33rd byte onwards: Actual key/cert
+[Max size single cert/key -> 4096 Bytes(Including Length & CRC)]
+
+0xd000 - 0x1000 - Offsets
+Offsets:
+0-4096 - Private Key
+4097-8192 - Device Cert
+8193 - 12288 - CA Cert
+
+API Usage:
+
+Fetching the private key:
+    #include <string.h>
+    #include "esp_log.h"
+    #include "secure_cert_operations.h"
+    uint32_t len;
+    if (secure_cert_get_priv_key(NULL, &len) == ESP_OK) {
+        unsigned char * buffer = (unsigned char *)calloc(1, len+1);
+        secure_cert_get_priv_key(buffer, &len);
+        ESP_LOGI("App", "PEM KEY: \nLength: %d\n%s", strlen((char *)buffer), buffer);
+        free(buffer);
+    }
+
+Fetching the device cert:
+    #include <string.h>
+    #include "esp_log.h"
+    #include "secure_cert_operations.h"
+    uint32_t len;
+    if (secure_cert_get_device_cert(NULL, &len) == ESP_OK) {
+        unsigned char * buffer = (unsigned char *)calloc(1, len+1);
+        secure_cert_get_device_cert(buffer, &len);
+        ESP_LOGI("App", "Device Cert: \nLength: %d\n%s", strlen((char *)buffer), buffer);
+        free(buffer);
+    }
+
+Fetching the ca cert:
+    #include <string.h>
+    #include "esp_log.h"
+    #include "secure_cert_operations.h"
+    uint32_t len;
+    if (secure_cert_get_ca_cert(NULL, &len) == ESP_OK) {
+        unsigned char * buffer = (unsigned char *)calloc(1, len+1);
+        secure_cert_get_ca_cert(buffer, &len);
+        ESP_LOGI("App", "CA Cert: \nLength: %d\n%s", strlen((char *)buffer), buffer);
+        free(buffer);
+    }
+*/


### PR DESCRIPTION
Pre-provisioned ESP32 modules have cloud certificates programmed in
the sec_cert partition, these certificates need to be put into NVS, which
is the NVM ported in iot_pkcs_pal.c. Adding an alternate way to use
SPI flash in the PAL layer to read pre-prov residing on the flash during the
TLS handshake..

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.