### PR TITLE
Fix Full_TCP test retry logic & disable DNS cache on all builds

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -350,8 +350,8 @@ static BaseType_t prvAwsIotBrokerConnectHelper( Socket_t xSocket,
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvConnectHelper( Socket_t xSocket,
-                                    Server_t xConn )
+static BaseType_t prvConnect( Socket_t xSocket,
+                              Server_t xConn )
 {
     BaseType_t xResult = pdFAIL;
     SocketsSockaddr_t xAddress;
@@ -376,15 +376,27 @@ static BaseType_t prvConnectHelper( Socket_t xSocket,
 
     if( xResult == SOCKETS_ERROR_NONE )
     {
-        uint32_t ulInitialRetryPeriodMs = tcptestLOOP_DELAY_MS;
-        BaseType_t xMaxRetries = tcptestRETRY_CONNECTION_TIMES;
-        RETRY_EXPONENTIAL( xResult = SOCKETS_Connect( xSocket,
-                                                      &xAddress,
-                                                      sizeof( xAddress ) ),
-                           SOCKETS_ERROR_NONE,
-                           ulInitialRetryPeriodMs,
-                           xMaxRetries );
+        xResult = SOCKETS_Connect( xSocket,
+                                   &xAddress,
+                                   sizeof( xAddress ) );
     }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvConnectHelper( Socket_t xSocket,
+                                    Server_t xConn )
+{
+    BaseType_t xResult = pdFAIL;
+    uint32_t ulInitialRetryPeriodMs = tcptestLOOP_DELAY_MS;
+    BaseType_t xMaxRetries = tcptestRETRY_CONNECTION_TIMES;
+
+    RETRY_EXPONENTIAL( xResult = prvConnect( xSocket,
+                                             xConn ),
+                       SOCKETS_ERROR_NONE,
+                       ulInitialRetryPeriodMs,
+                       xMaxRetries );
 
     return xResult;
 }

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -83,8 +83,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -83,8 +83,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -89,8 +89,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -83,8 +83,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -89,8 +89,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -83,8 +83,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 10 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 10 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -86,8 +86,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -79,8 +79,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -85,8 +85,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -85,8 +85,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -87,8 +87,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -87,8 +87,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -80,8 +80,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -80,8 +80,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,15 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: This feature should not be used with services behind a load balancer,
+ * since occasionally one of the addresses returned may not be available due to
+ * eventual consistency.  Until FreeRTOS+TCP caches more than a single DNS
+ * result for a hostname lookup, it's recommended to disaqble this feature when
+ * contacting services behind a load balancer.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -80,11 +80,12 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket.
  *
- * NOTE: This feature should not be used with services behind a load balancer,
- * since occasionally one of the addresses returned may not be available due to
- * eventual consistency.  Until FreeRTOS+TCP caches more than a single DNS
- * result for a hostname lookup, it's recommended to disaqble this feature when
- * contacting services behind a load balancer.
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
  */
 #define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: This feature should not be used with services behind a load balancer,
+ * since occasionally one of the addresses returned may not be available due to
+ * eventual consistency.  Until FreeRTOS+TCP caches more than a single DNS
+ * result for a hostname lookup, it's recommended to disaqble this feature when
+ * contacting services behind a load balancer.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -74,11 +74,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket.
  *
- * NOTE: This feature should not be used with services behind a load balancer,
- * since occasionally one of the addresses returned may not be available due to
- * eventual consistency.  Until FreeRTOS+TCP caches more than a single DNS
- * result for a hostname lookup, it's recommended to disaqble this feature when
- * contacting services behind a load balancer.
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
  */
 #define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -73,8 +73,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -73,8 +73,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -80,8 +80,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -80,8 +80,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -77,8 +77,16 @@ useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
 and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
 socket has been destroyed, the result will be stored into the cache.  The next
 call to FreeRTOS_gethostbyname() will return immediately, without even creating
-a socket. */
-#define ipconfigUSE_DNS_CACHE				( 1 )
+a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE				( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS		( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -77,8 +77,16 @@ useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
 and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
 socket has been destroyed, the result will be stored into the cache.  The next
 call to FreeRTOS_gethostbyname() will return immediately, without even creating
-a socket. */
-#define ipconfigUSE_DNS_CACHE				( 1 )
+a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE				( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS		( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -78,8 +78,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -72,8 +72,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -89,8 +89,16 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -83,8 +83,16 @@
  * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
- * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
+ * a socket.
+ *
+ * NOTE: Use caution when enabling the DNS cache and connecting to services which
+ * use a load balancer.  Since the cache only holds a single IP address, if that
+ * address is out of date, no connections to the host will succeed until the TTL
+ * expires.  See this GitHub issue for more details.
+ *
+ * https://github.com/FreeRTOS/FreeRTOS/issues/58
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 0 )
 #define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

We observed a test failure in continuous integration testing in which no retries to the AWS IoT endpoint succeeded.  There are two root causes:

1. The Full_TCP test suite was not re-resolving hostnames as part of the retry logic.
1. The FreeRTOS+TCP DNS cache stores only a single IP address, even though the DNS query
response returned a list of 6 of them.  The one that FreeRTOS+TCP cached (the first one in the response) was no longer valid.  Until the TTL expired, no connections to that endpoint could succeed.

This change addresses 1) by reworking the Full_TCP test suite retry logic, and 2) by disabling the FreeRTOS+TCP DNS cache in all demo and test builds.

See the following issue for more details; if this feature gets implemented in FreeRTOS+TCP, we would be able to re-enable the DNS cache in the demo and test builds.

https://github.com/FreeRTOS/FreeRTOS/issues/58

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.