### PR TITLE
Move waitAfterDisconnect to unit test in BLE

### DIFF
--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c
@@ -245,8 +245,6 @@ TEST_GROUP_RUNNER( Full_BLE_END_TO_END_MQTT )
     /*RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, LastWillAndTestament );*/
     /*RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, RestorePreviousSession );*/
 
-    RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, WaitAfterDisconnect );
-
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, SubscribeCompleteReentrancy );
     RUN_TEST_CASE( Full_BLE_END_TO_END_MQTT, IncomingPublishReentrancy );
 
@@ -299,10 +297,6 @@ TEST( Full_BLE_END_TO_END_MQTT, RestorePreviousSession )
     RUN_MQTT_SYSTEM_TEST( RestorePreviousSession );
 }
 
-TEST( Full_BLE_END_TO_END_MQTT, WaitAfterDisconnect )
-{
-    RUN_MQTT_SYSTEM_TEST( WaitAfterDisconnect );
-}
 
 TEST( Full_BLE_END_TO_END_MQTT, SubscribeCompleteReentrancy )
 {


### PR DESCRIPTION
Remove waitAfterDisconnect test from BLE

Description
-----------

waitAfterDisconnect test was made a unit test in #1844 . Removing this test from BLE system test as well.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.