### PR TITLE
Fix -Wstringop-truncation warning in JSON encoder

### DIFF
--- a/libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c
+++ b/libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c
@@ -414,12 +414,12 @@ static void _appendBoolean( _jsonContainer_t * pContainer,
 {
     if( value == true )
     {
-        strncpy( ( char * ) _jsonContainerPointer( pContainer ), _JSON_BOOL_TRUE, _JSON_BOOL_TRUE_LENGTH );
+        memcpy( _jsonContainerPointer( pContainer ), _JSON_BOOL_TRUE, _JSON_BOOL_TRUE_LENGTH );
         pContainer->offset += _JSON_BOOL_TRUE_LENGTH;
     }
     else
     {
-        strncpy( ( char * ) _jsonContainerPointer( pContainer ), _JSON_BOOL_FALSE, _JSON_BOOL_FALSE_LENGTH );
+        memcpy( _jsonContainerPointer( pContainer ), _JSON_BOOL_FALSE, _JSON_BOOL_FALSE_LENGTH );
         pContainer->offset += _JSON_BOOL_FALSE_LENGTH;
     }
 }
@@ -462,7 +462,7 @@ static void _appendData( _jsonContainer_t * pContainer,
             break;
 
         case IOT_SERIALIZER_SCALAR_NULL:
-            strncpy( ( char * ) _jsonContainerPointer( pContainer ), _JSON_NULL_VALUE, _JSON_NULL_VALUE_LENGTH );
+            memcpy( _jsonContainerPointer( pContainer ), _JSON_NULL_VALUE, _JSON_NULL_VALUE_LENGTH );
             pContainer->offset += _JSON_NULL_VALUE_LENGTH;
             break;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix -Wstringop-truncation warning in JSON encoder

Serializer tests pass.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.