### PR TITLE
Fixed a string that was cast to a pointer, causing a faulty sizeof. A…

### DIFF
--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -42,6 +42,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -54,8 +54,11 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
-#define configPKCS11_DEFAULT_USER_PIN                      ( ( CK_UTF8CHAR_PTR ) "0000" )
+#define configPKCS11_DEFAULT_USER_PIN                       "0000"
 
 /**
  * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
@@ -61,6 +61,9 @@ extern const char * pcPkcs11GetThingName(void);
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
 

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -54,8 +54,11 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
-#define configPKCS11_DEFAULT_USER_PIN                      ( ( CK_UTF8CHAR_PTR ) "0000" )
+#define configPKCS11_DEFAULT_USER_PIN                      "0000"
 
 /**
  * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN                      "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
@@ -49,6 +49,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/iot_pkcs11_config.h
@@ -40,6 +40,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_pkcs11_config.h
@@ -40,6 +40,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
@@ -44,6 +44,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/iot_pkcs11_config.h
@@ -41,6 +41,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
@@ -44,6 +44,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
@@ -49,6 +49,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/iot_pkcs11_config.h
@@ -45,6 +45,9 @@ extern const char * pcPkcs11GetThingName(void);
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
@@ -49,6 +49,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
@@ -49,6 +49,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
@@ -42,6 +42,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
 * protections. However, since typical microcontroller applications lack one or
 * both of those, the user PIN is assumed to be used herein for interoperability
 * purposes only, and not as a security feature.
+*
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
 */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN                      "0000"
 

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN                      "0000"
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
@@ -43,6 +43,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
@@ -44,6 +44,9 @@
  * protections. However, since typical microcontroller applications lack one or
  * both of those, the user PIN is assumed to be used herein for interoperability
  * purposes only, and not as a security feature.
+ *
+ * Note: Do not cast this to a pointer! The library calls sizeof to get the length
+ * of this string.
  */
 #define configPKCS11_DEFAULT_USER_PIN    "0000"
 


### PR DESCRIPTION
…dded warnings to pkcs11 config files to try and prevent the same mistake.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.