### PR TITLE
Fix defeneder test build failure on multiple platforms

### DIFF
--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -469,16 +469,16 @@ static void _copyDataCallbackFunction( void * param1,
      * (eg. Marvell) pass -ffreestanding flag to the compiler which results in
      * __STDC_HOSTED__ being defined to 0 and therefore, cbor_value_to_pretty
      * not being available. */
-    #if !defined( __STDC_HOSTED__ ) || __STDC_HOSTED__-0 == 1
-    {
-        if( pCallbackInfo->eventType == AWS_IOT_DEFENDER_METRICS_REJECTED )
+    #if !defined( __STDC_HOSTED__ ) || __STDC_HOSTED__ - 0 == 1
         {
-            CborParser cborParser;
-            CborValue cborValue;
-            cbor_parser_init( pCallbackInfo->pPayload, pCallbackInfo->payloadLength, 0, &cborParser, &cborValue );
-            cbor_value_to_pretty( stdout, &cborValue );
+            if( pCallbackInfo->eventType == AWS_IOT_DEFENDER_METRICS_REJECTED )
+            {
+                CborParser cborParser;
+                CborValue cborValue;
+                cbor_parser_init( pCallbackInfo->pPayload, pCallbackInfo->payloadLength, 0, &cborParser, &cborValue );
+                cbor_value_to_pretty( stdout, &cborValue );
+            }
         }
-    }
     #endif /* __STDC_HOSTED__ check */
 
     /* Copy data from pCallbackInfo to _callbackInfo. */

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -463,14 +463,23 @@ static void _copyDataCallbackFunction( void * param1,
     /* Silence the compiler. */
     ( void ) param1;
 
-    /* Print out rejected message to stdout. */
-    if( pCallbackInfo->eventType == AWS_IOT_DEFENDER_METRICS_REJECTED )
+    /* Print out rejected message to stdout. The function used for printing
+     * i.e. cbor_value_to_pretty is available only in the hosted environment.
+     * The following #if guard is needed because some of the platforms
+     * (eg. Marvell) pass -ffreestanding flag to the compiler which results in
+     * __STDC_HOSTED__ being defined to 0 and therefore, cbor_value_to_pretty
+     * not being available. */
+    #if !defined( __STDC_HOSTED__ ) || __STDC_HOSTED__-0 == 1
     {
-        CborParser cborParser;
-        CborValue cborValue;
-        cbor_parser_init( pCallbackInfo->pPayload, pCallbackInfo->payloadLength, 0, &cborParser, &cborValue );
-        cbor_value_to_pretty( stdout, &cborValue );
+        if( pCallbackInfo->eventType == AWS_IOT_DEFENDER_METRICS_REJECTED )
+        {
+            CborParser cborParser;
+            CborValue cborValue;
+            cbor_parser_init( pCallbackInfo->pPayload, pCallbackInfo->payloadLength, 0, &cborParser, &cborValue );
+            cbor_value_to_pretty( stdout, &cborValue );
+        }
     }
+    #endif /* __STDC_HOSTED__ check */
 
     /* Copy data from pCallbackInfo to _callbackInfo. */
     if( pCallbackInfo != NULL )

--- a/vendors/cypress/WICED_SDK/apps/demo/aws_demo/aws_demo.mk
+++ b/vendors/cypress/WICED_SDK/apps/demo/aws_demo/aws_demo.mk
@@ -126,6 +126,7 @@ $(NAME)_SOURCES    := $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborparser.c \
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborparser_dup_string.c \
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborpretty.c \
+                      $(AFR_THIRDPARTY_PATH)tinycbor/cborpretty_stdio.c \
                       $(AFR_C_SDK_STANDARD_PATH)serializer/src/cbor/iot_serializer_tinycbor_decoder.c \
                       $(AFR_C_SDK_STANDARD_PATH)serializer/src/cbor/iot_serializer_tinycbor_encoder.c \
                       $(AFR_C_SDK_STANDARD_PATH)serializer/src/json/iot_serializer_json_decoder.c \

--- a/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
+++ b/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
@@ -130,6 +130,7 @@ $(NAME)_SOURCES    := $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborparser.c \
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborparser_dup_string.c \
                       $(AFR_THIRDPARTY_PATH)tinycbor/cborpretty.c \
+                      $(AFR_THIRDPARTY_PATH)tinycbor/cborpretty_stdio.c \
                       $(AFR_ABSTRACTIONS_PATH)wifi/test/iot_test_wifi.c \
                       $(AFR_FREERTOS_PLUS_STANDARD_PATH)tls/test/iot_test_tls.c \
                       $(AFR_ABSTRACTIONS_PATH)secure_sockets/test/iot_test_tcp.c \

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
@@ -106,6 +106,8 @@ COMPONENT_SRCDIRS += ../.. \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/mqtt/test/mock \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/serializer/test \
         ${AMAZON_FREERTOS_SDK_DIR}/aws/defender/test \
+        ${AMAZON_FREERTOS_SDK_DIR}/aws/defender/test/unit \
+        ${AMAZON_FREERTOS_SDK_DIR}/aws/defender/test/system \
         ${AMAZON_FREERTOS_SDK_DIR}/aws/shadow/test \
         ${AMAZON_FREERTOS_SDK_DIR}/aws/shadow/test/unit \
         ${AMAZON_FREERTOS_SDK_DIR}/aws/shadow/test/system \
@@ -135,7 +137,7 @@ COMPONENT_ADD_INCLUDEDIRS += $(AMAZON_FREERTOS_TESTS_DIR)/include \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/https/src \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/mqtt/src \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/mqtt/test/mock \
-        ${AMAZON_FREERTOS_SDK_DIR}/aws/defender/src/private \
+        ${AMAZON_FREERTOS_SDK_DIR}/aws/defender/src \
         ${AMAZON_FREERTOS_SDK_DIR}/aws/shadow/src \
         ${AMAZON_FREERTOS_ARF_PLUS_DIR}/aws/greengrass/src
 

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
@@ -40,6 +40,7 @@
 #define testrunnerFULL_OTA_PAL_ENABLED              0
 #define testrunnerFULL_MQTT_ALPN_ENABLED            0
 #define testrunnerFULL_PKCS11_ENABLED               0
+#define testrunnerFULL_DEFENDER_ENABLED             0
 #define testrunnerFULL_CRYPTO_ENABLED               0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED     0
 #define testrunnerFULL_MQTT_AGENT_ENABLED           0

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
@@ -29,40 +29,40 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED                          0
 
 /* Unsupported tests */
-#define testrunnerFULL_OTA_CBOR_ENABLED               testrunnerUNSUPPORTED
-#define testrunnerFULL_POSIX_ENABLED                  testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED                testrunnerUNSUPPORTED
+#define testrunnerFULL_POSIX_ENABLED                   testrunnerUNSUPPORTED
 
 /* Enable tests by setting defines to 1 */
-#define testrunnerFULL_OTA_AGENT_ENABLED            0
-#define testrunnerFULL_OTA_PAL_ENABLED              0
-#define testrunnerFULL_MQTT_ALPN_ENABLED            0
-#define testrunnerFULL_PKCS11_ENABLED               0
-#define testrunnerFULL_DEFENDER_ENABLED             0
-#define testrunnerFULL_CRYPTO_ENABLED               0
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED     0
-#define testrunnerFULL_MQTT_AGENT_ENABLED           0
-#define testrunnerFULL_TCP_ENABLED                  1
-#define testrunnerFULL_GGD_ENABLED                  0
-#define testrunnerFULL_GGD_HELPER_ENABLED           0
-#define testrunnerFULL_SHADOW_ENABLED               0
-#define testrunnerFULL_SHADOWv4_ENABLED             0
-#define testrunnerFULL_MQTTv4_ENABLED               0
-#define testrunnerFULL_WIFI_ENABLED                 0
-#define testrunnerFULL_MEMORYLEAK_ENABLED           0
-#define testrunnerFULL_TLS_ENABLED                  0
-#define testrunnerFULL_BLE_END_TO_END_TEST_ENABLED  0
-#define testrunnerFULL_BLE_ENABLED                  0
-#define testrunnerFULL_BLE_STRESS_TEST_ENABLED      0
-#define testrunnerFULL_BLE_KPI_TEST_ENABLED         0
-#define testrunnerFULL_BLE_INTEGRATION_TEST_ENABLED 0
-#define testrunnerFULL_WIFI_PROVISIONING_ENABLED    0
-#define testrunnerUTIL_PLATFORM_CLOCK_ENABLED       0
-#define testrunnerFULL_LINEAR_CONTAINERS_ENABLED    0
-#define testrunnerUTIL_PLATFORM_THREADS_ENABLED     0
-#define testrunnerFULL_SERIALIZER_ENABLED           0
-#define testrunnerFULL_HTTPS_CLIENT_ENABLED         0
+#define testrunnerFULL_OTA_AGENT_ENABLED               0
+#define testrunnerFULL_OTA_PAL_ENABLED                 0
+#define testrunnerFULL_MQTT_ALPN_ENABLED               0
+#define testrunnerFULL_PKCS11_ENABLED                  0
+#define testrunnerFULL_DEFENDER_ENABLED                0
+#define testrunnerFULL_CRYPTO_ENABLED                  0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED        0
+#define testrunnerFULL_MQTT_AGENT_ENABLED              0
+#define testrunnerFULL_TCP_ENABLED                     1
+#define testrunnerFULL_GGD_ENABLED                     0
+#define testrunnerFULL_GGD_HELPER_ENABLED              0
+#define testrunnerFULL_SHADOW_ENABLED                  0
+#define testrunnerFULL_SHADOWv4_ENABLED                0
+#define testrunnerFULL_MQTTv4_ENABLED                  0
+#define testrunnerFULL_WIFI_ENABLED                    0
+#define testrunnerFULL_MEMORYLEAK_ENABLED              0
+#define testrunnerFULL_TLS_ENABLED                     0
+#define testrunnerFULL_BLE_END_TO_END_TEST_ENABLED     0
+#define testrunnerFULL_BLE_ENABLED                     0
+#define testrunnerFULL_BLE_STRESS_TEST_ENABLED         0
+#define testrunnerFULL_BLE_KPI_TEST_ENABLED            0
+#define testrunnerFULL_BLE_INTEGRATION_TEST_ENABLED    0
+#define testrunnerFULL_WIFI_PROVISIONING_ENABLED       0
+#define testrunnerUTIL_PLATFORM_CLOCK_ENABLED          0
+#define testrunnerFULL_LINEAR_CONTAINERS_ENABLED       0
+#define testrunnerUTIL_PLATFORM_THREADS_ENABLED        0
+#define testrunnerFULL_SERIALIZER_ENABLED              0
+#define testrunnerFULL_HTTPS_CLIENT_ENABLED            0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
@@ -36,6 +36,7 @@
 #define testrunnerFULL_OTA_AGENT_ENABLED           0
 #define testrunnerFULL_OTA_PAL_ENABLED             0
 #define testrunnerFULL_MQTT_ALPN_ENABLED           0
+#define testrunnerFULL_DEFENDER_ENABLED            0
 #define testrunnerFULL_PKCS11_ENABLED              0
 #define testrunnerFULL_CRYPTO_ENABLED              0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0


### PR DESCRIPTION
This PR fixes defender test failures on multiple platfroms.

**Cypress:** A file in tinybor which was not compiled for Cypress resulted in linker error.
**Esp32:** Defender test files were not getting built in the make files. 
**Marvell:** Marvell passes `-ffreestanding` flag to the compiler which results in `__STDC_HOSTED__` being defined to 0. In this case the function used for printing a cbor value `cbor_value_to_pretty`
is not available and this results in a linker error. 

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.