### PR TITLE
Export the compile commands in CMake

### DIFF
--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -3,6 +3,9 @@ if(CMAKE_CROSSCOMPILING)
     enable_language(ASM)
 endif()
 
+# Export the json compile commands databse.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+
 # Set some global path variables.
 get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 set(AFR_ROOT_DIR ${__root_dir} CACHE INTERNAL "FreeRTOS source root.")


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Export the json compile commands file from CMake. This will generate a `compile_commands.json` file under the build directory, which contains the compiler flags for each file.

**Note: this only works for non-IDE generators like makefile and ninja. It doesn't work for IDE generators since they typically hide the compiler commands.**

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.