### PR TITLE
Fix breaking CBMC proof for DNSgetHostByName_a/_cancel & ReadNameField

### DIFF
--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -23,7 +23,8 @@
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
     "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
-    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
+    "MAX_REQ_SIZE={MAX_REQ_SIZE}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -22,7 +22,8 @@
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
-    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/ReadNameField/Makefile.json
+++ b/tools/cbmc/proofs/ReadNameField/Makefile.json
@@ -2,6 +2,10 @@
   "ENTRY": "ReadNameField",
 
 ################################################################
+#Enable DNS callbacks or else ReadNameField is not defined
+  "callbacks": "1",
+
+################################################################
 # This is the network buffer size.  Set to any positive value.
   "NETWORK_BUFFER_SIZE" :  "10",
 
@@ -44,6 +48,8 @@
   "DEF":
   [
     "NETWORK_BUFFER_SIZE={NETWORK_BUFFER_SIZE}",
-    "NAME_SIZE={NAME_SIZE}"
+    "NAME_SIZE={NAME_SIZE}",
+    "ipconfigDNS_USE_CALLBACKS={callbacks}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ]
 }


### PR DESCRIPTION
Fix the breaking CBMC proof for DNSgetHostByName_a & DNSgetHostByName_cancel & ReadNameField.

Description
-----------
Added a #define in all three Makefile.json to declare an essential macro ipconfigDNS_CACHE_NAME_LENGTH used in CBMC proofs which is not defined if (ipconfigUSE_DNS_CACHE == 0).
Previous PR https://github.com/aws/amazon-freertos/pull/1928 disabled the use of DNS cache which broke the proofs.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.