### PR TITLE
Fix build failure for TI tests for cmake

### DIFF
--- a/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
+++ b/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
@@ -232,12 +232,12 @@
 
 /* I2C */
 #if defined( IOT_TEST_COMMON_IO_I2C_SUPPORTED ) && ( IOT_TEST_COMMON_IO_I2C_SUPPORTED >= 1 )
-    extern uint8_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
-    extern uint8_t uctestIotI2CDeviceRegister;    /* Slave I2C register address used in read/write tests */
-    extern uint8_t uctestIotI2CWriteVal;          /* Write value that will be used in the register write test */
-    extern uint8_t uctestIotI2CInstanceIdx;       /* I2C instance used in the test */
-    extern uint8_t uctestIotI2CInstanceNum;       /* The total number of I2C instances on the device */
-    extern uint8_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
+    extern uint16_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
+    extern uint8_t uctestIotI2CDeviceRegister;     /* Slave I2C register address used in read/write tests */
+    extern uint8_t uctestIotI2CWriteVal;           /* Write value that will be used in the register write test */
+    extern uint8_t uctestIotI2CInstanceIdx;        /* I2C instance used in the test */
+    extern uint8_t uctestIotI2CInstanceNum;        /* The total number of I2C instances on the device */
+    extern uint16_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
 
 /**
  * Board specific I2C config set

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -46,8 +46,6 @@
 /*-----------------------------------------------------------*/
 #define testIotI2C_BAUDRATE               IOT_I2C_FAST_MODE_BPS
 #define testIotI2C_BAUDRATE_LOW_SPEED     IOT_I2C_STANDARD_MODE_BPS
-#define testIotI2C_INSTANCE               uctestIotI2CInstanceIdx
-#define testIotI2C_INSTANCE_NUM           uctestIotI2CInstanceNum
 #define testIotI2C_DEFAULT_TIMEOUT        500 /**< 500 msec */
 #define testIotI2C_FAST_TIMEOUT           100 /**< 100 msec */
 #define testIotI2C_INVALID_IOCTL_INDEX    UINT32_MAX
@@ -70,16 +68,13 @@ typedef struct CallbackParam
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
 
-uint8_t uctestIotI2CSlaveAddr = 0;           /**< The slave address to be set for the I2C port. */
-uint8_t uctestIotI2CInvalidSlaveAddr = 0xFF; /**< The slave address to be set for the I2C port. */
-uint8_t uctestIotI2CDeviceRegister = 0;      /**< The device register to be set for the I2C port. */
-uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to device. */
-uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
-uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
-
-uint8_t ucAssistedTestIotI2CSlaveAddr = 0;   /**< The slave address to be set for the assisted test. */
-
-extern IotI2CHandle_t gIotI2cHandle[ testIotI2C_HANDLE_NUM ];
+uint16_t uctestIotI2CSlaveAddr = 0;             /**< The slave address to be set for the I2C port. */
+uint16_t uctestIotI2CInvalidSlaveAddr = 0xFFFF; /**< The slave address to be set for the I2C port. */
+uint8_t uctestIotI2CDeviceRegister = 0;         /**< The device register to be set for the I2C port. */
+uint8_t uctestIotI2CWriteVal = 0;               /**< The write value to write to device. */
+uint8_t uctestIotI2CInstanceIdx = 0;            /**< The current I2C test instance index */
+uint8_t uctestIotI2CInstanceNum = 1;            /**< The total I2C test instance number */
+uint16_t ucAssistedTestIotI2CSlaveAddr = 0;     /**< The slave address to be set for the assisted test. */
 
 /*-----------------------------------------------------------*/
 /* Static Globals */
@@ -107,18 +102,6 @@ TEST_GROUP( TEST_IOT_I2C );
  */
 TEST_SETUP( TEST_IOT_I2C )
 {
-    IotI2CHandle_t xGlobalI2CHandle = gIotI2cHandle[ testIotI2C_INSTANCE ];
-    int32_t lRetVal;
-
-    /* Close global handle it was opened. */
-    if( xGlobalI2CHandle != NULL )
-    {
-        lRetVal = iot_i2c_close( xGlobalI2CHandle );
-        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
-
-        gIotI2cHandle[ testIotI2C_INSTANCE ] = NULL;
-    }
-
     if( xtestIotI2CSemaphore == NULL )
     {
         xtestIotI2CSemaphore = xSemaphoreCreateBinary();
@@ -236,7 +219,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseSuccess )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -251,21 +234,24 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseSuccess )
 TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseFail )
 {
     IotI2CHandle_t xI2CHandle;
-    IotI2CHandle_t xI2CHandle_1;
+    IotI2CHandle_t xI2CHandle_1 = NULL;
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
-    /* Open i2c to initialize hardware again */
-    xI2CHandle_1 = iot_i2c_open( testIotI2C_INSTANCE );
-    TEST_ASSERT_EQUAL( NULL, xI2CHandle_1 );
+    if( TEST_PROTECT() )
+    {
+        /* Open i2c to initialize hardware again */
+        xI2CHandle_1 = iot_i2c_open( uctestIotI2CInstanceIdx );
+        TEST_ASSERT_EQUAL( NULL, xI2CHandle_1 );
+    }
 
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-    /* Close same i2c again which is NULL */
+    /* Close same i2c again which is not open */
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_INVALID_VALUE, lRetVal );
 
@@ -285,7 +271,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseFailUnsupportInst )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE_NUM );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceNum );
     TEST_ASSERT_EQUAL( NULL, xI2CHandle );
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -308,7 +294,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSetGetConfigurationSuccess )
     xI2CConfig_write.ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -357,7 +343,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSetGetConfigurationFail )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -399,7 +385,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadAsyncSuccess )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -469,7 +455,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -536,7 +522,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadChainSuccess )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -601,7 +587,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailIoctl )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -663,7 +649,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailReadTwice )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -719,7 +705,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailSetAddr )
     uint8_t ucReadValue;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -756,7 +742,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -828,7 +814,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelFail )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -850,7 +836,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelUnsupported )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -885,7 +871,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -961,7 +947,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1009,7 +995,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailIoctl )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1059,7 +1045,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailWriteTwice )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1112,7 +1098,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadSyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1176,7 +1162,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1233,7 +1219,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncFail )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1271,7 +1257,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1338,7 +1324,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1380,7 +1366,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncFail )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1418,7 +1404,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CGetBusStateSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1470,7 +1456,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSendNoStopUnsupported )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )

--- a/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
+++ b/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
@@ -284,7 +284,6 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
 {
     CK_RV xResult = CKR_OK;
     CK_ULONG ulCount = 0;
-    CK_BBOOL xFindInit = CK_FALSE;
     CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
     CK_ATTRIBUTE xTemplate[ 2 ] = { 0 };
 
@@ -314,7 +313,6 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
 
     if( CKR_OK == xResult )
     {
-        xFindInit = CK_TRUE;
         /* Find the first matching object, if any. */
         xResult = pxFunctionList->C_FindObjects( xSession,
                                                  pxHandle,
@@ -322,12 +320,12 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
                                                  &ulCount );
     }
 
-    if( CK_TRUE == xFindInit )
+    if( CKR_OK == xResult )
     {
         xResult = pxFunctionList->C_FindObjectsFinal( xSession );
     }
 
-    if( ulCount == 0 )
+    if( ( NULL != pxHandle ) && ( ulCount == 0 ) )
     {
         *pxHandle = CK_INVALID_HANDLE;
     }

--- a/libraries/freertos_plus/standard/pkcs11/utest/iot_pkcs11_utest.c
+++ b/libraries/freertos_plus/standard/pkcs11/utest/iot_pkcs11_utest.c
@@ -745,6 +745,28 @@ void test_IotPkcs11_xFindObjectWithLabelAndClass( void )
 }
 
 /*!
+ * @brief xFindObjectWithLabelAndClass All calls succeed but no object was found.
+ *
+ */
+void test_IotPkcs11_xFindObjectWithLabelAndClassNoObjectsFound( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xHandle = { 0 };
+    CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
+
+    vCommonStubs();
+    C_FindObjectsInit_IgnoreAndReturn( CKR_OK );
+    C_FindObjects_IgnoreAndReturn( CKR_OK );
+    C_FindObjectsFinal_IgnoreAndReturn( CKR_OK );
+    xResult = xFindObjectWithLabelAndClass( xHandle,
+                                            pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                            CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+    TEST_ASSERT_EQUAL( CK_INVALID_HANDLE, xPrivateKeyHandle );
+}
+
+/*!
  * @brief xFindObjectWithLabelAndClass Bad arguments test path.
  *
  */
@@ -754,7 +776,13 @@ void test_IotPkcs11_xFindObjectWithLabelAndClassNullArgs( void )
     CK_SESSION_HANDLE xHandle = { 0 };
     CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
 
+    /* NULL label name. */
     xResult = xFindObjectWithLabelAndClass( xHandle, NULL, CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+
+    TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+
+    /* NULL object handle. */
+    xResult = xFindObjectWithLabelAndClass( xHandle, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, CKO_PRIVATE_KEY, NULL );
 
     TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -23,7 +23,8 @@
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
     "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
-    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
+    "MAX_REQ_SIZE={MAX_REQ_SIZE}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -22,7 +22,8 @@
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
-    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/ReadNameField/Makefile.json
+++ b/tools/cbmc/proofs/ReadNameField/Makefile.json
@@ -2,6 +2,10 @@
   "ENTRY": "ReadNameField",
 
 ################################################################
+#Enable DNS callbacks or else ReadNameField is not defined
+  "callbacks": "1",
+
+################################################################
 # This is the network buffer size.  Set to any positive value.
   "NETWORK_BUFFER_SIZE" :  "10",
 
@@ -44,6 +48,8 @@
   "DEF":
   [
     "NETWORK_BUFFER_SIZE={NETWORK_BUFFER_SIZE}",
-    "NAME_SIZE={NAME_SIZE}"
+    "NAME_SIZE={NAME_SIZE}",
+    "ipconfigDNS_USE_CALLBACKS={callbacks}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ]
 }

--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -3,6 +3,9 @@ if(CMAKE_CROSSCOMPILING)
     enable_language(ASM)
 endif()
 
+# Export the json compile commands databse.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+
 # Set some global path variables.
 get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 set(AFR_ROOT_DIR ${__root_dir} CACHE INTERNAL "FreeRTOS source root.")

--- a/vendors/ti/boards/cc3220_launchpad/ccs.cmake
+++ b/vendors/ti/boards/cc3220_launchpad/ccs.cmake
@@ -27,10 +27,17 @@ set(link_dependent_libs
 )
 
 # Force the use of response file to avoid "command line too long" error.
+# These are needed to be put in this file as opposed to arm-ti.cmake because
+# in that case the archiver starts to function incorrectly for mbedtls. The
+# archiver starts to interpret the response file as object file and puts it in
+# the archive as opposed to the actual object files written in that response
+# file. The problem arises because for the TI archiver the response file flag is
+# "@" while for the TI linker it is nothing (empty string).
 SET(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
 SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
 
-# Default response file flag is "@".  TI's compiler doesn't require that.
+# Default response file flag is "@". TI's compiler requires it to be
+# space (" "). Note that the empty string does not work.
 set(CMAKE_C_RESPONSE_FILE_LINK_FLAG " ")
 set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG " ")
 

--- a/vendors/ti/boards/cc3220_launchpad/ccs.cmake
+++ b/vendors/ti/boards/cc3220_launchpad/ccs.cmake
@@ -26,6 +26,14 @@ set(link_dependent_libs
     "${simplelink_dir}/source/ti/drivers/net/wifi/ccs/rtos/simplelink.a"
 )
 
+# Force the use of response file to avoid "command line too long" error.
+SET(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+
+# Default response file flag is "@".  TI's compiler doesn't require that.
+set(CMAKE_C_RESPONSE_FILE_LINK_FLAG " ")
+set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG " ")
+
 # -------------------------------------------------------------------------------------------------
 # FreeRTOS portable layers
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Description
-----------

The Ninja generator combines linker and post build commands using '&&'
which results in a long string. Windows has a limit of 8191 characters
on the command line string length. We were hitting that limit for TI and
were getting "command string too long" error.

This commit updates the cmake files to force Ninja to use response files
which is a feature implemented for exactly this purpose and results in a
much smaller command string.

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.