### PR TITLE
Add support for Common I/O (UART, SPI and I2C) on ESP32

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -121,6 +121,7 @@ set(
     "${esp_idf_dir}/components/soc/include"
     "${esp_idf_dir}/components/spi_flash/include"
     "${esp_idf_dir}/components/vfs/include"
+    "${esp_idf_dir}/components/esp_ringbuf/include/"
     "${extra_components_dir}/freertos/include"
     "${extra_components_dir}/mbedtls/port/include"
 )
@@ -324,6 +325,34 @@ target_link_libraries(
 
 endif()
 
+# Common I/O
+afr_mcu_port(common_io)
+target_sources(
+    AFR::common_io::mcu_port
+    INTERFACE
+        "${afr_ports_dir}/common_io/iot_i2c.c"
+        "${afr_ports_dir}/common_io/iot_spi.c"
+        "${afr_ports_dir}/common_io/iot_uart.c"
+         $<${AFR_IS_TESTING}:${afr_ports_dir}/common_io/iot_test_common_io_internal.c>
+)
+target_include_directories(
+    AFR::common_io::mcu_port
+    INTERFACE
+        "${afr_ports_dir}/common_io/include"
+        "${AFR_ROOT_DIR}/libraries/abstractions/common_io/test"
+)
+
+
+target_compile_options(
+    AFR::common_io::mcu_port
+    INTERFACE
+    -Wno-implicit-function-declaration
+    -Wno-format -Wno-maybe-uninitialized
+    -Wno-pointer-sign
+    -Wno-unused-but-set-variable
+    -Wno-incompatible-pointer-types
+)
+
 if(AFR_IS_TESTING)
 target_compile_definitions(
     AFR::compiler::mcu_port
@@ -349,6 +378,7 @@ target_link_libraries(
         AFR::pkcs11
         AFR::ota_mqtt
         AFR::ota_http
+        AFR::common_io
 )
 
 # -------------------------------------------------------------------------------------------------
@@ -375,6 +405,7 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
             AFR::wifi
             AFR::utils
             AFR::ble
+            AFR::common_io
     )
 endif()
 

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
@@ -64,5 +64,6 @@
 #define testrunnerUTIL_PLATFORM_THREADS_ENABLED        0
 #define testrunnerFULL_SERIALIZER_ENABLED              0
 #define testrunnerFULL_HTTPS_CLIENT_ENABLED            0
+#define testrunnerFULL_COMMON_IO_ENABLED               0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/iot_test_common_io_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/iot_test_common_io_config.h
@@ -1,0 +1,69 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TEST_IOT_CONFIG_H_
+#define _TEST_IOT_CONFIG_H_
+
+/* I2C includes */
+#include "iot_i2c.h"
+
+/* SPI includes */
+#include "iot_spi.h"
+
+
+/*------------------------UART-------------------------------*/
+
+/* UART is supported. */
+#define IOT_TEST_COMMON_IO_UART_SUPPORTED    1
+
+/* How many UART ports are being test. */
+#define UART_TEST_SET                        1
+
+/* Instance ID 3 corresponds to UART4. */
+extern const uint8_t uartTestPort[ UART_TEST_SET ];
+/* Following configurations are not being used for now. */
+extern const uint32_t uartIotUartFlowControl[ UART_TEST_SET ];
+extern const uint32_t uartIotUartParity[ UART_TEST_SET ];
+extern const uint32_t uartIotUartWordLength[ UART_TEST_SET ];
+extern const uint32_t uartIotUartStopBits[ UART_TEST_SET ];
+
+/* How many I2C ports are being test. */
+#define I2C_TEST_SET                        1
+
+#define IOT_TEST_COMMON_IO_I2C_SUPPORTED                     1
+
+#if ( IOT_TEST_COMMON_IO_I2C_SUPPORTED == 1 )
+    #define IOT_TEST_COMMON_IO_I2C_SUPPORTED_SEND_NO_STOP    1
+    #define IOT_TEST_COMMON_IO_I2C_SUPPORTED_CANCEL          0
+#endif
+
+extern uint16_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
+extern uint8_t uctestIotI2CDeviceRegister;     /* Slave I2C register address used in read/write tests */
+extern uint8_t uctestIotI2CWriteVal;           /* Write value that will be used in the register write test */
+extern uint8_t uctestIotI2CInstanceIdx;        /* I2C instance used in the test */
+extern uint8_t uctestIotI2CInstanceNum;        /* The total number of I2C instances on the device */
+extern uint16_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
+
+/*------------------------SPI-------------------------------*/
+#define IOT_TEST_COMMON_IO_SPI_SUPPORTED                     1
+
+#define SPI_TEST_SET                                         1
+
+extern uint32_t ultestIotSpiInstance;
+extern IotSPIMode_t xtestIotSPIDefaultConfigMode;
+extern IotSPIBitOrder_t xtestIotSPIDefaultconfigBitOrder;
+extern uint32_t ultestIotSPIFrequency;
+extern uint32_t ultestIotSPIDummyValue;
+
+#endif /* ifndef _TEST_IOT_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/ports/common_io/component.mk
+++ b/vendors/espressif/boards/esp32/ports/common_io/component.mk
@@ -1,0 +1,10 @@
+AMAZON_FREERTOS_COMMON_IO_DIR := ../../../../../../libraries/abstractions/common_io
+
+COMPONENT_SRCDIRS := .
+
+COMPONENT_ADD_INCLUDEDIRS := $(AMAZON_FREERTOS_COMMON_IO_DIR)/include \
+							 $(AMAZON_FREERTOS_COMMON_IO_DIR)/test \
+							 ./include
+
+CFLAGS += -Wno-format -Wno-maybe-uninitialized -Wno-pointer-sign -Wno-incompatible-pointer-types -Wno-unused-but-set-variable
+

--- a/vendors/espressif/boards/esp32/ports/common_io/include/iot_board_gpio.h
+++ b/vendors/espressif/boards/esp32/ports/common_io/include/iot_board_gpio.h
@@ -1,0 +1,99 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _BOARD_GPIO_H_
+#define _BOARD_GPIO_H_
+
+#define ESP_GPIO_PORTS ( 2 )
+#define ESP_GPIO_PORT0 ( 0 )
+#define ESP_GPIO_PORT1 ( 1 )
+#define ESP_GPIO_PORT2 ( 2 )
+
+#define ESP_MAX_UART_PORTS 3
+#define ESP_MAX_I2C_PORTS 2
+#define ESP_MAX_LED_NUM 3
+#define ESP_MAX_PWM_CHANNELS 3 /*Should be less then LEDC_CHANNEL_MAX(0-7)*/
+#define ESP_MAX_SPI_PORTS 2
+
+struct esp_uart_pin_config {
+    uint8_t txd_pin;
+    uint8_t rxd_pin;
+};
+
+struct esp_i2c_pin_config {
+    uint8_t scl_pin;
+    uint8_t sda_pin;
+};
+
+struct esp_led_pin_config {
+    uint8_t led_num;
+};
+
+struct esp_pwm_pin_config {
+    uint8_t pwm_num;
+};
+
+struct esp_spi_pin_config {
+    uint8_t mosi_pin;
+    uint8_t miso_pin;
+    uint8_t clk_pin;
+    uint8_t cs_pin;
+};
+
+/* Configuration to be assigned internally for UART to pin mappings */
+#define ESP_UART_PIN_MAP  {       \
+    /* UART 0 */                  \
+    { GPIO_NUM_1, GPIO_NUM_3 },   \
+    /* UART 1: this ACK team's preference */  \
+    { GPIO_NUM_19, GPIO_NUM_22 }, \
+    /* UART 2 */                  \
+    { GPIO_NUM_17, GPIO_NUM_16 }, \
+}
+
+/* Configuration to be assigned internally for I2C to pin mappings */
+#define ESP_I2C_PIN_MAP  {       \
+    /* I2C 0 */                  \
+    { GPIO_NUM_25, GPIO_NUM_26 },   \
+    /* I2C 1 */                  \
+    { GPIO_NUM_19, GPIO_NUM_22 }, \
+}
+
+/* Configuration to be assigned internally for LED to pin mappings */
+#define ESP_LED_PIN_MAP  {  \
+    {GPIO_NUM_25},  \
+    {GPIO_NUM_22},  \
+    {GPIO_NUM_26},  \
+}
+
+/* Configuration to be assigned internally for PWM to pin mappings */
+#define ESP_PWM_PIN_MAP  {  \
+    {GPIO_NUM_5},  \
+    {GPIO_NUM_0},  \
+    {GPIO_NUM_27}, \
+}
+
+/* Configuration to be assigned internally for SPI to pin mappings */
+#define ESP_SPI_PIN_MAP  {  \
+    /* SPI 1: MOSI, MISO, CLK, CS */ \
+    { GPIO_NUM_12, GPIO_NUM_13, GPIO_NUM_14, GPIO_NUM_15 },  \
+    /* SPI 2 */ \
+    { GPIO_NUM_12, GPIO_NUM_13, GPIO_NUM_14, GPIO_NUM_15 },  \
+}
+
+/* define GPIO ports used for AFQP test */
+#define aws_hal_GPIO_TEST_PORT_A ( 3 )
+#define aws_hal_GPIO_TEST_PORT_B ( 4 )
+
+#endif /* _BOARD_GPIO_H_ */
+

--- a/vendors/espressif/boards/esp32/ports/common_io/iot_i2c.c
+++ b/vendors/espressif/boards/esp32/ports/common_io/iot_i2c.c
@@ -1,0 +1,432 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+#include "iot_i2c.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "driver/i2c.h"
+#include "iot_board_gpio.h"
+#include "freertos/timers.h"
+
+static const char *TAG = "esp-hal-i2c";
+
+#define ACK_CHECK_EN 0x1                        /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS 0x0                       /*!< I2C master will not check ack from slave */
+#define ACK_VAL 0x0                             /*!< I2C ack value */
+#define NACK_VAL 0x1                            /*!< I2C nack value */
+#define SET_REGISTER_ADDR 1
+#define SET_BUFFER_WRITE 0
+#define BYTES_TO_WRITE_AT_ONE_TIME 20
+#define BYTES_TO_READ_AT_ONE_TIME 20
+#define SEM_WAIT_TICKS 0
+static volatile uint8_t i2c_bit_mask;
+
+typedef struct {
+    IotI2CConfig_t iot_i2c_config;
+    int32_t i2c_port_num;
+    bool driver_installed;
+    void (*func)(IotI2COperationStatus_t arg1, void *arg2);
+    void *arg;
+    void *pvBuffer;
+    size_t xBytes;
+    bool is_slave_addr_set;
+    bool is_send_no_stop_flag_set;
+    uint32_t bytes_to_read;
+    uint32_t bytes_to_write;
+    uint8_t slave_addr;
+    unsigned async_op: 1;
+    i2c_cmd_handle_t cmd;
+    SemaphoreHandle_t i2c_semph;
+} i2c_ctx_t;
+
+static struct esp_i2c_pin_config esp_i2c_pin_map[ESP_MAX_I2C_PORTS] = ESP_I2C_PIN_MAP;
+
+static void IRAM_ATTR async_cb(i2c_trans_status_t status, void *arg);
+
+IotI2CHandle_t iot_i2c_open(int32_t lI2CInstance)
+{
+    if (lI2CInstance < 0 || lI2CInstance > 1) {
+        ESP_LOGE(TAG, "Invalid arguments");
+        return NULL;
+    }
+    if (0x01 & (i2c_bit_mask >> lI2CInstance)) {
+        ESP_LOGE(TAG, "I2C Handler is already initialised");
+        return NULL;
+    }
+    i2c_ctx_t *i2c_ctx = (i2c_ctx_t *)calloc(1, sizeof(i2c_ctx_t));
+    if (i2c_ctx == NULL) {
+        ESP_LOGE(TAG, "Could not allocate memory for i2c context");
+        return NULL;
+    }
+    IotI2CHandle_t iot_i2c_handler = (void *) i2c_ctx;
+    i2c_ctx->i2c_port_num = lI2CInstance;
+    i2c_bit_mask |= BIT(lI2CInstance);
+    i2c_ctx->i2c_semph = xSemaphoreCreateBinary();
+    if (i2c_ctx->i2c_semph == NULL) {
+        ESP_LOGE(TAG, "Failed to create binary semaphore");
+        free(i2c_ctx);
+        return NULL;
+    }
+    xSemaphoreGive(i2c_ctx->i2c_semph);
+    return iot_i2c_handler;
+}
+
+int32_t iot_i2c_ioctl( IotI2CHandle_t const pxI2CPeripheral, IotI2CIoctlRequest_t xI2CRequest, void *const pvBuffer)
+{
+    esp_err_t ret;
+    if (xI2CRequest != eI2CSendNoStopFlag) {
+        if (pxI2CPeripheral == NULL || pvBuffer == NULL) {
+            ESP_LOGE(TAG, "Invalid arguments");
+            return IOT_I2C_INVALID_VALUE;
+        }
+    }
+    i2c_ctx_t *i2c_ctx = (i2c_ctx_t *) pxI2CPeripheral;
+
+    switch (xI2CRequest) {
+    case eI2CSetMasterConfig : {
+        if (xSemaphoreTake(i2c_ctx->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+            return IOT_I2C_BUSY;
+        }
+        IotI2CConfig_t *iot_i2c_handler = (IotI2CConfig_t *) pvBuffer;
+        i2c_ctx->iot_i2c_config.ulBusFreq = iot_i2c_handler->ulBusFreq;
+        i2c_ctx->iot_i2c_config.ulMasterTimeout = iot_i2c_handler->ulMasterTimeout;
+        int32_t i2c_port_num = (int32_t) i2c_ctx->i2c_port_num;
+
+        if (i2c_ctx->driver_installed) {
+            esp_err_t ret = i2c_driver_delete(i2c_port_num);
+            if (ret != ESP_OK) {
+                ESP_LOGE(TAG, "i2c driver delete failed");
+                xSemaphoreGive(i2c_ctx->i2c_semph);
+                return IOT_I2C_INVALID_VALUE;
+            }
+            i2c_ctx->driver_installed = false;
+            ESP_LOGD(TAG, "i2c driver delete success");
+        }
+
+        i2c_config_t i2c_conf = {
+            .mode = I2C_MODE_MASTER,
+            .sda_io_num = (gpio_num_t)esp_i2c_pin_map[i2c_port_num].sda_pin,
+            .sda_pullup_en = GPIO_PULLUP_ENABLE,
+            .scl_io_num = esp_i2c_pin_map[i2c_port_num].scl_pin,
+            .scl_pullup_en = GPIO_PULLUP_ENABLE,
+            .master.clk_speed = i2c_ctx->iot_i2c_config.ulBusFreq,
+        };
+        ret = i2c_param_config(i2c_port_num, &i2c_conf);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "config failed");
+            xSemaphoreGive(i2c_ctx->i2c_semph);
+            return IOT_I2C_INVALID_VALUE;
+        }
+        ret = i2c_driver_install(i2c_port_num, i2c_conf.mode, 0, 0, 0);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "driver install failed");
+            xSemaphoreGive(i2c_ctx->i2c_semph);
+            return IOT_I2C_INVALID_VALUE;
+        }
+        ESP_LOGD(TAG, "driver installed");
+        if (i2c_ctx->iot_i2c_config.ulMasterTimeout > 0) {
+            ret = i2c_set_timeout(i2c_port_num, (i2c_ctx->iot_i2c_config.ulMasterTimeout * 80));
+            if (ret != ESP_OK) {
+                ESP_LOGE(TAG, "timeout failed");
+                xSemaphoreGive(i2c_ctx->i2c_semph);
+                return IOT_I2C_INVALID_VALUE;
+            }
+        }
+        i2c_ctx->driver_installed = true;
+        i2c_master_register_callback_with_isr(i2c_ctx->i2c_port_num, async_cb, (void *) i2c_ctx);
+        xSemaphoreGive(i2c_ctx->i2c_semph);
+        return IOT_I2C_SUCCESS;
+    }
+    break;
+    case eI2CGetMasterConfig : {
+        IotI2CConfig_t *iot_i2c_handler = (IotI2CConfig_t *) pvBuffer;
+        iot_i2c_handler->ulBusFreq = i2c_ctx->iot_i2c_config.ulBusFreq;
+        iot_i2c_handler->ulMasterTimeout = i2c_ctx->iot_i2c_config.ulMasterTimeout;
+        return IOT_I2C_SUCCESS;
+    }
+    case eI2CSetSlaveAddr : {
+        if (xSemaphoreTake(i2c_ctx->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+            return IOT_I2C_BUSY;
+        }
+        i2c_ctx->slave_addr = (*(uint8_t *)pvBuffer);
+        i2c_ctx->is_slave_addr_set = true;
+        xSemaphoreGive(i2c_ctx->i2c_semph);
+        return IOT_I2C_SUCCESS;
+    }
+    case eI2CGetBusState : {
+        IotI2CBusStatus_t *bus_state = (IotI2CBusStatus_t *) pvBuffer;
+        *bus_state = (xSemaphoreTake(i2c_ctx->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) ? eI2cBusBusy : eI2CBusIdle;
+        if (*bus_state == eI2CBusIdle) {
+            xSemaphoreGive(i2c_ctx->i2c_semph);
+        }
+        return IOT_I2C_SUCCESS;
+    }
+    case eI2CGetTxNoOfbytes : {
+        uint16_t *tx_bytes = (uint16_t *) pvBuffer;
+        *tx_bytes = i2c_ctx->bytes_to_write;
+        return IOT_I2C_SUCCESS;
+    }
+    case eI2CGetRxNoOfbytes : {
+        uint16_t *rx_bytes = (uint16_t *) pvBuffer;
+        *rx_bytes = i2c_ctx->bytes_to_read;
+        return IOT_I2C_SUCCESS;
+    }
+    case eI2CSendNoStopFlag : {
+        i2c_ctx->is_send_no_stop_flag_set = true;
+        return IOT_I2C_SUCCESS;
+    }
+    default :
+        ESP_LOGE(TAG, "Invalid argument");
+        return IOT_I2C_INVALID_VALUE;
+    }
+}
+
+static void i2c_callback_dispatch(void *arg, i2c_trans_status_t status)
+{
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) arg;
+    uint8_t op_status = (status != I2C_TRANS_STATUS_DONE) ? eI2CDriverFailed : eI2CCompleted;
+    i2c_cmd_link_delete(iot_i2c_handler->cmd);
+    xSemaphoreGive(iot_i2c_handler->i2c_semph);
+    if (iot_i2c_handler->func) {
+        iot_i2c_handler->func(op_status, iot_i2c_handler->arg);
+    }
+}
+
+static void IRAM_ATTR async_cb(i2c_trans_status_t status, void *arg)
+{
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) arg;
+    if (iot_i2c_handler->async_op) {
+        if (xTimerPendFunctionCallFromISR(i2c_callback_dispatch, arg, status, NULL) == pdFALSE) {
+            abort();
+        }
+        iot_i2c_handler->async_op = false;
+    }
+}
+
+void iot_i2c_set_callback(IotI2CHandle_t const pxI2CPeripheral, IotI2CCallback_t xCallback, void *pvUserContext)
+{
+    if (pxI2CPeripheral == NULL || xCallback == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments");
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+
+    iot_i2c_handler->arg = pvUserContext;
+    iot_i2c_handler->func = (void *)xCallback;
+
+}
+
+int32_t iot_i2c_read_async( IotI2CHandle_t const pxI2CPeripheral, uint8_t *const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret = ESP_OK;
+    if (pxI2CPeripheral == NULL || pvBuffer == NULL) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+    int32_t i2c_port_num = (int32_t) iot_i2c_handler->i2c_port_num;
+    uint8_t *src_buf = (uint8_t *) pvBuffer;
+    if (!iot_i2c_handler->is_slave_addr_set) {
+        ESP_LOGE(TAG, "Slave address not set");
+        return IOT_I2C_SLAVE_ADDRESS_NOT_SET;
+    }
+    if (!iot_i2c_handler->driver_installed) {
+        return IOT_I2C_INVALID_VALUE;
+    }
+    if (xSemaphoreTake(iot_i2c_handler->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+        return IOT_I2C_BUSY;
+    }
+
+    iot_i2c_handler->async_op = true;
+    iot_i2c_handler->cmd = i2c_cmd_link_create();
+    ret  = i2c_master_start(iot_i2c_handler->cmd);
+    ret |= i2c_master_write_byte(iot_i2c_handler->cmd, iot_i2c_handler->slave_addr << 1 | I2C_MASTER_READ, ACK_CHECK_EN);
+    if (xBytes > 1) {
+        ret |= i2c_master_read(iot_i2c_handler->cmd, src_buf, xBytes - 1, ACK_VAL);
+    }
+    ret |= i2c_master_read_byte(iot_i2c_handler->cmd, (uint8_t *)(src_buf + xBytes - 1), NACK_VAL);
+    if (iot_i2c_handler->is_send_no_stop_flag_set == false) {
+        ret |= i2c_master_stop(iot_i2c_handler->cmd);
+    }
+    ret |= i2c_master_cmd_begin_async(i2c_port_num, iot_i2c_handler->cmd);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "i2c master read failed");
+        xSemaphoreGive(iot_i2c_handler->i2c_semph);
+        return IOT_I2C_READ_FAILED;
+    }
+    iot_i2c_handler->is_send_no_stop_flag_set = false;
+    iot_i2c_handler->bytes_to_read = xBytes;
+    return (ret == ESP_OK) ?  IOT_I2C_SUCCESS : IOT_I2C_READ_FAILED;
+}
+
+int32_t iot_i2c_write_async( IotI2CHandle_t const pxI2CPeripheral, uint8_t *const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret = ESP_OK;
+    if (pxI2CPeripheral == NULL || pvBuffer == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+    int32_t i2c_port_num = (int32_t) iot_i2c_handler->i2c_port_num;
+    uint8_t *src_buf = (uint8_t *) pvBuffer;
+    if (!iot_i2c_handler->is_slave_addr_set) {
+        ESP_LOGE(TAG, "Slave address not set");
+        return IOT_I2C_SLAVE_ADDRESS_NOT_SET;
+    }
+
+    if (!iot_i2c_handler->driver_installed) {
+        return IOT_I2C_INVALID_VALUE;
+    }
+
+    if (xSemaphoreTake(iot_i2c_handler->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+        return IOT_I2C_BUSY;
+    }
+
+    iot_i2c_handler->async_op = true;
+    iot_i2c_handler->cmd = i2c_cmd_link_create();
+    ret  = i2c_master_start(iot_i2c_handler->cmd);
+    ret |= i2c_master_write_byte(iot_i2c_handler->cmd, iot_i2c_handler->slave_addr << 1 | I2C_MASTER_WRITE, ACK_CHECK_EN);
+    ret = i2c_master_write(iot_i2c_handler->cmd, src_buf, xBytes, ACK_CHECK_EN);
+    if (iot_i2c_handler->is_send_no_stop_flag_set == false) {
+        ret |= i2c_master_stop(iot_i2c_handler->cmd);
+    }
+    ret |= i2c_master_cmd_begin_async(i2c_port_num, iot_i2c_handler->cmd);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "i2c master write failed");
+        xSemaphoreGive(iot_i2c_handler->i2c_semph);
+        return IOT_I2C_WRITE_FAILED;
+    }
+    iot_i2c_handler->bytes_to_write = xBytes;
+    iot_i2c_handler->is_send_no_stop_flag_set = false;
+    return (ret == ESP_OK) ?  IOT_I2C_SUCCESS : IOT_I2C_WRITE_FAILED;
+}
+
+int32_t iot_i2c_read_sync( IotI2CHandle_t const pxI2CPeripheral, uint8_t *const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret = ESP_OK;
+    if (pxI2CPeripheral == NULL || pvBuffer == NULL) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+    int32_t i2c_port_num = (int32_t) iot_i2c_handler->i2c_port_num;
+    uint8_t *src_buf = (uint8_t *) pvBuffer;
+    if (!iot_i2c_handler->is_slave_addr_set) {
+        ESP_LOGE(TAG, "Slave address not set");
+        return IOT_I2C_SLAVE_ADDRESS_NOT_SET;
+    }
+    if (xSemaphoreTake(iot_i2c_handler->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+        return IOT_I2C_BUSY;
+    }
+
+    iot_i2c_handler->async_op = false;
+    iot_i2c_handler->cmd = i2c_cmd_link_create();
+    ret  = i2c_master_start(iot_i2c_handler->cmd);
+    ret |= i2c_master_write_byte(iot_i2c_handler->cmd, iot_i2c_handler->slave_addr << 1 | I2C_MASTER_READ, ACK_CHECK_EN);
+    if (xBytes > 1) {
+        ret |= i2c_master_read(iot_i2c_handler->cmd, src_buf, xBytes - 1, ACK_VAL);
+    }
+    ret |= i2c_master_read_byte(iot_i2c_handler->cmd, (uint8_t *)(src_buf + xBytes - 1), NACK_VAL);
+    if (iot_i2c_handler->is_send_no_stop_flag_set == false) {
+        ret |= i2c_master_stop(iot_i2c_handler->cmd);
+    }
+    ret |= i2c_master_cmd_begin(i2c_port_num, iot_i2c_handler->cmd, 1000 / portTICK_RATE_MS);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "i2c master read failed");
+        xSemaphoreGive(iot_i2c_handler->i2c_semph);
+        return IOT_I2C_READ_FAILED;
+    }
+    i2c_cmd_link_delete(iot_i2c_handler->cmd);
+    iot_i2c_handler->is_send_no_stop_flag_set = false;
+    iot_i2c_handler->bytes_to_read = xBytes;
+    xSemaphoreGive(iot_i2c_handler->i2c_semph);
+    return (ret == ESP_OK) ?  IOT_I2C_SUCCESS : IOT_I2C_READ_FAILED;
+}
+
+int32_t iot_i2c_write_sync( IotI2CHandle_t const pxI2CPeripheral, uint8_t *const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret = ESP_OK;
+    if (pxI2CPeripheral == NULL || pvBuffer == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+    int32_t i2c_port_num = (int32_t) iot_i2c_handler->i2c_port_num;
+    uint8_t *src_buf = (uint8_t *) pvBuffer;
+    if (!iot_i2c_handler->is_slave_addr_set) {
+        ESP_LOGE(TAG, "Slave address not set");
+        return IOT_I2C_SLAVE_ADDRESS_NOT_SET;
+    }
+    if (xSemaphoreTake(iot_i2c_handler->i2c_semph, SEM_WAIT_TICKS) == pdFALSE) {
+        return IOT_I2C_BUSY;
+    }
+
+    iot_i2c_handler->async_op = false;
+    iot_i2c_handler->cmd = i2c_cmd_link_create();
+    ret  = i2c_master_start(iot_i2c_handler->cmd);
+    ret |= i2c_master_write_byte(iot_i2c_handler->cmd, iot_i2c_handler->slave_addr << 1 | I2C_MASTER_WRITE, ACK_CHECK_EN);
+    ret = i2c_master_write(iot_i2c_handler->cmd, src_buf, xBytes, ACK_CHECK_EN);
+    if (iot_i2c_handler->is_send_no_stop_flag_set == false) {
+        ret |= i2c_master_stop(iot_i2c_handler->cmd);
+    }
+    ret |= i2c_master_cmd_begin(i2c_port_num, iot_i2c_handler->cmd, 1000 / portTICK_RATE_MS );
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "i2c master write failed");
+        xSemaphoreGive(iot_i2c_handler->i2c_semph);
+        return IOT_I2C_WRITE_FAILED;
+    }
+    i2c_cmd_link_delete(iot_i2c_handler->cmd);
+    iot_i2c_handler->bytes_to_write = xBytes;
+    iot_i2c_handler->is_send_no_stop_flag_set = false;
+    xSemaphoreGive(iot_i2c_handler->i2c_semph);
+    return (ret == ESP_OK) ?  IOT_I2C_SUCCESS : IOT_I2C_WRITE_FAILED;
+}
+
+int32_t iot_i2c_close(IotI2CHandle_t const pxI2CPeripheral)
+{
+    if (pxI2CPeripheral == NULL) {
+        ESP_LOGE(TAG, "Invalid I2C Handler");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    i2c_ctx_t *iot_i2c_handler = (i2c_ctx_t *) pxI2CPeripheral;
+    if (!(0x01 & (i2c_bit_mask >> iot_i2c_handler->i2c_port_num))) {
+        ESP_LOGE(TAG, "I2C Handler is not initialised");
+        return IOT_I2C_INVALID_VALUE;
+    }
+    if (iot_i2c_handler->i2c_semph) {
+        xSemaphoreTake(iot_i2c_handler->i2c_semph, portMAX_DELAY);
+    }
+    i2c_bit_mask = i2c_bit_mask & ~(BIT(iot_i2c_handler->i2c_port_num));
+    int32_t i2c_port_num = (int32_t) iot_i2c_handler->i2c_port_num;
+    if (iot_i2c_handler->driver_installed) {
+        esp_err_t ret = i2c_driver_delete(i2c_port_num);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Invalid arguments");
+            xSemaphoreGive(iot_i2c_handler->i2c_semph);
+            return IOT_I2C_INVALID_VALUE;
+        }
+    }
+    if (iot_i2c_handler->i2c_semph) {
+        vSemaphoreDelete(iot_i2c_handler->i2c_semph);
+        iot_i2c_handler->i2c_semph = NULL;
+    }
+    free(pxI2CPeripheral);
+    return IOT_I2C_SUCCESS;
+}
+
+int32_t iot_i2c_cancel(IotI2CHandle_t const pxI2CPeripheral)
+
+{
+    return IOT_I2C_FUNCTION_NOT_SUPPORTED;
+}

--- a/vendors/espressif/boards/esp32/ports/common_io/iot_spi.c
+++ b/vendors/espressif/boards/esp32/ports/common_io/iot_spi.c
@@ -1,0 +1,522 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string.h>
+#include "esp_log.h"
+#include "driver/spi_master.h"
+#include "esp_timer.h"
+#include <esp_err.h>
+#include <iot_spi.h>
+#include <iot_board_gpio.h>
+
+#define WAIT_TICKS (10)
+#define NULL_BUF_SZ (1024 * 4)
+
+static const char* TAG="esp-iot-spi";
+
+typedef enum {
+    SPI_NONE,
+    SPI_READ,
+    SPI_WRITE,
+    SPI_TRANSFER,
+} spi_mode_t;
+
+typedef struct {
+    uint8_t spi_port_num;
+    spi_device_handle_t handle;
+    spi_bus_config_t spi_bus_config;
+    IotSPIMasterConfig_t iot_spi_master_conf;
+    spi_device_interface_config_t spi_device_config;
+    uint32_t bytes_read;
+    uint32_t bytes_written;
+    esp_timer_handle_t tmr_handle;
+    void (*func) ( IotSPITransactionStatus_t arg1, void * arg2);
+    void * arg;
+    char * null_tx;
+    spi_transaction_t spi_transact;
+    SemaphoreHandle_t spi_semph;
+    spi_mode_t spi_op_mode;
+    IotSPITransactionStatus_t status;
+} spi_ctx_t;
+
+static struct esp_spi_pin_config esp_spi_pin_map[ESP_MAX_SPI_PORTS] = ESP_SPI_PIN_MAP;
+static volatile uint8_t spi_bit_mask;
+
+void spi_callback_dispatch(void *args)
+{
+    spi_ctx_t *spi_ctx = (spi_ctx_t *)args;
+    spi_device_get_trans_result(spi_ctx->handle, &spi_ctx->spi_transact, WAIT_TICKS);
+
+    if (spi_ctx->func) {
+        spi_ctx->func(spi_ctx->status, spi_ctx->arg);
+    }
+
+    xSemaphoreGive(spi_ctx->spi_semph);
+}
+
+IRAM_ATTR void spi_post_trans_cb(spi_transaction_t *args)
+{
+    spi_transaction_t  *spi_trans = (spi_transaction_t *)args;
+    spi_ctx_t *spi_ctx = (spi_ctx_t *)spi_trans->user;
+
+    switch (spi_ctx->spi_op_mode) {
+        case SPI_READ:
+            spi_ctx->bytes_read = (spi_trans->rxlength / 8);
+            spi_ctx->bytes_written = 0;
+            break;
+        case SPI_WRITE:
+            spi_ctx->bytes_read = 0;
+            spi_ctx->bytes_written = (spi_trans->length / 8);
+            break;
+        case SPI_TRANSFER:
+            spi_ctx->bytes_read = (spi_trans->rxlength / 8);
+            spi_ctx->bytes_written = (spi_trans->length / 8);
+            break;
+        case SPI_NONE:
+        default:
+            return;
+    }
+    spi_ctx->status = eSPISuccess;
+    esp_timer_start_once(spi_ctx->tmr_handle, 0);
+}
+
+IotSPIHandle_t iot_spi_open( int32_t lSPIInstance )
+{
+    esp_err_t ret;
+    if (lSPIInstance < 1 || lSPIInstance > 2 ) {
+        ESP_LOGE(TAG, "Invalid arguments %s", __func__);
+        return NULL;
+    }
+    if (!(0x01 & spi_bit_mask >> lSPIInstance)) {
+        spi_ctx_t *spi_ctx = (spi_ctx_t *) calloc(1, sizeof(spi_ctx_t));
+        if (spi_ctx == NULL) {
+            ESP_LOGE(TAG, "Could not allocate memory for spi context");
+            return NULL;
+        }
+
+        spi_ctx->spi_port_num = lSPIInstance;
+        spi_ctx->spi_bus_config.flags = 0;
+        spi_ctx->spi_bus_config.mosi_io_num = esp_spi_pin_map[lSPIInstance - 1].mosi_pin;
+        spi_ctx->spi_bus_config.miso_io_num = esp_spi_pin_map[lSPIInstance - 1].miso_pin;
+        spi_ctx->spi_bus_config.sclk_io_num = esp_spi_pin_map[lSPIInstance - 1].clk_pin;
+        spi_ctx->spi_bus_config.quadhd_io_num = -1;
+        spi_ctx->spi_bus_config.quadwp_io_num = -1;
+        spi_ctx->spi_bus_config.max_transfer_sz = NULL_BUF_SZ; //since DMA is to be used
+        spi_ctx->spi_device_config.mode = 0;
+        spi_ctx->spi_device_config.clock_speed_hz = 1000000;
+        spi_ctx->spi_device_config.duty_cycle_pos = 128; //50% duty cycle
+        spi_ctx->spi_device_config.spics_io_num = esp_spi_pin_map[lSPIInstance - 1].cs_pin;
+        spi_ctx->spi_device_config.cs_ena_pretrans = 1;
+        spi_ctx->spi_device_config.cs_ena_posttrans = 1;
+        spi_ctx->spi_device_config.flags = 0; //default MSB first for rx tx operation
+        spi_ctx->spi_device_config.queue_size = 10;
+        spi_ctx->spi_device_config.post_cb = spi_post_trans_cb;
+        spi_ctx->spi_device_config.pre_cb = NULL;
+        spi_ctx->spi_device_config.command_bits = 0;
+        spi_ctx->spi_device_config.address_bits = 0;
+
+        spi_ctx->null_tx = heap_caps_calloc(NULL_BUF_SZ, 1, MALLOC_CAP_DMA);
+        if (spi_ctx->null_tx == NULL) {
+            ESP_LOGE(TAG, "Failed to alloc null_tx !");
+            goto err;
+        }
+
+        spi_ctx->spi_semph = xSemaphoreCreateBinary();
+        if (spi_ctx->spi_semph == NULL) {
+            ESP_LOGE(TAG, "Failed to create read binary semaphore");
+            goto err;
+        }
+
+        esp_timer_create_args_t tmr_create_args = {
+            .callback = spi_callback_dispatch,
+            .arg = spi_ctx,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "SPI application CB",
+        };
+
+        if (esp_timer_create(&tmr_create_args, &spi_ctx->tmr_handle) != ESP_OK) {
+            ESP_LOGE(TAG, "Timer creation failed");
+            goto err;
+        }
+
+        ret = spi_bus_initialize(spi_ctx->spi_port_num, &spi_ctx->spi_bus_config, lSPIInstance);
+        ret |= spi_bus_add_device(spi_ctx->spi_port_num, &spi_ctx->spi_device_config, &spi_ctx->handle);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "spi bus initialization failed");
+            goto err;
+        }
+
+        /* Ensure first semaphore take could succeed */
+        xSemaphoreGive(spi_ctx->spi_semph);
+
+        IotSPIHandle_t iot_spi_handler = (void *) spi_ctx;
+        spi_bit_mask = spi_bit_mask | BIT(lSPIInstance);
+        return iot_spi_handler;
+err:
+        if (spi_ctx->null_tx) {
+            free(spi_ctx->null_tx);
+        }
+
+        if (spi_ctx->spi_semph) {
+            vSemaphoreDelete(spi_ctx->spi_semph);
+        }
+
+        if (spi_ctx->tmr_handle) {
+            esp_timer_delete(spi_ctx->tmr_handle);
+        }
+
+        if (spi_ctx->handle) {
+            spi_bus_remove_device(spi_ctx->handle);
+            spi_bus_free(spi_ctx->spi_port_num);
+        }
+
+        free(spi_ctx);
+        return NULL;
+    } else {
+        ESP_LOGE(TAG, "driver already open for given instance");
+        return NULL;
+    }
+}
+
+void iot_spi_set_callback(IotSPIHandle_t const pxSPIPeripheral, IotSPICallback_t xCallback, void * pvUserContext)
+{
+    if (pxSPIPeripheral == NULL || xCallback == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments %s", __func__);
+    }
+    spi_ctx_t *spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    spi_ctx->arg = pvUserContext;
+    spi_ctx->func = (void *)xCallback;
+}
+
+int32_t iot_spi_ioctl( IotSPIHandle_t const pxSPIPeripheral,
+                       IotSPIIoctlRequest_t xSPIRequest,
+                       void * const pvBuffer )
+{
+    if ( pxSPIPeripheral == NULL || pvBuffer == NULL ) {
+        ESP_LOGE(TAG, "Invalid arguments %s", __func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+    esp_err_t ret = ESP_OK;
+    spi_ctx_t *spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+    switch (xSPIRequest)
+    {
+    case eSPISetMasterConfig:
+       if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+            ESP_LOGE(TAG, "SPI bus busy");
+            return IOT_SPI_BUS_BUSY;
+        }
+
+        ret |= spi_bus_remove_device(spi_ctx->handle);
+        ret |= spi_bus_free(spi_ctx->spi_port_num);
+
+        if (ret == ESP_ERR_INVALID_ARG) {
+            ESP_LOGE(TAG, "Invalid SPI handler %s", __func__);
+            xSemaphoreGive(spi_ctx->spi_semph);
+            return IOT_SPI_INVALID_VALUE;
+        } else if (ret == ESP_ERR_INVALID_STATE) {
+            ESP_LOGE(TAG, "device is already freed %s", __func__);
+            xSemaphoreGive(spi_ctx->spi_semph);
+            return IOT_SPI_INVALID_VALUE;
+        }
+        IotSPIMasterConfig_t *iot_spi_cfg = (IotSPIMasterConfig_t *) pvBuffer;
+        spi_ctx->spi_device_config.mode = iot_spi_cfg->eMode;
+        if (iot_spi_cfg->ulFreq == 0) {
+            spi_ctx->spi_device_config.clock_speed_hz = 1000000; //default clk speed
+        } else {
+            spi_ctx->spi_device_config.clock_speed_hz = iot_spi_cfg->ulFreq;
+        }
+        spi_ctx->spi_device_config.duty_cycle_pos = 128; //50% duty cycle
+        spi_ctx->spi_device_config.spics_io_num = esp_spi_pin_map[spi_ctx->spi_port_num - 1].cs_pin;
+        spi_ctx->spi_device_config.cs_ena_pretrans = 1;
+        spi_ctx->spi_device_config.cs_ena_posttrans = 1;
+        if (iot_spi_cfg->eSetBitOrder == eSPILSBFirst) {
+            spi_ctx->spi_device_config.flags = SPI_DEVICE_BIT_LSBFIRST; //LSB first for tx and rx operation
+        } else {
+            spi_ctx->spi_device_config.flags = 0; //default MSB first for rx tx operation
+        }
+        spi_ctx->spi_device_config.queue_size = 10;
+        vTaskDelay(100);
+        ret = spi_bus_initialize(spi_ctx->spi_port_num, &spi_ctx->spi_bus_config, 1);
+        ret |= spi_bus_add_device(spi_ctx->spi_port_num, &spi_ctx->spi_device_config, &spi_ctx->handle);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "SPI adding of device failed");
+            xSemaphoreGive(spi_ctx->spi_semph);
+            return IOT_SPI_INVALID_VALUE;
+        }
+        memcpy(&spi_ctx->iot_spi_master_conf, iot_spi_cfg, sizeof(IotSPIMasterConfig_t));
+        xSemaphoreGive(spi_ctx->spi_semph);
+        break;
+
+    case eSPIGetMasterConfig: {
+        IotSPIMasterConfig_t *iot_spi_cfg = (IotSPIMasterConfig_t *) pvBuffer;
+        memcpy(iot_spi_cfg, &spi_ctx->iot_spi_master_conf, sizeof(IotSPIMasterConfig_t));
+        break;
+    }
+
+    case eSPIGetTxNoOfbytes: {
+        uint32_t *txbytes = (uint32_t*) pvBuffer;
+        txbytes = &spi_ctx->bytes_written;
+        break;
+    }
+
+    case eSPIGetRxNoOfbytes: {
+        uint32_t *rxbytes = (uint32_t*) pvBuffer;
+        rxbytes = &spi_ctx->bytes_read;
+        break;
+    }
+
+    default:
+        return IOT_SPI_INVALID_VALUE;
+    }
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_write_sync(IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret;
+    if (pxSPIPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.length = xBytes * 8; //length need to be set in bits
+    spi_ctx->spi_transact.tx_buffer = pvBuffer;
+
+    ret = spi_device_transmit(spi_ctx->handle, &spi_ctx->spi_transact);
+
+    spi_ctx->bytes_written = (spi_ctx->spi_transact.length / 8);
+    spi_ctx->bytes_read = 0;
+
+    xSemaphoreGive(spi_ctx->spi_semph);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to write SPI sync data");
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_read_sync(IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    esp_err_t ret;
+    if (pxSPIPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.tx_buffer = spi_ctx->null_tx;
+    spi_ctx->spi_transact.rxlength = xBytes * 8; //length needs to be set in bits
+    spi_ctx->spi_transact.rx_buffer = pvBuffer;
+
+    ret = spi_device_transmit(spi_ctx->handle, &spi_ctx->spi_transact);
+
+    spi_ctx->bytes_read = (spi_ctx->spi_transact.rxlength / 8);
+    spi_ctx->bytes_written = 0;
+
+    xSemaphoreGive(spi_ctx->spi_semph);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read SPI sync data");
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_write_async(IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    if (pxSPIPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.length = xBytes * 8;
+    spi_ctx->spi_transact.tx_buffer = pvBuffer;
+    spi_ctx->spi_transact.user = spi_ctx;
+
+    spi_ctx->spi_op_mode = SPI_WRITE;
+
+    if (spi_device_queue_trans(spi_ctx->handle, &spi_ctx->spi_transact, WAIT_TICKS) != ESP_OK) {
+        spi_ctx->spi_op_mode = SPI_NONE;
+        spi_ctx->bytes_written = 0;
+        spi_ctx->bytes_read = 0;
+        xSemaphoreGive(spi_ctx->spi_semph);
+        return IOT_SPI_TRANSFER_ERROR;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_read_async(IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    if (pxSPIPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.tx_buffer = spi_ctx->null_tx;
+    spi_ctx->spi_transact.length = xBytes * 8;
+    spi_ctx->spi_transact.rxlength = xBytes * 8;
+    spi_ctx->spi_transact.rx_buffer = pvBuffer;
+    spi_ctx->spi_transact.user = spi_ctx;
+
+    spi_ctx->spi_op_mode = SPI_READ;
+
+    if (spi_device_queue_trans(spi_ctx->handle, &spi_ctx->spi_transact, WAIT_TICKS) != ESP_OK) {
+        spi_ctx->spi_op_mode = SPI_NONE;
+        spi_ctx->bytes_written = 0;
+        spi_ctx->bytes_read = 0;
+        xSemaphoreGive(spi_ctx->spi_semph);
+        return IOT_SPI_TRANSFER_ERROR;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_transfer_sync( IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvTxBuffer, uint8_t * const pvRxBuffer, size_t xBytes )
+{
+    esp_err_t ret;
+    if (pxSPIPeripheral == NULL || pvTxBuffer == NULL || pvRxBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.rxlength = xBytes * 8; //length needs to be set in bits
+    spi_ctx->spi_transact.length = xBytes * 8;   //length needs to be set in bits
+    spi_ctx->spi_transact.tx_buffer = pvTxBuffer;
+    spi_ctx->spi_transact.rx_buffer = pvRxBuffer;
+
+    ret = spi_device_transmit(spi_ctx->handle, &spi_ctx->spi_transact);
+
+    spi_ctx->bytes_read = (spi_ctx->spi_transact.rxlength / 8);
+    spi_ctx->bytes_written = (spi_ctx->spi_transact.length / 8);
+
+    xSemaphoreGive(spi_ctx->spi_semph);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to transfer SPI data");
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_transfer_async(IotSPIHandle_t const pxSPIPeripheral, uint8_t * const pvTxBuffer, uint8_t * const pvRxBuffer, size_t xBytes)
+{
+    if (pxSPIPeripheral == NULL || pvTxBuffer == NULL || pvRxBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG,"Invalid arguments %s",__func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t * spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+
+    if (!xSemaphoreTake(spi_ctx->spi_semph, WAIT_TICKS)) {
+        ESP_LOGE(TAG,"SPI bus is busy %s", __func__);
+        return IOT_SPI_BUS_BUSY;
+    }
+
+    memset(&spi_ctx->spi_transact, 0, sizeof(spi_transaction_t));
+    spi_ctx->spi_transact.rxlength = xBytes * 8; //length needs to be set in bits
+    spi_ctx->spi_transact.length = xBytes * 8;   //length needs to be set in bits
+    spi_ctx->spi_transact.tx_buffer = pvTxBuffer;
+    spi_ctx->spi_transact.rx_buffer = pvRxBuffer;
+    spi_ctx->spi_transact.user = spi_ctx;
+
+    spi_ctx->spi_op_mode = SPI_TRANSFER;
+
+    if (spi_device_queue_trans(spi_ctx->handle, &spi_ctx->spi_transact, WAIT_TICKS) != ESP_OK) {
+        spi_ctx->spi_op_mode = SPI_NONE;
+        spi_ctx->bytes_written = 0;
+        spi_ctx->bytes_read = 0;
+        xSemaphoreGive(spi_ctx->spi_semph);
+        return IOT_SPI_TRANSFER_ERROR;
+    }
+
+    return IOT_SPI_SUCCESS;
+}
+
+int32_t iot_spi_close( IotSPIHandle_t const pxSPIPeripheral )
+{
+    esp_err_t ret;
+    if (pxSPIPeripheral == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments %s", __func__);
+        return IOT_SPI_INVALID_VALUE;
+    }
+
+    spi_ctx_t *spi_ctx = (spi_ctx_t *) pxSPIPeripheral;
+    if (0x01 & spi_bit_mask >> spi_ctx->spi_port_num) {
+        // Block till the transactions are complete
+        xSemaphoreTake(spi_ctx->spi_semph, portMAX_DELAY);
+        ret |= spi_bus_remove_device(spi_ctx->handle);
+        ret |= spi_bus_free(spi_ctx->spi_port_num);
+
+        if (spi_ctx->spi_semph) {
+            vSemaphoreDelete(spi_ctx->spi_semph);
+        }
+
+        spi_bit_mask = spi_bit_mask & ~(BIT(spi_ctx->spi_port_num));
+        free(pxSPIPeripheral);
+        return (ret == ESP_OK) ? IOT_SPI_SUCCESS : IOT_SPI_INVALID_VALUE;
+    } else {
+        return IOT_SPI_INVALID_VALUE;
+    }
+}
+
+int32_t iot_spi_cancel( IotSPIHandle_t const pxSPIPeripheral )
+{
+    return IOT_SPI_FUNCTION_NOT_SUPPORTED;
+}

--- a/vendors/espressif/boards/esp32/ports/common_io/iot_test_common_io_internal.c
+++ b/vendors/espressif/boards/esp32/ports/common_io/iot_test_common_io_internal.c
@@ -1,0 +1,69 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "iot_test_common_io_internal.h"
+#include "iot_i2c.h"
+
+/* UART */
+const uint8_t uartTestPort[ UART_TEST_SET ] = { 2 };
+/* Following configurations are not being used for now. */
+const uint32_t uartIotUartFlowControl[ UART_TEST_SET ] = { 0 };
+const uint32_t uartIotUartParity[ UART_TEST_SET ] = { 0 };
+const uint32_t uartIotUartWordLength[ UART_TEST_SET ] = { 0 };
+const uint32_t uartIotUartStopBits[ UART_TEST_SET ] = { 0 };
+
+void SET_TEST_IOT_UART_CONFIG( int testSet )
+{
+    uctestIotUartPort = uartTestPort[ testSet ];
+}
+
+/* I2C */
+const uint8_t i2cTestSlaveAddr[ I2C_TEST_SET ] = { 0xD4 };
+const uint8_t i2cTestDeviceRegister[ I2C_TEST_SET ] = { 0x73 };
+const uint8_t i2cTestWriteVal[ I2C_TEST_SET ] = { 0b01101010 };
+const uint8_t i2cTestInstanceIdx[ I2C_TEST_SET ] = { 0 };
+const uint8_t i2cTestInstanceNum[ I2C_TEST_SET ] = { 2 };
+
+/* Not used by tests in this code base. */
+IotI2CHandle_t gIotI2cHandle[ 4 ] = { NULL, NULL, NULL, NULL };
+
+void SET_TEST_IOT_I2C_CONFIG( int testSet )
+{
+    uctestIotI2CSlaveAddr = i2cTestSlaveAddr[ testSet ];
+    uctestIotI2CDeviceRegister = i2cTestDeviceRegister[ testSet ];
+    uctestIotI2CWriteVal = i2cTestWriteVal[ testSet ];
+    uctestIotI2CInstanceIdx = i2cTestInstanceIdx[ testSet ];
+    uctestIotI2CInstanceNum = i2cTestInstanceNum[ testSet ];
+}
+
+/* SPI */
+
+const uint8_t spiTestPort[ SPI_TEST_SET ] = { 1 };
+const uint32_t spiIotMode[ SPI_TEST_SET ] = { eSPIMode0 };
+const uint32_t spiIotSpitBitOrder[ SPI_TEST_SET ] = { eSPIMSBFirst };
+const uint32_t spiIotFrequency[ SPI_TEST_SET ] = { 500000U };
+const uint32_t spiIotDummyValue[ SPI_TEST_SET ] = { 0 };
+
+void SET_TEST_IOT_SPI_CONFIG(int testSet)
+{
+    ultestIotSpiInstance = spiTestPort[ testSet ] ;
+    xtestIotSPIDefaultConfigMode = spiIotMode[ testSet ];
+    xtestIotSPIDefaultconfigBitOrder = spiIotSpitBitOrder[ testSet ];
+    ultestIotSPIFrequency = spiIotFrequency[ testSet ];
+    ultestIotSPIDummyValue = spiIotDummyValue[ testSet ];
+}

--- a/vendors/espressif/boards/esp32/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/esp32/ports/common_io/iot_uart.c
@@ -1,0 +1,522 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iot_uart.h"
+#include "esp_log.h"
+#include "driver/uart.h"
+#include "string.h"
+#include "iot_board_gpio.h"
+#include "freertos/timers.h"
+
+static const char *TAG = "esp-hal-uart";
+/**/
+#define BUF_SIZE (1024) //This needs to be more then the UART FIFO Length(>128)
+#define UART_READ_CB_STACK (512 * 4)
+#define SEM_WAIT_TIME (60000 / portTICK_RATE_MS)
+#define UART_TX_WAIT_TIME (60000 / portTICK_RATE_MS)
+/* UART hardware FIFO is of 128 bytes and default threshold value for RX full FIFO interupt is 120 bytes.
+ * When crital sections of other peripherals(for example WiFi or Bluetooth in power save) run for longer
+ * time(sometimes interupts are masked), there is a possibility of UART RX FIFO to overflow.
+ * Hence reducing RX full FIFO threshold to 60 bytes, gives us time to handle uart interupt
+ * since there is more room in hardware FIFO(128 - 60 = 68 bytes) i.e. making FIFO empty more frequently.
+ */
+#define UART_RX_FULL_THRESH  (60)
+#define UART_TIMEOUT_THRESH  (10)
+#define UART_TX_EMPTY_THRESH (10)
+
+typedef struct {
+    IotUARTConfig_t iot_uart_conf;
+    void (*func)(IotUARTOperationStatus_t arg1, void *arg2);
+    void *arg;
+    char *read_buf;
+    char *write_buf;
+    size_t bytes_to_read;
+    size_t bytes_to_write;
+    size_t async_bytes_written;
+    size_t async_bytes_read;
+    int32_t uart_port_num;
+    esp_timer_handle_t uart_timer_wr_hdl;
+    esp_timer_handle_t uart_timer_rd_hdl;
+    SemaphoreHandle_t uart_rd_cb_wait;
+    SemaphoreHandle_t uart_wr_cb_wait;
+    unsigned wr_op_in_progress: 1;
+    unsigned rd_op_in_progress: 1;
+    unsigned uart_rd_op_cancel_req: 1;
+    unsigned uart_wr_op_cancel_req: 1;
+} uart_ctx_t;
+
+static struct esp_uart_pin_config esp_uart_pin_map[ESP_MAX_UART_PORTS] = ESP_UART_PIN_MAP;
+static volatile uint8_t uart_bit_mask, uart_is_installed_bit_mask;
+
+IRAM_ATTR static void esp32_uart_write_cb(void *param, unsigned int ulparam)
+{
+    ESP_EARLY_LOGD(TAG, "%s", __func__);
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) param;
+    int bytes_write_tmp = 0;
+    uint8_t *write_buffer = uart_ctx->write_buf;
+    uint8_t op_status = eUartWriteCompleted;
+    int actual_bytes_to_write = 0;
+    if (uart_ctx->uart_wr_op_cancel_req) {
+        ESP_EARLY_LOGD(TAG, "cancel operation recieved");
+        op_status = eUartLastWriteFailed;
+        if (uart_ctx->func) {
+            ESP_EARLY_LOGD(TAG, "%s invoking callback %p", __func__, uart_ctx->func);
+            uart_ctx->func(op_status, uart_ctx->arg);
+        }
+        uart_ctx->bytes_to_write = 0;
+        uart_ctx->wr_op_in_progress = false;
+        uart_ctx->uart_wr_op_cancel_req = false;
+        xSemaphoreGive(uart_ctx->uart_wr_cb_wait);
+        return;
+    }
+
+    if (uart_ctx->bytes_to_write == 0) {
+        if (uart_ctx->func) {
+            ESP_EARLY_LOGD(TAG, "%s invoking callback %p", __func__, uart_ctx->func);
+            uart_ctx->func(op_status, uart_ctx->arg);
+        }
+        uart_ctx->bytes_to_write = 0;
+        uart_ctx->wr_op_in_progress = false;
+        xSemaphoreGive(uart_ctx->uart_wr_cb_wait);
+        return;
+    }
+
+    actual_bytes_to_write = uart_ctx->bytes_to_write < UART_FIFO_LEN ? uart_ctx->bytes_to_write : UART_FIFO_LEN;
+    uart_enable_intr_mask(uart_ctx->uart_port_num, UART_TX_DONE_INT_ENA_M);
+    bytes_write_tmp = uart_write_bytes(uart_ctx->uart_port_num, write_buffer, actual_bytes_to_write);
+    uart_ctx->write_buf += bytes_write_tmp;
+    uart_ctx->bytes_to_write -= bytes_write_tmp;
+    uart_ctx->async_bytes_written += bytes_write_tmp;
+}
+
+IRAM_ATTR static void esp32_uart_read_cb(void *param, unsigned int ulparam)
+{
+    ESP_EARLY_LOGD(TAG, "%s", __func__);
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) param;
+    int bytes_read_tmp = 0;
+    uint8_t op_status = eUartReadCompleted;
+    uint8_t *read_buffer = uart_ctx->read_buf;
+    int actual_bytes_to_read = UART_FIFO_LEN * 2;
+
+    if (uart_ctx->uart_rd_op_cancel_req) {
+        ESP_EARLY_LOGD(TAG, "cancel operation recieved");
+        op_status = eUartLastReadFailed;
+        if (uart_ctx->func) {
+            ESP_EARLY_LOGD(TAG, "%s invoking callback %p", __func__, uart_ctx->func);
+            uart_ctx->func(op_status, uart_ctx->arg);
+        }
+        uart_ctx->bytes_to_read = 0;
+        uart_ctx->rd_op_in_progress = false;
+        uart_ctx->uart_rd_op_cancel_req = false;
+        xSemaphoreGive(uart_ctx->uart_rd_cb_wait);
+        return;
+    }
+
+    if (actual_bytes_to_read > uart_ctx->bytes_to_read) {
+        actual_bytes_to_read = uart_ctx->bytes_to_read;
+    }
+    uart_enable_rx_intr(uart_ctx->uart_port_num);
+    bytes_read_tmp = uart_read_bytes(uart_ctx->uart_port_num, read_buffer, actual_bytes_to_read, 0);
+    uart_ctx->read_buf += bytes_read_tmp;
+    uart_ctx->bytes_to_read -= bytes_read_tmp;
+    uart_ctx->async_bytes_read += bytes_read_tmp;
+    if (uart_ctx->bytes_to_read <= 0) {
+        op_status = eUartReadCompleted;
+        if (uart_ctx->func) {
+            ESP_EARLY_LOGD(TAG, "%s invoking callback %p", __func__, uart_ctx->func);
+            uart_ctx->func(op_status, uart_ctx->arg);
+        }
+        uart_ctx->bytes_to_read = 0;
+        uart_ctx->rd_op_in_progress = false;
+        uart_ctx->uart_rd_op_cancel_req = false;
+        xSemaphoreGive(uart_ctx->uart_rd_cb_wait);
+        return;
+    }
+}
+
+IRAM_ATTR void uart_event_cb(uart_event_t uart_event, void *param)
+{
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) param;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if (uart_event.type == UART_TX_DONE && uart_ctx->wr_op_in_progress) {
+        if (esp_timer_start_once(uart_ctx->uart_timer_wr_hdl, 0)!= ESP_OK) {
+            ESP_EARLY_LOGE(TAG, "%s: failed to create timer for write async", __func__);
+            xSemaphoreGiveFromISR(uart_ctx->uart_wr_cb_wait, &xHigherPriorityTaskWoken);
+            return;
+        }
+    } else if (uart_event.type == UART_DATA && uart_ctx->rd_op_in_progress) {
+        if (esp_timer_start_once(uart_ctx->uart_timer_rd_hdl, 0)!= ESP_OK) {
+            ESP_EARLY_LOGE(TAG, "%s: failed to create timer for read async", __func__);
+            xSemaphoreGiveFromISR(uart_ctx->uart_rd_cb_wait, &xHigherPriorityTaskWoken);
+            return;
+        }
+    }
+}
+
+static esp_err_t iot_uart_driver_install(uint8_t uart_num, uart_config_t uart_conf)
+{
+    esp_err_t ret;
+    uart_intr_config_t uart_intr = {
+        .intr_enable_mask = UART_RXFIFO_FULL_INT_ENA_M
+                            | UART_RXFIFO_TOUT_INT_ENA_M
+                            | UART_FRM_ERR_INT_ENA_M
+                            | UART_RXFIFO_OVF_INT_ENA_M
+                            | UART_BRK_DET_INT_ENA_M
+                            | UART_PARITY_ERR_INT_ENA_M
+                            | UART_TX_DONE_INT_ENA_M,
+        .rxfifo_full_thresh = UART_RX_FULL_THRESH,
+        .rx_timeout_thresh = UART_TIMEOUT_THRESH,
+        .txfifo_empty_intr_thresh = UART_TX_EMPTY_THRESH
+    };
+    ret = uart_param_config(uart_num, &uart_conf);
+    ret |= uart_set_pin(uart_num, esp_uart_pin_map[uart_num].txd_pin, esp_uart_pin_map[uart_num].rxd_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    ret |= uart_driver_install(uart_num, BUF_SIZE * 2, BUF_SIZE * 2, 0, NULL, 0);
+    ret |= uart_intr_config(uart_num, &uart_intr);
+    if (ret != ESP_ERR_INVALID_ARG && ret != ESP_OK) {
+        return ESP_FAIL;
+    }
+    return ret;
+}
+
+IotUARTHandle_t iot_uart_open(int32_t lUartInstance)
+{
+    if (lUartInstance < 0 || lUartInstance > ESP_MAX_UART_PORTS) {
+        return NULL;
+    }
+    if (!(0x01 & uart_bit_mask >> lUartInstance)) {
+        uart_ctx_t *uart_ctx = (uart_ctx_t *) calloc(1, sizeof(uart_ctx_t));
+        if (uart_ctx == NULL) {
+            ESP_LOGD(TAG, "Could not allocate memory for uart context");
+            return NULL;
+        }
+        //Set default configuration
+        uart_ctx->uart_port_num = lUartInstance;
+        uart_config_t uart_config = {
+            .baud_rate = IOT_UART_BAUD_RATE_DEFAULT,
+            .data_bits = UART_DATA_8_BITS,
+            .parity = UART_PARITY_DISABLE,
+            .stop_bits = UART_STOP_BITS_1,
+            .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+        };
+        esp_err_t ret = iot_uart_driver_install(lUartInstance, uart_config);
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to install uart driver");
+            free(uart_ctx);
+            return NULL;
+        } else if (ret == ESP_ERR_INVALID_ARG) {
+            uart_is_installed_bit_mask |= BIT(lUartInstance);
+            ESP_LOGD(TAG, "uart bit already installed mask: %d\n", uart_is_installed_bit_mask);
+        }
+
+        uart_ctx->uart_rd_cb_wait = xSemaphoreCreateBinary();
+        if (uart_ctx->uart_rd_cb_wait == NULL) {
+            ESP_LOGD(TAG, "Failed to create read binary semaphore");
+            free(uart_ctx);
+            return NULL;
+        }
+
+        uart_ctx->uart_wr_cb_wait = xSemaphoreCreateBinary();
+        if (uart_ctx->uart_wr_cb_wait == NULL) {
+            ESP_LOGD(TAG, "Failed to create write binary semaphore");
+            vSemaphoreDelete(uart_ctx->uart_rd_cb_wait);
+            free(uart_ctx);
+            return NULL;
+        }
+        //Create a callback function to handle UART event from ISR
+        ret = uart_register_callback_with_isr(lUartInstance, uart_event_cb, (void *)uart_ctx);
+
+        /* Ensure first semaphore take could succeed */
+        xSemaphoreGive(uart_ctx->uart_rd_cb_wait);
+        xSemaphoreGive(uart_ctx->uart_wr_cb_wait);
+
+        //Create timer for write async
+        esp_timer_create_args_t write_timer = {
+            .callback = (esp_timer_cb_t)esp32_uart_write_cb,
+            .arg = (void *) uart_ctx,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "uart wr timer",
+        };
+        ret = esp_timer_create(&write_timer, &uart_ctx->uart_timer_wr_hdl);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to create uart write timer %d", ret);
+            return NULL;
+        }
+
+        //Create timer for read async
+        esp_timer_create_args_t read_timer = {
+            .callback = (esp_timer_cb_t)esp32_uart_read_cb,
+            .arg = (void *) uart_ctx,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "uart rd timer",
+        };
+        ret = esp_timer_create(&read_timer, &uart_ctx->uart_timer_rd_hdl);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to create uart read timer %d", ret);
+            return NULL;
+        }
+
+        IotUARTHandle_t iot_uart_handler = (void *) uart_ctx;
+        uart_bit_mask = uart_bit_mask | BIT(lUartInstance);
+        return iot_uart_handler;
+    } else {
+        ESP_LOGD(TAG, "driver already open for the instance");
+        return NULL;
+    }
+}
+
+int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlRequest_t xUartRequest, void * const pvBuffer)
+{
+    esp_err_t ret;
+    uart_ctx_t *iot_uart_handler = (uart_ctx_t *) pxUartPeripheral;
+
+    if (pxUartPeripheral == NULL || pvBuffer == NULL) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    if (xUartRequest == eGetTxNoOfbytes) {
+        size_t *tx_bytes_write = (size_t *)pvBuffer;
+        *tx_bytes_write = uart_ctx->async_bytes_written;
+        return IOT_UART_SUCCESS;
+    } else if (xUartRequest == eGetRxNoOfbytes) {
+        size_t *rx_bytes_read = (size_t *)pvBuffer;
+        *rx_bytes_read = uart_ctx->async_bytes_read;
+        return IOT_UART_SUCCESS;
+    }
+    if (!iot_uart_handler->wr_op_in_progress && !iot_uart_handler->rd_op_in_progress) {
+        switch(xUartRequest) {
+            case eUartSetConfig : {
+                int32_t uart_port_num = uart_ctx->uart_port_num;
+                IotUARTConfig_t *iot_uart_config = (IotUARTConfig_t *) pvBuffer;
+                memcpy(&uart_ctx->iot_uart_conf, iot_uart_config, sizeof(IotUARTConfig_t));
+                uart_config_t uart_config;
+                uart_config.baud_rate = iot_uart_config->ulBaudrate;
+                uart_config.data_bits = iot_uart_config->ucWordlength;
+                if (iot_uart_config->ucFlowControl == true) {
+                    uart_config.flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
+                    uart_config.rx_flow_ctrl_thresh = UART_FIFO_LEN;
+                }
+                switch (iot_uart_config->xParity) {
+                    case eUartParityNone:
+                    uart_config.parity = UART_PARITY_DISABLE;
+                    break;
+                    case eUartParityOdd:
+                    uart_config.parity = UART_PARITY_ODD;
+                    break;
+                    case eUartParityEven:
+                    uart_config.parity = UART_PARITY_EVEN;
+                    break;
+                    default:
+                    uart_config.parity = UART_PARITY_DISABLE;
+                }
+                switch (iot_uart_config->xStopbits) {
+                    case eUartStopBitsOne:
+                    uart_config.stop_bits = UART_STOP_BITS_1;
+                    break;
+                    case eUartStopBitsTwo:
+                    uart_config.stop_bits = UART_STOP_BITS_2;
+                    break;
+                    default:
+                    uart_config.stop_bits = UART_STOP_BITS_1;
+                }
+                if (iot_uart_config->ulBaudrate == 0) {
+                    uart_config.baud_rate = IOT_UART_BAUD_RATE_DEFAULT;
+                }
+                ret = uart_driver_delete(uart_port_num);
+                ret |= iot_uart_driver_install(uart_port_num, uart_config);
+                //Create a callback function to handle UART event from ISR
+                ret = uart_register_callback_with_isr(uart_port_num, uart_event_cb, (void *)iot_uart_handler);
+                return (ret == ESP_OK) ? IOT_UART_SUCCESS : IOT_UART_INVALID_VALUE;
+            }
+            case eUartGetConfig : {
+                IotUARTConfig_t *iot_uart_config = (IotUARTConfig_t *) pvBuffer;
+                memcpy(iot_uart_config, &uart_ctx->iot_uart_conf, sizeof(IotUARTConfig_t));
+                return IOT_UART_SUCCESS;
+            }
+            default :
+            return IOT_UART_INVALID_VALUE;
+        }
+    } else {
+        return IOT_UART_BUSY;
+    }
+}
+
+void iot_uart_set_callback(IotUARTHandle_t const pxUartPeripheral, IotUARTCallback_t xCallback, void * pvUserContext)
+{
+    if (pxUartPeripheral == NULL || xCallback == NULL) {
+        ESP_LOGD(TAG, "Invalid arguments");
+    }
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+
+    uart_ctx->arg = pvUserContext;
+    uart_ctx->func = (void *)xCallback;
+}
+
+int32_t iot_uart_read_async(IotUARTHandle_t const pxUartPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    ESP_LOGD(TAG, "%s: %p %p %d", __func__, pxUartPeripheral, pvBuffer, xBytes);
+
+    if (pxUartPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGE(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    uart_ctx->read_buf = (char *) pvBuffer;
+    uart_ctx->bytes_to_read = xBytes;
+
+    //Read from another task to make async
+    if (!xSemaphoreTake(uart_ctx->uart_rd_cb_wait, SEM_WAIT_TIME)) {
+        ESP_LOGE(TAG, "%s: failed to acquire read sem", __func__);
+        return IOT_UART_READ_FAILED;
+    }
+    uart_enable_rx_intr(uart_ctx->uart_port_num);
+    uart_ctx->rd_op_in_progress = true;
+    return IOT_UART_SUCCESS;
+}
+
+int32_t iot_uart_write_async(IotUARTHandle_t const pxUartPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    ESP_LOGD(TAG, "%s: %p %p %d", __func__, pxUartPeripheral, pvBuffer, xBytes);
+
+    if (pxUartPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    if (!xSemaphoreTake(uart_ctx->uart_wr_cb_wait, SEM_WAIT_TIME)) {
+        ESP_LOGE(TAG, "%s: failed to acquire write sem", __func__);
+        return IOT_UART_WRITE_FAILED;
+    }
+    uart_ctx->wr_op_in_progress = true;
+    uart_ctx->write_buf = (char *)pvBuffer;
+    uart_ctx->bytes_to_write = xBytes;
+    esp_timer_start_once(uart_ctx->uart_timer_wr_hdl, 0);
+    return IOT_UART_SUCCESS;
+}
+
+int32_t iot_uart_read_sync(IotUARTHandle_t const pxUartPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    if (pxUartPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+    uint8_t *src_buf = (uint8_t *) pvBuffer;
+    int32_t uart_port_num = ((uart_ctx_t *)pxUartPeripheral)->uart_port_num;
+    int bytes_read = uart_read_bytes(uart_port_num, src_buf, xBytes, portMAX_DELAY);
+    return (bytes_read == xBytes) ? IOT_UART_SUCCESS : IOT_UART_READ_FAILED;
+}
+
+int32_t iot_uart_write_sync(IotUARTHandle_t const pxUartPeripheral, uint8_t * const pvBuffer, size_t xBytes)
+{
+    if (pxUartPeripheral == NULL || pvBuffer == NULL || xBytes == 0) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+    char *src_buf = (char *) pvBuffer;
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    int32_t uart_port_num = uart_ctx->uart_port_num;
+    uart_enable_intr_mask(uart_port_num, UART_TX_DONE_INT_ENA_M);
+    int bytes_written = uart_write_bytes(uart_port_num, src_buf, xBytes);
+    if (bytes_written == xBytes) {
+        if (uart_wait_tx_done(uart_port_num, UART_TX_WAIT_TIME) != ESP_OK) {
+            ESP_LOGE(TAG, "uart write sync failed");
+            return IOT_UART_WRITE_FAILED;
+        }
+    }
+    return IOT_UART_SUCCESS;
+}
+
+int32_t iot_uart_close(IotUARTHandle_t const pxUartPeripheral)
+{
+    esp_err_t ret = ESP_OK;
+    if (pxUartPeripheral == NULL) {
+        ESP_LOGE(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    int32_t uart_port_num = uart_ctx->uart_port_num;
+    if (0x01 & uart_bit_mask >> uart_port_num) {
+        if (uart_ctx->rd_op_in_progress) {
+            uart_ctx->uart_rd_op_cancel_req = true;
+            /* Ensure no active operations on UART before flusing all data */
+            if (!xSemaphoreTake(uart_ctx->uart_rd_cb_wait, SEM_WAIT_TIME)) {
+                ESP_LOGE(TAG, "%s: failed to acquire read sem", __func__);
+                return IOT_UART_INVALID_VALUE;
+            }
+            xSemaphoreGive(uart_ctx->uart_rd_cb_wait);
+        }
+        if (uart_ctx->wr_op_in_progress) {
+            uart_ctx->uart_wr_op_cancel_req = true;
+            if (!xSemaphoreTake(uart_ctx->uart_wr_cb_wait, SEM_WAIT_TIME)) {
+                ESP_LOGE(TAG, "%s: failed to acquire write sem", __func__);
+                return IOT_UART_INVALID_VALUE;
+            }
+            xSemaphoreGive(uart_ctx->uart_wr_cb_wait);
+        }
+        if (0x01 & !(uart_is_installed_bit_mask >> uart_port_num)) {
+            ret |= uart_flush_input(uart_port_num);
+            ret |= uart_driver_delete(uart_port_num);
+            uart_is_installed_bit_mask &= ~(BIT(uart_port_num));
+        }
+        esp_timer_stop(uart_ctx->uart_timer_wr_hdl);
+        esp_timer_stop(uart_ctx->uart_timer_rd_hdl);
+        esp_timer_delete(uart_ctx->uart_timer_wr_hdl);
+        esp_timer_delete(uart_ctx->uart_timer_rd_hdl);
+        if (uart_ctx->uart_rd_cb_wait) {
+            vSemaphoreDelete(uart_ctx->uart_rd_cb_wait);
+        }
+        if (uart_ctx->uart_wr_cb_wait) {
+            vSemaphoreDelete(uart_ctx->uart_wr_cb_wait);
+        }
+        uart_bit_mask = uart_bit_mask & ~(BIT(uart_port_num));
+        free(pxUartPeripheral);
+        return (ret == ESP_OK) ? IOT_UART_SUCCESS : IOT_UART_INVALID_VALUE;
+    } else {
+        return IOT_UART_INVALID_VALUE;
+    }
+}
+
+int32_t iot_uart_cancel(IotUARTHandle_t const pxUartPeripheral)
+{
+    esp_err_t ret;
+    if (pxUartPeripheral == NULL) {
+        ESP_LOGD(TAG, "Invalid arguments");
+        return IOT_UART_INVALID_VALUE;
+    }
+    uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
+    int32_t uart_port_num = uart_ctx->uart_port_num;
+
+    if (!uart_ctx->rd_op_in_progress && !uart_ctx->wr_op_in_progress) {
+        return IOT_UART_NOTHING_TO_CANCEL;
+    } else if (uart_ctx->rd_op_in_progress) {
+        uart_ctx->uart_rd_op_cancel_req = true;
+        ESP_LOGD(TAG, "operation cancel request: %d\n", uart_ctx->uart_rd_op_cancel_req);
+        /* Ensure no active operations on UART before flusing all data */
+        if (!xSemaphoreTake(uart_ctx->uart_rd_cb_wait, SEM_WAIT_TIME)) {
+            ESP_LOGE(TAG, "%s: failed to acquire read sem", __func__);
+            uart_ctx->uart_rd_op_cancel_req = false;
+            return IOT_UART_INVALID_VALUE;
+        }
+        xSemaphoreGive(uart_ctx->uart_rd_cb_wait);
+
+        ret |= uart_flush_input(uart_port_num);
+        return (ret == ESP_OK) ? IOT_UART_SUCCESS : IOT_UART_INVALID_VALUE;
+    } else {
+        ESP_LOGE(TAG, "write cancel not supported");
+        return IOT_UART_FUNCTION_NOT_SUPPORTED;
+    }
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR intends to add support for UART, SPI and I2C modules in Common I/O

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.