### PR TITLE
Align compiler flags with IDE build

### DIFF
--- a/demos/include/aws_clientcredential_keys.h
+++ b/demos/include/aws_clientcredential_keys.h
@@ -37,7 +37,7 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyCLIENT_CERTIFICATE_PEM                   ""
+#define keyCLIENT_CERTIFICATE_PEM                   NULL
 
 /*
  * @brief PEM-encoded issuer certificate for AWS IoT Just In Time Registration (JITR).
@@ -58,7 +58,7 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    ""
+#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
 
 /*
  * @brief PEM-encoded client private key.
@@ -71,6 +71,6 @@
  * "...base64 data...\n"\
  * "-----END RSA PRIVATE KEY-----\n"
  */
-#define keyCLIENT_PRIVATE_KEY_PEM                   ""
+#define keyCLIENT_PRIVATE_KEY_PEM                   NULL
 
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H */

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -3,6 +3,7 @@
 if (AFR_ENABLE_UNIT_TESTS)
     add_subdirectory(abstractions/secure_sockets)
     add_subdirectory(freertos_plus/standard/pkcs11/)
+    add_subdirectory(abstractions/pkcs11/)
     add_subdirectory(c_sdk/standard/ble)
     return()
 endif()

--- a/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
+++ b/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
@@ -232,12 +232,12 @@
 
 /* I2C */
 #if defined( IOT_TEST_COMMON_IO_I2C_SUPPORTED ) && ( IOT_TEST_COMMON_IO_I2C_SUPPORTED >= 1 )
-    extern uint8_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
-    extern uint8_t uctestIotI2CDeviceRegister;    /* Slave I2C register address used in read/write tests */
-    extern uint8_t uctestIotI2CWriteVal;          /* Write value that will be used in the register write test */
-    extern uint8_t uctestIotI2CInstanceIdx;       /* I2C instance used in the test */
-    extern uint8_t uctestIotI2CInstanceNum;       /* The total number of I2C instances on the device */
-    extern uint8_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
+    extern uint16_t uctestIotI2CSlaveAddr;         /* Address of Slave I2C (7-bit address) connected to the bus */
+    extern uint8_t uctestIotI2CDeviceRegister;     /* Slave I2C register address used in read/write tests */
+    extern uint8_t uctestIotI2CWriteVal;           /* Write value that will be used in the register write test */
+    extern uint8_t uctestIotI2CInstanceIdx;        /* I2C instance used in the test */
+    extern uint8_t uctestIotI2CInstanceNum;        /* The total number of I2C instances on the device */
+    extern uint16_t ucAssistedTestIotI2CSlaveAddr; /* The slave address to be set for the assisted test. */
 
 /**
  * Board specific I2C config set

--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -46,8 +46,6 @@
 /*-----------------------------------------------------------*/
 #define testIotI2C_BAUDRATE               IOT_I2C_FAST_MODE_BPS
 #define testIotI2C_BAUDRATE_LOW_SPEED     IOT_I2C_STANDARD_MODE_BPS
-#define testIotI2C_INSTANCE               uctestIotI2CInstanceIdx
-#define testIotI2C_INSTANCE_NUM           uctestIotI2CInstanceNum
 #define testIotI2C_DEFAULT_TIMEOUT        500 /**< 500 msec */
 #define testIotI2C_FAST_TIMEOUT           100 /**< 100 msec */
 #define testIotI2C_INVALID_IOCTL_INDEX    UINT32_MAX
@@ -70,16 +68,13 @@ typedef struct CallbackParam
  * framework invoking these tests */
 /*-----------------------------------------------------------*/
 
-uint8_t uctestIotI2CSlaveAddr = 0;           /**< The slave address to be set for the I2C port. */
-uint8_t uctestIotI2CInvalidSlaveAddr = 0xFF; /**< The slave address to be set for the I2C port. */
-uint8_t uctestIotI2CDeviceRegister = 0;      /**< The device register to be set for the I2C port. */
-uint8_t uctestIotI2CWriteVal = 0;            /**< The write value to write to device. */
-uint8_t uctestIotI2CInstanceIdx = 0;         /**< The current I2C test instance index */
-uint8_t uctestIotI2CInstanceNum = 1;         /**< The total I2C test instance number */
-
-uint8_t ucAssistedTestIotI2CSlaveAddr = 0;   /**< The slave address to be set for the assisted test. */
-
-extern IotI2CHandle_t gIotI2cHandle[ testIotI2C_HANDLE_NUM ];
+uint16_t uctestIotI2CSlaveAddr = 0;             /**< The slave address to be set for the I2C port. */
+uint16_t uctestIotI2CInvalidSlaveAddr = 0xFFFF; /**< The slave address to be set for the I2C port. */
+uint8_t uctestIotI2CDeviceRegister = 0;         /**< The device register to be set for the I2C port. */
+uint8_t uctestIotI2CWriteVal = 0;               /**< The write value to write to device. */
+uint8_t uctestIotI2CInstanceIdx = 0;            /**< The current I2C test instance index */
+uint8_t uctestIotI2CInstanceNum = 1;            /**< The total I2C test instance number */
+uint16_t ucAssistedTestIotI2CSlaveAddr = 0;     /**< The slave address to be set for the assisted test. */
 
 /*-----------------------------------------------------------*/
 /* Static Globals */
@@ -107,18 +102,6 @@ TEST_GROUP( TEST_IOT_I2C );
  */
 TEST_SETUP( TEST_IOT_I2C )
 {
-    IotI2CHandle_t xGlobalI2CHandle = gIotI2cHandle[ testIotI2C_INSTANCE ];
-    int32_t lRetVal;
-
-    /* Close global handle it was opened. */
-    if( xGlobalI2CHandle != NULL )
-    {
-        lRetVal = iot_i2c_close( xGlobalI2CHandle );
-        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
-
-        gIotI2cHandle[ testIotI2C_INSTANCE ] = NULL;
-    }
-
     if( xtestIotI2CSemaphore == NULL )
     {
         xtestIotI2CSemaphore = xSemaphoreCreateBinary();
@@ -236,7 +219,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseSuccess )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -251,21 +234,24 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseSuccess )
 TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseFail )
 {
     IotI2CHandle_t xI2CHandle;
-    IotI2CHandle_t xI2CHandle_1;
+    IotI2CHandle_t xI2CHandle_1 = NULL;
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
-    /* Open i2c to initialize hardware again */
-    xI2CHandle_1 = iot_i2c_open( testIotI2C_INSTANCE );
-    TEST_ASSERT_EQUAL( NULL, xI2CHandle_1 );
+    if( TEST_PROTECT() )
+    {
+        /* Open i2c to initialize hardware again */
+        xI2CHandle_1 = iot_i2c_open( uctestIotI2CInstanceIdx );
+        TEST_ASSERT_EQUAL( NULL, xI2CHandle_1 );
+    }
 
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
-    /* Close same i2c again which is NULL */
+    /* Close same i2c again which is not open */
     lRetVal = iot_i2c_close( xI2CHandle );
     TEST_ASSERT_EQUAL( IOT_I2C_INVALID_VALUE, lRetVal );
 
@@ -285,7 +271,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2COpenCloseFailUnsupportInst )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE_NUM );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceNum );
     TEST_ASSERT_EQUAL( NULL, xI2CHandle );
 
     lRetVal = iot_i2c_close( xI2CHandle );
@@ -308,7 +294,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSetGetConfigurationSuccess )
     xI2CConfig_write.ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -357,7 +343,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSetGetConfigurationFail )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -399,7 +385,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadAsyncSuccess )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -469,7 +455,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -536,7 +522,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadChainSuccess )
         .ulMasterTimeout = testIotI2C_DEFAULT_TIMEOUT
     };
 
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -601,7 +587,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailIoctl )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -663,7 +649,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailReadTwice )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -719,7 +705,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailSetAddr )
     uint8_t ucReadValue;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -756,7 +742,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelReadSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -828,7 +814,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelFail )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -850,7 +836,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CCancelUnsupported )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -885,7 +871,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -961,7 +947,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1009,7 +995,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailIoctl )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1059,7 +1045,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteAsyncFailWriteTwice )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1112,7 +1098,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteThenReadSyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1176,7 +1162,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1233,7 +1219,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadSyncFail )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1271,7 +1257,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1338,7 +1324,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncAssisted )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1380,7 +1366,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CWriteSyncFail )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1418,7 +1404,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CGetBusStateSuccess )
     };
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )
@@ -1470,7 +1456,7 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CSendNoStopUnsupported )
     int32_t lRetVal;
 
     /* Open i2c to initialize hardware */
-    xI2CHandle = iot_i2c_open( testIotI2C_INSTANCE );
+    xI2CHandle = iot_i2c_open( uctestIotI2CInstanceIdx );
     TEST_ASSERT_NOT_EQUAL( NULL, xI2CHandle );
 
     if( TEST_PROTECT() )

--- a/libraries/abstractions/pkcs11/CMakeLists.txt
+++ b/libraries/abstractions/pkcs11/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(AFR_ENABLE_UNIT_TESTS)
+    add_subdirectory(utest)
+    return()
+endif()
 afr_module(NAME pkcs11_implementation)
 
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
@@ -92,7 +96,6 @@ else()
             AFR::utils
             3rdparty::mbedtls
     )
-
 endif()
 
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -509,6 +509,15 @@ CK_RV prvMbedTLS_Initialize( void )
         memset( &xP11Context, 0, sizeof( xP11Context ) );
         xP11Context.xObjectList.xMutex = xSemaphoreCreateMutex();
 
+        if( xP11Context.xObjectList.xMutex == NULL )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+    }
+
+    if( xResult == CKR_OK )
+    {
+
         CRYPTO_Init();
         /* Initialize the entropy source and DRBG for the PKCS#11 module */
         mbedtls_entropy_init( &xP11Context.xMbedEntropyContext );

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -128,7 +128,7 @@ typedef int ( * pfnMbedTlsSign )( void * ctx,
  * @brief Indicates that no PKCS #11 operation is underway for given session.
  *
  */
-#define pkcs11NO_OPERATION     ( ( CK_MECHANISM_TYPE ) 0xFFFFFFFFF )
+#define pkcs11NO_OPERATION     ( ( CK_MECHANISM_TYPE ) -1 )
 
 /**
  * @ingroup pkcs11_macros
@@ -755,7 +755,7 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
         CK_RV xResult = CKR_OK;
         CK_BBOOL xFreeMemory = CK_FALSE;
         CK_BYTE_PTR pxObject = NULL;
-        CK_ATTRIBUTE xLabel;
+        CK_ATTRIBUTE xLabel = { 0 };
         CK_OBJECT_HANDLE xPalHandle;
         CK_OBJECT_HANDLE xPalHandle2;
         CK_OBJECT_HANDLE xAppHandle2;
@@ -2192,9 +2192,9 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
                           CK_OBJECT_HANDLE_PTR pxObject )
 {
     mbedtls_pk_context xMbedContext;
-    int lDerKeyLength;
+    int lDerKeyLength = 0;
     CK_BYTE_PTR pxDerKey = NULL;
-    CK_KEY_TYPE xKeyType;
+    CK_KEY_TYPE xKeyType = 0;
     CK_RV xResult = CKR_OK;
     CK_ATTRIBUTE_PTR pxLabel = NULL;
     CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
@@ -2368,7 +2368,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_CreateObject )( CK_SESSION_HANDLE xSession,
                                               CK_OBJECT_HANDLE_PTR pxObject )
 { /*lint !e9072 It's OK to have different parameter name. */
     CK_RV xResult = PKCS11_SESSION_VALID_AND_MODULE_INITIALIZED( xSession );
-    CK_OBJECT_CLASS xClass;
+    CK_OBJECT_CLASS xClass = 0;
 
     if( ( NULL == pxTemplate ) ||
         ( NULL == pxObject ) )

--- a/libraries/abstractions/pkcs11/utest/CMakeLists.txt
+++ b/libraries/abstractions/pkcs11/utest/CMakeLists.txt
@@ -1,0 +1,142 @@
+project ("abstractions pkcs11 cmock unit test")
+cmake_minimum_required (VERSION 3.13)
+set(3rdparty_dir "${AFR_ROOT_DIR}/libraries/3rdparty")
+set(abstractions_dir "${AFR_ROOT_DIR}/libraries/abstractions")
+set(standard_dir "${AFR_ROOT_DIR}/libraries/freertos_plus/standard")
+set(kernel_dir "${AFR_ROOT_DIR}/freertos_kernel")
+set(common_dir "${AFR_ROOT_DIR}/libraries/c_sdk/standard/common")
+
+# Mock library
+list(APPEND mock_list
+    "${abstractions_dir}/pkcs11/include/iot_pkcs11_pal.h"
+    "${kernel_dir}/include/portable.h"
+    "${kernel_dir}/include/queue.h"
+    "${common_dir}/include/iot_logging_task.h"
+    "${standard_dir}/crypto/include/iot_crypto.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/platform_util.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/ctr_drbg.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/sha256.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/base64.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/bignum.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/entropy.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/md.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/rsa.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/ecp.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/ecdsa.h"
+    "${3rdparty_dir}/mbedtls_utils/mbedtls_error.h"
+    "${3rdparty_dir}/mbedtls/include/mbedtls/pk.h"
+    "${standard_dir}/utils/include/iot_pki_utils.h"
+    )
+
+create_mock_list(pkcs11_mbedtls_mock 
+                 "${mock_list}"
+                 "${abstractions_dir}/pkcs11/utest/project.yml"
+                 )
+
+target_compile_definitions(pkcs11_mbedtls_mock PUBLIC
+        portHAS_STACK_OVERFLOW_CHECKING=1
+        portUSING_MPU_WRAPPERS=1
+        MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+        )
+
+target_include_directories(pkcs11_mbedtls_mock PUBLIC
+        "${standard_dir}/crypto/include"
+        "${common_dir}/include"
+        "${3rdparty_dir}/mbedtls/include/mbedtls"
+        "${3rdparty_dir}/mbedtls_utils"
+        "${kernel_dir}/include"
+        "${standard_dir}/utils/include"
+        "${AFR_ROOT_DIR}/tests/unit_test/linux/config_files"
+        "${abstractions_dir}/pkcs11/include"
+        "${standard_dir}/pkcs11/include"
+        )
+
+# PKCS #11 header files must always come before the mbedTLS header files
+target_include_directories(pkcs11_mbedtls_mock BEFORE PUBLIC
+        "${3rdparty_dir}/pkcs11"
+        )
+
+add_dependencies(pkcs11_mbedtls_mock
+                 cmock
+                 unity
+                 )
+
+# Real libraries
+add_library(pkcs11_mbedtls_real STATIC
+        ${3rdparty_dir}/mbedtls/library/pk_wrap.c
+        ${abstractions_dir}/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+        )
+
+target_include_directories(pkcs11_mbedtls_real PUBLIC
+       "${standard_dir}/pkcs11/include"
+       "${standard_dir}/utils/include"
+       "${common_dir}/include/"
+       "${standard_dir}/utils/include"
+       "${abstractions_dir}/pkcs11/include"
+       "${AFR_ROOT_DIR}/tests/unit_test/linux/config_files"
+       "${3rdparty_dir}/mbedtls/include"
+       "${3rdparty_dir}/mbedtls_utils"
+       "${standard_dir}/crypto/include"
+       "${AFR_ROOT_DIR}/tests/include"
+       "${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/include/private"
+       "${kernel_dir}/include"
+       "${CMAKE_CURRENT_BINARY_DIR}/mocks"
+        )
+
+# PKCS #11 header files must always come before the mbedTLS header files
+target_include_directories(pkcs11_mbedtls_real BEFORE PUBLIC
+        "${3rdparty_dir}/pkcs11"
+        )
+
+set_target_properties(pkcs11_mbedtls_real PROPERTIES
+        COMPILE_FLAGS "-Wall \
+                    -fprofile-arcs -ftest-coverage -fprofile-generate \
+                    -include portableDefs.h -Wno-unused-but-set-variable"
+        LINK_FLAGS "-fprofile-arcs -ftest-coverage \
+                    -fprofile-generate"
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+        )
+
+add_dependencies(pkcs11_mbedtls_real pkcs11_mbedtls_mock)
+target_link_libraries(pkcs11_mbedtls_real PUBLIC
+        -lpkcs11_mbedtls_mock
+        -lgcov
+    )
+
+list(APPEND link_list
+        -lpkcs11_mbedtls_mock
+        libunity.a
+        libcmock.a
+        libpkcs11_mbedtls_real.a
+    )
+
+list(APPEND dep_list
+        pkcs11_mbedtls_real
+    )
+
+# Unit test build
+create_test(iot_pkcs11_mbedtls_utest
+        iot_pkcs11_mbedtls_utest.c
+        "${link_list}"
+        "${dep_list}"
+        )
+
+target_include_directories(iot_pkcs11_mbedtls_utest PUBLIC
+        ${standard_dir}/pkcs11/include
+        ${common_dir}/include
+        ${standard_dir}/utils/include
+        ${abstractions_dir}/pkcs11/include
+        ${3rdparty_dir}/mbedtls/include
+        ${3rdparty_dir}/mbedtls/include/mbedtls
+        ${AFR_ROOT_DIR}/tests/include
+        ${standard_dir}/crypto/include
+        ${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/include/private
+        ${3rdparty_dir}/mbedtls_utils
+        ${kernel_dir}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/mocks
+        )
+
+# PKCS #11 header files must always come before the mbedTLS header files
+target_include_directories(iot_pkcs11_mbedtls_utest BEFORE PUBLIC
+        "${3rdparty_dir}/pkcs11"
+        )

--- a/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
+++ b/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
@@ -1,0 +1,282 @@
+/*
+ * FreeRTOS PKCS #11 V2.0.3
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Mock includes. */
+#include "mock_iot_crypto.h"
+#include "mock_queue.h"
+#include "mock_ctr_drbg.h"
+#include "mock_entropy.h"
+
+/* PKCS #11 includes. */
+#include "iot_pkcs11_config.h"
+#include "iot_pkcs11.h"
+
+/* Test includes. */
+#include "unity.h"
+
+
+
+static uint16_t usMallocFreeCalls = 0;
+
+/* ==========================  CALLBACK FUNCTIONS =========================== */
+
+/*!
+ * @brief Wrapper stub for malloc.
+ */
+void * pvPkcs11MallocCb( size_t size,
+                         int numCalls )
+{
+    usMallocFreeCalls++;
+    return ( void * ) malloc( size );
+}
+
+/*!
+ * @brief Wrapper stub for free.
+ *
+ */
+void vPkcs11FreeCb( void * ptr,
+                    int numCalls )
+{
+    usMallocFreeCalls--;
+    free( ptr );
+}
+
+/* ============================   UNITY FIXTURES ============================ */
+void setUp( void )
+{
+}
+
+/* called before each testcase */
+void tearDown( void )
+{
+    TEST_ASSERT_EQUAL_INT_MESSAGE( 0, usMallocFreeCalls,
+                                   "free is not called the same number of times as malloc, \
+        you might have a memory leak!!" );
+    usMallocFreeCalls = 0;
+}
+
+/* called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/* called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ======================  TESTING C_Initialize  ============================ */
+
+/*!
+ * @brief C_Initialize happy path.
+ *
+ */
+void test_pkcs11_C_Initialize( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    /* Hack: Giving out pointer to xResult when creating a mutex. This unit testcase
+     * will never use the actual mutex. */
+    xQueueCreateMutex_IgnoreAndReturn( ( SemaphoreHandle_t ) &xResult );
+    CRYPTO_Init_Ignore();
+    mbedtls_entropy_init_Ignore();
+    mbedtls_ctr_drbg_init_Ignore();
+    mbedtls_ctr_drbg_seed_IgnoreAndReturn( 0 );
+    xResult = C_Initialize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+    mbedtls_entropy_free_CMockIgnore();
+    mbedtls_ctr_drbg_free_CMockIgnore();
+    vQueueDelete_CMockIgnore();
+    xResult = C_Finalize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+}
+
+/*!
+ * @brief C_Initialize memory failure when creating a mutex.
+ *
+ */
+void test_pkcs11_C_InitializeMemFail( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    xQueueCreateMutex_IgnoreAndReturn( NULL );
+    CRYPTO_Init_Ignore();
+    mbedtls_entropy_init_Ignore();
+    mbedtls_ctr_drbg_init_Ignore();
+    mbedtls_ctr_drbg_seed_IgnoreAndReturn( 0 );
+    xResult = C_Initialize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_HOST_MEMORY, xResult );
+}
+
+/*!
+ * @brief C_Initialize failed to seed DRBG.
+ *
+ */
+void test_pkcs11_C_InitializeSeedFail( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    /* Hack: Giving out pointer to xResult when creating a mutex. This unit testcase
+     * will never use the actual mutex. */
+    xQueueCreateMutex_IgnoreAndReturn( ( SemaphoreHandle_t ) &xResult );
+    CRYPTO_Init_Ignore();
+    mbedtls_entropy_init_Ignore();
+    mbedtls_ctr_drbg_init_Ignore();
+    mbedtls_ctr_drbg_seed_IgnoreAndReturn( 1 );
+    xResult = C_Initialize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+}
+
+/*!
+ * @brief C_Initialize already initialized.
+ *
+ */
+void test_pkcs11_C_InitializeInitTwice( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    xQueueCreateMutex_IgnoreAndReturn( ( SemaphoreHandle_t ) &xResult );
+    CRYPTO_Init_Ignore();
+    mbedtls_entropy_init_Ignore();
+    mbedtls_ctr_drbg_init_Ignore();
+    mbedtls_ctr_drbg_seed_IgnoreAndReturn( 0 );
+    xResult = C_Initialize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+    xResult = C_Initialize( NULL );
+    TEST_ASSERT_EQUAL( CKR_CRYPTOKI_ALREADY_INITIALIZED, xResult );
+
+    mbedtls_entropy_free_CMockIgnore();
+    mbedtls_ctr_drbg_free_CMockIgnore();
+    vQueueDelete_CMockIgnore();
+    xResult = C_Finalize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+}
+
+/* ======================  TESTING C_Finalize  ============================ */
+
+/*!
+ * @brief C_Finalize happy path.
+ *
+ */
+void test_pkcs11_C_Finalize( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    xQueueCreateMutex_IgnoreAndReturn( ( SemaphoreHandle_t ) &xResult );
+    CRYPTO_Init_Ignore();
+    mbedtls_entropy_init_Ignore();
+    mbedtls_ctr_drbg_init_Ignore();
+    mbedtls_ctr_drbg_seed_IgnoreAndReturn( 0 );
+    xResult = C_Initialize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+    mbedtls_entropy_free_CMockIgnore();
+    mbedtls_ctr_drbg_free_CMockIgnore();
+    vQueueDelete_CMockIgnore();
+    xResult = C_Finalize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+}
+
+/*!
+ * @brief C_Finalize initialize was not already called.
+ *
+ */
+void test_pkcs11_C_FinalizeUninitialized( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    mbedtls_entropy_free_CMockIgnore();
+    mbedtls_ctr_drbg_free_CMockIgnore();
+    vQueueDelete_CMockIgnore();
+    xResult = C_Finalize( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_CRYPTOKI_NOT_INITIALIZED, xResult );
+}
+
+/*!
+ * @brief C_Finalize was called with a non-null pointer.
+ *
+ */
+void test_pkcs11_C_FinalizeBadArgs( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    mbedtls_entropy_free_CMockIgnore();
+    mbedtls_ctr_drbg_free_CMockIgnore();
+    vQueueDelete_CMockIgnore();
+    xResult = C_Finalize( ( CK_VOID_PTR ) &xResult );
+
+    TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+}
+
+/* ======================  TESTING C_GetFunctionList  ============================ */
+
+/*!
+ * @brief C_GetFunctionList happy path.
+ *
+ */
+void test_pkcs11_C_GetFunctionList( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
+
+    xResult = C_GetFunctionList( &pxFunctionList );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+}
+
+/*!
+ * @brief C_GetFunctionList bad args.
+ *
+ */
+void test_pkcs11_C_GetFunctionListBadArgs( void )
+{
+    CK_RV xResult = CKR_OK;
+
+    xResult = C_GetFunctionList( NULL );
+
+    TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+}
+
+/* ======================  END TESTING ============================ */

--- a/libraries/abstractions/pkcs11/utest/project.yml
+++ b/libraries/abstractions/pkcs11/utest/project.yml
@@ -27,16 +27,25 @@
   :verbosity: 3
   :attributes:
     - PRIVILEGED_FUNCTION
+    - MBEDTLS_DEPRECATED
     - 'int fcntl(int s, int cmd, ...);'
   :strippables:
     - PRIVILEGED_FUNCTION
     - portDONT_DISCARD
+    - MBEDTLS_DEPRECATED
     - '(?:fcntl\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
+    - '(?:vQueueUnregisterQueue\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
+    - '(?:pcQueueGetName\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
+    - '(?:vQueueAddToRegistry\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
   :treat_externs: :include
   :includes_c_pre_header:
     - "portableDefs.h"
   :includes_h_pre_orig_header:
     - "portableDefs.h"
+  :includes_c_pre_header:
+    - "iot_pkcs11.h" # For iot_pkcs11_pal.h
+    - "md_internal.h"
+    - "pk_internal.h"
   :includes:
     - "portableDefs.h"
     - "projdefs.h"

--- a/libraries/abstractions/secure_sockets/utest/CMakeLists.txt
+++ b/libraries/abstractions/secure_sockets/utest/CMakeLists.txt
@@ -15,7 +15,9 @@
                 "${freertos_plus_dir}/standard/tls/include/iot_tls.h"
                 "${3rdparty_dir}/lwip/src/include/lwip/sockets.h"
             )
-    create_mock_list(secure_sockets_mock "${mock_list}"
+    create_mock_list(secure_sockets_mock 
+                "${mock_list}"
+                "${CMAKE_SOURCE_DIR}/tools/cmock/project.yml"
             )
     target_include_directories(secure_sockets_mock PUBLIC
                 "${3rdparty_dir}/lwip/src/include"

--- a/libraries/c_sdk/standard/ble/utest/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/utest/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND mock_list
         )
 create_mock_list(iot_ble_data_transfer_mock
         "${mock_list}"
+        "${CMAKE_SOURCE_DIR}/tools/cmock/project.yml"
         )
 
 target_include_directories(iot_ble_data_transfer_mock PUBLIC

--- a/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
+++ b/libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c
@@ -284,7 +284,6 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
 {
     CK_RV xResult = CKR_OK;
     CK_ULONG ulCount = 0;
-    CK_BBOOL xFindInit = CK_FALSE;
     CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
     CK_ATTRIBUTE xTemplate[ 2 ] = { 0 };
 
@@ -314,7 +313,6 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
 
     if( CKR_OK == xResult )
     {
-        xFindInit = CK_TRUE;
         /* Find the first matching object, if any. */
         xResult = pxFunctionList->C_FindObjects( xSession,
                                                  pxHandle,
@@ -322,12 +320,12 @@ CK_RV xFindObjectWithLabelAndClass( CK_SESSION_HANDLE xSession,
                                                  &ulCount );
     }
 
-    if( CK_TRUE == xFindInit )
+    if( CKR_OK == xResult )
     {
         xResult = pxFunctionList->C_FindObjectsFinal( xSession );
     }
 
-    if( ulCount == 0 )
+    if( ( NULL != pxHandle ) && ( ulCount == 0 ) )
     {
         *pxHandle = CK_INVALID_HANDLE;
     }

--- a/libraries/freertos_plus/standard/pkcs11/utest/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/pkcs11/utest/CMakeLists.txt
@@ -23,7 +23,10 @@ list(APPEND preprocessed_mock_list
     )
 
 
-create_mock_list(pkcs11_mock "${mock_list}")
+create_mock_list(pkcs11_mock 
+    "${mock_list}"
+    "${CMAKE_SOURCE_DIR}/tools/cmock/project.yml"
+    )
 preprocess_mock_list(pkcs11_mock ${preprocessed_mock_list} "${unix_flags}")
 
 

--- a/libraries/freertos_plus/standard/pkcs11/utest/iot_pkcs11_utest.c
+++ b/libraries/freertos_plus/standard/pkcs11/utest/iot_pkcs11_utest.c
@@ -745,6 +745,28 @@ void test_IotPkcs11_xFindObjectWithLabelAndClass( void )
 }
 
 /*!
+ * @brief xFindObjectWithLabelAndClass All calls succeed but no object was found.
+ *
+ */
+void test_IotPkcs11_xFindObjectWithLabelAndClassNoObjectsFound( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xHandle = { 0 };
+    CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
+
+    vCommonStubs();
+    C_FindObjectsInit_IgnoreAndReturn( CKR_OK );
+    C_FindObjects_IgnoreAndReturn( CKR_OK );
+    C_FindObjectsFinal_IgnoreAndReturn( CKR_OK );
+    xResult = xFindObjectWithLabelAndClass( xHandle,
+                                            pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                            CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+    TEST_ASSERT_EQUAL( CK_INVALID_HANDLE, xPrivateKeyHandle );
+}
+
+/*!
  * @brief xFindObjectWithLabelAndClass Bad arguments test path.
  *
  */
@@ -754,7 +776,13 @@ void test_IotPkcs11_xFindObjectWithLabelAndClassNullArgs( void )
     CK_SESSION_HANDLE xHandle = { 0 };
     CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
 
+    /* NULL label name. */
     xResult = xFindObjectWithLabelAndClass( xHandle, NULL, CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+
+    TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+
+    /* NULL object handle. */
+    xResult = xFindObjectWithLabelAndClass( xHandle, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, CKO_PRIVATE_KEY, NULL );
 
     TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
 }

--- a/tests/include/aws_clientcredential_keys.h
+++ b/tests/include/aws_clientcredential_keys.h
@@ -37,7 +37,7 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyCLIENT_CERTIFICATE_PEM                   ""
+#define keyCLIENT_CERTIFICATE_PEM                   NULL
 
 /*
  * @brief PEM-encoded issuer certificate for AWS IoT Just In Time Registration (JITR).
@@ -58,7 +58,7 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    ""
+#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
 
 /*
  * @brief PEM-encoded client private key.
@@ -71,6 +71,6 @@
  * "...base64 data...\n"\
  * "-----END RSA PRIVATE KEY-----\n"
  */
-#define keyCLIENT_PRIVATE_KEY_PEM                   ""
+#define keyCLIENT_PRIVATE_KEY_PEM                   NULL
 
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H */

--- a/tests/unit_test/linux/config_files/config.h
+++ b/tests/unit_test/linux/config_files/config.h
@@ -1,0 +1,3324 @@
+/**
+ * \file config.h
+ *
+ * \brief Configuration options (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively, and reduce the global
+ *  memory footprint.
+ */
+
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+#if defined( _MSC_VER ) && !defined( _CRT_SECURE_NO_DEPRECATE )
+    #define _CRT_SECURE_NO_DEPRECATE    1
+#endif
+
+/**
+ * \name SECTION: System support
+ *
+ * This section sets system specific settings.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_HAVE_ASM
+ *
+ * The compiler has support for asm().
+ *
+ * Requires support for asm() in compiler.
+ *
+ * Used in:
+ *      library/aria.c
+ *      library/timing.c
+ *      include/mbedtls/bn_mul.h
+ *
+ * Required by:
+ *      MBEDTLS_AESNI_C
+ *      MBEDTLS_PADLOCK_C
+ *
+ * Comment to disable the use of assembly code.
+ */
+#define MBEDTLS_HAVE_ASM
+
+/**
+ * \def MBEDTLS_NO_UDBL_DIVISION
+ *
+ * The platform lacks support for double-width integer division (64-bit
+ * division on a 32-bit platform, 128-bit division on a 64-bit platform).
+ *
+ * Used in:
+ *      include/mbedtls/bignum.h
+ *      library/bignum.c
+ *
+ * The bignum code uses double-width division to speed up some operations.
+ * Double-width division is often implemented in software that needs to
+ * be linked with the program. The presence of a double-width integer
+ * type is usually detected automatically through preprocessor macros,
+ * but the automatic detection cannot know whether the code needs to
+ * and can be linked with an implementation of division for that type.
+ * By default division is assumed to be usable if the type is present.
+ * Uncomment this option to prevent the use of double-width division.
+ *
+ * Note that division for the native integer type is always required.
+ * Furthermore, a 64-bit type is always required even on a 32-bit
+ * platform, but it need not support multiplication or division. In some
+ * cases it is also desirable to disable some double-width operations. For
+ * example, if double-width division is implemented in software, disabling
+ * it can reduce code size in some embedded targets.
+ */
+/*#define MBEDTLS_NO_UDBL_DIVISION */
+
+/**
+ * \def MBEDTLS_NO_64BIT_MULTIPLICATION
+ *
+ * The platform lacks support for 32x32 -> 64-bit multiplication.
+ *
+ * Used in:
+ *      library/poly1305.c
+ *
+ * Some parts of the library may use multiplication of two unsigned 32-bit
+ * operands with a 64-bit result in order to speed up computations. On some
+ * platforms, this is not available in hardware and has to be implemented in
+ * software, usually in a library provided by the toolchain.
+ *
+ * Sometimes it is not desirable to have to link to that library. This option
+ * removes the dependency of that library on platforms that lack a hardware
+ * 64-bit multiplier by embedding a software implementation in Mbed TLS.
+ *
+ * Note that depending on the compiler, this may decrease performance compared
+ * to using the library function provided by the toolchain.
+ */
+/*#define MBEDTLS_NO_64BIT_MULTIPLICATION */
+
+/**
+ * \def MBEDTLS_HAVE_SSE2
+ *
+ * CPU supports SSE2 instruction set.
+ *
+ * Uncomment if the CPU supports SSE2 (IA-32 specific).
+ */
+/*#define MBEDTLS_HAVE_SSE2 */
+
+/**
+ * \def MBEDTLS_HAVE_TIME
+ *
+ * System has time.h and time().
+ * The time does not need to be correct, only time differences are used,
+ * by contrast with MBEDTLS_HAVE_TIME_DATE
+ *
+ * Defining MBEDTLS_HAVE_TIME allows you to specify MBEDTLS_PLATFORM_TIME_ALT,
+ * MBEDTLS_PLATFORM_TIME_MACRO, MBEDTLS_PLATFORM_TIME_TYPE_MACRO and
+ * MBEDTLS_PLATFORM_STD_TIME.
+ *
+ * Comment if your system does not support time functions
+ */
+/*#define MBEDTLS_HAVE_TIME */
+
+/**
+ * \def MBEDTLS_HAVE_TIME_DATE
+ *
+ * System has time.h, time(), and an implementation for
+ * mbedtls_platform_gmtime_r() (see below).
+ * The time needs to be correct (not necesarily very accurate, but at least
+ * the date should be correct). This is used to verify the validity period of
+ * X.509 certificates.
+ *
+ * Comment if your system does not have a correct clock.
+ *
+ * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
+ * behaves similarly to the gmtime_r() function from the C standard. Refer to
+ * the documentation for mbedtls_platform_gmtime_r() for more information.
+ *
+ * \note It is possible to configure an implementation for
+ * mbedtls_platform_gmtime_r() at compile-time by using the macro
+ * MBEDTLS_PLATFORM_GMTIME_R_ALT.
+ */
+/*#define MBEDTLS_HAVE_TIME_DATE */
+
+/**
+ * \def MBEDTLS_CHECK_PARAMS_ASSERT
+ *
+ * Allow MBEDTLS_PARAM_FAILED() to call `assert`, and make it default to
+ * `assert`. This macro is only used if #MBEDTLS_CHECK_PARAMS is defined.
+ *
+ * If this macro is not defined, then MBEDTLS_PARAM_FAILED() defaults to
+ * calling a function mbedtls_param_failed(). See the documentation of
+ * #MBEDTLS_CHECK_PARAMS for details.
+ *
+ * Uncomment to allow MBEDTLS_PARAM_FAILED() to call `assert`.
+ */
+/*#define MBEDTLS_CHECK_PARAMS_ASSERT */
+
+/**
+ * \def MBEDTLS_PLATFORM_MEMORY
+ *
+ * Enable the memory allocation layer.
+ *
+ * By default mbed TLS uses the system-provided calloc() and free().
+ * This allows different allocators (self-implemented or provided) to be
+ * provided to the platform abstraction layer.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY without the
+ * MBEDTLS_PLATFORM_{FREE,CALLOC}_MACROs will provide
+ * "mbedtls_platform_set_calloc_free()" allowing you to set an alternative calloc() and
+ * free() function pointer at runtime.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY and specifying
+ * MBEDTLS_PLATFORM_{CALLOC,FREE}_MACROs will allow you to specify the
+ * alternate function at compile time.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Enable this layer to allow use of alternative memory allocators.
+ */
+#define MBEDTLS_PLATFORM_MEMORY
+
+#ifdef CONFIG_MEDTLS_USE_AFR_MEMORY
+    #include <stddef.h>
+
+    extern void * pvCalloc( size_t xNumElements,
+                            size_t xSize );
+    extern void vPortFree( void * pv );
+    #define MBEDTLS_PLATFORM_CALLOC_MACRO    pvCalloc
+    #define MBEDTLS_PLATFORM_FREE_MACRO      vPortFree
+#endif
+
+/**
+ * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+ *
+ * Do not assign standard functions in the platform layer (e.g. calloc() to
+ * MBEDTLS_PLATFORM_STD_CALLOC and printf() to MBEDTLS_PLATFORM_STD_PRINTF)
+ *
+ * This makes sure there are no linking errors on platforms that do not support
+ * these functions. You will HAVE to provide alternatives, either at runtime
+ * via the platform_set_xxx() functions or at compile time by setting
+ * the MBEDTLS_PLATFORM_STD_XXX defines, or enabling a
+ * MBEDTLS_PLATFORM_XXX_MACRO.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Uncomment to prevent default assignment of standard functions in the
+ * platform layer.
+ */
+/*#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
+
+/**
+ * \def MBEDTLS_PLATFORM_EXIT_ALT
+ *
+ * MBEDTLS_PLATFORM_XXX_ALT: Uncomment a macro to let mbed TLS support the
+ * function in the platform abstraction layer.
+ *
+ * Example: In case you uncomment MBEDTLS_PLATFORM_PRINTF_ALT, mbed TLS will
+ * provide a function "mbedtls_platform_set_printf()" that allows you to set an
+ * alternative printf function pointer.
+ *
+ * All these define require MBEDTLS_PLATFORM_C to be defined!
+ *
+ * \note MBEDTLS_PLATFORM_SNPRINTF_ALT is required on Windows;
+ * it will be enabled automatically by check_config.h
+ *
+ * \warning MBEDTLS_PLATFORM_XXX_ALT cannot be defined at the same time as
+ * MBEDTLS_PLATFORM_XXX_MACRO!
+ *
+ * Requires: MBEDTLS_PLATFORM_TIME_ALT requires MBEDTLS_HAVE_TIME
+ *
+ * Uncomment a macro to enable alternate implementation of specific base
+ * platform function
+ */
+/*#define MBEDTLS_PLATFORM_EXIT_ALT */
+/*#define MBEDTLS_PLATFORM_TIME_ALT */
+/*#define MBEDTLS_PLATFORM_FPRINTF_ALT */
+/*#define MBEDTLS_PLATFORM_PRINTF_ALT */
+/*#define MBEDTLS_PLATFORM_SNPRINTF_ALT */
+/*#define MBEDTLS_PLATFORM_NV_SEED_ALT */
+/*#define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
+
+/**
+ * \def MBEDTLS_DEPRECATED_WARNING
+ *
+ * Mark deprecated functions so that they generate a warning if used.
+ * Functions deprecated in one version will usually be removed in the next
+ * version. You can enable this to help you prepare the transition to a new
+ * major version by making sure your code is not using these functions.
+ *
+ * This only works with GCC and Clang. With other compilers, you may want to
+ * use MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Uncomment to get warnings on using deprecated functions.
+ */
+/*#define MBEDTLS_DEPRECATED_WARNING */
+
+/**
+ * \def MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Remove deprecated functions so that they generate an error if used.
+ * Functions deprecated in one version will usually be removed in the next
+ * version. You can enable this to help you prepare the transition to a new
+ * major version by making sure your code is not using these functions.
+ *
+ * Uncomment to get errors on using deprecated functions.
+ */
+#define MBEDTLS_DEPRECATED_REMOVED
+
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration option controls whether the library validates more of
+ * the parameters passed to it.
+ *
+ * When this flag is not defined, the library only attempts to validate an
+ * input parameter if: (1) they may come from the outside world (such as the
+ * network, the filesystem, etc.) or (2) not validating them could result in
+ * internal memory errors such as overflowing a buffer controlled by the
+ * library. On the other hand, it doesn't attempt to validate parameters whose
+ * values are fully controlled by the application (such as pointers).
+ *
+ * When this flag is defined, the library additionally attempts to validate
+ * parameters that are fully controlled by the application, and should always
+ * be valid if the application code is fully correct and trusted.
+ *
+ * For example, when a function accepts as input a pointer to a buffer that may
+ * contain untrusted data, and its documentation mentions that this pointer
+ * must not be NULL:
+ * - the pointer is checked to be non-NULL only if this option is enabled
+ * - the content of the buffer is always validated
+ *
+ * When this flag is defined, if a library function receives a parameter that
+ * is invalid, it will:
+ * - invoke the macro MBEDTLS_PARAM_FAILED() which by default expands to a
+ *   call to the function mbedtls_param_failed()
+ * - immediately return (with a specific error code unless the function
+ *   returns void and can't communicate an error).
+ *
+ * When defining this flag, you also need to:
+ * - either provide a definition of the function mbedtls_param_failed() in
+ *   your application (see platform_util.h for its prototype) as the library
+ *   calls that function, but does not provide a default definition for it,
+ * - or provide a different definition of the macro MBEDTLS_PARAM_FAILED()
+ *   below if the above mechanism is not flexible enough to suit your needs.
+ *   See the documentation of this macro later in this file.
+ *
+ * Uncomment to enable validation of application-controlled parameters.
+ */
+/*#define MBEDTLS_CHECK_PARAMS */
+
+/* \} name SECTION: System support */
+
+/**
+ * \name SECTION: mbed TLS feature support
+ *
+ * This section sets support for features that are or are not needed
+ * within the modules that are enabled.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_TIMING_ALT
+ *
+ * Uncomment to provide your own alternate implementation for mbedtls_timing_hardclock(),
+ * mbedtls_timing_get_timer(), mbedtls_set_alarm(), mbedtls_set/get_delay()
+ *
+ * Only works if you have MBEDTLS_TIMING_C enabled.
+ *
+ * You will need to provide a header "timing_alt.h" and an implementation at
+ * compile time.
+ */
+/*#define MBEDTLS_TIMING_ALT */
+
+/**
+ * \def MBEDTLS_AES_ALT
+ *
+ * MBEDTLS__MODULE_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternate core implementation of a symmetric crypto, an arithmetic or hash
+ * module (e.g. platform specific assembly optimized implementations). Keep
+ * in mind that the function prototypes should remain the same.
+ *
+ * This replaces the whole module. If you only want to replace one of the
+ * functions, use one of the MBEDTLS__FUNCTION_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_AES_ALT, mbed TLS will no longer
+ * provide the "struct mbedtls_aes_context" definition and omit the base
+ * function declarations and implementations. "aes_alt.h" will be included from
+ * "aes.h" to include the new function definitions.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * module.
+ *
+ * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
+ *
+ */
+/*#define MBEDTLS_AES_ALT */
+/*#define MBEDTLS_ARC4_ALT */
+/*#define MBEDTLS_ARIA_ALT */
+/*#define MBEDTLS_BLOWFISH_ALT */
+/*#define MBEDTLS_CAMELLIA_ALT */
+/*#define MBEDTLS_CCM_ALT */
+/*#define MBEDTLS_CHACHA20_ALT */
+/*#define MBEDTLS_CHACHAPOLY_ALT */
+/*#define MBEDTLS_CMAC_ALT */
+/*#define MBEDTLS_DES_ALT */
+/*#define MBEDTLS_DHM_ALT */
+/*#define MBEDTLS_ECJPAKE_ALT */
+/*#define MBEDTLS_GCM_ALT */
+/*#define MBEDTLS_NIST_KW_ALT */
+/*#define MBEDTLS_MD2_ALT */
+/*#define MBEDTLS_MD4_ALT */
+/*#define MBEDTLS_MD5_ALT */
+/*#define MBEDTLS_POLY1305_ALT */
+/*#define MBEDTLS_RIPEMD160_ALT */
+/*#define MBEDTLS_RSA_ALT */
+/*#define MBEDTLS_SHA1_ALT */
+/*#define MBEDTLS_SHA256_ALT */
+/*#define MBEDTLS_SHA512_ALT */
+/*#define MBEDTLS_XTEA_ALT */
+
+/*
+ * When replacing the elliptic curve module, pleace consider, that it is
+ * implemented with two .c files:
+ *      - ecp.c
+ *      - ecp_curves.c
+ * You can replace them very much like all the other MBEDTLS__MODULE_NAME__ALT
+ * macros as described above. The only difference is that you have to make sure
+ * that you provide functionality for both .c files.
+ */
+/*#define MBEDTLS_ECP_ALT */
+
+/**
+ * \def MBEDTLS_MD2_PROCESS_ALT
+ *
+ * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
+ * alternate core implementation of symmetric crypto or hash function. Keep in
+ * mind that function prototypes should remain the same.
+ *
+ * This replaces only one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
+ * no longer provide the mbedtls_sha1_process() function, but it will still provide
+ * the other function (using your mbedtls_sha1_process() function) and the definition
+ * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
+ * with this definition.
+ *
+ * \note Because of a signature change, the core AES encryption and decryption routines are
+ *       currently named mbedtls_aes_internal_encrypt and mbedtls_aes_internal_decrypt,
+ *       respectively. When setting up alternative implementations, these functions should
+ *       be overriden, but the wrapper functions mbedtls_aes_decrypt and mbedtls_aes_encrypt
+ *       must stay untouched.
+ *
+ * \note If you use the AES_xxx_ALT macros, then is is recommended to also set
+ *       MBEDTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
+ *       tables.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ *
+ * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, we recommend avoiding
+ *            dependencies on them, and considering stronger message digests
+ *            and ciphers instead.
+ *
+ */
+/*#define MBEDTLS_MD2_PROCESS_ALT */
+/*#define MBEDTLS_MD4_PROCESS_ALT */
+/*#define MBEDTLS_MD5_PROCESS_ALT */
+/*#define MBEDTLS_RIPEMD160_PROCESS_ALT */
+/*#define MBEDTLS_SHA1_PROCESS_ALT */
+/*#define MBEDTLS_SHA256_PROCESS_ALT */
+/*#define MBEDTLS_SHA512_PROCESS_ALT */
+/*#define MBEDTLS_DES_SETKEY_ALT */
+/*#define MBEDTLS_DES_CRYPT_ECB_ALT */
+/*#define MBEDTLS_DES3_CRYPT_ECB_ALT */
+/*#define MBEDTLS_AES_SETKEY_ENC_ALT */
+/*#define MBEDTLS_AES_SETKEY_DEC_ALT */
+/*#define MBEDTLS_AES_ENCRYPT_ALT */
+/*#define MBEDTLS_AES_DECRYPT_ALT */
+/*#define MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+/*#define MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
+/*#define MBEDTLS_ECDSA_VERIFY_ALT */
+/*#define MBEDTLS_ECDSA_SIGN_ALT */
+/*#define MBEDTLS_ECDSA_GENKEY_ALT */
+
+/**
+ * \def MBEDTLS_ECP_INTERNAL_ALT
+ *
+ * Expose a part of the internal interface of the Elliptic Curve Point module.
+ *
+ * MBEDTLS_ECP__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternative core implementation of elliptic curve arithmetic. Keep in mind
+ * that function prototypes should remain the same.
+ *
+ * This partially replaces one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS_ECP_ALT flag. The original implementation
+ * is still present and it is used for group structures not supported by the
+ * alternative.
+ *
+ * Any of these options become available by defining MBEDTLS_ECP_INTERNAL_ALT
+ * and implementing the following functions:
+ *      unsigned char mbedtls_internal_ecp_grp_capable(
+ *          const mbedtls_ecp_group *grp )
+ *      int  mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp )
+ *      void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp )
+ * The mbedtls_internal_ecp_grp_capable function should return 1 if the
+ * replacement functions implement arithmetic for the given group and 0
+ * otherwise.
+ * The functions mbedtls_internal_ecp_init and mbedtls_internal_ecp_free are
+ * called before and after each point operation and provide an opportunity to
+ * implement optimized set up and tear down instructions.
+ *
+ * Example: In case you uncomment MBEDTLS_ECP_INTERNAL_ALT and
+ * MBEDTLS_ECP_DOUBLE_JAC_ALT, mbed TLS will still provide the ecp_double_jac
+ * function, but will use your mbedtls_internal_ecp_double_jac if the group is
+ * supported (your mbedtls_internal_ecp_grp_capable function returns 1 when
+ * receives it as an argument). If the group is not supported then the original
+ * implementation is used. The other functions and the definition of
+ * mbedtls_ecp_group and mbedtls_ecp_point will not change, so your
+ * implementation of mbedtls_internal_ecp_double_jac and
+ * mbedtls_internal_ecp_grp_capable must be compatible with this definition.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ */
+/* Required for all the functions in this section */
+/*#define MBEDTLS_ECP_INTERNAL_ALT */
+/* Support for Weierstrass curves with Jacobi representation */
+/*#define MBEDTLS_ECP_RANDOMIZE_JAC_ALT */
+/*#define MBEDTLS_ECP_ADD_MIXED_ALT */
+/*#define MBEDTLS_ECP_DOUBLE_JAC_ALT */
+/*#define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT */
+/*#define MBEDTLS_ECP_NORMALIZE_JAC_ALT */
+/* Support for curves with Montgomery arithmetic */
+/*#define MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT */
+/*#define MBEDTLS_ECP_RANDOMIZE_MXZ_ALT */
+/*#define MBEDTLS_ECP_NORMALIZE_MXZ_ALT */
+
+/**
+ * \def MBEDTLS_TEST_NULL_ENTROPY
+ *
+ * Enables testing and use of mbed TLS without any configured entropy sources.
+ * This permits use of the library on platforms before an entropy source has
+ * been integrated (see for example the MBEDTLS_ENTROPY_HARDWARE_ALT or the
+ * MBEDTLS_ENTROPY_NV_SEED switches).
+ *
+ * WARNING! This switch MUST be disabled in production builds, and is suitable
+ * only for development.
+ * Enabling the switch negates any security provided by the library.
+ *
+ * Requires MBEDTLS_ENTROPY_C, MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+ *
+ */
+/*#define MBEDTLS_TEST_NULL_ENTROPY */
+
+/**
+ * \def MBEDTLS_ENTROPY_HARDWARE_ALT
+ *
+ * Uncomment this macro to let mbed TLS use your own implementation of a
+ * hardware entropy collector.
+ *
+ * Your function must be called \c mbedtls_hardware_poll(), have the same
+ * prototype as declared in entropy_poll.h, and accept NULL as first argument.
+ *
+ * Uncomment to use your own hardware entropy collector.
+ */
+/*#define MBEDTLS_ENTROPY_HARDWARE_ALT */
+
+/**
+ * \def MBEDTLS_AES_ROM_TABLES
+ *
+ * Use precomputed AES tables stored in ROM.
+ *
+ * Uncomment this macro to use precomputed AES tables stored in ROM.
+ * Comment this macro to generate AES tables in RAM at runtime.
+ *
+ * Tradeoff: Using precomputed ROM tables reduces RAM usage by ~8kb
+ * (or ~2kb if \c MBEDTLS_AES_FEWER_TABLES is used) and reduces the
+ * initialization time before the first AES operation can be performed.
+ * It comes at the cost of additional ~8kb ROM use (resp. ~2kb if \c
+ * MBEDTLS_AES_FEWER_TABLES below is used), and potentially degraded
+ * performance if ROM access is slower than RAM access.
+ *
+ * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
+ *
+ */
+#define MBEDTLS_AES_ROM_TABLES
+
+/**
+ * \def MBEDTLS_AES_FEWER_TABLES
+ *
+ * Use less ROM/RAM for AES tables.
+ *
+ * Uncommenting this macro omits 75% of the AES tables from
+ * ROM / RAM (depending on the value of \c MBEDTLS_AES_ROM_TABLES)
+ * by computing their values on the fly during operations
+ * (the tables are entry-wise rotations of one another).
+ *
+ * Tradeoff: Uncommenting this reduces the RAM / ROM footprint
+ * by ~6kb but at the cost of more arithmetic operations during
+ * runtime. Specifically, one has to compare 4 accesses within
+ * different tables to 4 accesses with additional arithmetic
+ * operations within the same table. The performance gain/loss
+ * depends on the system and memory details.
+ *
+ * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
+ *
+ */
+/*#define MBEDTLS_AES_FEWER_TABLES */
+
+/**
+ * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
+ *
+ * Use less ROM for the Camellia implementation (saves about 768 bytes).
+ *
+ * Uncomment this macro to use less memory for Camellia.
+ */
+/*#define MBEDTLS_CAMELLIA_SMALL_MEMORY */
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ */
+#define MBEDTLS_CIPHER_MODE_CBC
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ */
+#define MBEDTLS_CIPHER_MODE_CFB
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ */
+#define MBEDTLS_CIPHER_MODE_CTR
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_OFB
+ *
+ * Enable Output Feedback mode (OFB) for symmetric ciphers.
+ */
+/*#define MBEDTLS_CIPHER_MODE_OFB */
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_XTS
+ *
+ * Enable Xor-encrypt-xor with ciphertext stealing mode (XTS) for AES.
+ */
+/*#define MBEDTLS_CIPHER_MODE_XTS */
+
+/**
+ * \def MBEDTLS_CIPHER_NULL_CIPHER
+ *
+ * Enable NULL cipher.
+ * Warning: Only do so when you know what you are doing. This allows for
+ * encryption or channels without any security!
+ *
+ * Requires MBEDTLS_ENABLE_WEAK_CIPHERSUITES as well to enable
+ * the following ciphersuites:
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_MD5
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA
+ *
+ * Uncomment this macro to enable the NULL cipher and ciphersuites
+ */
+/*#define MBEDTLS_CIPHER_NULL_CIPHER */
+
+/** \def MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+ *
+ * Uncomment this macro to use a 128-bit key in the CTR_DRBG module.
+ * By default, CTR_DRBG uses a 256-bit key.
+ */
+/*#define MBEDTLS_CTR_DRBG_USE_128_BIT_KE */
+
+/**
+ * \def MBEDTLS_REMOVE_3DES_CIPHERSUITES
+ *
+ * Remove 3DES ciphersuites by default in SSL / TLS.
+ * This flag removes the ciphersuites based on 3DES from the default list as
+ * returned by mbedtls_ssl_list_ciphersuites(). However, it is still possible
+ * to enable (some of) them with mbedtls_ssl_conf_ciphersuites() by including
+ * them explicitly.
+ *
+ * A man-in-the-browser attacker can recover authentication tokens sent through
+ * a TLS connection using a 3DES based cipher suite (see "On the Practical
+ * (In-)Security of 64-bit Block Ciphers" by Karthikeyan Bhargavan and Gaëtan
+ * Leurent, see https://sweet32.info/SWEET32_CCS16.pdf). If this attack falls
+ * in your threat model or you are unsure, then you should keep this option
+ * enabled to remove 3DES based cipher suites.
+ *
+ * Comment this macro to keep 3DES in the default ciphersuite list.
+ */
+#define MBEDTLS_REMOVE_3DES_CIPHERSUITES
+
+/**
+ * \def MBEDTLS_CIPHER_PADDING_PKCS7
+ *
+ * MBEDTLS_CIPHER_PADDING_XXX: Uncomment or comment macros to add support for
+ * specific padding modes in the cipher layer with cipher modes that support
+ * padding (e.g. CBC)
+ *
+ * If you disable all padding modes, only full blocks can be used with CBC.
+ *
+ * Enable padding modes in the cipher layer.
+ */
+#define MBEDTLS_CIPHER_PADDING_PKCS7
+#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+#define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/**
+ * \def MBEDTLS_ENABLE_WEAK_CIPHERSUITES
+ *
+ * Enable weak ciphersuites in SSL / TLS.
+ * Warning: Only do so when you know what you are doing. This allows for
+ * channels with virtually no security at all!
+ *
+ * This enables the following ciphersuites:
+ *      MBEDTLS_TLS_RSA_WITH_DES_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_DES_CBC_SHA
+ *
+ * Uncomment this macro to enable weak ciphersuites
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ */
+/*#define MBEDTLS_ENABLE_WEAK_CIPHERSUITES */
+
+/**
+ * \def MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+ *
+ * Remove RC4 ciphersuites by default in SSL / TLS.
+ * This flag removes the ciphersuites based on RC4 from the default list as
+ * returned by mbedtls_ssl_list_ciphersuites(). However, it is still possible to
+ * enable (some of) them with mbedtls_ssl_conf_ciphersuites() by including them
+ * explicitly.
+ *
+ * Uncomment this macro to remove RC4 ciphersuites by default.
+ */
+#define MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+
+/**
+ * \def MBEDTLS_ECP_DP_SECP192R1_ENABLED
+ *
+ * MBEDTLS_ECP_XXXX_ENABLED: Enables specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Comment macros to disable the curve and functions for it
+ */
+/*#define MBEDTLS_ECP_DP_SECP192R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_SECP224R1_ENABLED */
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+/*#define MBEDTLS_ECP_DP_SECP384R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_SECP521R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_SECP192K1_ENABLED */
+/*#define MBEDTLS_ECP_DP_SECP224K1_ENABLED */
+/*#define MBEDTLS_ECP_DP_SECP256K1_ENABLED */
+/*#define MBEDTLS_ECP_DP_BP256R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_BP384R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_BP512R1_ENABLED */
+/*#define MBEDTLS_ECP_DP_CURVE25519_ENABLED */
+/*#define MBEDTLS_ECP_DP_CURVE448_ENABLED */
+
+/**
+ * \def MBEDTLS_ECP_NIST_OPTIM
+ *
+ * Enable specific 'modulo p' routines for each NIST prime.
+ * Depending on the prime and architecture, makes operations 4 to 8 times
+ * faster on the corresponding curve.
+ *
+ * Comment this macro to disable NIST curves optimisation.
+ */
+#define MBEDTLS_ECP_NIST_OPTIM
+
+/**
+ * \def MBEDTLS_ECP_RESTARTABLE
+ *
+ * Enable "non-blocking" ECC operations that can return early and be resumed.
+ *
+ * This allows various functions to pause by returning
+ * #MBEDTLS_ERR_ECP_IN_PROGRESS (or, for functions in the SSL module,
+ * #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) and then be called later again in
+ * order to further progress and eventually complete their operation. This is
+ * controlled through mbedtls_ecp_set_max_ops() which limits the maximum
+ * number of ECC operations a function may perform before pausing; see
+ * mbedtls_ecp_set_max_ops() for more information.
+ *
+ * This is useful in non-threaded environments if you want to avoid blocking
+ * for too long on ECC (and, hence, X.509 or SSL/TLS) operations.
+ *
+ * Uncomment this macro to enable restartable ECC computations.
+ *
+ * \note  This option only works with the default software implementation of
+ *        elliptic curve functionality. It is incompatible with
+ *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_XXX_ALT and MBEDTLS_ECDSA_XXX_ALT.
+ */
+/*#define MBEDTLS_ECP_RESTARTABLE */
+
+/**
+ * \def MBEDTLS_ECDSA_DETERMINISTIC
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+ * Standard ECDSA is "fragile" in the sense that lack of entropy when signing
+ * may result in a compromise of the long-term signing key. This is avoided by
+ * the deterministic variant.
+ *
+ * Requires: MBEDTLS_HMAC_DRBG_C
+ *
+ * Comment this macro to disable deterministic ECDSA.
+ */
+/*#define MBEDTLS_ECDSA_DETERMINISTIC */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+ *
+ * Enable the PSK based ciphersuite modes in SSL / TLS.
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+ *
+ * Enable the DHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_RC4_128_SHA
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+ *
+ * Enable the ECDHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+ *
+ * Enable the RSA-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+ *
+ * Enable the RSA-only based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_MD5
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+ *
+ * Enable the DHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+ *
+ * Enable the ECDHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_RC4_128_SHA
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+ *
+ * Enable the ECDHE-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_ECDSA_C, MBEDTLS_X509_CRT_PARSE_C,
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+ *
+ * Enable the ECDH-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+ *
+ * Enable the ECDH-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED */
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ *
+ * Enable the ECJPAKE based ciphersuite modes in SSL / TLS.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Requires: MBEDTLS_ECJPAKE_C
+ *           MBEDTLS_SHA256_C
+ *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+ */
+/*#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
+
+/**
+ * \def MBEDTLS_PK_PARSE_EC_EXTENDED
+ *
+ * Enhance support for reading EC keys using variants of SEC1 not allowed by
+ * RFC 5915 and RFC 5480.
+ *
+ * Currently this means parsing the SpecifiedECDomain choice of EC
+ * parameters (only known groups are supported, not arbitrary domains, to
+ * avoid validation issues).
+ *
+ * Disable if you only need to support RFC 5915 + 5480 key formats.
+ */
+/*#define MBEDTLS_PK_PARSE_EC_EXTENDED */
+
+/**
+ * \def MBEDTLS_ERROR_STRERROR_DUMMY
+ *
+ * Enable a dummy error function to make use of mbedtls_strerror() in
+ * third party libraries easier when MBEDTLS_ERROR_C is disabled
+ * (no effect when MBEDTLS_ERROR_C is enabled).
+ *
+ * You can safely disable this if MBEDTLS_ERROR_C is enabled, or if you're
+ * not using mbedtls_strerror() or error_strerror() in your application.
+ *
+ * Disable if you run into name conflicts and want to really remove the
+ * mbedtls_strerror()
+ */
+/*#define MBEDTLS_ERROR_STRERROR_DUMMY */
+
+/**
+ * \def MBEDTLS_GENPRIME
+ *
+ * Enable the prime-number generation code.
+ *
+ * Requires: MBEDTLS_BIGNUM_C
+ */
+#define MBEDTLS_GENPRIME
+
+/**
+ * \def MBEDTLS_FS_IO
+ *
+ * Enable functions that use the filesystem.
+ */
+/*#define MBEDTLS_FS_IO */
+
+/**
+ * \def MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+ *
+ * Do not add default entropy sources. These are the platform specific,
+ * mbedtls_timing_hardclock and HAVEGE based poll functions.
+ *
+ * This is useful to have more control over the added entropy sources in an
+ * application.
+ *
+ * Uncomment this macro to prevent loading of default entropy functions.
+ */
+/*#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES */
+
+/**
+ * \def MBEDTLS_NO_PLATFORM_ENTROPY
+ *
+ * Do not use built-in platform entropy functions.
+ * This is useful if your platform does not support
+ * standards like the /dev/urandom or Windows CryptoAPI.
+ *
+ * Uncomment this macro to disable the built-in platform entropy functions.
+ */
+/*#define MBEDTLS_NO_PLATFORM_ENTROPY */
+
+/**
+ * \def MBEDTLS_ENTROPY_FORCE_SHA256
+ *
+ * Force the entropy accumulator to use a SHA-256 accumulator instead of the
+ * default SHA-512 based one (if both are available).
+ *
+ * Requires: MBEDTLS_SHA256_C
+ *
+ * On 32-bit systems SHA-256 can be much faster than SHA-512. Use this option
+ * if you have performance concerns.
+ *
+ * This option is only useful if both MBEDTLS_SHA256_C and
+ * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
+ */
+#define MBEDTLS_ENTROPY_FORCE_SHA256
+
+/**
+ * \def MBEDTLS_ENTROPY_NV_SEED
+ *
+ * Enable the non-volatile (NV) seed file-based entropy source.
+ * (Also enables the NV seed read/write functions in the platform layer)
+ *
+ * This is crucial (if not required) on systems that do not have a
+ * cryptographic entropy source (in hardware or kernel) available.
+ *
+ * Requires: MBEDTLS_ENTROPY_C, MBEDTLS_PLATFORM_C
+ *
+ * \note The read/write functions that are used by the entropy source are
+ *       determined in the platform layer, and can be modified at runtime and/or
+ *       compile-time depending on the flags (MBEDTLS_PLATFORM_NV_SEED_*) used.
+ *
+ * \note If you use the default implementation functions that read a seedfile
+ *       with regular fopen(), please make sure you make a seedfile with the
+ *       proper name (defined in MBEDTLS_PLATFORM_STD_NV_SEED_FILE) and at
+ *       least MBEDTLS_ENTROPY_BLOCK_SIZE bytes in size that can be read from
+ *       and written to or you will get an entropy source error! The default
+ *       implementation will only use the first MBEDTLS_ENTROPY_BLOCK_SIZE
+ *       bytes from the file.
+ *
+ * \note The entropy collector will write to the seed file before entropy is
+ *       given to an external source, to update it.
+ */
+/*#define MBEDTLS_ENTROPY_NV_SEED */
+
+/**
+ * \def MBEDTLS_MEMORY_DEBUG
+ *
+ * Enable debugging of buffer allocator memory issues. Automatically prints
+ * (to stderr) all (fatal) messages on memory allocation issues. Enables
+ * function for 'debug output' of allocated memory.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Uncomment this macro to let the buffer allocator print out error messages.
+ */
+/*#define MBEDTLS_MEMORY_DEBUG */
+
+/**
+ * \def MBEDTLS_MEMORY_BACKTRACE
+ *
+ * Include backtrace information with each allocated block.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *           GLIBC-compatible backtrace() an backtrace_symbols() support
+ *
+ * Uncomment this macro to include backtrace information
+ */
+/*#define MBEDTLS_MEMORY_BACKTRACE */
+
+/**
+ * \def MBEDTLS_PK_RSA_ALT_SUPPORT
+ *
+ * Support external private RSA keys (eg from a HSM) in the PK layer.
+ *
+ * Comment this macro to disable support for external private RSA keys.
+ */
+#define MBEDTLS_PK_RSA_ALT_SUPPORT
+
+/**
+ * \def MBEDTLS_PKCS1_V15
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ *
+ * Requires: MBEDTLS_RSA_C
+ *
+ * This enables support for PKCS#1 v1.5 operations.
+ */
+#define MBEDTLS_PKCS1_V15
+
+/**
+ * \def MBEDTLS_PKCS1_V21
+ *
+ * Enable support for PKCS#1 v2.1 encoding.
+ *
+ * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C
+ *
+ * This enables support for RSAES-OAEP and RSASSA-PSS operations.
+ */
+/*#define MBEDTLS_PKCS1_V21 */
+
+/**
+ * \def MBEDTLS_RSA_NO_CRT
+ *
+ * Do not use the Chinese Remainder Theorem
+ * for the RSA private operation.
+ *
+ * Uncomment this macro to disable the use of CRT in RSA.
+ *
+ */
+/*#define MBEDTLS_RSA_NO_CRT */
+
+/**
+ * \def MBEDTLS_SELF_TEST
+ *
+ * Enable the checkup functions (*_self_test).
+ */
+#define MBEDTLS_SELF_TEST
+
+/**
+ * \def MBEDTLS_SHA256_SMALLER
+ *
+ * Enable an implementation of SHA-256 that has lower ROM footprint but also
+ * lower performance.
+ *
+ * The default implementation is meant to be a reasonnable compromise between
+ * performance and size. This version optimizes more aggressively for size at
+ * the expense of performance. Eg on Cortex-M4 it reduces the size of
+ * mbedtls_sha256_process() from ~2KB to ~0.5KB for a performance hit of about
+ * 30%.
+ *
+ * Uncomment to enable the smaller implementation of SHA256.
+ */
+/*#define MBEDTLS_SHA256_SMALLER */
+
+/**
+ * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
+ *
+ * Enable sending of alert messages in case of encountered errors as per RFC.
+ * If you choose not to send the alert messages, mbed TLS can still communicate
+ * with other servers, only debugging of failures is harder.
+ *
+ * The advantage of not sending alert messages, is that no information is given
+ * about reasons for failures thus preventing adversaries of gaining intel.
+ *
+ * Enable sending of all alert messages
+ */
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/**
+ * \def MBEDTLS_SSL_ASYNC_PRIVATE
+ *
+ * Enable asynchronous external private key operations in SSL. This allows
+ * you to configure an SSL connection to call an external cryptographic
+ * module to perform private key operations instead of performing the
+ * operation inside the library.
+ *
+ */
+/*#define MBEDTLS_SSL_ASYNC_PRIVATE */
+
+/**
+ * \def MBEDTLS_SSL_DEBUG_ALL
+ *
+ * Enable the debug messages in SSL module for all issues.
+ * Debug messages have been disabled in some places to prevent timing
+ * attacks due to (unbalanced) debugging function calls.
+ *
+ * If you need all error reporting you should enable this during debugging,
+ * but remove this for production servers that should log as well.
+ *
+ * Uncomment this macro to report all debug messages on errors introducing
+ * a timing side-channel.
+ *
+ */
+/*#define MBEDTLS_SSL_DEBUG_ALL */
+
+/** \def MBEDTLS_SSL_ENCRYPT_THEN_MAC
+ *
+ * Enable support for Encrypt-then-MAC, RFC 7366.
+ *
+ * This allows peers that both support it to use a more robust protection for
+ * ciphersuites using CBC, providing deep resistance against timing attacks
+ * on the padding or underlying cipher.
+ *
+ * This only affects CBC ciphersuites, and is useless if none is defined.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1    or
+ *           MBEDTLS_SSL_PROTO_TLS1_1  or
+ *           MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Encrypt-then-MAC
+ */
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+
+/** \def MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+ *
+ * Enable support for Extended Master Secret, aka Session Hash
+ * (draft-ietf-tls-session-hash-02).
+ *
+ * This was introduced as "the proper fix" to the Triple Handshake familiy of
+ * attacks, but it is recommended to always use it (even if you disable
+ * renegotiation), since it actually fixes a more fundamental issue in the
+ * original SSL/TLS design, and has implications beyond Triple Handshake.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1    or
+ *           MBEDTLS_SSL_PROTO_TLS1_1  or
+ *           MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Extended Master Secret.
+ */
+#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+
+/**
+ * \def MBEDTLS_SSL_FALLBACK_SCSV
+ *
+ * Enable support for FALLBACK_SCSV (draft-ietf-tls-downgrade-scsv-00).
+ *
+ * For servers, it is recommended to always enable this, unless you support
+ * only one version of TLS, or know for sure that none of your clients
+ * implements a fallback strategy.
+ *
+ * For clients, you only need this if you're using a fallback strategy, which
+ * is not recommended in the first place, unless you absolutely need it to
+ * interoperate with buggy (version-intolerant) servers.
+ *
+ * Comment this macro to disable support for FALLBACK_SCSV
+ */
+/*#define MBEDTLS_SSL_FALLBACK_SCSV */
+
+/**
+ * \def MBEDTLS_SSL_HW_RECORD_ACCEL
+ *
+ * Enable hooking functions in SSL module for hardware acceleration of
+ * individual records.
+ *
+ * Uncomment this macro to enable hooking functions.
+ */
+/*#define MBEDTLS_SSL_HW_RECORD_ACCEL */
+
+/**
+ * \def MBEDTLS_SSL_CBC_RECORD_SPLITTING
+ *
+ * Enable 1/n-1 record splitting for CBC mode in SSLv3 and TLS 1.0.
+ *
+ * This is a countermeasure to the BEAST attack, which also minimizes the risk
+ * of interoperability issues compared to sending 0-length records.
+ *
+ * Comment this macro to disable 1/n-1 record splitting.
+ */
+/*#define MBEDTLS_SSL_CBC_RECORD_SPLITTING */
+
+/**
+ * \def MBEDTLS_SSL_RENEGOTIATION
+ *
+ * Enable support for TLS renegotiation.
+ *
+ * The two main uses of renegotiation are (1) refresh keys on long-lived
+ * connections and (2) client authentication after the initial handshake.
+ * If you don't need renegotiation, it's probably better to disable it, since
+ * it has been associated with security issues in the past and is easy to
+ * misuse/misunderstand.
+ *
+ * Comment this to disable support for renegotiation.
+ *
+ * \note   Even if this option is disabled, both client and server are aware
+ *         of the Renegotiation Indication Extension (RFC 5746) used to
+ *         prevent the SSL renegotiation attack (see RFC 5746 Sect. 1).
+ *         (See \c mbedtls_ssl_conf_legacy_renegotiation for the
+ *          configuration of this extension).
+ *
+ */
+/*#define MBEDTLS_SSL_RENEGOTIATION */
+
+/**
+ * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
+ *
+ * Enable support for receiving and parsing SSLv2 Client Hello messages for the
+ * SSL Server module (MBEDTLS_SSL_SRV_C).
+ *
+ * Uncomment this macro to enable support for SSLv2 Client Hello messages.
+ */
+/*#define MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO */
+
+/**
+ * \def MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
+ *
+ * Pick the ciphersuite according to the client's preferences rather than ours
+ * in the SSL Server module (MBEDTLS_SSL_SRV_C).
+ *
+ * Uncomment this macro to respect client's ciphersuite order
+ */
+/*#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE */
+
+/**
+ * \def MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+ *
+ * Enable support for RFC 6066 max_fragment_length extension in SSL.
+ *
+ * Comment this macro to disable support for the max_fragment_length extension
+ */
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+
+/**
+ * \def MBEDTLS_SSL_PROTO_SSL3
+ *
+ * Enable support for SSL 3.0.
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for SSL 3.0
+ */
+/*#define MBEDTLS_SSL_PROTO_SSL3 */
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1
+ *
+ * Enable support for TLS 1.0.
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for TLS 1.0
+ */
+/*#define MBEDTLS_SSL_PROTO_TLS1 */
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_1
+ *
+ * Enable support for TLS 1.1 (and DTLS 1.0 if DTLS is enabled).
+ *
+ * Requires: MBEDTLS_MD5_C
+ *           MBEDTLS_SHA1_C
+ *
+ * Comment this macro to disable support for TLS 1.1 / DTLS 1.0
+ */
+/*#define MBEDTLS_SSL_PROTO_TLS1_1 */
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Enable support for TLS 1.2 (and DTLS 1.2 if DTLS is enabled).
+ *
+ * Requires: MBEDTLS_SHA1_C or MBEDTLS_SHA256_C or MBEDTLS_SHA512_C
+ *           (Depends on ciphersuites)
+ *
+ * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
+ */
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/**
+ * \def MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Enable support for DTLS (all available versions).
+ *
+ * Enable this and MBEDTLS_SSL_PROTO_TLS1_1 to enable DTLS 1.0,
+ * and/or this and MBEDTLS_SSL_PROTO_TLS1_2 to enable DTLS 1.2.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1_1
+ *        or MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for DTLS
+ */
+/*#define MBEDTLS_SSL_PROTO_DTLS */
+
+/**
+ * \def MBEDTLS_SSL_ALPN
+ *
+ * Enable support for RFC 7301 Application Layer Protocol Negotiation.
+ *
+ * Comment this macro to disable support for ALPN.
+ */
+#define MBEDTLS_SSL_ALPN
+
+/**
+ * \def MBEDTLS_SSL_DTLS_ANTI_REPLAY
+ *
+ * Enable support for the anti-replay mechanism in DTLS.
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *           MBEDTLS_SSL_PROTO_DTLS
+ *
+ * \warning Disabling this is often a security risk!
+ * See mbedtls_ssl_conf_dtls_anti_replay() for details.
+ *
+ * Comment this to disable anti-replay in DTLS.
+ */
+/*#define MBEDTLS_SSL_DTLS_ANTI_REPLAY */
+
+/**
+ * \def MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Enable support for HelloVerifyRequest on DTLS servers.
+ *
+ * This feature is highly recommended to prevent DTLS servers being used as
+ * amplifiers in DoS attacks against other hosts. It should always be enabled
+ * unless you know for sure amplification cannot be a problem in the
+ * environment in which your server operates.
+ *
+ * \warning Disabling this can ba a security risk! (see above)
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Comment this to disable support for HelloVerifyRequest.
+ */
+/*#define MBEDTLS_SSL_DTLS_HELLO_VERIFY */
+
+/**
+ * \def MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+ *
+ * Enable server-side support for clients that reconnect from the same port.
+ *
+ * Some clients unexpectedly close the connection and try to reconnect using the
+ * same source port. This needs special support from the server to handle the
+ * new connection securely, as described in section 4.2.8 of RFC 6347. This
+ * flag enables that support.
+ *
+ * Requires: MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Comment this to disable support for clients reusing the source port.
+ */
+/*#define MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE */
+
+/**
+ * \def MBEDTLS_SSL_DTLS_BADMAC_LIMIT
+ *
+ * Enable support for a limit of records with bad MAC.
+ *
+ * See mbedtls_ssl_conf_dtls_badmac_limit().
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ */
+/*#define MBEDTLS_SSL_DTLS_BADMAC_LIMIT */
+
+/**
+ * \def MBEDTLS_SSL_SESSION_TICKETS
+ *
+ * Enable support for RFC 5077 session tickets in SSL.
+ * Client-side, provides full support for session tickets (maintainance of a
+ * session store remains the responsibility of the application, though).
+ * Server-side, you also need to provide callbacks for writing and parsing
+ * tickets, including authenticated encryption and key management. Example
+ * callbacks are provided by MBEDTLS_SSL_TICKET_C.
+ *
+ * Comment this macro to disable support for SSL session tickets
+ */
+/*#define MBEDTLS_SSL_SESSION_TICKETS */
+
+/**
+ * \def MBEDTLS_SSL_EXPORT_KEYS
+ *
+ * Enable support for exporting key block and master secret.
+ * This is required for certain users of TLS, e.g. EAP-TLS.
+ *
+ * Comment this macro to disable support for key export
+ */
+/*#define MBEDTLS_SSL_EXPORT_KEYS */
+
+/**
+ * \def MBEDTLS_SSL_SERVER_NAME_INDICATION
+ *
+ * Enable support for RFC 6066 server name indication (SNI) in SSL.
+ *
+ * Requires: MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Comment this macro to disable support for server name indication in SSL
+ */
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/**
+ * \def MBEDTLS_SSL_TRUNCATED_HMAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+/*#define MBEDTLS_SSL_TRUNCATED_HMAC */
+
+/**
+ * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
+ *
+ * Fallback to old (pre-2.7), non-conforming implementation of the truncated
+ * HMAC extension which also truncates the HMAC key. Note that this option is
+ * only meant for a transitory upgrade period and is likely to be removed in
+ * a future version of the library.
+ *
+ * \warning The old implementation is non-compliant and has a security weakness
+ *          (2^80 brute force attack on the HMAC key used for a single,
+ *          uninterrupted connection). This should only be enabled temporarily
+ *          when (1) the use of truncated HMAC is essential in order to save
+ *          bandwidth, and (2) the peer is an Mbed TLS stack that doesn't use
+ *          the fixed implementation yet (pre-2.7).
+ *
+ * \deprecated This option is deprecated and will likely be removed in a
+ *             future version of Mbed TLS.
+ *
+ * Uncomment to fallback to old, non-compliant truncated HMAC implementation.
+ *
+ * Requires: MBEDTLS_SSL_TRUNCATED_HMAC
+ */
+/*#define MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT */
+
+/**
+ * \def MBEDTLS_THREADING_ALT
+ *
+ * Provide your own alternate threading implementation.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to allow your own alternate threading implementation.
+ */
+#define MBEDTLS_THREADING_ALT
+
+/**
+ * \def MBEDTLS_THREADING_PTHREAD
+ *
+ * Enable the pthread wrapper layer for the threading layer.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to enable pthread mutexes.
+ */
+/*#define MBEDTLS_THREADING_PTHREAD */
+
+/**
+ * \def MBEDTLS_VERSION_FEATURES
+ *
+ * Allow run-time checking of compile-time enabled features. Thus allowing users
+ * to check at run-time if the library is for instance compiled with threading
+ * support via mbedtls_version_check_feature().
+ *
+ * Requires: MBEDTLS_VERSION_C
+ *
+ * Comment this to disable run-time checking and save ROM space
+ */
+#define MBEDTLS_VERSION_FEATURES
+
+/**
+ * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
+ *
+ * If set, the X509 parser will not break-off when parsing an X509 certificate
+ * and encountering an extension in a v1 or v2 certificate.
+ *
+ * Uncomment to prevent an error.
+ */
+/*#define MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3 */
+
+/**
+ * \def MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+ *
+ * If set, the X509 parser will not break-off when parsing an X509 certificate
+ * and encountering an unknown critical extension.
+ *
+ * \warning Depending on your PKI use, enabling this can be a security risk!
+ *
+ * Uncomment to prevent an error.
+ */
+/*#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION */
+
+/**
+ * \def MBEDTLS_X509_CHECK_KEY_USAGE
+ *
+ * Enable verification of the keyUsage extension (CA and leaf certificates).
+ *
+ * Disabling this avoids problems with mis-issued and/or misused
+ * (intermediate) CA and leaf certificates.
+ *
+ * \warning Depending on your PKI use, disabling this can be a security risk!
+ *
+ * Comment to skip keyUsage checking for both CA and leaf certificates.
+ */
+#define MBEDTLS_X509_CHECK_KEY_USAGE
+
+/**
+ * \def MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+ *
+ * Enable verification of the extendedKeyUsage extension (leaf certificates).
+ *
+ * Disabling this avoids problems with mis-issued and/or misused certificates.
+ *
+ * \warning Depending on your PKI use, disabling this can be a security risk!
+ *
+ * Comment to skip extendedKeyUsage checking for certificates.
+ */
+#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+
+/**
+ * \def MBEDTLS_X509_RSASSA_PSS_SUPPORT
+ *
+ * Enable parsing and verification of X.509 certificates, CRLs and CSRS
+ * signed with RSASSA-PSS (aka PKCS#1 v2.1).
+ *
+ * Comment this macro to disallow using RSASSA-PSS in certificates.
+ */
+/*#define MBEDTLS_X509_RSASSA_PSS_SUPPORT */
+
+/**
+ * \def MBEDTLS_ZLIB_SUPPORT
+ *
+ * If set, the SSL/TLS module uses ZLIB to support compression and
+ * decompression of packet data.
+ *
+ * \warning TLS-level compression MAY REDUCE SECURITY! See for example the
+ * CRIME attack. Before enabling this option, you should examine with care if
+ * CRIME or similar exploits may be a applicable to your use case.
+ *
+ * \note Currently compression can't be used with DTLS.
+ *
+ * \deprecated This feature is deprecated and will be removed
+ *             in the next major revision of the library.
+ *
+ * Used in: library/ssl_tls.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This feature requires zlib library and headers to be present.
+ *
+ * Uncomment to enable use of ZLIB
+ */
+/*#define MBEDTLS_ZLIB_SUPPORT */
+/* \} name SECTION: mbed TLS feature support */
+
+/**
+ * \name SECTION: mbed TLS modules
+ *
+ * This section enables or disables entire modules in mbed TLS
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_AESNI_C
+ *
+ * Enable AES-NI support on x86-64.
+ *
+ * Module:  library/aesni.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the AES-NI instructions on x86-64
+ */
+/*#define MBEDTLS_AESNI_C */
+
+/**
+ * \def MBEDTLS_AES_C
+ *
+ * Enable the AES block cipher.
+ *
+ * Module:  library/aes.c
+ * Caller:  library/cipher.c
+ *          library/pem.c
+ *          library/ctr_drbg.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *
+ * PEM_PARSE uses AES for decrypting encrypted keys.
+ */
+#define MBEDTLS_AES_C
+
+/**
+ * \def MBEDTLS_ARC4_C
+ *
+ * Enable the ARCFOUR stream cipher.
+ *
+ * Module:  library/arc4.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_RSA_WITH_RC4_128_MD5
+ *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
+ *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+ *
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. If possible, we recommend avoidng dependencies on
+ *            it, and considering stronger ciphers instead.
+ *
+ */
+/*#define MBEDTLS_ARC4_C */
+
+/**
+ * \def MBEDTLS_ASN1_PARSE_C
+ *
+ * Enable the generic ASN1 parser.
+ *
+ * Module:  library/asn1.c
+ * Caller:  library/x509.c
+ *          library/dhm.c
+ *          library/pkcs12.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ */
+#define MBEDTLS_ASN1_PARSE_C
+
+/**
+ * \def MBEDTLS_ASN1_WRITE_C
+ *
+ * Enable the generic ASN1 writer.
+ *
+ * Module:  library/asn1write.c
+ * Caller:  library/ecdsa.c
+ *          library/pkwrite.c
+ *          library/x509_create.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ */
+#define MBEDTLS_ASN1_WRITE_C
+
+/**
+ * \def MBEDTLS_BASE64_C
+ *
+ * Enable the Base64 module.
+ *
+ * Module:  library/base64.c
+ * Caller:  library/pem.c
+ *
+ * This module is required for PEM support (required by X.509).
+ */
+#define MBEDTLS_BASE64_C
+
+/**
+ * \def MBEDTLS_BIGNUM_C
+ *
+ * Enable the multi-precision integer library.
+ *
+ * Module:  library/bignum.c
+ * Caller:  library/dhm.c
+ *          library/ecp.c
+ *          library/ecdsa.c
+ *          library/rsa.c
+ *          library/rsa_internal.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for RSA, DHM and ECC (ECDH, ECDSA) support.
+ */
+#define MBEDTLS_BIGNUM_C
+
+/**
+ * \def MBEDTLS_BLOWFISH_C
+ *
+ * Enable the Blowfish block cipher.
+ *
+ * Module:  library/blowfish.c
+ */
+/*#define MBEDTLS_BLOWFISH_C */
+
+/**
+ * \def MBEDTLS_CAMELLIA_C
+ *
+ * Enable the Camellia block cipher.
+ *
+ * Module:  library/camellia.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+/*#define MBEDTLS_CAMELLIA_C */
+
+/**
+ * \def MBEDTLS_ARIA_C
+ *
+ * Enable the ARIA block cipher.
+ *
+ * Module:  library/aria.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384
+ */
+/*#define MBEDTLS_ARIA_C */
+
+/**
+ * \def MBEDTLS_CCM_C
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Module:  library/ccm.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C
+ *
+ * This module enables the AES-CCM ciphersuites, if other requisites are
+ * enabled as well.
+ */
+/*#define MBEDTLS_CCM_C */
+
+/**
+ * \def MBEDTLS_CERTS_C
+ *
+ * Enable the test certificates.
+ *
+ * Module:  library/certs.c
+ * Caller:
+ *
+ * This module is used for testing (ssl_client/server).
+ */
+/*#define MBEDTLS_CERTS_C */
+
+/**
+ * \def MBEDTLS_CHACHA20_C
+ *
+ * Enable the ChaCha20 stream cipher.
+ *
+ * Module:  library/chacha20.c
+ */
+/*#define MBEDTLS_CHACHA20_C */
+
+/**
+ * \def MBEDTLS_CHACHAPOLY_C
+ *
+ * Enable the ChaCha20-Poly1305 AEAD algorithm.
+ *
+ * Module:  library/chachapoly.c
+ *
+ * This module requires: MBEDTLS_CHACHA20_C, MBEDTLS_POLY1305_C
+ */
+/*#define MBEDTLS_CHACHAPOLY_C */
+
+/**
+ * \def MBEDTLS_CIPHER_C
+ *
+ * Enable the generic cipher layer.
+ *
+ * Module:  library/cipher.c
+ * Caller:  library/ssl_tls.c
+ *
+ * Uncomment to enable generic cipher wrappers.
+ */
+#define MBEDTLS_CIPHER_C
+
+/**
+ * \def MBEDTLS_CMAC_C
+ *
+ * Enable the CMAC (Cipher-based Message Authentication Code) mode for block
+ * ciphers.
+ *
+ * Module:  library/cmac.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
+ *
+ */
+/*#define MBEDTLS_CMAC_C */
+
+/**
+ * \def MBEDTLS_CTR_DRBG_C
+ *
+ * Enable the CTR_DRBG AES-based random generator.
+ * The CTR_DRBG generator uses AES-256 by default.
+ * To use AES-128 instead, enable MBEDTLS_CTR_DRBG_USE_128_BIT_KEY below.
+ *
+ * Module:  library/ctr_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_AES_C
+ *
+ * This module provides the CTR_DRBG AES random number generator.
+ */
+#define MBEDTLS_CTR_DRBG_C
+
+/**
+ * \def MBEDTLS_DEBUG_C
+ *
+ * Enable the debug functions.
+ *
+ * Module:  library/debug.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * This module provides debugging functions.
+ */
+/*#define MBEDTLS_DEBUG_C */
+
+/**
+ * \def MBEDTLS_DES_C
+ *
+ * Enable the DES block cipher.
+ *
+ * Module:  library/des.c
+ * Caller:  library/pem.c
+ *          library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_3DES_EDE_CBC_SHA
+ *
+ * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ */
+/*#define MBEDTLS_DES_C */
+
+/**
+ * \def MBEDTLS_DHM_C
+ *
+ * Enable the Diffie-Hellman-Merkle module.
+ *
+ * Module:  library/dhm.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module is used by the following key exchanges:
+ *      DHE-RSA, DHE-PSK
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+/*#define MBEDTLS_DHM_C */
+
+/**
+ * \def MBEDTLS_ECDH_C
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Module:  library/ecdh.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA, ECDHE-RSA, DHE-PSK
+ *
+ * Requires: MBEDTLS_ECP_C
+ */
+#define MBEDTLS_ECDH_C
+
+/**
+ * \def MBEDTLS_ECDSA_C
+ *
+ * Enable the elliptic curve DSA library.
+ *
+ * Module:  library/ecdsa.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA
+ *
+ * Requires: MBEDTLS_ECP_C, MBEDTLS_ASN1_WRITE_C, MBEDTLS_ASN1_PARSE_C
+ */
+#define MBEDTLS_ECDSA_C
+
+/**
+ * \def MBEDTLS_ECJPAKE_C
+ *
+ * Enable the elliptic curve J-PAKE library.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Module:  library/ecjpake.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECJPAKE
+ *
+ * Requires: MBEDTLS_ECP_C, MBEDTLS_MD_C
+ */
+/*#define MBEDTLS_ECJPAKE_C */
+
+/**
+ * \def MBEDTLS_ECP_C
+ *
+ * Enable the elliptic curve over GF(p) library.
+ *
+ * Module:  library/ecp.c
+ * Caller:  library/ecdh.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C and at least one MBEDTLS_ECP_DP_XXX_ENABLED
+ */
+#define MBEDTLS_ECP_C
+
+/**
+ * \def MBEDTLS_ENTROPY_C
+ *
+ * Enable the platform-specific entropy code.
+ *
+ * Module:  library/entropy.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SHA512_C or MBEDTLS_SHA256_C
+ *
+ * This module provides a generic entropy pool
+ */
+#define MBEDTLS_ENTROPY_C
+
+/**
+ * \def MBEDTLS_ERROR_C
+ *
+ * Enable error code to error string conversion.
+ *
+ * Module:  library/error.c
+ * Caller:
+ *
+ * This module enables mbedtls_strerror().
+ */
+/*#define MBEDTLS_ERROR_C */
+
+/**
+ * \def MBEDTLS_GCM_C
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Module:  library/gcm.c
+ *
+ * Requires: MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C
+ *
+ * This module enables the AES-GCM and CAMELLIA-GCM ciphersuites, if other
+ * requisites are enabled as well.
+ */
+#define MBEDTLS_GCM_C
+
+/**
+ * \def MBEDTLS_HAVEGE_C
+ *
+ * Enable the HAVEGE random generator.
+ *
+ * Warning: the HAVEGE random generator is not suitable for virtualized
+ *          environments
+ *
+ * Warning: the HAVEGE random generator is dependent on timing and specific
+ *          processor traits. It is therefore not advised to use HAVEGE as
+ *          your applications primary random generator or primary entropy pool
+ *          input. As a secondary input to your entropy pool, it IS able add
+ *          the (limited) extra entropy it provides.
+ *
+ * Module:  library/havege.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_TIMING_C
+ *
+ * Uncomment to enable the HAVEGE random generator.
+ */
+/*#define MBEDTLS_HAVEGE_C */
+
+/**
+ * \def MBEDTLS_HKDF_C
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Module:  library/hkdf.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the Hashed Message Authentication Code
+ * (HMAC)-based key derivation function (HKDF).
+ */
+/*#define MBEDTLS_HKDF_C */
+
+/**
+ * \def MBEDTLS_HMAC_DRBG_C
+ *
+ * Enable the HMAC_DRBG random generator.
+ *
+ * Module:  library/hmac_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * Uncomment to enable the HMAC_DRBG random number geerator.
+ */
+/*#define MBEDTLS_HMAC_DRBG_C */
+
+/**
+ * \def MBEDTLS_NIST_KW_C
+ *
+ * Enable the Key Wrapping mode for 128-bit block ciphers,
+ * as defined in NIST SP 800-38F. Only KW and KWP modes
+ * are supported. At the moment, only AES is approved by NIST.
+ *
+ * Module:  library/nist_kw.c
+ *
+ * Requires: MBEDTLS_AES_C and MBEDTLS_CIPHER_C
+ */
+/*#define MBEDTLS_NIST_KW_C */
+
+/**
+ * \def MBEDTLS_MD_C
+ *
+ * Enable the generic message digest layer.
+ *
+ * Module:  library/md.c
+ * Caller:
+ *
+ * Uncomment to enable generic message digest wrappers.
+ */
+#define MBEDTLS_MD_C
+
+/**
+ * \def MBEDTLS_MD2_C
+ *
+ * Enable the MD2 hash algorithm.
+ *
+ * Module:  library/md2.c
+ * Caller:
+ *
+ * Uncomment to enable support for (rare) MD2-signed X.509 certs.
+ *
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+/*#define MBEDTLS_MD2_C */
+
+/**
+ * \def MBEDTLS_MD4_C
+ *
+ * Enable the MD4 hash algorithm.
+ *
+ * Module:  library/md4.c
+ * Caller:
+ *
+ * Uncomment to enable support for (rare) MD4-signed X.509 certs.
+ *
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+/*#define MBEDTLS_MD4_C */
+
+/**
+ * \def MBEDTLS_MD5_C
+ *
+ * Enable the MD5 hash algorithm.
+ *
+ * Module:  library/md5.c
+ * Caller:  library/md.c
+ *          library/pem.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
+ * depending on the handshake parameters. Further, it is used for checking
+ * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * encrypted keys.
+ *
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+/*#define MBEDTLS_MD5_C */
+
+/**
+ * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Enable the buffer allocator implementation that makes use of a (stack)
+ * based buffer to 'allocate' dynamic memory. (replaces calloc() and free()
+ * calls)
+ *
+ * Module:  library/memory_buffer_alloc.c
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *           MBEDTLS_PLATFORM_MEMORY (to use it within mbed TLS)
+ *
+ * Enable this module to enable the buffer memory allocator.
+ */
+/*#define MBEDTLS_MEMORY_BUFFER_ALLOC_C */
+
+/**
+ * \def MBEDTLS_NET_C
+ *
+ * Enable the TCP and UDP over IPv6/IPv4 networking routines.
+ *
+ * \note This module only works on POSIX/Unix (including Linux, BSD and OS X)
+ * and Windows. For other platforms, you'll want to disable it, and write your
+ * own networking callbacks to be passed to \c mbedtls_ssl_set_bio().
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://tls.mbed.org/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/net_sockets.c
+ *
+ * This module provides networking routines.
+ */
+/*#define MBEDTLS_NET_C */
+
+/**
+ * \def MBEDTLS_OID_C
+ *
+ * Enable the OID database.
+ *
+ * Module:  library/oid.c
+ * Caller:  library/asn1write.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ *          library/pkwrite.c
+ *          library/rsa.c
+ *          library/x509.c
+ *          library/x509_create.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * This modules translates between OIDs and internal values.
+ */
+#define MBEDTLS_OID_C
+
+/**
+ * \def MBEDTLS_PADLOCK_C
+ *
+ * Enable VIA Padlock support on x86.
+ *
+ * Module:  library/padlock.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the VIA PadLock on x86.
+ */
+/*#define MBEDTLS_PADLOCK_C */
+
+/**
+ * \def MBEDTLS_PEM_PARSE_C
+ *
+ * Enable PEM decoding / parsing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/dhm.c
+ *          library/pkparse.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for decoding / parsing PEM files.
+ */
+#define MBEDTLS_PEM_PARSE_C
+
+/**
+ * \def MBEDTLS_PEM_WRITE_C
+ *
+ * Enable PEM encoding / writing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/pkwrite.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for encoding / writing PEM files.
+ */
+/*#define MBEDTLS_PEM_WRITE_C */
+
+/**
+ * \def MBEDTLS_PK_C
+ *
+ * Enable the generic public (asymetric) key layer.
+ *
+ * Module:  library/pk.c
+ * Caller:  library/ssl_tls.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * Requires: MBEDTLS_RSA_C or MBEDTLS_ECP_C
+ *
+ * Uncomment to enable generic public key wrappers.
+ */
+#define MBEDTLS_PK_C
+
+/**
+ * \def MBEDTLS_PK_PARSE_C
+ *
+ * Enable the generic public (asymetric) key parser.
+ *
+ * Module:  library/pkparse.c
+ * Caller:  library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key parse functions.
+ */
+#define MBEDTLS_PK_PARSE_C
+
+/**
+ * \def MBEDTLS_PK_WRITE_C
+ *
+ * Enable the generic public (asymetric) key writer.
+ *
+ * Module:  library/pkwrite.c
+ * Caller:  library/x509write.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key write functions.
+ */
+#define MBEDTLS_PK_WRITE_C
+
+/**
+ * \def MBEDTLS_PKCS5_C
+ *
+ * Enable PKCS#5 functions.
+ *
+ * Module:  library/pkcs5.c
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the PKCS#5 functions.
+ */
+/*#define MBEDTLS_PKCS5_C */
+
+/**
+ * \def MBEDTLS_PKCS11_C
+ *
+ * Enable wrapper for PKCS#11 smartcard support.
+ *
+ * Module:  library/pkcs11.c
+ * Caller:  library/pk.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * This module enables SSL/TLS PKCS #11 smartcard support.
+ * Requires the presence of the PKCS#11 helper library (libpkcs11-helper)
+ */
+/*#define MBEDTLS_PKCS11_C */
+
+/**
+ * \def MBEDTLS_PKCS12_C
+ *
+ * Enable PKCS#12 PBE functions.
+ * Adds algorithms for parsing PKCS#8 encrypted private keys
+ *
+ * Module:  library/pkcs12.c
+ * Caller:  library/pkparse.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ * Can use:  MBEDTLS_ARC4_C
+ *
+ * This module enables PKCS#12 functions.
+ */
+/*#define MBEDTLS_PKCS12_C */
+
+/**
+ * \def MBEDTLS_PLATFORM_C
+ *
+ * Enable the platform abstraction layer that allows you to re-assign
+ * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
+ *
+ * Enabling MBEDTLS_PLATFORM_C enables to use of MBEDTLS_PLATFORM_XXX_ALT
+ * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
+ * above to be specified at runtime or compile time respectively.
+ *
+ * \note This abstraction layer must be enabled on Windows (including MSYS2)
+ * as other module rely on it for a fixed snprintf implementation.
+ *
+ * Module:  library/platform.c
+ * Caller:  Most other .c files
+ *
+ * This module enables abstraction of common (libc) functions.
+ */
+/*#define MBEDTLS_PLATFORM_C */
+
+/**
+ * \def MBEDTLS_POLY1305_C
+ *
+ * Enable the Poly1305 MAC algorithm.
+ *
+ * Module:  library/poly1305.c
+ * Caller:  library/chachapoly.c
+ */
+/*#define MBEDTLS_POLY1305_C */
+
+/**
+ * \def MBEDTLS_RIPEMD160_C
+ *
+ * Enable the RIPEMD-160 hash algorithm.
+ *
+ * Module:  library/ripemd160.c
+ * Caller:  library/md.c
+ *
+ */
+/*#define MBEDTLS_RIPEMD160_C */
+
+/**
+ * \def MBEDTLS_RSA_C
+ *
+ * Enable the RSA public-key cryptosystem.
+ *
+ * Module:  library/rsa.c
+ *          library/rsa_internal.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *          library/x509.c
+ *
+ * This module is used by the following key exchanges:
+ *      RSA, DHE-RSA, ECDHE-RSA, RSA-PSK
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C
+ */
+#define MBEDTLS_RSA_C
+
+/**
+ * \def MBEDTLS_SHA1_C
+ *
+ * Enable the SHA1 cryptographic hash algorithm.
+ *
+ * Module:  library/sha1.c
+ * Caller:  library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *          library/x509write_crt.c
+ *
+ * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
+ * depending on the handshake parameters, and for SHA1-signed certificates.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+#define MBEDTLS_SHA1_C
+
+/**
+ * \def MBEDTLS_SHA256_C
+ *
+ * Enable the SHA-224 and SHA-256 cryptographic hash algorithms.
+ *
+ * Module:  library/sha256.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * This module adds support for SHA-224 and SHA-256.
+ * This module is required for the SSL/TLS 1.2 PRF function.
+ */
+#define MBEDTLS_SHA256_C
+
+/**
+ * \def MBEDTLS_SHA512_C
+ *
+ * Enable the SHA-384 and SHA-512 cryptographic hash algorithms.
+ *
+ * Module:  library/sha512.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * This module adds support for SHA-384 and SHA-512.
+ */
+/*#define MBEDTLS_SHA512_C */
+
+/**
+ * \def MBEDTLS_SSL_CACHE_C
+ *
+ * Enable simple SSL cache implementation.
+ *
+ * Module:  library/ssl_cache.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_CACHE_C
+ */
+/*#define MBEDTLS_SSL_CACHE_C */
+
+/**
+ * \def MBEDTLS_SSL_COOKIE_C
+ *
+ * Enable basic implementation of DTLS cookies for hello verification.
+ *
+ * Module:  library/ssl_cookie.c
+ * Caller:
+ */
+/*#define MBEDTLS_SSL_COOKIE_C */
+
+/**
+ * \def MBEDTLS_SSL_TICKET_C
+ *
+ * Enable an implementation of TLS server-side callbacks for session tickets.
+ *
+ * Module:  library/ssl_ticket.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_CIPHER_C
+ */
+/*#define MBEDTLS_SSL_TICKET_C */
+
+/**
+ * \def MBEDTLS_SSL_CLI_C
+ *
+ * Enable the SSL/TLS client code.
+ *
+ * Module:  library/ssl_cli.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS client support.
+ */
+#define MBEDTLS_SSL_CLI_C
+
+/**
+ * \def MBEDTLS_SSL_SRV_C
+ *
+ * Enable the SSL/TLS server code.
+ *
+ * Module:  library/ssl_srv.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS server support.
+ */
+/*#define MBEDTLS_SSL_SRV_C */
+
+/**
+ * \def MBEDTLS_SSL_TLS_C
+ *
+ * Enable the generic SSL/TLS code.
+ *
+ * Module:  library/ssl_tls.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ *           and at least one of the MBEDTLS_SSL_PROTO_XXX defines
+ *
+ * This module is required for SSL/TLS.
+ */
+#define MBEDTLS_SSL_TLS_C
+
+/**
+ * \def MBEDTLS_THREADING_C
+ *
+ * Enable the threading abstraction layer.
+ * By default mbed TLS assumes it is used in a non-threaded environment or that
+ * contexts are not shared between threads. If you do intend to use contexts
+ * between threads, you will need to enable this layer to prevent race
+ * conditions. See also our Knowledge Base article about threading:
+ * https://tls.mbed.org/kb/development/thread-safety-and-multi-threading
+ *
+ * Module:  library/threading.c
+ *
+ * This allows different threading implementations (self-implemented or
+ * provided).
+ *
+ * You will have to enable either MBEDTLS_THREADING_ALT or
+ * MBEDTLS_THREADING_PTHREAD.
+ *
+ * Enable this layer to allow use of mutexes within mbed TLS
+ */
+#define MBEDTLS_THREADING_C
+
+/**
+ * \def MBEDTLS_TIMING_C
+ *
+ * Enable the semi-portable timing interface.
+ *
+ * \note The provided implementation only works on POSIX/Unix (including Linux,
+ * BSD and OS X) and Windows. On other platforms, you can either disable that
+ * module and provide your own implementations of the callbacks needed by
+ * \c mbedtls_ssl_set_timer_cb() for DTLS, or leave it enabled and provide
+ * your own implementation of the whole module by setting
+ * \c MBEDTLS_TIMING_ALT in the current file.
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://tls.mbed.org/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/timing.c
+ * Caller:  library/havege.c
+ *
+ * This module is used by the HAVEGE random number generator.
+ */
+/*#define MBEDTLS_TIMING_C */
+
+/**
+ * \def MBEDTLS_VERSION_C
+ *
+ * Enable run-time version information.
+ *
+ * Module:  library/version.c
+ *
+ * This module provides run-time version information.
+ */
+#define MBEDTLS_VERSION_C
+
+/**
+ * \def MBEDTLS_X509_USE_C
+ *
+ * Enable X.509 core for using certificates.
+ *
+ * Module:  library/x509.c
+ * Caller:  library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C,
+ *           MBEDTLS_PK_PARSE_C
+ *
+ * This module is required for the X.509 parsing modules.
+ */
+#define MBEDTLS_X509_USE_C
+
+/**
+ * \def MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Enable X.509 certificate parsing.
+ *
+ * Module:  library/x509_crt.c
+ * Caller:  library/ssl_cli.c
+ *          library/ssl_srv.c
+ *          library/ssl_tls.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 certificate parsing.
+ */
+#define MBEDTLS_X509_CRT_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CRL_PARSE_C
+ *
+ * Enable X.509 CRL parsing.
+ *
+ * Module:  library/x509_crl.c
+ * Caller:  library/x509_crt.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 CRL parsing.
+ */
+/*#define MBEDTLS_X509_CRL_PARSE_C */
+
+/**
+ * \def MBEDTLS_X509_CSR_PARSE_C
+ *
+ * Enable X.509 Certificate Signing Request (CSR) parsing.
+ *
+ * Module:  library/x509_csr.c
+ * Caller:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is used for reading X.509 certificate request.
+ */
+/*#define MBEDTLS_X509_CSR_PARSE_C */
+
+/**
+ * \def MBEDTLS_X509_CREATE_C
+ *
+ * Enable X.509 core for creating certificates.
+ *
+ * Module:  library/x509_create.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_WRITE_C
+ *
+ * This module is the basis for creating X.509 certificates and CSRs.
+ */
+/*#define MBEDTLS_X509_CREATE_C */
+
+/**
+ * \def MBEDTLS_X509_CRT_WRITE_C
+ *
+ * Enable creating X.509 certificates.
+ *
+ * Module:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate creation.
+ */
+/*#define MBEDTLS_X509_CRT_WRITE_C */
+
+/**
+ * \def MBEDTLS_X509_CSR_WRITE_C
+ *
+ * Enable creating X.509 Certificate Signing Requests (CSR).
+ *
+ * Module:  library/x509_csr_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate request writing.
+ */
+/*#define MBEDTLS_X509_CSR_WRITE_C */
+
+/**
+ * \def MBEDTLS_XTEA_C
+ *
+ * Enable the XTEA block cipher.
+ *
+ * Module:  library/xtea.c
+ * Caller:
+ */
+/*#define MBEDTLS_XTEA_C */
+
+/* \} name SECTION: mbed TLS modules */
+
+/**
+ * \name SECTION: Module configuration options
+ *
+ * This section allows for the setting of module specific sizes and
+ * configuration options. The default values are already present in the
+ * relevant header files and should suffice for the regular use cases.
+ *
+ * Our advice is to enable options and change their values here
+ * only if you have a good reason and know the consequences.
+ *
+ * Please check the respective header file for documentation on these
+ * parameters (to prevent duplicate documentation).
+ * \{
+ */
+
+/* MPI / BIGNUM options */
+/*#define MBEDTLS_MPI_WINDOW_SIZE            6 / **< Maximum windows size used. * / */
+/*#define MBEDTLS_MPI_MAX_SIZE            1024 / **< Maximum number of bytes for usable MPIs. * / */
+
+/* CTR_DRBG options */
+/*#define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48 / **< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) * / */
+/*#define MBEDTLS_CTR_DRBG_RESEED_INTERVAL        10000 / **< Interval before reseed is performed by default * / */
+/*#define MBEDTLS_CTR_DRBG_MAX_INPUT                256 / **< Maximum number of additional input bytes * / */
+/*#define MBEDTLS_CTR_DRBG_MAX_REQUEST             1024 / **< Maximum number of requested bytes per call * / */
+/*#define MBEDTLS_CTR_DRBG_MAX_SEED_INPUT           384 / **< Maximum size of (re)seed buffer * / */
+
+/* HMAC_DRBG options */
+/*#define MBEDTLS_HMAC_DRBG_RESEED_INTERVAL   10000 / **< Interval before reseed is performed by default * / */
+/*#define MBEDTLS_HMAC_DRBG_MAX_INPUT           256 / **< Maximum number of additional input bytes * / */
+/*#define MBEDTLS_HMAC_DRBG_MAX_REQUEST        1024 / **< Maximum number of requested bytes per call * / */
+/*#define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384 / **< Maximum size of (re)seed buffer * / */
+
+/* ECP options */
+/*#define MBEDTLS_ECP_MAX_BITS             521 / **< Maximum bit size of groups * / */
+/*#define MBEDTLS_ECP_WINDOW_SIZE            6 / **< Maximum window size used * / */
+/*#define MBEDTLS_ECP_FIXED_POINT_OPTIM      1 / **< Enable fixed-point speed-up * / */
+
+/* Entropy options */
+/*#define MBEDTLS_ENTROPY_MAX_SOURCES                20 / **< Maximum number of sources supported * / */
+/*#define MBEDTLS_ENTROPY_MAX_GATHER                128 / **< Maximum amount requested from entropy sources * / */
+/*#define MBEDTLS_ENTROPY_MIN_HARDWARE               32 / **< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released * / */
+
+/* Memory buffer allocator options */
+/*#define MBEDTLS_MEMORY_ALIGN_MULTIPLE      4 / **< Align on multiples of this value * / */
+
+/* Platform options */
+/*#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> / **< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. * / */
+/*#define MBEDTLS_PLATFORM_STD_CALLOC        calloc / **< Default allocator to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_FREE            free / **< Default free to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_EXIT            exit / **< Default exit to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_TIME            time / **< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled * / */
+/*#define MBEDTLS_PLATFORM_STD_FPRINTF      fprintf / **< Default fprintf to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_PRINTF        printf / **< Default printf to use, can be undefined * / */
+/* Note: your snprintf must correclty zero-terminate the buffer! */
+/*#define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf / **< Default snprintf to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0 / **< Default exit value to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1 / **< Default exit value to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read / **< Default nv_seed_read function to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write / **< Default nv_seed_write function to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" / **< Seed file to read/write with default implementation * / */
+
+/* To Use Function Macros MBEDTLS_PLATFORM_C must be enabled */
+/* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
+/*#define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc / **< Default allocator macro to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_FREE_MACRO            free / **< Default free macro to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_EXIT_MACRO            exit / **< Default exit macro to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_TIME_MACRO            time / **< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled * / */
+/*#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t / **< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled * / */
+/*#define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf / **< Default fprintf macro to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_PRINTF_MACRO        printf / **< Default printf macro to use, can be undefined * / */
+/* Note: your snprintf must correclty zero-terminate the buffer! */
+/*#define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf / **< Default snprintf macro to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read / **< Default nv_seed_read function to use, can be undefined * / */
+/*#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write / **< Default nv_seed_write function to use, can be undefined * / */
+
+/**
+ * \brief       This macro is invoked by the library when an invalid parameter
+ *              is detected that is only checked with MBEDTLS_CHECK_PARAMS
+ *              (see the documentation of that option for context).
+ *
+ *              When you leave this undefined here, a default definition is
+ *              provided that invokes the function mbedtls_param_failed(),
+ *              which is declared in platform_util.h for the benefit of the
+ *              library, but that you need to define in your application.
+ *
+ *              When you define this here, this replaces the default
+ *              definition in platform_util.h (which no longer declares the
+ *              function mbedtls_param_failed()) and it is your responsibility
+ *              to make sure this macro expands to something suitable (in
+ *              particular, that all the necessary declarations are visible
+ *              from within the library - you can ensure that by providing
+ *              them in this file next to the macro definition).
+ *
+ *              Note that you may define this macro to expand to nothing, in
+ *              which case you don't have to worry about declarations or
+ *              definitions. However, you will then be notified about invalid
+ *              parameters only in non-void functions, and void function will
+ *              just silently return early on invalid parameters, which
+ *              partially negates the benefits of enabling
+ *              #MBEDTLS_CHECK_PARAMS in the first place, so is discouraged.
+ *
+ * \param cond  The expression that should evaluate to true, but doesn't.
+ */
+/*#define MBEDTLS_PARAM_FAILED( cond )               assert( cond ) */
+
+/* SSL Cache options */
+/*#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 / **< 1 day  * / */
+/*#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 / **< Maximum entries in cache * / */
+
+/* SSL options */
+
+/** \def MBEDTLS_SSL_MAX_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of incoming and outgoing plaintext fragments.
+ *
+ * This determines the size of both the incoming and outgoing TLS I/O buffers
+ * in such a way that both are capable of holding the specified amount of
+ * plaintext data, regardless of the protection mechanism used.
+ *
+ * To configure incoming and outgoing I/O buffers separately, use
+ * #MBEDTLS_SSL_IN_CONTENT_LEN and #MBEDTLS_SSL_OUT_CONTENT_LEN,
+ * which overwrite the value set by this option.
+ *
+ * \note When using a value less than the default of 16KB on the client, it is
+ *       recommended to use the Maximum Fragment Length (MFL) extension to
+ *       inform the server about this limitation. On the server, there
+ *       is no supported, standardized way of informing the client about
+ *       restriction on the maximum size of incoming messages, and unless
+ *       the limitation has been communicated by other means, it is recommended
+ *       to only change the outgoing buffer size #MBEDTLS_SSL_OUT_CONTENT_LEN
+ *       while keeping the default value of 16KB for the incoming buffer.
+ *
+ * Uncomment to set the maximum plaintext size of both
+ * incoming and outgoing I/O buffers.
+ */
+#define MBEDTLS_SSL_MAX_CONTENT_LEN    8192
+
+/** \def MBEDTLS_SSL_IN_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of incoming plaintext fragments.
+ *
+ * This determines the size of the incoming TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * If this option is undefined, it inherits its value from
+ * #MBEDTLS_SSL_MAX_CONTENT_LEN.
+ *
+ * \note When using a value less than the default of 16KB on the client, it is
+ *       recommended to use the Maximum Fragment Length (MFL) extension to
+ *       inform the server about this limitation. On the server, there
+ *       is no supported, standardized way of informing the client about
+ *       restriction on the maximum size of incoming messages, and unless
+ *       the limitation has been communicated by other means, it is recommended
+ *       to only change the outgoing buffer size #MBEDTLS_SSL_OUT_CONTENT_LEN
+ *       while keeping the default value of 16KB for the incoming buffer.
+ *
+ * Uncomment to set the maximum plaintext size of the incoming I/O buffer
+ * independently of the outgoing I/O buffer.
+ */
+/*#define MBEDTLS_SSL_IN_CONTENT_LEN              16384 */
+
+/** \def MBEDTLS_SSL_OUT_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of outgoing plaintext fragments.
+ *
+ * This determines the size of the outgoing TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * If this option undefined, it inherits its value from
+ * #MBEDTLS_SSL_MAX_CONTENT_LEN.
+ *
+ * It is possible to save RAM by setting a smaller outward buffer, while keeping
+ * the default inward 16384 byte buffer to conform to the TLS specification.
+ *
+ * The minimum required outward buffer size is determined by the handshake
+ * protocol's usage. Handshaking will fail if the outward buffer is too small.
+ * The specific size requirement depends on the configured ciphers and any
+ * certificate data which is sent during the handshake.
+ *
+ * Uncomment to set the maximum plaintext size of the outgoing I/O buffer
+ * independently of the incoming I/O buffer.
+ */
+/*#define MBEDTLS_SSL_OUT_CONTENT_LEN             16384 */
+
+/** \def MBEDTLS_SSL_DTLS_MAX_BUFFERING
+ *
+ * Maximum number of heap-allocated bytes for the purpose of
+ * DTLS handshake message reassembly and future message buffering.
+ *
+ * This should be at least 9/8 * MBEDTLSSL_IN_CONTENT_LEN
+ * to account for a reassembled handshake message of maximum size,
+ * together with its reassembly bitmap.
+ *
+ * A value of 2 * MBEDTLS_SSL_IN_CONTENT_LEN (32768 by default)
+ * should be sufficient for all practical situations as it allows
+ * to reassembly a large handshake message (such as a certificate)
+ * while buffering multiple smaller handshake messages.
+ *
+ */
+/*#define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768 */
+
+/*#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 / **< Lifetime of session tickets (if enabled) * / */
+/*#define MBEDTLS_PSK_MAX_LEN               32 / **< Max size of TLS pre-shared keys, in bytes (default 256 bits) * / */
+/*#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 / **< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued * / */
+
+/**
+ * Complete list of ciphersuites to use, in order of preference.
+ *
+ * \warning No dependency checking is done on that field! This option can only
+ * be used to restrict the set of available ciphersuites. It is your
+ * responsibility to make sure the needed modules are active.
+ *
+ * Use this to save a few hundred bytes of ROM (default ordering of all
+ * available ciphersuites) and a few to a few hundred bytes of RAM.
+ *
+ * The value below is only an example, not the default.
+ */
+/*#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 */
+
+/* X509 options */
+/*#define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8   / **< Maximum number of intermediate CAs in a verification chain. * / */
+/*#define MBEDTLS_X509_MAX_FILE_PATH_LEN     512 / **< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). * / */
+
+/**
+ * Allow SHA-1 in the default TLS configuration for certificate signing.
+ * Without this build-time option, SHA-1 support must be activated explicitly
+ * through mbedtls_ssl_conf_cert_profile. Turning on this option is not
+ * recommended because of it is possible to generate SHA-1 collisions, however
+ * this may be safe for legacy infrastructure where additional controls apply.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+/*#define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES */
+
+/**
+ * Allow SHA-1 in the default TLS configuration for TLS 1.2 handshake
+ * signature and ciphersuite selection. Without this build-time option, SHA-1
+ * support must be activated explicitly through mbedtls_ssl_conf_sig_hashes.
+ * The use of SHA-1 in TLS <= 1.1 and in HMAC-SHA-1 is always allowed by
+ * default. At the time of writing, there is no practical attack on the use
+ * of SHA-1 in handshake signatures, hence this option is turned on by default
+ * to preserve compatibility with existing peers, but the general
+ * warning applies nonetheless:
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+/*#define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE */
+
+/**
+ * Uncomment the macro to let mbed TLS use your alternate implementation of
+ * mbedtls_platform_zeroize(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * mbedtls_platform_zeroize() is a widely used function across the library to
+ * zero a block of memory. The implementation is expected to be secure in the
+ * sense that it has been written to prevent the compiler from removing calls
+ * to mbedtls_platform_zeroize() as part of redundant code elimination
+ * optimizations. However, it is difficult to guarantee that calls to
+ * mbedtls_platform_zeroize() will not be optimized by the compiler as older
+ * versions of the C language standards do not provide a secure implementation
+ * of memset(). Therefore, MBEDTLS_PLATFORM_ZEROIZE_ALT enables users to
+ * configure their own implementation of mbedtls_platform_zeroize(), for
+ * example by using directives specific to their compiler, features from newer
+ * C standards (e.g using memset_s() in C11) or calling a secure memset() from
+ * their system (e.g explicit_bzero() in BSD).
+ */
+/*#define MBEDTLS_PLATFORM_ZEROIZE_ALT */
+
+/**
+ * Uncomment the macro to let Mbed TLS use your alternate implementation of
+ * mbedtls_platform_gmtime_r(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * gmtime() is not a thread-safe function as defined in the C standard. The
+ * library will try to use safer implementations of this function, such as
+ * gmtime_r() when available. However, if Mbed TLS cannot identify the target
+ * system, the implementation of mbedtls_platform_gmtime_r() will default to
+ * using the standard gmtime(). In this case, calls from the library to
+ * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
+ * if MBEDTLS_THREADING_C is enabled. We recommend that calls from outside the
+ * library are also guarded with this mutex to avoid race conditions. However,
+ * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
+ * unconditionally use the implementation for mbedtls_platform_gmtime_r()
+ * supplied at compile time.
+ */
+/*#define MBEDTLS_PLATFORM_GMTIME_R_ALT */
+
+/* \} name SECTION: Customisation configuration options */
+
+/* Target and application specific configurations
+ *
+ * Allow user to override any previous default.
+ */
+#if defined( MBEDTLS_USER_CONFIG_FILE )
+    #include MBEDTLS_USER_CONFIG_FILE
+#endif
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -23,7 +23,8 @@
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
     "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
-    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
+    "MAX_REQ_SIZE={MAX_REQ_SIZE}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -22,7 +22,8 @@
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
-    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ],
   "OPT" : "-m32"
 }

--- a/tools/cbmc/proofs/ReadNameField/Makefile.json
+++ b/tools/cbmc/proofs/ReadNameField/Makefile.json
@@ -2,6 +2,10 @@
   "ENTRY": "ReadNameField",
 
 ################################################################
+#Enable DNS callbacks or else ReadNameField is not defined
+  "callbacks": "1",
+
+################################################################
 # This is the network buffer size.  Set to any positive value.
   "NETWORK_BUFFER_SIZE" :  "10",
 
@@ -44,6 +48,8 @@
   "DEF":
   [
     "NETWORK_BUFFER_SIZE={NETWORK_BUFFER_SIZE}",
-    "NAME_SIZE={NAME_SIZE}"
+    "NAME_SIZE={NAME_SIZE}",
+    "ipconfigDNS_USE_CALLBACKS={callbacks}",
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
   ]
 }

--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -3,6 +3,9 @@ if(CMAKE_CROSSCOMPILING)
     enable_language(ASM)
 endif()
 
+# Export the json compile commands databse.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+
 # Set some global path variables.
 get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 set(AFR_ROOT_DIR ${__root_dir} CACHE INTERNAL "FreeRTOS source root.")

--- a/tools/cmake/afr_metadata.cmake
+++ b/tools/cmake/afr_metadata.cmake
@@ -294,6 +294,14 @@ function(afr_write_metadata)
         endif()
     endforeach()
 
+    if(TARGET 3rdparty::mbedtls)
+        list(
+            APPEND src_console
+            "${AFR_3RDPARTY_DIR}/mbedtls_config"
+            "${AFR_3RDPARTY_DIR}/mbedtls_utils"
+        )
+    endif()
+
     # Append extra files for FreeRTOS console.
     list(
         APPEND src_console

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -76,7 +76,7 @@ endfunction()
 
 # Generates a mock library based on a module's header file
 # places the generated source file in the build directory
-function(create_mock_list mock_name mock_list)
+function(create_mock_list mock_name mock_list cmock_config)
     set(mocks_dir "${CMAKE_CURRENT_BINARY_DIR}/mocks")
     add_library(${mock_name} SHARED)
     foreach (mock_file IN LISTS mock_list)
@@ -96,20 +96,20 @@ function(create_mock_list mock_name mock_list)
                   OUTPUT ${mocks_dir}/mock_${mock_file_name}.c
                   COMMAND ruby
                   ${CMAKE_SOURCE_DIR}/libraries/3rdparty/CMock/lib/cmock.rb
-                  -o${CMAKE_SOURCE_DIR}/tools/cmock/project.yml ${mock_file_abs}
+                  -o${cmock_config} ${mock_file_abs}
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 )
         target_sources(${mock_name} PUBLIC
                        ${mocks_dir}/mock_${mock_file_name}.c
-                )
+        )
 
         target_include_directories(${mock_name} PUBLIC
                                    ${mock_file_dir}
-                )
+        )
     endforeach()
     target_include_directories(${mock_name} PUBLIC
                                ${mocks_dir}
-            )
+           )
     set_target_properties(${mock_name} PROPERTIES
                         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
                         POSITION_INDEPENDENT_CODE ON

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -47,11 +47,10 @@ afr_mcu_port(compiler)
 target_compile_definitions(
     AFR::compiler::mcu_port
     INTERFACE $<$<COMPILE_LANGUAGE:C>:${compiler_defined_symbols}>
-    -D__MICROLIB
-    -D_REENT_SMALL 
     -DPRODUCT_VERSION=m487 
     -DCONFIG_REPEATER 
     -DSUPPORT_MBEDTLS 
+    -DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_user_config.h\"
     -DHAL_DFS_MODULE_ENABLED 
     -DLWIP_NO_STDINT_H=1 
     -DLWIP_TIMEVAL_PRIVATE=1

--- a/vendors/ti/boards/cc3220_launchpad/ccs.cmake
+++ b/vendors/ti/boards/cc3220_launchpad/ccs.cmake
@@ -26,6 +26,21 @@ set(link_dependent_libs
     "${simplelink_dir}/source/ti/drivers/net/wifi/ccs/rtos/simplelink.a"
 )
 
+# Force the use of response file to avoid "command line too long" error.
+# These are needed to be put in this file as opposed to arm-ti.cmake because
+# in that case the archiver starts to function incorrectly for mbedtls. The
+# archiver starts to interpret the response file as object file and puts it in
+# the archive as opposed to the actual object files written in that response
+# file. The problem arises because for the TI archiver the response file flag is
+# "@" while for the TI linker it is nothing (empty string).
+SET(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+
+# Default response file flag is "@". TI's compiler requires it to be
+# space (" "). Note that the empty string does not work.
+set(CMAKE_C_RESPONSE_FILE_LINK_FLAG " ")
+set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG " ")
+
 # -------------------------------------------------------------------------------------------------
 # FreeRTOS portable layers
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Incorrect compiler flags in the cmake build were causing tests in CI to fail due to stack overflow.  This change aligns the cmake build's flags with those of the IDE build and fixes the problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.