### PR TITLE
Fix build failure for TI tests for cmake

### DIFF
--- a/vendors/ti/boards/cc3220_launchpad/ccs.cmake
+++ b/vendors/ti/boards/cc3220_launchpad/ccs.cmake
@@ -26,6 +26,21 @@ set(link_dependent_libs
     "${simplelink_dir}/source/ti/drivers/net/wifi/ccs/rtos/simplelink.a"
 )
 
+# Force the use of response file to avoid "command line too long" error.
+# These are needed to be put in this file as opposed to arm-ti.cmake because
+# in that case the archiver starts to function incorrectly for mbedtls. The
+# archiver starts to interpret the response file as object file and puts it in
+# the archive as opposed to the actual object files written in that response
+# file. The problem arises because for the TI archiver the response file flag is
+# "@" while for the TI linker it is nothing (empty string).
+SET(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+
+# Default response file flag is "@". TI's compiler requires it to be
+# space (" "). Note that the empty string does not work.
+set(CMAKE_C_RESPONSE_FILE_LINK_FLAG " ")
+set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG " ")
+
 # -------------------------------------------------------------------------------------------------
 # FreeRTOS portable layers
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Description
-----------

The Ninja generator combines linker and post build commands using '&&' which results in a long string. Windows has a limit of 8191 characters on the command line string length. We were hitting that limit for TI and were getting "command string too long" error.

This commit updates the cmake files to force Ninja to use response files which is a feature implemented for exactly this purpose and results in a much smaller command string.

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.