### PR TITLE
Add mbedtls_config and mbedtls_utils to metadata.

### DIFF
--- a/tools/cmake/afr_metadata.cmake
+++ b/tools/cmake/afr_metadata.cmake
@@ -294,6 +294,14 @@ function(afr_write_metadata)
         endif()
     endforeach()
 
+    if(TARGET 3rdparty::mbedtls)
+        list(
+            APPEND src_console
+            "${AFR_3RDPARTY_DIR}/mbedtls_config"
+            "${AFR_3RDPARTY_DIR}/mbedtls_utils"
+        )
+    endif()
+
     # Append extra files for FreeRTOS console.
     list(
         APPEND src_console


### PR DESCRIPTION
Add mbedtls_config and mbedtls_utils to the source list for console
metadata.

Add mbedtls_config and mbedtls_utils folders to the CMake Metadata output for the FreeRTOS Console.

Description
-----------
Add an explicit case in the Metadata module to include the above directories.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.