### PR TITLE
Fix compiler warnings on msvc in aws_dev_mode_key_provisioning.c.

### DIFF
--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -181,7 +181,7 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
             { CKA_EC_PARAMS, NULL /* pxEcParams*/,        EC_PARAMS_LENGTH                                 },
             { CKA_VALUE,     NULL /* pxD*/,               EC_D_LENGTH                                      }
         };
-        
+
         /* Aggregate initializers must not use the address of an automatic variable. */
         /* See MSVC Compiler Warning C4221 */
         xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
@@ -268,11 +268,11 @@ static CK_RV prvProvisionPrivateRSAKey( CK_SESSION_HANDLE xSession,
 
         CK_ATTRIBUTE xPrivateKeyTemplate[] =
         {
-            { CKA_CLASS,            NULL /* &xPrivateKeyClass */,            sizeof( CK_OBJECT_CLASS )                        },
-            { CKA_KEY_TYPE,         NULL /* &xPrivateKeyType */,             sizeof( CK_KEY_TYPE )                            },
+            { CKA_CLASS,            NULL /* &xPrivateKeyClass */, sizeof( CK_OBJECT_CLASS )                        },
+            { CKA_KEY_TYPE,         NULL /* &xPrivateKeyType */,  sizeof( CK_KEY_TYPE )                            },
             { CKA_LABEL,            pucLabel,                     ( CK_ULONG ) strlen( ( const char * ) pucLabel ) },
-            { CKA_TOKEN,            NULL /* &xTrue */,                       sizeof( CK_BBOOL )                               },
-            { CKA_SIGN,             NULL /* &xTrue */,                       sizeof( CK_BBOOL )                               },
+            { CKA_TOKEN,            NULL /* &xTrue */,            sizeof( CK_BBOOL )                               },
+            { CKA_SIGN,             NULL /* &xTrue */,            sizeof( CK_BBOOL )                               },
             { CKA_MODULUS,          pxRsaParams->modulus + 1,     MODULUS_LENGTH                                   },
             { CKA_PRIVATE_EXPONENT, pxRsaParams->d + 1,           D_LENGTH                                         },
             { CKA_PUBLIC_EXPONENT,  pxRsaParams->e + 1,           E_LENGTH                                         },
@@ -408,23 +408,23 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
                                               NULL, 0 );
         CK_ATTRIBUTE xPublicKeyTemplate[] =
         {
-            { CKA_CLASS,           NULL /* &xClass */,           sizeof( CK_OBJECT_CLASS )                    },
-            { CKA_KEY_TYPE,        NULL /* &xPublicKeyType */,   sizeof( CK_KEY_TYPE )                        },
-            { CKA_TOKEN,           NULL /* &xTrue */,            sizeof( xTrue )                              },
-            { CKA_MODULUS,         NULL /* &xModulus + 1 */,     MODULUS_LENGTH                               },     /* Extra byte allocated at beginning for 0 padding. */
-            { CKA_VERIFY,          NULL /* &xTrue */,            sizeof( xTrue )                              },
-            { CKA_PUBLIC_EXPONENT, NULL /* xPublicExponent */,   sizeof( xPublicExponent )                    },
-            { CKA_LABEL,           pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
+            { CKA_CLASS,           NULL /* &xClass */,         sizeof( CK_OBJECT_CLASS )                    },
+            { CKA_KEY_TYPE,        NULL /* &xPublicKeyType */, sizeof( CK_KEY_TYPE )                        },
+            { CKA_TOKEN,           NULL /* &xTrue */,          sizeof( xTrue )                              },
+            { CKA_MODULUS,         NULL /* &xModulus + 1 */,   MODULUS_LENGTH                               },       /* Extra byte allocated at beginning for 0 padding. */
+            { CKA_VERIFY,          NULL /* &xTrue */,          sizeof( xTrue )                              },
+            { CKA_PUBLIC_EXPONENT, NULL /* xPublicExponent */, sizeof( xPublicExponent )                    },
+            { CKA_LABEL,           pucPublicKeyLabel,          strlen( ( const char * ) pucPublicKeyLabel ) }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
         /* See MSVC Compiler Warning C4221 */
-        xPublicKeyTemplate[0].pValue = &xClass;
-        xPublicKeyTemplate[1].pValue = &xPublicKeyType;
-        xPublicKeyTemplate[2].pValue = &xTrue;
-        xPublicKeyTemplate[3].pValue = &xModulus + 1;
-        xPublicKeyTemplate[4].pValue = &xTrue;
-        xPublicKeyTemplate[5].pValue = xPublicExponent;
+        xPublicKeyTemplate[ 0 ].pValue = &xClass;
+        xPublicKeyTemplate[ 1 ].pValue = &xPublicKeyType;
+        xPublicKeyTemplate[ 2 ].pValue = &xTrue;
+        xPublicKeyTemplate[ 3 ].pValue = &xModulus + 1;
+        xPublicKeyTemplate[ 4 ].pValue = &xTrue;
+        xPublicKeyTemplate[ 5 ].pValue = xPublicExponent;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) xPublicKeyTemplate,
@@ -451,23 +451,23 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
 
         CK_ATTRIBUTE xPublicKeyTemplate[] =
         {
-            { CKA_CLASS,     NULL /* &xClass */,           sizeof( xClass )                             },
-            { CKA_KEY_TYPE,  NULL /* &xPublicKeyType */,   sizeof( xPublicKeyType )                     },
-            { CKA_TOKEN,     NULL /* &xTrue */,            sizeof( xTrue )                              },
-            { CKA_VERIFY,    NULL /* &xTrue */,            sizeof( xTrue )                              },
-            { CKA_EC_PARAMS, NULL /* xEcParams */,         sizeof( xEcParams )                          },
-            { CKA_EC_POINT,  NULL /* xEcPoint */,          xLength + 2                                  },
-            { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
+            { CKA_CLASS,     NULL /* &xClass */,         sizeof( xClass )                             },
+            { CKA_KEY_TYPE,  NULL /* &xPublicKeyType */, sizeof( xPublicKeyType )                     },
+            { CKA_TOKEN,     NULL /* &xTrue */,          sizeof( xTrue )                              },
+            { CKA_VERIFY,    NULL /* &xTrue */,          sizeof( xTrue )                              },
+            { CKA_EC_PARAMS, NULL /* xEcParams */,       sizeof( xEcParams )                          },
+            { CKA_EC_POINT,  NULL /* xEcPoint */,        xLength + 2                                  },
+            { CKA_LABEL,     pucPublicKeyLabel,          strlen( ( const char * ) pucPublicKeyLabel ) }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
         /* See MSVC Compiler Warning C4221 */
-        xPublicKeyTemplate[0].pValue = &xClass;
-        xPublicKeyTemplate[1].pValue = &xPublicKeyType;
-        xPublicKeyTemplate[2].pValue = &xTrue;
-        xPublicKeyTemplate[3].pValue = &xTrue;
-        xPublicKeyTemplate[4].pValue = xEcParams;
-        xPublicKeyTemplate[5].pValue = xEcPoint;
+        xPublicKeyTemplate[ 0 ].pValue = &xClass;
+        xPublicKeyTemplate[ 1 ].pValue = &xPublicKeyType;
+        xPublicKeyTemplate[ 2 ].pValue = &xTrue;
+        xPublicKeyTemplate[ 3 ].pValue = &xTrue;
+        xPublicKeyTemplate[ 4 ].pValue = xEcParams;
+        xPublicKeyTemplate[ 5 ].pValue = xEcPoint;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) xPublicKeyTemplate,
@@ -507,35 +507,35 @@ CK_RV xProvisionGenerateKeyPairRSA( CK_SESSION_HANDLE xSession,
     CK_BBOOL xTrue = CK_TRUE;
     CK_ATTRIBUTE xPublicKeyTemplate[] =
     {
-        { CKA_ENCRYPT,        NULL /* &xTrue */,            sizeof( xTrue )                              },
-        { CKA_VERIFY,         NULL /* &xTrue */,            sizeof( xTrue )                              },
-        { CKA_MODULUS_BITS,   NULL /* &xModulusBits */,     sizeof( xModulusBits )                       },
-        { CKA_PUBLIC_EXPONENT,NULL /* xPublicExponent */,   sizeof( xPublicExponent )                    },
-        { CKA_LABEL,           pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
+        { CKA_ENCRYPT,         NULL /* &xTrue */,          sizeof( xTrue )                              },
+        { CKA_VERIFY,          NULL /* &xTrue */,          sizeof( xTrue )                              },
+        { CKA_MODULUS_BITS,    NULL /* &xModulusBits */,   sizeof( xModulusBits )                       },
+        { CKA_PUBLIC_EXPONENT, NULL /* xPublicExponent */, sizeof( xPublicExponent )                    },
+        { CKA_LABEL,           pucPublicKeyLabel,          strlen( ( const char * ) pucPublicKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
     /* See MSVC Compiler Warning C4221 */
-    xPublicKeyTemplate[0].pValue = &xTrue;
-    xPublicKeyTemplate[1].pValue = &xTrue;
-    xPublicKeyTemplate[2].pValue = &xModulusBits;
-    xPublicKeyTemplate[3].pValue = &xPublicExponent;
+    xPublicKeyTemplate[ 0 ].pValue = &xTrue;
+    xPublicKeyTemplate[ 1 ].pValue = &xTrue;
+    xPublicKeyTemplate[ 2 ].pValue = &xModulusBits;
+    xPublicKeyTemplate[ 3 ].pValue = &xPublicExponent;
 
     CK_ATTRIBUTE xPrivateKeyTemplate[] =
     {
-        { CKA_TOKEN,   NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_PRIVATE, NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_DECRYPT, NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_SIGN,    NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_TOKEN,   NULL /* &xTrue */,  sizeof( xTrue )                               },
+        { CKA_PRIVATE, NULL /* &xTrue */,  sizeof( xTrue )                               },
+        { CKA_DECRYPT, NULL /* &xTrue */,  sizeof( xTrue )                               },
+        { CKA_SIGN,    NULL /* &xTrue */,  sizeof( xTrue )                               },
         { CKA_LABEL,   pucPrivateKeyLabel, strlen( ( const char * ) pucPrivateKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
     /* See MSVC Compiler Warning C4221 */
-    xPrivateKeyTemplate[0].pValue = &xTrue;
-    xPrivateKeyTemplate[1].pValue = &xTrue;
-    xPrivateKeyTemplate[2].pValue = &xTrue;
-    xPrivateKeyTemplate[3].pValue = &xTrue;
+    xPrivateKeyTemplate[ 0 ].pValue = &xTrue;
+    xPrivateKeyTemplate[ 1 ].pValue = &xTrue;
+    xPrivateKeyTemplate[ 2 ].pValue = &xTrue;
+    xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 
@@ -571,33 +571,33 @@ CK_RV xProvisionGenerateKeyPairEC( CK_SESSION_HANDLE xSession,
     CK_BBOOL xTrue = CK_TRUE;
     CK_ATTRIBUTE xPublicKeyTemplate[] =
     {
-        { CKA_KEY_TYPE,  NULL /* &xKeyType */,         sizeof( xKeyType )                           },
-        { CKA_VERIFY,    NULL /* &xTrue */,            sizeof( xTrue )                              },
-        { CKA_EC_PARAMS, NULL /* xEcParams */,         sizeof( xEcParams )                          },
-        { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
+        { CKA_KEY_TYPE,  NULL /* &xKeyType */, sizeof( xKeyType )                           },
+        { CKA_VERIFY,    NULL /* &xTrue */,    sizeof( xTrue )                              },
+        { CKA_EC_PARAMS, NULL /* xEcParams */, sizeof( xEcParams )                          },
+        { CKA_LABEL,     pucPublicKeyLabel,    strlen( ( const char * ) pucPublicKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
     /* See MSVC Compiler Warning C4221 */
-    xPublicKeyTemplate[0].pValue = &xKeyType;
-    xPublicKeyTemplate[1].pValue = &xTrue;
-    xPublicKeyTemplate[2].pValue = &xEcParams;
+    xPublicKeyTemplate[ 0 ].pValue = &xKeyType;
+    xPublicKeyTemplate[ 1 ].pValue = &xTrue;
+    xPublicKeyTemplate[ 2 ].pValue = &xEcParams;
 
     CK_ATTRIBUTE xPrivateKeyTemplate[] =
     {
-        { CKA_KEY_TYPE, NULL /* &xKeyType */,          sizeof( xKeyType )                            },
-        { CKA_TOKEN,    NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_PRIVATE,  NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_SIGN,     NULL /* &xTrue */,             sizeof( xTrue )                               },
-        { CKA_LABEL,    pucPrivateKeyLabel, strlen( ( const char * ) pucPrivateKeyLabel ) }
+        { CKA_KEY_TYPE, NULL /* &xKeyType */, sizeof( xKeyType )                            },
+        { CKA_TOKEN,    NULL /* &xTrue */,    sizeof( xTrue )                               },
+        { CKA_PRIVATE,  NULL /* &xTrue */,    sizeof( xTrue )                               },
+        { CKA_SIGN,     NULL /* &xTrue */,    sizeof( xTrue )                               },
+        { CKA_LABEL,    pucPrivateKeyLabel,   strlen( ( const char * ) pucPrivateKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
     /* See MSVC Compiler Warning C4221 */
-    xPrivateKeyTemplate[0].pValue = &xKeyType;
-    xPrivateKeyTemplate[1].pValue = &xTrue;
-    xPrivateKeyTemplate[2].pValue = &xTrue;
-    xPrivateKeyTemplate[3].pValue = &xTrue;
+    xPrivateKeyTemplate[ 0 ].pValue = &xKeyType;
+    xPrivateKeyTemplate[ 1 ].pValue = &xTrue;
+    xPrivateKeyTemplate[ 2 ].pValue = &xTrue;
+    xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -173,14 +173,22 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
     {
         CK_ATTRIBUTE xPrivateKeyTemplate[] =
         {
-            { CKA_CLASS,     &xPrivateKeyClass, sizeof( CK_OBJECT_CLASS )                        },
-            { CKA_KEY_TYPE,  &xPrivateKeyType,  sizeof( CK_KEY_TYPE )                            },
-            { CKA_LABEL,     pucLabel,          ( CK_ULONG ) strlen( ( const char * ) pucLabel ) },
-            { CKA_TOKEN,     &xTrue,            sizeof( CK_BBOOL )                               },
-            { CKA_SIGN,      &xTrue,            sizeof( CK_BBOOL )                               },
-            { CKA_EC_PARAMS, pxEcParams,        EC_PARAMS_LENGTH                                 },
-            { CKA_VALUE,     pxD,               EC_D_LENGTH                                      }
+            { CKA_CLASS,     NULL /* &xPrivateKeyClass*/, sizeof( CK_OBJECT_CLASS )                        },
+            { CKA_KEY_TYPE,  NULL /* &xPrivateKeyType*/,  sizeof( CK_KEY_TYPE )                            },
+            { CKA_LABEL,     pucLabel,                    ( CK_ULONG ) strlen( ( const char * ) pucLabel ) },
+            { CKA_TOKEN,     NULL /* &xTrue*/,            sizeof( CK_BBOOL )                               },
+            { CKA_SIGN,      NULL /* &xTrue*/,            sizeof( CK_BBOOL )                               },
+            { CKA_EC_PARAMS, NULL /* pxEcParams*/,        EC_PARAMS_LENGTH                                 },
+            { CKA_VALUE,     NULL /* pxD*/,               EC_D_LENGTH                                      }
         };
+        
+        /* Automatic variables cannot be used to initialize an aggregate initializer. */
+        xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
+        xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
+        xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
+        xPrivateKeyTemplate[ 4 ].pValue = &xTrue;
+        xPrivateKeyTemplate[ 5 ].pValue = pxEcParams;
+        xPrivateKeyTemplate[ 6 ].pValue = pxD;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
@@ -259,11 +267,11 @@ static CK_RV prvProvisionPrivateRSAKey( CK_SESSION_HANDLE xSession,
 
         CK_ATTRIBUTE xPrivateKeyTemplate[] =
         {
-            { CKA_CLASS,            &xPrivateKeyClass,            sizeof( CK_OBJECT_CLASS )                        },
-            { CKA_KEY_TYPE,         &xPrivateKeyType,             sizeof( CK_KEY_TYPE )                            },
+            { CKA_CLASS,            NULL /* &xPrivateKeyClass */,            sizeof( CK_OBJECT_CLASS )                        },
+            { CKA_KEY_TYPE,         NULL /* &xPrivateKeyType */,             sizeof( CK_KEY_TYPE )                            },
             { CKA_LABEL,            pucLabel,                     ( CK_ULONG ) strlen( ( const char * ) pucLabel ) },
-            { CKA_TOKEN,            &xTrue,                       sizeof( CK_BBOOL )                               },
-            { CKA_SIGN,             &xTrue,                       sizeof( CK_BBOOL )                               },
+            { CKA_TOKEN,            NULL /* &xTrue */,                       sizeof( CK_BBOOL )                               },
+            { CKA_SIGN,             NULL /* &xTrue */,                       sizeof( CK_BBOOL )                               },
             { CKA_MODULUS,          pxRsaParams->modulus + 1,     MODULUS_LENGTH                                   },
             { CKA_PRIVATE_EXPONENT, pxRsaParams->d + 1,           D_LENGTH                                         },
             { CKA_PUBLIC_EXPONENT,  pxRsaParams->e + 1,           E_LENGTH                                         },
@@ -273,6 +281,11 @@ static CK_RV prvProvisionPrivateRSAKey( CK_SESSION_HANDLE xSession,
             { CKA_EXPONENT_2,       pxRsaParams->exponent2 + 1,   EXPONENT_2_LENGTH                                },
             { CKA_COEFFICIENT,      pxRsaParams->coefficient + 1, COEFFICIENT_LENGTH                               }
         };
+
+        xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
+        xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
+        xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
+        xPrivateKeyTemplate[ 4 ].pValue = &xTrue;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
@@ -392,14 +405,22 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
                                               NULL, 0 );
         CK_ATTRIBUTE xPublicKeyTemplate[] =
         {
-            { CKA_CLASS,           &xClass,           sizeof( CK_OBJECT_CLASS )                    },
-            { CKA_KEY_TYPE,        &xPublicKeyType,   sizeof( CK_KEY_TYPE )                        },
-            { CKA_TOKEN,           &xTrue,            sizeof( xTrue )                              },
-            { CKA_MODULUS,         &xModulus + 1,     MODULUS_LENGTH                               },     /* Extra byte allocated at beginning for 0 padding. */
-            { CKA_VERIFY,          &xTrue,            sizeof( xTrue )                              },
-            { CKA_PUBLIC_EXPONENT, xPublicExponent,   sizeof( xPublicExponent )                    },
+            { CKA_CLASS,           NULL /* &xClass */,           sizeof( CK_OBJECT_CLASS )                    },
+            { CKA_KEY_TYPE,        NULL /* &xPublicKeyType */,   sizeof( CK_KEY_TYPE )                        },
+            { CKA_TOKEN,           NULL /* &xTrue */,            sizeof( xTrue )                              },
+            { CKA_MODULUS,         NULL /* &xModulus + 1 */,     MODULUS_LENGTH                               },     /* Extra byte allocated at beginning for 0 padding. */
+            { CKA_VERIFY,          NULL /* &xTrue */,            sizeof( xTrue )                              },
+            { CKA_PUBLIC_EXPONENT, NULL /* xPublicExponent */,   sizeof( xPublicExponent )                    },
             { CKA_LABEL,           pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
         };
+
+        /* Aggregate initializers must not use the address of an automatic variable. */
+        xPublicKeyTemplate[0].pValue = &xClass;
+        xPublicKeyTemplate[1].pValue = &xPublicKeyType;
+        xPublicKeyTemplate[2].pValue = &xTrue;
+        xPublicKeyTemplate[3].pValue = &xModulus + 1;
+        xPublicKeyTemplate[4].pValue = &xTrue;
+        xPublicKeyTemplate[5].pValue = xPublicExponent;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) xPublicKeyTemplate,
@@ -426,14 +447,22 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
 
         CK_ATTRIBUTE xPublicKeyTemplate[] =
         {
-            { CKA_CLASS,     &xClass,           sizeof( xClass )                             },
-            { CKA_KEY_TYPE,  &xPublicKeyType,   sizeof( xPublicKeyType )                     },
-            { CKA_TOKEN,     &xTrue,            sizeof( xTrue )                              },
-            { CKA_VERIFY,    &xTrue,            sizeof( xTrue )                              },
-            { CKA_EC_PARAMS, xEcParams,         sizeof( xEcParams )                          },
-            { CKA_EC_POINT,  xEcPoint,          xLength + 2                                  },
+            { CKA_CLASS,     NULL /* &xClass */,           sizeof( xClass )                             },
+            { CKA_KEY_TYPE,  NULL /* &xPublicKeyType */,   sizeof( xPublicKeyType )                     },
+            { CKA_TOKEN,     NULL /* &xTrue */,            sizeof( xTrue )                              },
+            { CKA_VERIFY,    NULL /* &xTrue */,            sizeof( xTrue )                              },
+            { CKA_EC_PARAMS, NULL /* xEcParams */,         sizeof( xEcParams )                          },
+            { CKA_EC_POINT,  NULL /* xEcPoint */,          xLength + 2                                  },
             { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
         };
+
+        /* Aggregate initializers must not use the address of an automatic variable. */
+        xPublicKeyTemplate[0].pValue = &xClass;
+        xPublicKeyTemplate[1].pValue = &xPublicKeyType;
+        xPublicKeyTemplate[2].pValue = &xTrue;
+        xPublicKeyTemplate[3].pValue = &xTrue;
+        xPublicKeyTemplate[4].pValue = xEcParams;
+        xPublicKeyTemplate[5].pValue = xEcPoint;
 
         xResult = pxFunctionList->C_CreateObject( xSession,
                                                   ( CK_ATTRIBUTE_PTR ) xPublicKeyTemplate,
@@ -473,21 +502,33 @@ CK_RV xProvisionGenerateKeyPairRSA( CK_SESSION_HANDLE xSession,
     CK_BBOOL xTrue = CK_TRUE;
     CK_ATTRIBUTE xPublicKeyTemplate[] =
     {
-        { CKA_ENCRYPT,         &xTrue,            sizeof( xTrue )                              },
-        { CKA_VERIFY,          &xTrue,            sizeof( xTrue )                              },
-        { CKA_MODULUS_BITS,    &xModulusBits,     sizeof( xModulusBits )                       },
-        { CKA_PUBLIC_EXPONENT, xPublicExponent,   sizeof( xPublicExponent )                    },
+        { CKA_ENCRYPT,        NULL /* &xTrue */,            sizeof( xTrue )                              },
+        { CKA_VERIFY,         NULL /* &xTrue */,            sizeof( xTrue )                              },
+        { CKA_MODULUS_BITS,   NULL /* &xModulusBits */,     sizeof( xModulusBits )                       },
+        { CKA_PUBLIC_EXPONENT,NULL /* xPublicExponent */,   sizeof( xPublicExponent )                    },
         { CKA_LABEL,           pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
     };
 
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    xPublicKeyTemplate[0].pValue = &xTrue;
+    xPublicKeyTemplate[1].pValue = &xTrue;
+    xPublicKeyTemplate[2].pValue = &xModulusBits;
+    xPublicKeyTemplate[3].pValue = &xPublicExponent;
+
     CK_ATTRIBUTE xPrivateKeyTemplate[] =
     {
-        { CKA_TOKEN,   &xTrue,             sizeof( xTrue )                               },
-        { CKA_PRIVATE, &xTrue,             sizeof( xTrue )                               },
-        { CKA_DECRYPT, &xTrue,             sizeof( xTrue )                               },
-        { CKA_SIGN,    &xTrue,             sizeof( xTrue )                               },
+        { CKA_TOKEN,   NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_PRIVATE, NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_DECRYPT, NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_SIGN,    NULL /* &xTrue */,             sizeof( xTrue )                               },
         { CKA_LABEL,   pucPrivateKeyLabel, strlen( ( const char * ) pucPrivateKeyLabel ) }
     };
+
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    xPrivateKeyTemplate[0].pValue = &xTrue;
+    xPrivateKeyTemplate[1].pValue = &xTrue;
+    xPrivateKeyTemplate[2].pValue = &xTrue;
+    xPrivateKeyTemplate[3].pValue = &xTrue;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 
@@ -523,20 +564,31 @@ CK_RV xProvisionGenerateKeyPairEC( CK_SESSION_HANDLE xSession,
     CK_BBOOL xTrue = CK_TRUE;
     CK_ATTRIBUTE xPublicKeyTemplate[] =
     {
-        { CKA_KEY_TYPE,  &xKeyType,         sizeof( xKeyType )                           },
-        { CKA_VERIFY,    &xTrue,            sizeof( xTrue )                              },
-        { CKA_EC_PARAMS, xEcParams,         sizeof( xEcParams )                          },
+        { CKA_KEY_TYPE,  NULL /* &xKeyType */,         sizeof( xKeyType )                           },
+        { CKA_VERIFY,    NULL /* &xTrue */,            sizeof( xTrue )                              },
+        { CKA_EC_PARAMS, NULL /* xEcParams */,         sizeof( xEcParams )                          },
         { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
     };
 
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    xPublicKeyTemplate[0].pValue = &xKeyType;
+    xPublicKeyTemplate[1].pValue = &xTrue;
+    xPublicKeyTemplate[2].pValue = &xEcParams;
+
     CK_ATTRIBUTE xPrivateKeyTemplate[] =
     {
-        { CKA_KEY_TYPE, &xKeyType,          sizeof( xKeyType )                            },
-        { CKA_TOKEN,    &xTrue,             sizeof( xTrue )                               },
-        { CKA_PRIVATE,  &xTrue,             sizeof( xTrue )                               },
-        { CKA_SIGN,     &xTrue,             sizeof( xTrue )                               },
+        { CKA_KEY_TYPE, NULL /* &xKeyType */,          sizeof( xKeyType )                            },
+        { CKA_TOKEN,    NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_PRIVATE,  NULL /* &xTrue */,             sizeof( xTrue )                               },
+        { CKA_SIGN,     NULL /* &xTrue */,             sizeof( xTrue )                               },
         { CKA_LABEL,    pucPrivateKeyLabel, strlen( ( const char * ) pucPrivateKeyLabel ) }
     };
+
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    xPrivateKeyTemplate[0].pValue = &xKeyType;
+    xPrivateKeyTemplate[1].pValue = &xTrue;
+    xPrivateKeyTemplate[2].pValue = &xTrue;
+    xPrivateKeyTemplate[3].pValue = &xTrue;
 
     xResult = C_GetFunctionList( &pxFunctionList );
 

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -183,6 +183,7 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
         };
         
         /* Aggregate initializers must not use the address of an automatic variable. */
+        /* See MSVC Compiler Warning C4221 */
         xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
         xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
         xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
@@ -283,6 +284,7 @@ static CK_RV prvProvisionPrivateRSAKey( CK_SESSION_HANDLE xSession,
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
+        /* See MSVC Compiler Warning C4221 */
         xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
         xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
         xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
@@ -416,6 +418,7 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
+        /* See MSVC Compiler Warning C4221 */
         xPublicKeyTemplate[0].pValue = &xClass;
         xPublicKeyTemplate[1].pValue = &xPublicKeyType;
         xPublicKeyTemplate[2].pValue = &xTrue;
@@ -458,6 +461,7 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
+        /* See MSVC Compiler Warning C4221 */
         xPublicKeyTemplate[0].pValue = &xClass;
         xPublicKeyTemplate[1].pValue = &xPublicKeyType;
         xPublicKeyTemplate[2].pValue = &xTrue;
@@ -511,6 +515,7 @@ CK_RV xProvisionGenerateKeyPairRSA( CK_SESSION_HANDLE xSession,
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
+    /* See MSVC Compiler Warning C4221 */
     xPublicKeyTemplate[0].pValue = &xTrue;
     xPublicKeyTemplate[1].pValue = &xTrue;
     xPublicKeyTemplate[2].pValue = &xModulusBits;
@@ -526,6 +531,7 @@ CK_RV xProvisionGenerateKeyPairRSA( CK_SESSION_HANDLE xSession,
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
+    /* See MSVC Compiler Warning C4221 */
     xPrivateKeyTemplate[0].pValue = &xTrue;
     xPrivateKeyTemplate[1].pValue = &xTrue;
     xPrivateKeyTemplate[2].pValue = &xTrue;
@@ -572,6 +578,7 @@ CK_RV xProvisionGenerateKeyPairEC( CK_SESSION_HANDLE xSession,
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
+    /* See MSVC Compiler Warning C4221 */
     xPublicKeyTemplate[0].pValue = &xKeyType;
     xPublicKeyTemplate[1].pValue = &xTrue;
     xPublicKeyTemplate[2].pValue = &xEcParams;
@@ -586,6 +593,7 @@ CK_RV xProvisionGenerateKeyPairEC( CK_SESSION_HANDLE xSession,
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
+    /* See MSVC Compiler Warning C4221 */
     xPrivateKeyTemplate[0].pValue = &xKeyType;
     xPrivateKeyTemplate[1].pValue = &xTrue;
     xPrivateKeyTemplate[2].pValue = &xTrue;

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -182,7 +182,7 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
             { CKA_VALUE,     NULL /* pxD*/,               EC_D_LENGTH                                      }
         };
         
-        /* Automatic variables cannot be used to initialize an aggregate initializer. */
+        /* Aggregate initializers must not use the address of an automatic variable. */
         xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
         xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
         xPrivateKeyTemplate[ 3 ].pValue = &xTrue;
@@ -282,6 +282,7 @@ static CK_RV prvProvisionPrivateRSAKey( CK_SESSION_HANDLE xSession,
             { CKA_COEFFICIENT,      pxRsaParams->coefficient + 1, COEFFICIENT_LENGTH                               }
         };
 
+        /* Aggregate initializers must not use the address of an automatic variable. */
         xPrivateKeyTemplate[ 0 ].pValue = &xPrivateKeyClass;
         xPrivateKeyTemplate[ 1 ].pValue = &xPrivateKeyType;
         xPrivateKeyTemplate[ 3 ].pValue = &xTrue;


### PR DESCRIPTION
All of the warnings were due to https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4221?view=vs-2019.

This warning means that you cannot use an auto allocated variable's address when initializing a struct. Therefore it is necessary to initialize a struct, and then initialize it's members.

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.