### PR TITLE
Use __CPROVER_havoc_object instead of __CPROVER_array_copy

### DIFF
--- a/tools/cbmc/proofs/HTTP/global_state_HTTP.c
+++ b/tools/cbmc/proofs/HTTP/global_state_HTTP.c
@@ -92,11 +92,7 @@ size_t IotNetworkInterfaceReceive( void * pConnection,
   __CPROVER_assert(pConnection, "IotNetworkInterfaceReceive pConnection");
   __CPROVER_assert(pBuffer, "IotNetworkInterfaceReceive pBuffer");
 
-  /* Fill the entire memory object pointed to by pBuffer with
-   * unconstrained data.  This use of __CPROVER_array_copy with a
-   * single byte is a common CBMC idiom. */
-  uint8_t byte;
-  __CPROVER_array_copy(pBuffer,&byte);
+  __CPROVER_havoc_object(pBuffer);
 
   size_t size;
   __CPROVER_assume(size <= bytesRequested);

--- a/tools/cbmc/proofs/ParseDNSReply/ParseDNSReply_harness.c
+++ b/tools/cbmc/proofs/ParseDNSReply/ParseDNSReply_harness.c
@@ -129,8 +129,6 @@ void harness() {
   buffer_size = NETWORK_BUFFER_SIZE - my_buffer_offset;
   __CPROVER_assume(my_buffer_offset <= NETWORK_BUFFER_SIZE);
 
-  __CPROVER_havoc_object(my_buffer);
-
   // Choose arbitrary pointer into the buffer
   size_t buffer_offset;
   uint8_t *pucUDPPayloadBuffer = buffer + buffer_offset;


### PR DESCRIPTION
<!--- Title -->
Use __CPROVER_havoc_object instead of __CPROVER_array_copy

Description
-----------
<!--- Describe your changes in detail -->
1. Use `__CPROVER_havoc_object` instead of `__CPROVER_array_copy`. This is self-documenting.
1. Remove unnecessary havoc of already unconstrained value.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.