### PR TITLE
Align Nuvoton cmake compiler flags with IDE build.

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -47,11 +47,10 @@ afr_mcu_port(compiler)
 target_compile_definitions(
     AFR::compiler::mcu_port
     INTERFACE $<$<COMPILE_LANGUAGE:C>:${compiler_defined_symbols}>
-    -D__MICROLIB
-    -D_REENT_SMALL 
     -DPRODUCT_VERSION=m487 
     -DCONFIG_REPEATER 
     -DSUPPORT_MBEDTLS 
+    -DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_user_config.h\"
     -DHAL_DFS_MODULE_ENABLED 
     -DLWIP_NO_STDINT_H=1 
     -DLWIP_TIMEVAL_PRIVATE=1


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Incorrect compiler flags in the cmake build were causing tests in CI to fail due to stack overflow. This change aligns the cmake build's flags with those of the IDE build and fixes the problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.