### PR TITLE
PKCS #11 Memory Leak Fixes and Provisioning Memory Leak Fix

### DIFF
--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -903,6 +903,7 @@ static CK_RV prvGetProvisionedState( CK_SESSION_HANDLE xSession,
     if( CKR_OK == xResult )
     {
         xResult = pxFunctionList->C_GetTokenInfo( pxSlotId[ 0 ], &xTokenInfo );
+        vPortFree( pxSlotId );
     }
 
     if( ( CKR_OK == xResult ) && ( '\0' != xTokenInfo.label[ 0 ] ) && ( ' ' != xTokenInfo.label[ 0 ] ) )

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -517,7 +517,6 @@ CK_RV prvMbedTLS_Initialize( void )
 
     if( xResult == CKR_OK )
     {
-
         CRYPTO_Init();
         /* Initialize the entropy source and DRBG for the PKCS#11 module */
         mbedtls_entropy_init( &xP11Context.xMbedEntropyContext );
@@ -973,7 +972,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_Finalize )( CK_VOID_PTR pvReserved )
             mbedtls_ctr_drbg_free( &xP11Context.xMbedDrbgCtx );
         }
 
-        vSemaphoreDelete( xP11Context.xObjectList.xMutex );
+        if( xP11Context.xObjectList.xMutex != NULL )
+        {
+            vSemaphoreDelete( xP11Context.xObjectList.xMutex );
+        }
 
         xP11Context.xIsInitialized = CK_FALSE;
     }

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -161,6 +161,12 @@ TEST_SETUP( Full_PKCS11_Capabilities )
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to initialize PKCS #11 module." );
     xResult = xInitializePkcs11Session( &xGlobalSession );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to open PKCS #11 session." );
+
+    #ifdef PKCS11_TEST_MEMORY_LEAK
+        /* Give the print buffer time to empty */
+        vTaskDelay( 500 );
+        xHeapBefore = xPortGetFreeHeapSize();
+    #endif
 }
 
 TEST_TEAR_DOWN( Full_PKCS11_Capabilities )
@@ -171,6 +177,13 @@ TEST_TEAR_DOWN( Full_PKCS11_Capabilities )
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to close session." );
     xResult = pxGlobalFunctionList->C_Finalize( NULL );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to finalize session." );
+
+    #ifdef PKCS11_TEST_MEMORY_LEAK
+        /* Give the print buffer time to empty */
+        vTaskDelay( 500 );
+        xHeapAfter = xPortGetFreeHeapSize();
+        configPRINTF( ( "Heap before %d, Heap After %d, Difference %d \r\n", xHeapBefore, xHeapAfter, ( xHeapAfter - xHeapBefore ) ) );
+    #endif
 }
 
 TEST_GROUP_RUNNER( Full_PKCS11_Capabilities )
@@ -189,6 +202,7 @@ TEST_SETUP( Full_PKCS11_NoObject )
         vTaskDelay( 500 );
         xHeapBefore = xPortGetFreeHeapSize();
     #endif
+
     CK_RV xResult;
 
     xResult = xInitializePKCS11();
@@ -429,26 +443,32 @@ void prvAfterRunningTests_Object( void )
 {
     /* Check if the test label is the same as the run-time label. */
 
-    /* If labels are the same, then we are assuming that this device does not
-     * have a secure element. */
-    if( ( 0 == strcmp( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) ) &&
-        ( 0 == strcmp( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ) ) )
-    {
-        /* Delete the old device private key and certificate, if that
-         * operation is supported by this port. Replace
-         * them with known-good AWS IoT credentials. */
-        xDestroyDefaultCryptoObjects( xGlobalSession );
+    /* Only reprovision a device that supports importing private keys. */
+    #if ( pkcs11testIMPORT_PRIVATE_KEY_SUPPORT == 1 )
 
-        /* Re-provision the device with default certs
-         * so that subsequent tests are not changed. */
-        vDevModeKeyProvisioning();
-        xCurrentCredentials = eClientCredential;
-    }
+        /* If labels are the same, then we are assuming that this device does not
+         * have a secure element. */
+        if( ( 0 == strcmp( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) ) &&
+            ( 0 == strcmp( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ) ) )
+        {
+            /* Delete the old device private key and certificate, if that
+             * operation is supported by this port. Replace
+             * them with known-good AWS IoT credentials. */
+            xDestroyDefaultCryptoObjects( xGlobalSession );
 
-    /* If the labels are different, then test credentials
-     * and application credentials are stored in separate
-     * slots which were not modified, so nothing special
-     * needs to be done. */
+            /* Re-provision the device with default certs
+             * so that subsequent tests are not changed. */
+            vDevModeKeyProvisioning();
+            xCurrentCredentials = eClientCredential;
+        }
+        else
+        {
+            /* If the labels are different, then test credentials
+             * and application credentials are stored in separate
+             * slots which were not modified, so nothing special
+             * needs to be done. */
+        }
+    #endif /* if ( pkcs11testIMPORT_PRIVATE_KEY_SUPPORT == 1 ) */
 }
 
 
@@ -840,6 +860,8 @@ TEST( Full_PKCS11_Capabilities, AFQP_Capabilities )
     xResult = pxGlobalFunctionList->C_GetMechanismInfo( pxSlotId[ 0 ], CKM_SHA256, &MechanismInfo );
     TEST_ASSERT_TRUE( CKR_OK == xResult );
     TEST_ASSERT_TRUE( 0 != ( CKF_DIGEST & MechanismInfo.flags ) );
+
+    vPortFree( pxSlotId );
 
     /* Check for consistency between static configuration and runtime key
      * generation settings. */


### PR DESCRIPTION
* Fix memory leak in AFQP_Capabilities due to pxSlotId not being freed.
* Fix memory leak in prvGetProvisionedState due to pxSlotId not being freed.
* Added NULL check in call to semaphore delete.
* Fixed strcmp logic to determine if a device was a secure element.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.