### PR TITLE
Removed unused function and credential includes in iot_pkcs11_mbedtls.c

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -51,16 +51,6 @@
 /* Custom mbedtls utils include. */
 #include "mbedtls_error.h"
 
-
-/* Credential includes. */
-#include "aws_clientcredential.h"
-#include "aws_clientcredential_keys.h"
-#include "iot_default_root_certificates.h"
-
-#if ( pkcs11configOTA_SUPPORTED == 1 )
-    #include "aws_ota_codesigner_certificate.h"
-#endif
-
 /* C runtime includes. */
 #include <stdio.h>
 #include <string.h>
@@ -829,69 +819,6 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
         return xResult;
     }
 #endif /* if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 ) */
-
-#if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED != 1 )
-
-/**
- * @brief Checks to see if the PKCS #11 object is NVM supported.
- *
- * @param[in] pucLabel            PKCS #11 object label
- * @param[in] xLength             Length of the label, in bytes.
- * @param[out] ppucCertData       pointer to certificate data.
- * @returns True if the object is not stored in NVM & must be looked up in header file.
- * False if object is an NVM supported object.
- */
-    BaseType_t xIsObjectWithNoNvmStorage( uint8_t * pucLabel,
-                                          size_t xLength,
-                                          uint8_t ** ppucCertData )
-    {
-        /* Disable unused parameter warning. */
-        ( void ) xLength;
-
-        BaseType_t xResult = CK_TRUE;
-
-        if( 0 == memcmp( pucLabel, pkcs11configLABEL_JITP_CERTIFICATE, strlen( ( char * ) pkcs11configLABEL_JITP_CERTIFICATE ) ) )
-        {
-            if( NULL != keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM )
-            {
-                *ppucCertData = ( uint8_t * ) keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM;
-            }
-            else
-            {
-                PKCS11_PRINT( ( "ERROR: JITP Certificate not specified.\r\n" ) );
-            }
-        }
-        else if( 0 == memcmp( pucLabel, pkcs11configLABEL_ROOT_CERTIFICATE, strlen( ( char * ) pkcs11configLABEL_ROOT_CERTIFICATE ) ) )
-        {
-            /* Use either Verisign or Starfield root CA,
-             * depending on whether this is an ATS endpoint. */
-            if( strstr( clientcredentialMQTT_BROKER_ENDPOINT, "-ats.iot" ) == NULL )
-            {
-                *ppucCertData = ( uint8_t * ) tlsVERISIGN_ROOT_CERTIFICATE_PEM;
-            }
-            else
-            {
-                *ppucCertData = ( uint8_t * ) tlsSTARFIELD_ROOT_CERTIFICATE_PEM;
-            }
-        }
-
-        #if ( pkcs11configOTA_SUPPORTED == 1 )
-            else if( 0 == memcmp( pucLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, strlen( ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
-            {
-                *ppucCertData = ( uint8_t * ) signingcredentialSIGNING_CERTIFICATE_PEM;
-            }
-        #endif
-        else
-        {
-            xResult = CK_FALSE;
-        }
-
-        return xResult;
-    }
-
-
-#endif /* if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED != 1 ) */
-
 
 /*-------------------------------------------------------------*/
 

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -43,11 +43,6 @@
 #include "iot_pkcs11.h"
 #include "iot_pkcs11_pal.h"
 
-/* Credential includes. */
-#include "aws_clientcredential.h"
-#include "aws_clientcredential_keys.h"
-#include "iot_default_root_certificates.h"
-
 /* OPTIGA(TM) Trust X Includes */
 #include "optiga/optiga_crypt.h"
 #include "optiga/optiga_util.h"
@@ -966,60 +961,6 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
 
     return xResult;
 }
-
-#if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED != 1 )
-
-/* Returns True if the object is not stored in NVM & must be looked up in header file.
- * Returns fals if object is an NVM supported object. */
-
-    BaseType_t xIsObjectWithNoNvmStorage( uint8_t * pucLabel,
-                                          size_t xLength,
-                                          uint8_t ** ppucCertData )
-    {
-        BaseType_t xResult = CK_TRUE;
-
-        if( 0 == memcmp( pucLabel, pkcs11configLABEL_JITP_CERTIFICATE, strlen( ( char * ) pkcs11configLABEL_JITP_CERTIFICATE ) ) )
-        {
-            if( NULL != keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM )
-            {
-                *ppucCertData = ( uint8_t * ) keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM;
-            }
-            else
-            {
-                PKCS11_PRINT( ( "ERROR: JITP Certificate not specified.\r\n" ) );
-            }
-        }
-        else if( 0 == memcmp( pucLabel, pkcs11configLABEL_ROOT_CERTIFICATE, strlen( ( char * ) pkcs11configLABEL_ROOT_CERTIFICATE ) ) )
-        {
-            /* Use either Verisign or Starfield root CA,
-             * depending on whether this is an ATS endpoint. */
-            if( strstr( clientcredentialMQTT_BROKER_ENDPOINT, "-ats.iot" ) == NULL )
-            {
-                *ppucCertData = ( uint8_t * ) tlsVERISIGN_ROOT_CERTIFICATE_PEM;
-            }
-            else
-            {
-                *ppucCertData = ( uint8_t * ) tlsSTARFIELD_ROOT_CERTIFICATE_PEM;
-            }
-        }
-
-        #if ( pkcs11configOTA_SUPPORTED == 1 )
-            else if( 0 == memcmp( pucLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, strlen( ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
-            {
-                *ppucCertData = ( uint8_t * ) signingcredentialSIGNING_CERTIFICATE_PEM;
-            }
-        #endif
-        else
-        {
-            xResult = CK_FALSE;
-        }
-
-        return xResult;
-    }
-
-
-#endif /* if ( pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED != 1 ) */
-
 
 #if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
iot_pkcs11_mbedtls.c has a function xIsObjectWithNoNvmStorage which is currently not used anywhere in the code. It's purpose is to check whether a PKCS #11 object was stored in NVM or in a header file. 

It is desirearable to remove this function because
1. It is unused / dead code.
2. We can remove aws_clientcredential.h, aws_clientcredential_keys.h, iot_default_root_certificates.h from our dependencies.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.