### PR TITLE
Hygiene/reduce arm gcc warnings

### DIFF
--- a/libraries/abstractions/pkcs11/ecc608a/iot_pkcs11_secure_element.c
+++ b/libraries/abstractions/pkcs11/ecc608a/iot_pkcs11_secure_element.c
@@ -298,7 +298,7 @@ const char * pcPkcs11GetThingName( void )
         0x12, 0x00,                                           /*14 */
         0x30, 0x00                                            /*15 */
     };
-#else  /* ifdef AMAZON_FREERTOS_ENABLE_UNIT_TESTS */
+#else /* ifdef AMAZON_FREERTOS_ENABLE_UNIT_TESTS */
 /** Standard Configuration Structure for ATECC608A devices */
     const uint8_t atecc608_config[] =
     {

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -305,7 +305,7 @@ static BaseType_t prvNonSecureConnectHelper( Socket_t xSocket,
                                              SocketsSockaddr_t * pxHostAddress )
 {
     /* Disable unused parameter warning. */
-    (void) xSocket;
+    ( void ) xSocket;
 
     /* Echo requests are sent to the echo server.  The echo server is
     * listening to tcptestECHO_PORT on this computer's IP address. */
@@ -853,7 +853,7 @@ static void prvSOCKETS_CloseInvalidParams( Server_t xConn )
     BaseType_t xResult;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     /* Try to close with an invalid socket. */
     xResult = SOCKETS_Close( SOCKETS_INVALID_SOCKET );
@@ -915,7 +915,7 @@ static void prvSOCKETS_ShutdownInvalidParams( Server_t xConn )
     BaseType_t xResult;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     xSocket = prvTcpSocketHelper( &xSocketOpen );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( SOCKETS_INVALID_SOCKET, xSocket, "Socket creation failed" );
@@ -1061,7 +1061,7 @@ static void prvSOCKETS_Socket_TCP( Server_t xConn )
     BaseType_t xResult;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     /* Make TCP socket. */
     xSocket = SOCKETS_Socket( SOCKETS_AF_INET,
@@ -1333,8 +1333,8 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_SetSockOpt_InvalidParams )
 static void prvSOCKETS_SetSockOpt_SNDTIMEO( Server_t xConn )
 {
     /* Disable unused parameter warning. */
-    (void) xConn;
- 
+    ( void ) xConn;
+
     /* TODO: This is a stub function. */
     TEST_FAIL_MESSAGE( "This test is not implemented." );
 }
@@ -1684,7 +1684,7 @@ static void prvSOCKETS_Socket_InvalidInputParams( Server_t xConn )
     BaseType_t xResult;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
@@ -1798,7 +1798,7 @@ static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
     Socket_t xSocket;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
@@ -1874,7 +1874,7 @@ static void prvSOCKETS_Connect_InvalidParams( Server_t xConn )
     uint32_t ulEchoServerIP;
 
     /* Disable unused parameter warning. */
-    (void) xConn;
+    ( void ) xConn;
 
     ulEchoServerIP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                               tcptestECHO_SERVER_ADDR1,

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -849,6 +849,9 @@ static void prvSOCKETS_CloseInvalidParams( Server_t xConn )
 {
     BaseType_t xResult;
 
+    /* Disable unused parameter warning. */
+    (void) xConn;
+
     /* Try to close with an invalid socket. */
     xResult = SOCKETS_Close( SOCKETS_INVALID_SOCKET );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_EINVAL, xResult, "Socket failed to close" );
@@ -907,6 +910,9 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_CloseWithoutReceiving )
 static void prvSOCKETS_ShutdownInvalidParams( Server_t xConn )
 {
     BaseType_t xResult;
+
+    /* Disable unused parameter warning. */
+    (void) xConn;
 
     xSocket = prvTcpSocketHelper( &xSocketOpen );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( SOCKETS_INVALID_SOCKET, xSocket, "Socket creation failed" );
@@ -1050,6 +1056,9 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_Recv_On_Unconnected_Socket )
 static void prvSOCKETS_Socket_TCP( Server_t xConn )
 {
     BaseType_t xResult;
+
+    /* Disable unused parameter warning. */
+    (void) xConn;
 
     /* Make TCP socket. */
     xSocket = SOCKETS_Socket( SOCKETS_AF_INET,
@@ -1320,6 +1329,9 @@ TEST( Full_TCP, AFQP_SECURE_SOCKETS_SetSockOpt_InvalidParams )
 
 static void prvSOCKETS_SetSockOpt_SNDTIMEO( Server_t xConn )
 {
+    /* Disable unused parameter warning. */
+    (void) xConn;
+ 
     /* TODO: This is a stub function. */
     TEST_FAIL_MESSAGE( "This test is not implemented." );
 }
@@ -1668,6 +1680,9 @@ static void prvSOCKETS_Socket_InvalidInputParams( Server_t xConn )
 {
     BaseType_t xResult;
 
+    /* Disable unused parameter warning. */
+    (void) xConn;
+
     tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
     /* Providing invalid domain. */
@@ -1779,6 +1794,9 @@ static void prvSOCKETS_Socket_ConcurrentCount( Server_t xConn )
     BaseType_t xSocketsCreated;
     Socket_t xSocket;
 
+    /* Disable unused parameter warning. */
+    (void) xConn;
+
     tcptestPRINTF( ( "Starting %s.\r\n", __FUNCTION__ ) );
 
     xResult = pdPASS;
@@ -1851,6 +1869,9 @@ static void prvSOCKETS_Connect_InvalidParams( Server_t xConn )
     SocketsSockaddr_t xEchoServerAddress;
 
     uint32_t ulEchoServerIP;
+
+    /* Disable unused parameter warning. */
+    (void) xConn;
 
     ulEchoServerIP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                               tcptestECHO_SERVER_ADDR1,

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -304,6 +304,9 @@ static BaseType_t prvSecureConnectHelper( Socket_t xSocket,
 static BaseType_t prvNonSecureConnectHelper( Socket_t xSocket,
                                              SocketsSockaddr_t * pxHostAddress )
 {
+    /* Disable unused parameter warning. */
+    (void) xSocket;
+
     /* Echo requests are sent to the echo server.  The echo server is
     * listening to tcptestECHO_PORT on this computer's IP address. */
     pxHostAddress->ulAddress = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
@@ -1091,7 +1094,7 @@ static void prvSOCKETS_SetSockOpt_RCVTIMEO( Server_t xConn )
     TickType_t xTimeout;
     TickType_t xTimeouts[] = { 30, 100, 10000 }; /* TODO: Add 0, nonblocking tests */
     uint8_t ucBuffer;
-    BaseType_t xIndex;
+    size_t xIndex;
 
 
     xResult = pdPASS;

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -74,7 +74,7 @@
 #define MAX_ADDRESS_LENGTH                   25
 
 /* Use a big number to represent no event happened in defender. */
-#define NO_EVENT                             ( 1u << ( 8 * sizeof( AwsIotDefenderEventType_t ) - 1 ) )
+#define NO_EVENT                             255
 
 static const uint32_t _ECHO_SERVER_IP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                  tcptestECHO_SERVER_ADDR1,

--- a/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
+++ b/libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c
@@ -74,7 +74,7 @@
 #define MAX_ADDRESS_LENGTH                   25
 
 /* Use a big number to represent no event happened in defender. */
-#define NO_EVENT                             10000
+#define NO_EVENT                             ( 1u << ( 8 * sizeof( AwsIotDefenderEventType_t ) - 1 ) )
 
 static const uint32_t _ECHO_SERVER_IP = SOCKETS_inet_addr_quick( tcptestECHO_SERVER_ADDR0,
                                                                  tcptestECHO_SERVER_ADDR1,

--- a/libraries/c_sdk/aws/defender/test/unit/aws_iot_tests_defender_unit.c
+++ b/libraries/c_sdk/aws/defender/test/unit/aws_iot_tests_defender_unit.c
@@ -55,7 +55,7 @@
  * @brief Default Invalid Metrics Group.
  * Used by the SetMetrics_with_invalid_metrics_group unit test.
  */
-#define AWS_IOT_DEFENDER_DEFAULT_INVALID_METRICS_GROUP    ( 10000 )
+#define AWS_IOT_DEFENDER_DEFAULT_INVALID_METRICS_GROUP    ( 10 )
 
 /* Empty callback structure passed to startInfo. */
 static const AwsIotDefenderCallback_t _emptyCallback = { .function = NULL, .pCallbackContext = NULL };

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -234,6 +234,9 @@ static void RunTests( void )
 
 void TEST_RUNNER_RunTests_task( void * pvParameters )
 {
+    /* Disable unused parameter warning. */
+    ( void ) pvParameters;
+
     /* Initialize unity. */
     UnityFixture.Verbose = 1;
     UnityFixture.GroupFilter = 0;

--- a/tests/common/iot_test_freertos.c
+++ b/tests/common/iot_test_freertos.c
@@ -73,6 +73,10 @@
     void vApplicationStackOverflowHook( TaskHandle_t xTask,
                                         char * pcTaskName )
     {
+        /* Disable unused parameter warnings. */
+        ( void ) xTask;
+        ( void ) pcTaskName;
+
         configPRINT_STRING( ( "ERROR: stack overflow with task \r\n" ) );
         portDISABLE_INTERRUPTS();
 


### PR DESCRIPTION
Resolve warnings from Defender and TCP test files with ARM GCC build

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.