### PR TITLE
common-io: Refactoring and updates to RTC test cases and top-level header file

### DIFF
--- a/libraries/abstractions/common_io/include/iot_rtc.h
+++ b/libraries/abstractions/common_io/include/iot_rtc.h
@@ -169,6 +169,7 @@ void iot_rtc_set_callback( IotRtcHandle_t const pxRtcHandle,
  *      - xRequest is invalid
  *      - pvBuffer == NULL (excluding eCancelRtcAlarm, eCancelRtcWakeup)
  *      - if date/time is set in the past for eSetRtcAlarm
+ *   - IOT_RTC_SET_FAILED if date/time is invalid for eSetRtcAlarm.
  *   - IOT_RTC_NOT_STARTED on error
  *   - IOT_RTC_FUNCTION_NOT_SUPPORTED if feature not supported
  *      - Only valid for eCancelRtcAlarm, eCancelRtcWakeup

--- a/libraries/abstractions/common_io/test/test_iot_rtc.c
+++ b/libraries/abstractions/common_io/test/test_iot_rtc.c
@@ -48,7 +48,7 @@
 #define testIotRTC_DEFAULT_CURRENT_DAY         ( 1 )    /* 1st of the month */
 #define testIotRTC_DEFAULT_CURRENT_HOUR        ( 0 )    /* 0th hour */
 #define testIotRTC_DEFAULT_CURRENT_MINUTE      ( 0 )    /* 0th minute */
-#define testIotRTC_DEFAULT_CURRENT_SECOND      ( 0 )    /* 0th second */
+#define testIotRTC_DEFAULT_CURRENT_SECOND      ( 10 )   /* 10th second */
 
 #define testIotRTC_SEC_TO_MSEC                 ( 1000 )
 #define testIotRTC_DELAY_SECONDS               ( 2 )
@@ -695,7 +695,7 @@ TEST( TEST_IOT_RTC, AFQP_IotRtcSetAlarmInvalid )
     xSetDateTime.ucDay = testIotRTC_DEFAULT_CURRENT_DAY;
     xSetDateTime.ucHour = testIotRTC_DEFAULT_CURRENT_HOUR;
     xSetDateTime.ucMinute = testIotRTC_DEFAULT_CURRENT_MINUTE;
-    xSetDateTime.ucSecond = testIotRTC_DEFAULT_CURRENT_SECOND + testIotRTC_DEFAULT_ALARM_TIME;
+    xSetDateTime.ucSecond = testIotRTC_DEFAULT_CURRENT_SECOND;
 
     if( TEST_PROTECT() )
     {


### PR DESCRIPTION
Description
-----------
* Added TEST_PROTECT sections to test cases
* Removed global handle as the usage of the RTC is always open -> close which means the handle would be closed after the first test had run (often without setting it to NULL again).
* Added "Week day" to the date/time structure for each test so that the whole structure is in a known state when performing the tests.
* Changed semaphore timeouts to not be "eternal".
* Added global variable that can be used to configure which RTC instance to open (test was hard-coded to 0)
* Updated/added expected return value to the top-level API header file based on how the test cases was setup (please feedback on this as the test and API description was not aligned).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.