### PR TITLE
Fix nuvoton's cmake build

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -50,7 +50,6 @@ target_compile_definitions(
     -DPRODUCT_VERSION=m487 
     -DCONFIG_REPEATER 
     -DSUPPORT_MBEDTLS 
-    -DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_user_config.h\"
     -DHAL_DFS_MODULE_ENABLED 
     -DLWIP_NO_STDINT_H=1 
     -DLWIP_TIMEVAL_PRIVATE=1
@@ -62,6 +61,12 @@ target_compile_definitions(
     -DM487 
     ${extra_define}
 )
+if(AFR_IS_TESTING)
+    target_compile_definitions(
+        AFR::compiler::mcu_port
+        INTERFACE -DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_user_config.h\"
+    )
+endif()
 target_compile_definitions(
     AFR::compiler::mcu_port
     INTERFACE $<$<COMPILE_LANGUAGE:ASM>:${assembler_defined_symbols}>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Nuvoton's cmake build is failing because of a regression introduced in #1957. Our PR checks didn't catch this because it's not including the Nuvoton CMake build, I've talked to them to address this issue.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.