### PR TITLE
Test: display error codes when a test fails

### DIFF
--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -262,7 +262,7 @@ typedef struct
     }                                                                             \
     else                                                                          \
     {                                                                             \
-        TEST_ASSERT_EQUAL_INT_MESSAGE( condition, message );                      \
+        TEST_ASSERT_EQUAL_INT_MESSAGE( expected, actual, message );               \
     }
 
 /* Helper functions. */

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -202,7 +202,7 @@ typedef struct
     }                                                                  \
     else                                                               \
     {                                                                  \
-        TEST_ASSERT_EQUAL( expected, actual );                         \
+        TEST_ASSERT_EQUAL_INT( expected, actual );                     \
     }
 
 #define TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( expected, actual, result ) \
@@ -222,7 +222,7 @@ typedef struct
     }                                                                             \
     else                                                                          \
     {                                                                             \
-        TEST_ASSERT_EQUAL_MESSAGE( expected, actual, message );                   \
+        TEST_ASSERT_EQUAL_INT_MESSAGE( expected, actual, message );               \
     }
 
 #define TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API_MSG( expected, actual, result, message ) \
@@ -242,7 +242,7 @@ typedef struct
     }                                                                \
     else                                                             \
     {                                                                \
-        TEST_ASSERT_EQUAL( expected, actual );                       \
+        TEST_ASSERT_EQUAL_INT( expected, actual );                   \
     }
 
 #define TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( expected, actual, result ) \
@@ -262,7 +262,7 @@ typedef struct
     }                                                                             \
     else                                                                          \
     {                                                                             \
-        TEST_ASSERT_EQUAL_MESSAGE( condition, message );                          \
+        TEST_ASSERT_EQUAL_INT_MESSAGE( condition, message );                      \
     }
 
 /* Helper functions. */

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -212,7 +212,7 @@ typedef struct
     }                                                                    \
     else                                                                 \
     {                                                                    \
-        TEST_ASSERT_NOT_EQ( expected, actual );                          \
+        TEST_ASSERT_NOT_EQUAL( expected, actual );                       \
     }
 
 #define TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG( expected, actual, result, message ) \
@@ -1047,7 +1047,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_InvalidDomainName )
     {
         xWiFiStatus = WIFI_GetHostIP( testwifiTEST_INVALID_DOMAIN_NAME, ucIPAddr );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Assert that the IP address is NOT found. */
         TEST_ASSERT_EQUAL_INT32( *( ( uint32_t * ) ucIPAddr ), 0 );

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -195,44 +195,74 @@ typedef struct
  */
 
 /* Custom WIFI Test asserts. */
-#define TEST_WIFI_ASSERT_REQUIRED_API( condition, result )             \
-    if( result == eWiFiNotSupported )                                  \
+#define TEST_WIFI_ASSERT_EQ_REQUIRED_API( expected, actual, result )   \
+    if( ( result ) == eWiFiNotSupported )                              \
     {                                                                  \
         TEST_FAIL_MESSAGE( "Required Wi-Fi API is not implemented." ); \
     }                                                                  \
     else                                                               \
     {                                                                  \
-        TEST_ASSERT( condition );                                      \
+        TEST_ASSERT_EQUAL( expected, actual );                         \
     }
 
-#define TEST_WIFI_ASSERT_REQUIRED_API_MSG( condition, result, message ) \
-    if( result == eWiFiNotSupported )                                   \
-    {                                                                   \
-        TEST_FAIL_MESSAGE( "Required Wi-Fi API is not implemented." );  \
-    }                                                                   \
-    else                                                                \
-    {                                                                   \
-        TEST_ASSERT_MESSAGE( condition, message );                      \
+#define TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( expected, actual, result ) \
+    if( ( result ) == eWiFiNotSupported )                                \
+    {                                                                    \
+        TEST_FAIL_MESSAGE( "Required Wi-Fi API is not implemented." );   \
+    }                                                                    \
+    else                                                                 \
+    {                                                                    \
+        TEST_ASSERT_NOT_EQ( expected, actual );                          \
     }
 
-#define TEST_WIFI_ASSERT_OPTIONAL_API( condition, result ) \
-    if( result == eWiFiNotSupported )                      \
-    {                                                      \
-        TEST_ASSERT( 1 );                                  \
-    }                                                      \
-    else                                                   \
-    {                                                      \
-        TEST_ASSERT( condition );                          \
+#define TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG( expected, actual, result, message ) \
+    if( ( result ) == eWiFiNotSupported )                                         \
+    {                                                                             \
+        TEST_FAIL_MESSAGE( "Required Wi-Fi API is not implemented." );            \
+    }                                                                             \
+    else                                                                          \
+    {                                                                             \
+        TEST_ASSERT_EQUAL_MESSAGE( expected, actual, message );                   \
     }
 
-#define TEST_WIFI_ASSERT_OPTIONAL_API_MSG( condition, result, message ) \
-    if( result == eWiFiNotSupported )                                   \
-    {                                                                   \
-        TEST_ASSERT( 1 );                                               \
-    }                                                                   \
-    else                                                                \
-    {                                                                   \
-        TEST_ASSERT_MESSAGE( condition, message );                      \
+#define TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API_MSG( expected, actual, result, message ) \
+    if( ( result ) == eWiFiNotSupported )                                             \
+    {                                                                                 \
+        TEST_FAIL_MESSAGE( "Required Wi-Fi API is not implemented." );                \
+    }                                                                                 \
+    else                                                                              \
+    {                                                                                 \
+        TEST_ASSERT_NOT_EQUAL_MESSAGE( expected, actual, message );                   \
+    }
+
+#define TEST_WIFI_ASSERT_EQ_OPTIONAL_API( expected, actual, result ) \
+    if( ( result ) == eWiFiNotSupported )                            \
+    {                                                                \
+        TEST_ASSERT( 1 );                                            \
+    }                                                                \
+    else                                                             \
+    {                                                                \
+        TEST_ASSERT_EQUAL( expected, actual );                       \
+    }
+
+#define TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( expected, actual, result ) \
+    if( ( result ) == eWiFiNotSupported )                                \
+    {                                                                    \
+        TEST_ASSERT( 1 );                                                \
+    }                                                                    \
+    else                                                                 \
+    {                                                                    \
+        TEST_ASSERT_NOT_EQUAL( expected, actual );                       \
+    }
+
+#define TEST_WIFI_ASSERT_EQ_OPTIONAL_API_MSG( expected, actual, result, message ) \
+    if( ( result ) == eWiFiNotSupported )                                         \
+    {                                                                             \
+        TEST_ASSERT( 1 );                                                         \
+    }                                                                             \
+    else                                                                          \
+    {                                                                             \
+        TEST_ASSERT_EQUAL_MESSAGE( condition, message );                          \
     }
 
 /* Helper functions. */
@@ -687,14 +717,14 @@ TEST( Full_WiFi, AFQP_WiFiOnOffLoop )
             xWiFiStatus = WIFI_Off();
             snprintf( cBuffer, sBufferLength,
                       "Failed WIFI_Off() in iteration %lu", ( long unsigned int ) ulIndex );
-            TEST_WIFI_ASSERT_OPTIONAL_API_MSG(
-                eWiFiSuccess == xWiFiStatus, xWiFiStatus, cBuffer );
+            TEST_WIFI_ASSERT_EQ_OPTIONAL_API_MSG(
+                eWiFiSuccess, xWiFiStatus, xWiFiStatus, cBuffer );
 
             xWiFiStatus = WIFI_On();
             snprintf( cBuffer, sBufferLength, "Failed WIFI_On() in iteration %lu",
                       ( long unsigned int ) ulIndex );
-            TEST_WIFI_ASSERT_REQUIRED_API_MSG(
-                eWiFiSuccess == xWiFiStatus, xWiFiStatus, cBuffer );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG(
+                eWiFiSuccess, xWiFiStatus, xWiFiStatus, cBuffer );
         }
     }
     else
@@ -717,20 +747,20 @@ TEST( Full_WiFi, AFQP_WiFiOnOff )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_Off();
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         if( eWiFiSuccess == xWiFiStatus )
         {
             xWiFiStatus = WIFI_On();
-            TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
             xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
-            TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
             vTaskDelay( testwifiCONNECTION_DELAY );
 
             xWiFiStatus = WIFI_Disconnect();
-            TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
         }
     }
     else
@@ -754,19 +784,19 @@ TEST( Full_WiFi, AFQP_WiFiMode )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetMode( &xWiFiDeviceMode );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         xWiFiStatus = WIFI_SetMode( eWiFiModeAP );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         xWiFiStatus = WIFI_SetMode( eWiFiModeP2P );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         xWiFiStatus = WIFI_SetMode( eWiFiModeStation );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         xWiFiStatus = WIFI_SetMode( xWiFiDeviceMode );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -784,7 +814,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetMode_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetMode( NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -798,7 +828,7 @@ TEST( Full_WiFi, AFQP_WIFI_SetMode_InvalidMode )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_SetMode( eWiFiModeNotSupported );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     /* Some ports will use an assert for invalid parameters instead of returning a failure code.
@@ -829,20 +859,20 @@ TEST( Full_WiFi, AFQP_WiFiConnectionLoop )
              ++sConnectLoop )
         {
             xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
-            TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
             vTaskDelay( testwifiCONNECTION_DELAY );
 
             TEST_ASSERT( prvRoundTripTest() == pdPASS );
 
             xWiFiStatus = WIFI_Disconnect();
-            TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
             vTaskDelay( testwifiCONNECTION_DELAY );
         }
 
         xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -868,7 +898,7 @@ TEST( Full_WiFi, AFQP_WiFiGetIP )
         /* Acquire the IP address. */
         xWiFiStatus = WIFI_GetIP( ucIPAddr );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Assert that the IP address is found. */
         TEST_ASSERT( *( ( uint32_t * ) ucIPAddr ) != 0 );
@@ -892,7 +922,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetIP_NullParameters )
     {
         xWiFiStatus = WIFI_GetIP( NULL );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -917,7 +947,7 @@ TEST( Full_WiFi, AFQP_WiFiGetMAC )
     {
         xWiFiStatus = WIFI_GetMAC( ucMacAddressVal );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         for( ulIndex = 0; ulIndex < testwifiMAC_ADDRESS_LENGTH; ulIndex++ )
         {
@@ -944,7 +974,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetMAC_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetMAC( NULL );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -964,7 +994,7 @@ TEST( Full_WiFi, AFQP_WiFiGetHostIP )
     {
         xWiFiStatus = WIFI_GetHostIP( testwifiTEST_DOMAIN_NAME, ucIPAddr );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Assert that the IP address is found. */
         TEST_ASSERT( *( ( uint32_t * ) ucIPAddr ) != 0 );
@@ -990,13 +1020,13 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetHostIP( testwifiTEST_DOMAIN_NAME, NULL );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetHostIP( NULL, ucIPAddr );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -1017,7 +1047,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_InvalidDomainName )
     {
         xWiFiStatus = WIFI_GetHostIP( testwifiTEST_INVALID_DOMAIN_NAME, ucIPAddr );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Assert that the IP address is NOT found. */
         TEST_ASSERT_EQUAL_INT32( *( ( uint32_t * ) ucIPAddr ), 0 );
@@ -1049,7 +1079,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_DomainNameLengthExceeded )
     {
         xWiFiStatus = WIFI_GetHostIP( testwifiTEST_INVALID_DOMAIN_NAME, ucIPAddr );
 
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Assert that the IP address is NOT found. */
         TEST_ASSERT_EQUAL_INT32( *( ( uint32_t * ) ucIPAddr ), 0 );
@@ -1067,7 +1097,7 @@ TEST( Full_WiFi, AFQP_WiFiScan )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_Scan( xScanResults, testwifiMAX_SCAN_NUMBER );
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -1085,7 +1115,7 @@ TEST( Full_WiFi, AFQP_WIFI_Scan_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_Scan( NULL, testwifiMAX_SCAN_NUMBER );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -1111,7 +1141,7 @@ TEST( Full_WiFi, AFQP_WiFiNetworkAddGetDelete )
 
         /* Add a network. */
         xWiFiStatus = WIFI_NetworkAdd( &xNetworkProfile, &usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Reset the network profile variable so that we can verify if we get the
          * one that was just added. */
@@ -1119,7 +1149,7 @@ TEST( Full_WiFi, AFQP_WiFiNetworkAddGetDelete )
 
         /* Get a network. */
         xWiFiStatus = WIFI_NetworkGet( &xNetworkProfile, usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* If successful, then implemented. So check network parameters are what was
          * just added. */
@@ -1136,7 +1166,7 @@ TEST( Full_WiFi, AFQP_WiFiNetworkAddGetDelete )
 
         /* Delete a network. */
         xWiFiStatus = WIFI_NetworkDelete( usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -1158,13 +1188,13 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkAdd_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_NetworkAdd( &xNetworkProfile, NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_NetworkAdd( NULL, &usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1178,7 +1208,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGet_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_NetworkGet( NULL, 0 );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1204,11 +1234,11 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkDelete_DeleteNonExistingNetwork )
 
         /* Add a network. */
         xWiFiStatus = WIFI_NetworkAdd( &xNetworkProfile, &usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Delete the network. */
         xWiFiStatus = WIFI_NetworkDelete( usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -1219,7 +1249,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkDelete_DeleteNonExistingNetwork )
     {
         /* Delete non-existing network. */
         xWiFiStatus = WIFI_NetworkDelete( usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -1244,11 +1274,11 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGetNonExistingNetwork )
 
         /* Add a network. */
         xWiFiStatus = WIFI_NetworkAdd( &xNetworkProfile, &usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         /* Delete the network. */
         xWiFiStatus = WIFI_NetworkDelete( usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -1259,7 +1289,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGetNonExistingNetwork )
     {
         /* Get non-existing network. */
         xWiFiStatus = WIFI_NetworkGet( &xNetworkProfile, usIndex );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess != xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 }
 
@@ -1283,7 +1313,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks )
         for( usIndex = 0; usIndex < testwifiMAX_NETWORK_SAVE_NUMBER; usIndex++ )
         {
             xWiFiStatus = WIFI_NetworkGet( &xNetworkProfile, usIndex );
-            TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess != xWiFiStatus, xWiFiStatus );
+            TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
         }
     }
 }
@@ -1376,26 +1406,32 @@ TEST( Full_WiFi, AFQP_WiFiPowerManagementMode )
     {
         xPMMode = eWiFiPMLowPower;
         xWiFiStatus = WIFI_SetPMMode( xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
         xWiFiStatus = WIFI_GetPMMode( &xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API(
-            ( eWiFiSuccess == xWiFiStatus && eWiFiPMLowPower == xPMMode ),
-            xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus,
+                                          xWiFiStatus );
+
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiPMLowPower, xPMMode,
+                                          xWiFiStatus );
 
         xPMMode = eWiFiPMAlwaysOn;
         xWiFiStatus = WIFI_SetPMMode( xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
         xWiFiStatus = WIFI_GetPMMode( &xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API(
-            ( eWiFiSuccess == xWiFiStatus && eWiFiPMAlwaysOn == xPMMode ),
-            xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus,
+                                          xWiFiStatus );
+
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiPMAlwaysOn, xPMMode,
+                                          xWiFiStatus );
 
         xPMMode = eWiFiPMNormal;
         xWiFiStatus = WIFI_SetPMMode( xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
         xWiFiStatus = WIFI_GetPMMode( &xPMMode, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API(
-            ( eWiFiSuccess == xWiFiStatus && eWiFiPMNormal == xPMMode ), xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API(
+            eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API(
+            eWiFiPMNormal, xPMMode, xWiFiStatus );
     }
     else
     {
@@ -1413,7 +1449,7 @@ TEST( Full_WiFi, AFQP_WIFI_SetPMMode_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_SetPMMode( eWiFiPMNormal, NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1429,13 +1465,13 @@ TEST( Full_WiFi, AFQP_WIFI_GetPMMode_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetPMMode( &xPMMode, NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_GetPMMode( NULL, ( void * ) &ulOptionValue );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1449,7 +1485,7 @@ TEST( Full_WiFi, AFQP_WIFI_SetPMMode_InvalidPMMode )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_SetPMMode( eWiFiPMNotSupported, NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1473,7 +1509,7 @@ TEST( Full_WiFi, AFQP_WiFiConfigureAP )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
     else
     {
@@ -1493,7 +1529,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( NULL );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     /* Set the network parameters with valid parameters */
@@ -1506,7 +1542,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     /* Null password. */
@@ -1517,7 +1553,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     /* Null password for open security network. */
@@ -1551,7 +1587,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_InvalidSecurityType )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1578,7 +1614,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_MaxSSIDLengthExceeded )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1605,7 +1641,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_MaxPasswordLengthExceeded )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConfigureAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1617,7 +1653,7 @@ TEST( Full_WiFi, AFQP_WiFiReset )
     WIFIReturnCode_t xWiFiStatus;
 
     xWiFiStatus = WIFI_Reset();
-    TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 }
 
 /**
@@ -1632,7 +1668,7 @@ TEST( Full_WiFi, AFQP_WiFiPing )
 
     xWiFiStatus = WIFI_Ping( ( uint8_t * ) &ulPingAddress, testwifiPING_COUNT,
                              testwifiPING_INTERVAL_MS );
-    TEST_WIFI_ASSERT_OPTIONAL_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_OPTIONAL_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 }
 
 /**
@@ -1647,7 +1683,7 @@ TEST( Full_WiFi, AFQP_WIFI_Ping_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_Ping( NULL, testwifiPING_COUNT, testwifiPING_INTERVAL_MS );
-        TEST_WIFI_ASSERT_OPTIONAL_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_OPTIONAL_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 }
 
@@ -1670,18 +1706,18 @@ TEST( Full_WiFi, AFQP_WiFiIsConnected )
         vTaskDelay( testwifiCONNECTION_DELAY );
 
         xIsConnected = WIFI_IsConnected();
-        TEST_WIFI_ASSERT_REQUIRED_API( pdTRUE == xIsConnected, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdTRUE, xIsConnected, xWiFiStatus );
 
         /* Confirm if we are truly connected with the round-trip test. */
         TEST_ASSERT( prvRoundTripTest() == pdPASS );
 
         xWiFiStatus = WIFI_Disconnect();
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess == xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
 
         vTaskDelay( testwifiCONNECTION_DELAY );
 
         xIsConnected = WIFI_IsConnected();
-        TEST_WIFI_ASSERT_REQUIRED_API( pdFALSE == xIsConnected, xIsConnected );
+        TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdFALSE, xIsConnected, xIsConnected );
 
         TEST_ASSERT( prvRoundTripTest() != pdPASS );
     }
@@ -1704,7 +1740,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConnectAP( NULL );
-        TEST_WIFI_ASSERT_REQUIRED_API( eWiFiSuccess != xWiFiStatus, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( xWiFiStatus, eWiFiSuccess, xWiFiStatus );
     }
 
     /* Null SSID */
@@ -1714,7 +1750,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 
     /* Test a null password when it is needed. */
@@ -1724,7 +1760,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_NullParameters )
     if( TEST_PROTECT() )
     {
         xWiFiStatus = WIFI_ConnectAP( &xNetworkParams );
-        TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
+        TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
     }
 
     /* Test a null password when it is not needed. */
@@ -1770,8 +1806,8 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_InvalidPassword )
             "WIFI_ConnectAP() returned success, but failed to connect." );
     }
 
-    TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
-    TEST_WIFI_ASSERT_REQUIRED_API( pdFALSE == xIsConnected, xIsConnected );
+    TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdFALSE, xIsConnected, xIsConnected );
 }
 
 /**
@@ -1803,8 +1839,8 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_InvalidSSID )
             "WIFI_ConnectAP() returned success, but failed to connect." );
     }
 
-    TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
-    TEST_WIFI_ASSERT_REQUIRED_API( pdFALSE == xIsConnected, xIsConnected );
+    TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdFALSE, xIsConnected, xIsConnected );
 }
 
 /**
@@ -1841,8 +1877,8 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_MaxSSIDLengthExceeded )
             "WIFI_ConnectAP() returned success, but failed to connect." );
     }
 
-    TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
-    TEST_WIFI_ASSERT_REQUIRED_API( pdFALSE == xIsConnected, xIsConnected );
+    TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdFALSE, xIsConnected, xIsConnected );
 }
 
 /**
@@ -1879,8 +1915,8 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_MaxPasswordLengthExceeded )
             "WIFI_ConnectAP() returned success, but failed to connect." );
     }
 
-    TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
-    TEST_WIFI_ASSERT_REQUIRED_API( pdFALSE == xIsConnected, xIsConnected );
+    TEST_WIFI_ASSERT_NOT_EQ_REQUIRED_API( eWiFiSuccess, xWiFiStatus, xWiFiStatus );
+    TEST_WIFI_ASSERT_EQ_REQUIRED_API( pdFALSE, xIsConnected, xIsConnected );
 }
 
 /**
@@ -1924,14 +1960,14 @@ TEST( Full_WiFi, AFQP_WiFiConnectMultipleAP )
                       "retries. Status was %d.",
                       xTestNetworkParams.pcSSID, ( int ) ulIndex, ( int ) xMaxRetries,
                       eWiFiStatus );
-            TEST_WIFI_ASSERT_REQUIRED_API_MSG(
-                eWiFiStatus == eWiFiSuccess, eWiFiStatus, cMessageString );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG(
+                eWiFiSuccess, eWiFiStatus, eWiFiStatus, cMessageString );
 
             vTaskDelay( testwifiCONNECTION_DELAY );
 
             xIsConnected = WIFI_IsConnected();
-            TEST_WIFI_ASSERT_REQUIRED_API_MSG(
-                pdTRUE == xIsConnected, xIsConnected,
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG(
+                pdTRUE, xIsConnected, xIsConnected,
                 ( "API is violated, we must connect to the new network." ) );
 
             /* Perform the round-trip test to verify we are actually connected.
@@ -1956,14 +1992,14 @@ TEST( Full_WiFi, AFQP_WiFiConnectMultipleAP )
                       "retries. Status was %d.",
                       xClientNetworkParams.pcSSID, ( int ) ulIndex, ( int ) xMaxRetries,
                       eWiFiStatus );
-            TEST_WIFI_ASSERT_REQUIRED_API_MSG(
-                eWiFiStatus == eWiFiSuccess, eWiFiStatus, cMessageString );
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG(
+                eWiFiSuccess, eWiFiStatus, eWiFiStatus, cMessageString );
 
             vTaskDelay( testwifiCONNECTION_DELAY );
 
             xIsConnected = WIFI_IsConnected();
-            TEST_WIFI_ASSERT_REQUIRED_API_MSG(
-                pdTRUE == xIsConnected, xIsConnected,
+            TEST_WIFI_ASSERT_EQ_REQUIRED_API_MSG(
+                pdTRUE, xIsConnected, xIsConnected,
                 ( "API is violated, we must connect to the new network." ) );
 
             /* Perform the round-trip test to verify we are actually connected. The


### PR DESCRIPTION
Add exact error messages to failing tests

Description
-----------
Currently tests only display true or false whether the test passed or failed
This Commit will display the exact error code received from the underlying Wifi implementation

Checklist
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.