### PR TITLE
Ensure cyobjstore is initialized

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
@@ -407,6 +407,13 @@ WIFIReturnCode_t WIFI_NetworkGet( WIFINetworkProfile_t * pxNetworkProfile, uint1
     configASSERT(pxNetworkProfile != NULL);
     if (cy_rtos_get_mutex(&wifiMutex, wificonfigMAX_SEMAPHORE_WAIT_TIME_MS) == CY_RSLT_SUCCESS)
     {
+        if (cy_objstore_is_initialized() == CY_OBJSTORE_NOT_INITIALIZED &&
+            cy_objstore_initialize(false, 1) != CY_RSLT_SUCCESS)
+        {
+            cy_rtos_set_mutex(&wifiMutex);
+            return eWiFiFailure;
+        }
+
         if (usIndex >= CY_TOTAL_WIFI_PROFILES ||
             cy_objstore_read_object(usIndex + CY_FIRST_WIFI_PROFILE, (uint8_t *)pxNetworkProfile, sizeof(WIFINetworkProfile_t)))
         {
@@ -432,6 +439,13 @@ WIFIReturnCode_t WIFI_NetworkDelete( uint16_t usIndex )
     uint32_t size;
     if (cy_rtos_get_mutex(&wifiMutex, wificonfigMAX_SEMAPHORE_WAIT_TIME_MS) == CY_RSLT_SUCCESS)
     {
+        if (cy_objstore_is_initialized() == CY_OBJSTORE_NOT_INITIALIZED &&
+            cy_objstore_initialize(false, 1) != CY_RSLT_SUCCESS)
+        {
+            cy_rtos_set_mutex(&wifiMutex);
+            return eWiFiFailure;
+        }
+
         if (usIndex >= CY_TOTAL_WIFI_PROFILES ||
             (cy_objstore_find_object(usIndex + CY_FIRST_WIFI_PROFILE, &index, &size) != CY_OBJSTORE_NO_SUCH_OBJECT &&
             cy_objstore_delete_object(usIndex + CY_FIRST_WIFI_PROFILE) != CY_RSLT_SUCCESS))


### PR DESCRIPTION
Ensure cyobjstore is initialized

Description
-----------
cyobjstore may be called before it is initialized. This patch makes sure cyobjstore is initialized.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.