### PR TITLE
Make Flags of proper width

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -70,12 +70,12 @@ the defined MTU size can contain at least a complete TCP packet. */
 /*
  * The meaning of the TCP flags:
  */
-#define ipTCP_FLAG_FIN			0x0001u /* No more data from sender */
-#define ipTCP_FLAG_SYN			0x0002u /* Synchronize sequence numbers */
-#define ipTCP_FLAG_RST			0x0004u /* Reset the connection */
-#define ipTCP_FLAG_PSH			0x0008u /* Push function: please push buffered data to the recv application */
-#define ipTCP_FLAG_ACK			0x0010u /* Acknowledgment field is significant */
-#define ipTCP_FLAG_URG			0x0020u /* Urgent pointer field is significant */
+#define ipTCP_FLAG_FIN			( ( uint8_t) 0x0001u ) /* No more data from sender */
+#define ipTCP_FLAG_SYN			( ( uint8_t) 0x0002u ) /* Synchronize sequence numbers */
+#define ipTCP_FLAG_RST			( ( uint8_t) 0x0004u ) /* Reset the connection */
+#define ipTCP_FLAG_PSH			( ( uint8_t) 0x0008u ) /* Push function: please push buffered data to the recv application */
+#define ipTCP_FLAG_ACK			( ( uint8_t) 0x0010u ) /* Acknowledgment field is significant */
+#define ipTCP_FLAG_URG			( ( uint8_t) 0x0020u ) /* Urgent pointer field is significant */
 #define ipTCP_FLAG_ECN			0x0040u /* ECN-Echo */
 #define ipTCP_FLAG_CWR			0x0080u /* Congestion Window Reduced */
 #define ipTCP_FLAG_NS			0x0100u /* ECN-nonce concealment protection */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -70,12 +70,12 @@ the defined MTU size can contain at least a complete TCP packet. */
 /*
  * The meaning of the TCP flags:
  */
-#define ipTCP_FLAG_FIN			( ( uint8_t) 0x0001u ) /* No more data from sender */
-#define ipTCP_FLAG_SYN			( ( uint8_t) 0x0002u ) /* Synchronize sequence numbers */
-#define ipTCP_FLAG_RST			( ( uint8_t) 0x0004u ) /* Reset the connection */
-#define ipTCP_FLAG_PSH			( ( uint8_t) 0x0008u ) /* Push function: please push buffered data to the recv application */
-#define ipTCP_FLAG_ACK			( ( uint8_t) 0x0010u ) /* Acknowledgment field is significant */
-#define ipTCP_FLAG_URG			( ( uint8_t) 0x0020u ) /* Urgent pointer field is significant */
+#define ipTCP_FLAG_FIN			( ( uint8_t) 0x01u ) /* No more data from sender */
+#define ipTCP_FLAG_SYN			( ( uint8_t) 0x02u ) /* Synchronize sequence numbers */
+#define ipTCP_FLAG_RST			( ( uint8_t) 0x04u ) /* Reset the connection */
+#define ipTCP_FLAG_PSH			( ( uint8_t) 0x08u ) /* Push function: please push buffered data to the recv application */
+#define ipTCP_FLAG_ACK			( ( uint8_t) 0x10u ) /* Acknowledgment field is significant */
+#define ipTCP_FLAG_URG			( ( uint8_t) 0x20u ) /* Urgent pointer field is significant */
 #define ipTCP_FLAG_ECN			0x0040u /* ECN-Echo */
 #define ipTCP_FLAG_CWR			0x0080u /* Congestion Window Reduced */
 #define ipTCP_FLAG_NS			0x0100u /* ECN-nonce concealment protection */


### PR DESCRIPTION
The TCP flags are not of proper width according to the header in the TCP protocol.

Description
-----------
The TCP flags are not of proper width according to the header in the TCP protocol. In absence of a cast, this value is downcasted from `uin16_t` to `uint8_t` to assign value to the 8 bit width `xTCP_HEADER.ucTCPFlags`.
These flags are designed to fit in a 6-bit wide value according to [RFC 793](https://tools.ietf.org/html/rfc793#section-3.1). The other bits are experimental and are defined in various RFCs. They are not used as of now in the +TCP stack except for the purposes of debugging.

The issue that triggered this PR:
Visual Studio build (v142) yields 2 warnings for `FreeRTOS_TCP_IP.c` file, both of which are `cast truncates constant value`.

```
1>amaon-freertos\amazon-freertos\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c(864,60): warning C4310: cast truncates constant value
1>amazon-freertos\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c(1885,56): warning C4310: cast truncates constant value
```

Both places downcast macro constants from `uin16_t` to `uint8_t` to assign value to the 8-bit width xTCP_HEADER.ucTCPFlags member [here](https://github.com/aws/amazon-freertos/blob/master/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h#L146)

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.