### PR TITLE
Fix nordic freertos timer create

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -153,8 +153,8 @@ static void _onNetworkStateChangeCallback( uint32_t network,
                                                     pNetworkInterface );
         }
     }
-    else if( ( ( state == eNetworkStateDisabled ) || ( state == eNetworkStateUnknown ) )
-		    && ( demoConnectedNetwork == network ) )
+    else if( ( ( state == eNetworkStateDisabled ) || ( state == eNetworkStateUnknown ) ) &&
+             ( demoConnectedNetwork == network ) )
     {
         if( pDemoContext->networkDisconnectedCallback != NULL )
         {

--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -153,7 +153,8 @@ static void _onNetworkStateChangeCallback( uint32_t network,
                                                     pNetworkInterface );
         }
     }
-    else if( ( state == eNetworkStateDisabled ) && ( demoConnectedNetwork == network ) )
+    else if( ( ( state == eNetworkStateDisabled ) || ( state == eNetworkStateUnknown ) )
+		    && ( demoConnectedNetwork == network ) )
     {
         if( pDemoContext->networkDisconnectedCallback != NULL )
         {

--- a/vendors/nordic/nRF5_SDK_15.2.0/components/libraries/timer/app_timer_freertos.c
+++ b/vendors/nordic/nRF5_SDK_15.2.0/components/libraries/timer/app_timer_freertos.c
@@ -134,7 +134,7 @@ uint32_t app_timer_create(app_timer_id_t const *      p_timer_id,
         return NRF_ERROR_INVALID_STATE;
     }
 
-    /* If already a FreeRTOS timer exists, delete and recreate the timer. */
+    /* If a FreeRTOS timer already exists, delete and recreate the timer. */
     if (pinfo->osHandle != NULL)
     {
         timer_handle = ( TimerHandle_t ) ( pinfo->osHandle );
@@ -154,15 +154,21 @@ uint32_t app_timer_create(app_timer_id_t const *      p_timer_id,
     memset(pinfo, 0, sizeof(app_timer_info_t));
 
     if (mode == APP_TIMER_MODE_SINGLE_SHOT)
+    {
         timer_mode = pdFALSE;
+    }
     else
+    {
         timer_mode = pdTRUE;
+    }
 
     pinfo->func = timeout_handler;
     pinfo->osHandle = xTimerCreate(" ", 1000, timer_mode, pinfo, app_timer_callback);
 
     if (pinfo->osHandle == NULL)
+    {
         err_code = NRF_ERROR_NULL;
+    }
 
     return err_code;
 }

--- a/vendors/nordic/nRF5_SDK_15.2.0/components/libraries/timer/app_timer_freertos.c
+++ b/vendors/nordic/nRF5_SDK_15.2.0/components/libraries/timer/app_timer_freertos.c
@@ -123,6 +123,7 @@ uint32_t app_timer_create(app_timer_id_t const *      p_timer_id,
     app_timer_info_t * pinfo = (app_timer_info_t*)(*p_timer_id);
     uint32_t      err_code = NRF_SUCCESS;
     unsigned long timer_mode;
+    TimerHandle_t timer_handle;
 
     if ((timeout_handler == NULL) || (p_timer_id == NULL))
     {
@@ -133,27 +134,35 @@ uint32_t app_timer_create(app_timer_id_t const *      p_timer_id,
         return NRF_ERROR_INVALID_STATE;
     }
 
-    if (pinfo->osHandle == NULL)
+    /* If already a FreeRTOS timer exists, delete and recreate the timer. */
+    if (pinfo->osHandle != NULL)
     {
-        /* New timer is created */
-        memset(pinfo, 0, sizeof(app_timer_info_t));
+        timer_handle = ( TimerHandle_t ) ( pinfo->osHandle );
+        /* Return error if the timer is active */
+        if( xTimerIsTimerActive( timer_handle ) )
+        {
+            return NRF_ERROR_INVALID_STATE;
+        }
 
-        if (mode == APP_TIMER_MODE_SINGLE_SHOT)
-            timer_mode = pdFALSE;
-        else
-            timer_mode = pdTRUE;
-
-        pinfo->func = timeout_handler;
-        pinfo->osHandle = xTimerCreate(" ", 1000, timer_mode, pinfo, app_timer_callback);
-
-        if (pinfo->osHandle == NULL)
-            err_code = NRF_ERROR_NULL;
+        if( xTimerDelete( timer_handle, portMAX_DELAY ) != pdTRUE )
+        {
+            return NRF_ERROR_INVALID_STATE;
+        }
     }
+
+    /* New timer is created */
+    memset(pinfo, 0, sizeof(app_timer_info_t));
+
+    if (mode == APP_TIMER_MODE_SINGLE_SHOT)
+        timer_mode = pdFALSE;
     else
-    {
-        /* Timer cannot be reinitialized using FreeRTOS API */
-        return NRF_ERROR_INVALID_STATE;
-    }
+        timer_mode = pdTRUE;
+
+    pinfo->func = timeout_handler;
+    pinfo->osHandle = xTimerCreate(" ", 1000, timer_mode, pinfo, app_timer_callback);
+
+    if (pinfo->osHandle == NULL)
+        err_code = NRF_ERROR_NULL;
 
     return err_code;
 }


### PR DESCRIPTION
Fix freertos timer create function for Nordic

Description
-----------
Nordic has an implementation for app timer APIs using FreeRTOS timers. `app_timer_create` API is expected to re-create a new timer with a new handler (note: there is no API to delete a timer). Currently the API returns an error if a timer already exists. With this PR, API ensures if timer is inactive, then delete and create a new timer with the new handler.

Also added a check in demo runner to handle user initiated network disable transition in network manager callback.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.