### PR TITLE
Update wait time in OTA suspend and resume E2E tests

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_cancel_update.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_cancel_update.py
@@ -77,10 +77,10 @@ class OtaTestDisconnectCancelUpdate(OtaTestCase):
         # Start an OTA Update.
         otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig, [self._protocol])
 
-        # Wait up to 3 minute until the job is in progress.
+        # Wait until the job is in progress.
         thing_name = self._otaAwsAgent._iotThing.thing_name
         exec_status = 'QUEUED'
-        timeout = time.time() + 180
+        timeout = time.time() + self._otaConfig['ota_timeout_sec']
         while exec_status == 'QUEUED' and time.time() < timeout:
             exec_status = self.get_job_exec_status(otaUpdateId, thing_name)
             time.sleep(1)

--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_resume.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_resume.py
@@ -77,10 +77,10 @@ class OtaTestDisconnectResume(OtaTestCase):
         # Start an OTA Update.
         otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig, [self._protocol])
 
-        # Wait up to 3 minute until the job is in progress.
+        # Wait until the job is in progress.
         thing_name = self._otaAwsAgent._iotThing.thing_name
         exec_status = 'QUEUED'
-        timeout = time.time() + 180
+        timeout = time.time() + self._otaConfig['ota_timeout_sec']
         while exec_status == 'QUEUED' and time.time() < timeout:
             exec_status = self.get_job_exec_status(otaUpdateId, thing_name)
             time.sleep(1)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Wait time is too short in OTA suspend and resume E2E tests. This PR replace the hardcode 3 mins with the timeout value from configuration.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.