### PR TITLE
Fix an issue about suspend/resume in OTA http

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -532,8 +532,9 @@ static void _httpResponseCompleteCallback( void * pPrivateData,
     /* OTA Event. */
     OTA_EventMsg_t eventMsg = { 0 };
 
-    /* Bail out if this callback is invoked after the OTA agent is stopped. */
-    if( _httpDownloader.pAgentCtx->eState == eOTA_AgentState_Stopped )
+    /* Bail out if this callback is invoked after the OTA agent is stopped or suspended. */
+    if( ( _httpDownloader.pAgentCtx->eState == eOTA_AgentState_Stopped ) ||
+        ( _httpDownloader.pAgentCtx->eState == eOTA_AgentState_Suspended ) )
     {
         return;
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
We should ignore any data received from network after OTA is in suspend
state. This fix an issue occurred in OTA E2E tests where OTA event
buffer is never freed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.