### PR TITLE
Only compile prvReadSackOption() when TCP sliding windows are used

### DIFF
--- a/tools/cbmc/patches/remove-static-in-freertos-tcp-ip.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-tcp-ip.patch
@@ -1,14 +1,5 @@
-From afc01793c4531cfbe9f92e7ca2ce9364983d987e Mon Sep 17 00:00:00 2001
-From: Mark R Tuttle <mrtuttle@amazon.com>
-Date: Tue, 12 May 2020 15:57:56 +0000
-Subject: [PATCH] modified lib
-
----
- .../freertos_plus_tcp/source/FreeRTOS_TCP_IP.c     | 24 ++++++++++++++++++++++
- 1 file changed, 24 insertions(+)
-
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
-index dc58621..963b576 100644
+index 7a2c00c68..cb537b347 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
 @@ -198,14 +198,22 @@ static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t *pxSocket );
@@ -34,18 +25,18 @@ index dc58621..963b576 100644
  											 size_t uxTotalLength,
  											 FreeRTOS_Socket_t * const pxSocket,
  											 BaseType_t xHasSYNFlag );
-@@ -214,7 +222,11 @@ static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-  * Skip past TCP header options when doing Selective ACK, until there are no
-  * more options left.
-  */
-+#ifdef CBMC
-+void prvReadSackOption( const uint8_t * const pucPtr,
-+#else
- static void prvReadSackOption( const uint8_t * const pucPtr,
-+#endif
- 							   size_t uxIndex,
- 							   FreeRTOS_Socket_t * const pxSocket );
- 
+@@ -215,7 +223,11 @@ static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
+ 	 * Skip past TCP header options when doing Selective ACK, until there are no
+ 	 * more options left.
+ 	 */
++	#ifdef CBMC
++	void prvReadSackOption( const uint8_t * const pucPtr,
++	#else
+ 	static void prvReadSackOption( const uint8_t * const pucPtr,
++	#endif
+ 								   size_t uxIndex,
+ 								   FreeRTOS_Socket_t * const pxSocket );
+ #endif/* ( ipconfigUSE_TCP_WIN == 1 ) */
 @@ -1137,7 +1149,11 @@ uint32_t ulInitialSequenceNumber = 0;
   * that: ((pxTCPHeader->ucTCPOffset & 0xf0) > 0x50), meaning that the TP header
   * is longer than the usual 20 (5 x 4) bytes.
@@ -58,7 +49,7 @@ index dc58621..963b576 100644
  {
  size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
  const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-@@ -1201,7 +1217,11 @@ uint8_t ucLength;
+@@ -1199,7 +1215,11 @@ uint8_t ucLength;
  }
  /*-----------------------------------------------------------*/
  
@@ -70,18 +61,15 @@ index dc58621..963b576 100644
  											 size_t uxTotalLength,
  											 FreeRTOS_Socket_t * const pxSocket,
  											 BaseType_t xHasSYNFlag )
-@@ -1346,7 +1366,11 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
- }
+@@ -1331,7 +1351,11 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+void prvReadSackOption( const uint8_t * const pucPtr,
-+#else
- static void prvReadSackOption( const uint8_t * const pucPtr,
-+#endif
- 							   size_t uxIndex,
- 							   FreeRTOS_Socket_t * const pxSocket )
- {
--- 
-2.7.4
-
+ #if( ipconfigUSE_TCP_WIN == 1 )
++	#ifdef CBMC
++	void prvReadSackOption( const uint8_t * const pucPtr,
++	#else
+ 	static void prvReadSackOption( const uint8_t * const pucPtr,
++	#endif
+ 								   size_t uxIndex,
+ 								   FreeRTOS_Socket_t * const pxSocket )
+ 	{


### PR DESCRIPTION
Make compilation of `prvReadSackOption()` dependent on `ipconfigUSE_TCP_WIN`
<!--- Title -->

Description
-----------
Since the function `prvCheckOptions()` was split-up into smaller parts, the function `prvReadSackOption()` was compiled unconditionally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.