### PR TITLE
Go Echo Server TLS 

### DIFF
--- a/tools/echo_server/echo_server.go
+++ b/tools/echo_server/echo_server.go
@@ -72,6 +72,17 @@ func secureEcho(certPath string, keyPath string, port string, verbose bool) {
 		MinVersion: tls.VersionTLS12,
 		RootCAs:    serverCAPool,
 		ClientAuth: tls.RequireAnyClientCert,
+		// Cipher suites supported by AWS IoT Core. Note this is the intersection of the set
+		// of cipher suites supported by GO and by AWS IoT Core.
+		// See the complete list of supported cipher suites at https://docs.aws.amazon.com/iot/latest/developerguide/transport-security.html.
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+		},
 	}
 
 	tlsConfig.Rand = rand.Reader

--- a/tools/echo_server/readme.md
+++ b/tools/echo_server/readme.md
@@ -34,13 +34,13 @@ The JSON file contains the following options:
 1. logging
     1. Enable this option to output log all messages received to a file.
 1. secure-connection
-    1. Enable this option to switch to using TLS for the echo server. Note you will have to complete the credential creation prequisite. 
+    1. Enable this option to switch to using TLS for the echo server. Note you will have to complete the credential creation prerequisite. 
 1. server-port
     1. Specify which port to open a socket on.
 1. server-certificate-location
-    1. Relative or abosolute path to the server certificate generated in the credetial creation prequisite.
+    1. Relative or absolute path to the server certificate generated in the credential creation prerequisite.
 1. server-key-location
-    1. Relative or abosolute path to the server key generated in the credetial creation prequisite.
+    1. Relative or absolute path to the server key generated in the credential creation prerequisite.
 ## Example Configuration
 ```json
 {
@@ -66,9 +66,9 @@ You have to alter these 3 files:
 
 * {amazon-freertos-root-directory}/tests/include/aws_clientcredential.h
 * {amazon-freertos-root-directory}/tests/include/aws_clientcredential_keys.h
-* {amazon-freertos-root-directory}/tests/include/aws_test_utils.h
+* {amazon-freertos-root-directory}/tests/include/aws_test_tcp.h
 
-After following the prequisite steps, you should have the following files:
+After following the prerequisite steps, you should have the following files:
 * certs/client.csr
 * certs/client.key
 * certs/client.pem


### PR DESCRIPTION
Only use TLS cipher suite's supported by AWS IoT Core

Description
-----------
Explicitly only allow the use of the cipher suite's AWS IoT Core uses.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.