### PR TITLE
Revert uncrustify change from PR #2015

### DIFF
--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -142,7 +142,6 @@ align_pp_define_gap             = 4        # unsigned number
 align_pp_define_span            = 3        # unsigned number
 cmt_cpp_to_c                    = true     # false/true
 cmt_star_cont                   = true     # false/true
-cmt_sp_before_star_cont         = 1        # unsigned number
 mod_full_brace_do               = add      # ignore/add/remove/force
 mod_full_brace_for              = add      # ignore/add/remove/force
 mod_full_brace_if               = add      # ignore/add/remove/force


### PR DESCRIPTION
Revert uncrustify change from PR #2015 

Description
-----------
Some changes to uncrustify came with #2015. The new change added a space to every *, this reverts this change.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.