### PR TITLE
Fix an include path issue in esp32 makefile

### DIFF
--- a/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/espressif_code/amazon-freertos-tests/component.mk
@@ -128,7 +128,6 @@ COMPONENT_SRCDIRS += ../.. \
 
 COMPONENT_ADD_INCLUDEDIRS += $(AMAZON_FREERTOS_TESTS_DIR)/include \
         $(AMAZON_FREERTOS_3RD_PARTY_DIR)/unity/src \
-        $(AMAZON_FREERTOS_DEMOS_DIR)/include \
         ${AMAZON_FREERTOS_SDK_DIR}/standard/ble/test \
         ${AMAZON_FREERTOS_ARF_PLUS_DIR}/aws/greengrass/test \
         ${AMAZON_FREERTOS_ARF_PLUS_DIR}/aws/ota/test \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
aws_tests project shouldn't add demos/include to the include paths, this is causing OTA PAL tests to use wrong header file and failing.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.