### PR TITLE
Xilinx Demo Finish Message Print Issue: Increased logging queue size

### DIFF
--- a/vendors/xilinx/boards/microzed/aws_demos/application_code/main.c
+++ b/vendors/xilinx/boards/microzed/aws_demos/application_code/main.c
@@ -53,7 +53,7 @@
 #include "aws_application_version.h"
 
 /* Logging Task Defines. */
-#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 64 )
 #define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
 
 /* Unit test defines. */


### PR DESCRIPTION
Description
-----------
This change increases the logging queue size so that the demo finished message prints for the CI to know that the demo finished successfully.

There have been changes that increased the amount of logging messages in this board. These include increased memory monitoring logging. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [n/a] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.