### PR TITLE
Comment out calls to TEST_MESSAGE

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -538,7 +538,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
         }
         else
         {
-            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
+            /* TEST_MESSAGE( "Start offset is not aligned with blockSize" ); */
         }
     }
 
@@ -627,7 +627,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
         }
         else
         {
-            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
+            /* TEST_MESSAGE( "Start offset is not aligned with blockSize" ); */
         }
     }
 
@@ -725,7 +725,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
         }
         else
         {
-            TEST_MESSAGE( "Start offset is not aligned with blockSize" );
+            /* TEST_MESSAGE( "Start offset is not aligned with blockSize" ); */
         }
     }
 

--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -670,23 +670,23 @@ static void testIotGpioInterrupt( IotGpioInterrupt_t eGpioInterrupt )
             switch( eGpioInterrupt )
             {
                 case eGpioInterruptRising:
-                    TEST_MESSAGE( "Rising edge interrupts not supported." );
+                    /* TEST_MESSAGE( "Rising edge interrupts not supported." ); */
                     break;
 
                 case eGpioInterruptFalling:
-                    TEST_MESSAGE( "Falling edge interrupts not supported." );
+                    /* TEST_MESSAGE( "Falling edge interrupts not supported." ); */
                     break;
 
                 case eGpioInterruptEdge:
-                    TEST_MESSAGE( "Both edge interrupts not supported." );
+                    /* TEST_MESSAGE( "Both edge interrupts not supported." ); */
                     break;
 
                 case eGpioInterruptLow:
-                    TEST_MESSAGE( "low-level interrupts not supported." );
+                    /* TEST_MESSAGE( "low-level interrupts not supported." ); */
                     break;
 
                 case eGpioInterruptHigh:
-                    TEST_MESSAGE( "high-level interrupts not supported." );
+                    /* TEST_MESSAGE( "high-level interrupts not supported." ); */
                     break;
 
                 default:


### PR DESCRIPTION
<!--- Commented TEST_MESSAGE() -->

Description
-----------

TEST_MESSAGE() requires Unity 2.4.4, currently the latest released.  Comment out these message to avoid requirement to uplevel Unity.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.