### PR TITLE
PKCS #11 Refactor

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -287,7 +287,7 @@ static P11Session_t * prvSessionPointerFromHandle( CK_SESSION_HANDLE xSession )
 {
     P11Session_t * pxSession = NULL;
 
-    if( ( xSession >= 1 ) && (xSession <= pkcs11configMAX_SESSIONS ) )
+    if( ( xSession >= 1 ) && ( xSession <= pkcs11configMAX_SESSIONS ) )
     {
         /* Decrement by 1, invalid handles in PKCS #11 are defined to be 0. */
         pxSession = &pxP11Sessions[ xSession - 1 ];

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -283,15 +283,14 @@ static CK_RV prvCheckValidSessionAndModule( const P11Session_t * pxSession )
 /**
  * @brief Maps an opaque caller session handle into its internal state structure.
  */
-static P11Session_t * prvSessionPointerFromHandle( const CK_SESSION_HANDLE xSession )
+static P11Session_t * prvSessionPointerFromHandle( CK_SESSION_HANDLE xSession )
 {
     P11Session_t * pxSession = NULL;
-    CK_SESSION_HANDLE xSessionHandle = xSession - 1;
 
-    if( xSessionHandle < pkcs11configMAX_SESSIONS )
+    if( ( xSession >= 1 ) && (xSession <= pkcs11configMAX_SESSIONS ) )
     {
         /* Decrement by 1, invalid handles in PKCS #11 are defined to be 0. */
-        pxSession = &pxP11Sessions[ xSessionHandle ];
+        pxSession = &pxP11Sessions[ xSession - 1 ];
     }
 
     return pxSession;

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -187,6 +187,7 @@ typedef struct P11Object_t
 typedef struct P11ObjectList_t
 {
     SemaphoreHandle_t xMutex;                            /**< @brief Mutex that protects write operations to the xObjects array. */
+    StaticSemaphore_t xMutexBuffer;                      /**< @brief Mutex buffer in order to avoid calling Malloc. */
     P11Object_t xObjects[ pkcs11configMAX_NUM_OBJECTS ]; /**< @brief List of PKCS #11 objects. */
 } P11ObjectList_t;
 
@@ -200,6 +201,8 @@ typedef struct P11Struct_t
     CK_BBOOL xIsInitialized;                     /**< @brief Indicates whether PKCS #11 module has been initialized with a call to C_Initialize. */
     mbedtls_ctr_drbg_context xMbedDrbgCtx;       /**< @brief CTR-DRBG context for PKCS #11 module - used to generate pseudo-random numbers. */
     mbedtls_entropy_context xMbedEntropyContext; /**< @brief Entropy context for PKCS #11 module - used to collect entropy for RNG. */
+    SemaphoreHandle_t xSessionMutex;             /**< @brief Mutex that protects write operations to the pxSession array. */
+    StaticSemaphore_t xSessionMutexBuffer;       /**< @brief Mutex buffer in order to avoid calling Malloc. */
     P11ObjectList_t xObjectList;                 /**< @brief List of PKCS #11 objects that have been found/created since module initialization.
                                                   *         The array position indicates the "App Handle"  */
 } P11Struct_t;
@@ -212,6 +215,7 @@ typedef struct P11Struct_t
 typedef struct P11Session
 {
     CK_ULONG ulState;                            /**< @brief Stores the session flags. */
+    CK_BBOOL xOpened;                            /**< @brief Set to CK_TRUE upon opening PKCS #11 session. */
     CK_MECHANISM_TYPE xOperationDigestMechanism; /**< @brief Indicates if a digest operation is in progress. */
     CK_BYTE * pxFindObjectLabel;                 /**< @brief Pointer to the label for the search in progress. Should be NULL if no search in progress. */
     uint8_t xFindObjectLabelLength;              /**< @brief Find object length flag. */
@@ -231,6 +235,11 @@ typedef struct P11Session
  * Entropy/randomness and object lists are shared across PKCS #11 sessions.
  */
 static P11Struct_t xP11Context;
+
+/**
+ * @brief The global PKCS #11 session list.
+ */
+static P11Session_t pxP11Sessions[ pkcs11configMAX_SESSIONS ] = { 0 };
 
 /**
  * @brief Helper to check if the current session is initialized and valid.
@@ -258,6 +267,11 @@ static CK_RV prvCheckValidSessionAndModule( const P11Session_t * pxSession )
     {
         xResult = CKR_SESSION_HANDLE_INVALID;
     }
+    /* coverity[misra_c_2012_rule_10_5_violation] */
+    else if( pxSession->xOpened == ( CK_BBOOL ) CK_FALSE )
+    {
+        xResult = CKR_SESSION_HANDLE_INVALID;
+    }
     else
     {
         /* Session is initialized and valid. */
@@ -271,11 +285,16 @@ static CK_RV prvCheckValidSessionAndModule( const P11Session_t * pxSession )
  */
 static P11Session_t * prvSessionPointerFromHandle( const CK_SESSION_HANDLE xSession )
 {
-    /* PKCS #11 uses opaque integer handles to manage sessions.
-     * It is necessary to cast this to a pointer in order to
-     * retrieve the session. */
-    /* coverity[misra_c_2012_rule_11_4_violation] */
-    return ( P11Session_t * ) xSession;
+    P11Session_t * pxSession = NULL;
+    CK_SESSION_HANDLE xSessionHandle = xSession - 1;
+
+    if( xSessionHandle < pkcs11configMAX_SESSIONS )
+    {
+        /* Decrement by 1, invalid handles in PKCS #11 are defined to be 0. */
+        pxSession = &pxP11Sessions[ xSessionHandle ];
+    }
+
+    return pxSession;
 }
 
 /**
@@ -455,9 +474,13 @@ CK_RV prvMbedTLS_Initialize( void )
     else
     {
         ( void ) memset( &xP11Context, 0, sizeof( xP11Context ) );
-        xP11Context.xObjectList.xMutex = xSemaphoreCreateMutex();
+        xP11Context.xObjectList.xMutex = xSemaphoreCreateMutexStatic(
+            &xP11Context.xObjectList.xMutexBuffer );
 
-        if( xP11Context.xObjectList.xMutex == NULL )
+        xP11Context.xSessionMutex = xSemaphoreCreateMutexStatic(
+            &xP11Context.xSessionMutexBuffer );
+
+        if( ( xP11Context.xObjectList.xMutex == NULL ) || ( xP11Context.xSessionMutex == NULL ) )
         {
             xResult = CKR_HOST_MEMORY;
         }
@@ -1668,6 +1691,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID slotID,
 {
     CK_RV xResult = CKR_OK;
     P11Session_t * pxSessionObj = NULL;
+    uint32_t ulSessionCount = 0;
 
     ( void ) ( slotID );
     ( void ) ( pApplication );
@@ -1702,19 +1726,36 @@ CK_DECLARE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID slotID,
      */
     if( CKR_OK == xResult )
     {
-        pxSessionObj = ( P11Session_t * ) pvPortMalloc( sizeof( struct P11Session ) );
-
-        if( NULL == pxSessionObj )
+        /* Get next open session slot. */
+        if( xSemaphoreTake( xP11Context.xSessionMutex, portMAX_DELAY ) == pdTRUE )
         {
-            xResult = CKR_HOST_MEMORY;
+            for( ulSessionCount = 0; ulSessionCount < ( uint32_t ) pkcs11configMAX_SESSIONS; ++ulSessionCount )
+            {
+                /* coverity[misra_c_2012_rule_10_5_violation] */
+                if( pxP11Sessions[ ulSessionCount ].xOpened == ( CK_BBOOL ) CK_FALSE )
+                {
+                    xResult = CKR_OK;
+                    pxSessionObj = &pxP11Sessions[ ulSessionCount ];
+                    /* coverity[misra_c_2012_rule_10_5_violation] */
+                    pxSessionObj->xOpened = ( CK_BBOOL ) CK_TRUE;
+                    break;
+                }
+                else
+                {
+                    /* No available session. */
+                    xResult = CKR_SESSION_COUNT;
+                }
+            }
+
+            ( void ) xSemaphoreGive( xP11Context.xSessionMutex );
+        }
+        else
+        {
+            xResult = CKR_FUNCTION_FAILED;
         }
 
-        /*
-         * Zero out the session structure.
-         */
         if( CKR_OK == xResult )
         {
-            ( void ) memset( pxSessionObj, 0, sizeof( P11Session_t ) );
             pxSessionObj->xSignMutex = xSemaphoreCreateMutex();
 
             if( NULL == pxSessionObj->xSignMutex )
@@ -1752,6 +1793,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID slotID,
 
     if( CKR_OK != xResult )
     {
+        PKCS11_PRINT( ( "Failed to open a new session with error %d \r\n", xResult ) );
+
         if( pxSessionObj != NULL )
         {
             if( pxSessionObj->xSignMutex != NULL )
@@ -1764,16 +1807,15 @@ CK_DECLARE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID slotID,
                 vSemaphoreDelete( pxSessionObj->xVerifyMutex );
             }
 
-            vPortFree( pxSessionObj );
+            ( void ) memset( pxSessionObj, 0, sizeof( P11Session_t ) );
+            *phSession = CK_INVALID_HANDLE;
         }
     }
     else
     {
-        /* PKCS #11 uses opaque integer handles to manage sessions.
-         * It is necessary to cast this to a pointer in order to
-         * retrieve the session. */
-        /* coverity[misra_c_2012_rule_11_4_violation] */
-        *phSession = ( CK_SESSION_HANDLE ) pxSessionObj;
+        /* Increment by one, as invalid handles in PKCS #11 are 0. */
+        ++ulSessionCount;
+        *phSession = ulSessionCount;
     }
 
     return xResult;
@@ -1794,9 +1836,19 @@ CK_DECLARE_FUNCTION( CK_RV, C_OpenSession )( CK_SLOT_ID slotID,
 CK_DECLARE_FUNCTION( CK_RV, C_CloseSession )( CK_SESSION_HANDLE hSession )
 {
     P11Session_t * pxSession = prvSessionPointerFromHandle( hSession );
-    CK_RV xResult = prvCheckValidSessionAndModule( pxSession );
+    CK_RV xResult = CKR_OK;
 
-    if( xResult == CKR_OK )
+    /* coverity[misra_c_2012_rule_10_5_violation] */
+    if( xP11Context.xIsInitialized == ( CK_BBOOL ) CK_FALSE )
+    {
+        xResult = CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+    else if( pxSession == NULL )
+    {
+        xResult = CKR_SESSION_HANDLE_INVALID;
+    }
+    /* coverity[misra_c_2012_rule_10_5_violation] */
+    else if( pxSession->xOpened == ( CK_BBOOL ) CK_TRUE )
     {
         /*
          * Tear down the session.
@@ -1818,7 +1870,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_CloseSession )( CK_SESSION_HANDLE hSession )
 
         mbedtls_sha256_free( &pxSession->xSHA256Context );
 
-        vPortFree( pxSession );
+        /* memset clears the open flag, so there is no need to set it to CK_FALSE */
+        ( void ) memset( pxSession, 0, sizeof( P11Session_t ) );
+    }
+    else
+    {
+        /* MISRA */
     }
 
     return xResult;
@@ -2503,9 +2560,14 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
     const P11Session_t * pxSession = prvSessionPointerFromHandle( hSession );
     CK_RV xResult = prvCheckValidSessionAndModule( pxSession );
 
-    if( ( NULL == pTemplate ) || ( 0UL == ulCount ) )
+    if( ( CKR_OK == xResult ) && ( ( ( NULL == pTemplate ) ) || ( 0UL == ulCount ) ) )
     {
         xResult = CKR_ARGUMENTS_BAD;
+    }
+
+    if( ( CKR_OK == xResult ) && ( CK_INVALID_HANDLE == hObject ) )
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
     }
 
     if( xResult == CKR_OK )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -61,6 +61,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -73,6 +73,12 @@
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -73,6 +73,12 @@
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
@@ -68,6 +68,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
@@ -63,6 +63,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/iot_pkcs11_config.h
@@ -60,6 +60,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
@@ -63,6 +63,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
@@ -74,6 +74,12 @@
 #define pkcs11configMAX_SESSIONS                           10
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
@@ -68,6 +68,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
@@ -68,6 +68,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
@@ -68,6 +68,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
@@ -61,6 +61,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
 * @brief Set to 1 if a PAL destroy object is implemented.
 *
 * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,16 @@
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ *
+ * @note The windows test port has an abnormally large value in order to have 
+ * enough sessions to successfully run all the model based PKCS #11 tests.
+ */
+#define pkcs11configMAX_SESSIONS                           250
+
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/vendor/boards/board/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/iot_pkcs11_config.h
@@ -59,6 +59,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
@@ -62,6 +62,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
@@ -63,6 +63,12 @@
 #define pkcs11configMAX_NUM_OBJECTS      6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality


### PR DESCRIPTION
PKCS #11 Refactor
Description
-----------
This fix refactors session handles to be managed by a static array, instead of casting pointer to 32 bit integers. This resolves MISRA
violation 11.4.

Along with this, the semaphore's used by this file are converted to being allocated statically, further reducing the heap impact of this library.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.