### PR TITLE
winsim+ecc608a network adapter fix

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSConfig.h
@@ -164,7 +164,7 @@ extern void vLoggingPrintf( const char * pcFormat,
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE       ( 4L )
+#define configNETWORK_INTERFACE_TO_USE       ( 0L )
 
 /* The address of an echo server that will be used by the two demo echo client
  * tasks:

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSConfig.h
@@ -171,7 +171,7 @@ extern void vLoggingPrint( const char * pcMessage );
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE       ( 3L )
+#define configNETWORK_INTERFACE_TO_USE       ( 0L )
 
 /* The address of an echo server that will be used by the two demo echo client
  * tasks:


### PR DESCRIPTION
winsim+ecc608a network adapter fix

Description
-----------
Default the selected adapter to 0 so the user gets a helpful message when setting up the winsim+ecc608a project.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.