### PR TITLE
PKCS #11 Refactor

### DIFF
--- a/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
+++ b/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
@@ -41,6 +41,8 @@
 /**
  * @functions_page{pkcs11_pal,PKCS #11 PAL, PKCS #11 PAL}
  * @functions_brief{PKCS #11 PAL Layer}
+ * - @function_name{pkcs11_pal_function_initialize}
+ * @function_brief{pkcs11_pal_function_initialize}
  * - @function_name{pkcs11_pal_function_saveobject}
  * @function_brief{pkcs11_pal_function_saveobject}
  * - @function_name{pkcs11_pal_function_destroyobject}
@@ -70,6 +72,16 @@
  * @function_snippet{pkcs11_pal,getobjectvaluecleanup,this}
  * @copydoc PKCS11_PAL_GetObjectValueCleanup
  */
+
+/**
+ * @brief Initializes the PKCS #11 PAL.
+ *
+ * @return CKR_OK on success.
+ * CKR_FUNCTION_FAILED on failure.
+ */
+/* @[declare_pkcs11_pal_initialize] */
+CK_RV PKCS11_PAL_Initialize( void );
+/* @[declare_pkcs11_pal_initialize] */
 
 /**
  * @brief Saves an object in non-volatile storage.

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -1302,6 +1302,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pInitArgs )
     if( xP11Context.xIsInitialized != ( CK_BBOOL ) CK_TRUE )
     {
         xResult = PKCS11_PAL_Initialize();
+
         if( xResult == CKR_OK )
         {
             xResult = prvMbedTLS_Initialize();

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -442,7 +442,7 @@ static CK_BBOOL prvOperationActive( const P11Session_t * pxSession )
  * @note: Before prvMbedTLS_Initialize can be called, CRYPTO_Init()
  * must be called to initialize the mbedTLS mutex functions.
  */
-CK_RV prvMbedTLS_Initialize( void )
+static CK_RV prvMbedTLS_Initialize( void )
 {
     CK_RV xResult = CKR_OK;
 
@@ -1270,8 +1270,6 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
 
 /*-------------------------------------------------------------*/
 
-#if !defined( pkcs11configC_INITIALIZE_ALT )
-
 /**
  * @brief Initializes Cryptoki.
  *
@@ -1293,27 +1291,30 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
  * for more information.
  */
 /* @[declare_pkcs11_mbedtls_c_initialize] */
-    CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pInitArgs )
+CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pInitArgs )
+{
+    ( void ) ( pInitArgs );
+
+    CK_RV xResult = CKR_OK;
+
+    /* See explanation in prvCheckValidSessionAndModule for this exception. */
+    /* coverity[misra_c_2012_rule_10_5_violation] */
+    if( xP11Context.xIsInitialized != ( CK_BBOOL ) CK_TRUE )
     {
-        ( void ) ( pInitArgs );
-
-        CK_RV xResult = CKR_OK;
-
-        /* See explanation in prvCheckValidSessionAndModule for this exception. */
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        if( xP11Context.xIsInitialized != ( CK_BBOOL ) CK_TRUE )
+        xResult = PKCS11_PAL_Initialize();
+        if( xResult == CKR_OK )
         {
             xResult = prvMbedTLS_Initialize();
         }
-        else
-        {
-            xResult = CKR_CRYPTOKI_ALREADY_INITIALIZED;
-        }
-
-        return xResult;
     }
+    else
+    {
+        xResult = CKR_CRYPTOKI_ALREADY_INITIALIZED;
+    }
+
+    return xResult;
+}
 /* @[declare_pkcs11_mbedtls_c_initialize] */
-#endif /* if !defined( pkcs11configC_INITIALIZE_ALT ) */
 
 /**
  * @brief Clean up miscellaneous Cryptoki-associated resources.

--- a/tests/unit_test/linux/config_files/iot_pkcs11_config.h
+++ b/tests/unit_test/linux/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -108,6 +108,11 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
     }
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
 * @brief Writes a file to local storage.
 *

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,8 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-
 /**
  * @brief PKCS #11 default user PIN.
  *
@@ -128,7 +126,7 @@
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"/* #define pkcs11configC_INITIALIZE_ALT */
+#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"/* 
 
 
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/iot_pkcs11_config.h
@@ -126,7 +126,7 @@
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"/* 
+#define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
 
 
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -108,6 +108,11 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
     }
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
 * @brief Writes a file to local storage.
 *

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -33,9 +33,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief ESP32 NVS Partition where PKCS #11 data is stored
  */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
@@ -40,9 +40,6 @@
 
 extern const char * pcPkcs11GetThingName(void);
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief ESP32 NVS Partition where PKCS #11 data is stored
  */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -33,9 +33,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief ESP32 NVS Partition where PKCS #11 data is stored
  */

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -161,6 +161,11 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
     }
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
  * @brief Writes a file to local storage.
  *

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/iot_pkcs11_config.h
@@ -38,9 +38,6 @@
 #define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
 #define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
@@ -356,23 +356,8 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
 }
 /*-----------------------------------------------------------*/
 
-extern CK_RV prvMbedTLS_Initialize( void );
-
-/**
- * @brief Initialize the Cryptoki module for use.
- *
- * Overrides the implementation of C_Initialize in
- * iot_pkcs11_mbedtls.c when pkcs11configC_INITIALIZE_ALT
- * is defined.
- */
-#ifndef pkcs11configC_INITIALIZE_ALT
-    #error XMC4800 requires alternate C_Initialization
-#endif
-
-CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
-{   /*lint !e9072 It's OK to have different parameter name. */
-    ( void ) ( pvInitArgs );
-
+CK_RV PKCS11_PAL_Initialize( void )
+{   
     CK_RV xResult = CKR_OK;
 
     E_EEPROM_XMC4_Init( &e_eeprom, sizeof( P11KeyConfig_t ) );
@@ -380,11 +365,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
     if( E_EEPROM_XMC4_IsFlashEmpty() == false )
     {
         E_EEPROM_XMC4_ReadArray( 0, ( uint8_t * const ) &P11KeyConfig, sizeof( P11KeyConfig_t ) );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xResult = prvMbedTLS_Initialize();
     }
 
     return xResult;

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -1109,11 +1109,7 @@ CK_DEFINE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
         /*
          *   Reset OPTIGA(TM) Trust X and open an application on it
          */
-        xResult = PKCS11_PAL_Initialize();
-        if( xResult == CKR_OK )
-        {
-            xResult = prvOPTIGATrustX_Initialize();
-        }
+        xResult = prvOPTIGATrustX_Initialize();
 
 
         CK_OBJECT_HANDLE xObject;

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -1093,42 +1093,40 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
 
 /*-------------------------------------------------------------*/
 
-#if !defined( pkcs11configC_INITIALIZE_ALT )
-
 /**
  * @brief Initialize the Cryptoki module for use.
  *
- * Overrides the implementation of C_Initialize in
- * aws_pkcs11_trustx.c when pkcs11configC_INITIALIZE_ALT
- * is defined.
  */
+CK_DEFINE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
+{ /*lint !e9072 It's OK to have different parameter name. */
+    ( void ) ( pvInitArgs );
 
-    CK_DEFINE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
-    { /*lint !e9072 It's OK to have different parameter name. */
-        ( void ) ( pvInitArgs );
+    CK_RV xResult = CKR_OK;
 
-        CK_RV xResult = CKR_OK;
-
-        /* Ensure that the FreeRTOS heap is used. */
-        if( xP11Context.xIsInitialized != CK_TRUE )
+    /* Ensure that the FreeRTOS heap is used. */
+    if( xP11Context.xIsInitialized != CK_TRUE )
+    {
+        /*
+         *   Reset OPTIGA(TM) Trust X and open an application on it
+         */
+        xResult = PKCS11_PAL_Initialize();
+        if( xResult == CKR_OK )
         {
-            /*
-             *   Reset OPTIGA(TM) Trust X and open an application on it
-             */
             xResult = prvOPTIGATrustX_Initialize();
-
-            CK_OBJECT_HANDLE xObject;
-            CK_OBJECT_HANDLE xPalHandle = PKCS11_PAL_FindObject( ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
-            xResult = prvAddObjectToList( xPalHandle, &xObject, ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
-        }
-        else
-        {
-            xResult = CKR_CRYPTOKI_ALREADY_INITIALIZED;
         }
 
-        return xResult;
+
+        CK_OBJECT_HANDLE xObject;
+        CK_OBJECT_HANDLE xPalHandle = PKCS11_PAL_FindObject( ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
+        xResult = prvAddObjectToList( xPalHandle, &xObject, ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
     }
-#endif /* if !defined( pkcs11configC_INITIALIZE_ALT ) */
+    else
+    {
+        xResult = CKR_CRYPTOKI_ALREADY_INITIALIZED;
+    }
+
+    return xResult;
+}
 
 /**
  * @brief Un-initialize the Cryptoki module.

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,10 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -98,6 +98,11 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
     }
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
  * @brief Writes a file to local storage.
  *

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,10 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -171,6 +171,11 @@ void prvHandleToFilenamePrivate( CK_OBJECT_HANDLE   xHandle,
 
 /*-----------------------------------------------------------*/
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
  * @brief Saves an object in non-volatile storage.
  *

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h
@@ -38,9 +38,6 @@
 #define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
 #define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -109,6 +109,11 @@ static uint64_t PIC32MZ_HW_TRNG_Get( void );
 
 /*-----------------------------------------------------------*/
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
  * @brief Saves an object in non-volatile storage.
  *

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/iot_pkcs11_config.h
@@ -34,9 +34,6 @@
 
 extern const char * pcPkcs11GetThingName(void);
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,7 +32,4 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/iot_pkcs11_config.h
@@ -38,7 +38,4 @@
 #define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "ESP_P11_Cert"
 #define pkcs11configFILE_NAME_KEY                   "ESP_P11_Key"
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 #endif /* _AWS_PKCS11_CONFIG_H_ include guard. */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_pkcs11_config.h
@@ -38,9 +38,6 @@
 #define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
 #define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_pkcs11_config.h
@@ -38,9 +38,6 @@
 #define pkcs11configFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
 #define pkcs11configFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
@@ -302,6 +302,11 @@ static BaseType_t prvFLASH_ReadFile( char * pcFileName,
     return xResult;
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
 * @brief Writes a file to local storage.
 *

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/iot_pkcs11_config.h
@@ -31,9 +31,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -278,40 +278,15 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
      * to be done. */
 }
 
-
-/**
- *      PKCS#11 Override
- *
- */
-
-extern CK_RV prvMbedTLS_Initialize( void );
-
-/**
- * @brief Initialize the Cryptoki module for use.
- *
- * Overrides the implementation of C_Initialize in
- * iot_pkcs11_mbedtls.c when pkcs11configC_INITIALIZE_ALT
- * is defined.
- */
-#ifndef pkcs11configC_INITIALIZE_ALT
-    #error LPC54018 requires alternate C_Initialization
-#endif
-
-CK_DECLARE_FUNCTION( CK_RV, C_Initialize )( CK_VOID_PTR pvInitArgs )
-{ /*lint !e9072 It's OK to have different parameter name. */
-    ( void ) ( pvInitArgs );
+CK_RV PKCS11_PAL_Initialize( void )
+{ 
 
     CK_RV xResult = CKR_OK;
 
     /* Initialize flash storage. */
     if( pdTRUE == mflash_init( g_cert_files, 1 ) )
     {
-        xResult = CKR_OK;
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xResult = prvMbedTLS_Initialize();
+        xResult = CKR_FUNCTION_FAILED;
     }
 
     return xResult;

--- a/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
 * @brief PKCS #11 default user PIN.
 *

--- a/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
@@ -152,6 +152,10 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
 
 /*-----------------------------------------------------------*/
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
 
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
                                         uint8_t * pucData,

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-#define pkcs11configC_INITIALIZE_ALT
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
@@ -162,9 +162,8 @@ static void update_dataflash_data_from_image(void);
 static void update_dataflash_data_mirror_from_image(void);
 static void check_dataflash_area(uint32_t retry_counter);
 
-extern CK_RV prvMbedTLS_Initialize( void );
 
-CK_RV C_Initialize( CK_VOID_PTR pvInitArgs )
+void PKCS11_PAL_Initialize( void )
 {
     CK_RV xResult = CKR_OK;
 
@@ -184,8 +183,6 @@ CK_RV C_Initialize( CK_VOID_PTR pvInitArgs )
     memcpy(&pkcs_control_block_data_image, (void *)&pkcs_control_block_data, sizeof(pkcs_control_block_data_image));
 
     R_FLASH_Close();
-
-    xResult = prvMbedTLS_Initialize();
 
     return xResult;
 }

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
@@ -299,6 +299,11 @@ P11KeyConfig_t P11KeyConfig __attribute__( ( section( "UNINIT_FIXED_LOC" ) ) );
 #endif /* ifdef USE_OFFLOAD_SSL */
 /*-----------------------------------------------------------*/
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /**
  * @brief Saves an object in non-volatile storage.
  *

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -379,6 +379,11 @@ void prvHandleToFileName( CK_OBJECT_HANDLE pxHandle,
 
 /*-----------------------------------------------------------*/
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
+
 /* PKCS #11 PAL Implementation. */
 
 /**

--- a/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/vendor/boards/board/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -36,6 +36,17 @@
 #include <stdio.h>
 #include <string.h>
 
+/**
+ * @brief Initializes the PKCS #11 PAL.
+ *
+ * @return CKR_OK on success.
+ * CKR_FUNCTION_FAILED on failure.
+ */
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    CK_RV xReturn = CKR_OK;
+    return xReturn;
+}
 
 /**
 * @brief Writes a file to local storage.

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/iot_pkcs11_config.h
@@ -32,9 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/iot_pkcs11_config.h
@@ -32,10 +32,6 @@
 #ifndef _AWS_PKCS11_CONFIG_H_
 #define _AWS_PKCS11_CONFIG_H_
 
-
-/* A non-standard version of C_INITIALIZE should be used by this port. */
-/* #define pkcs11configC_INITIALIZE_ALT */
-
 /**
  * @brief PKCS #11 default user PIN.
  *

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -102,6 +102,10 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
     }
 }
 
+CK_RV PKCS11_PAL_Initialize( void )
+{
+    return CKR_OK;
+}
 
 /**
  * @brief Saves an object in non-volatile storage.


### PR DESCRIPTION
Pkcs11 initialization refactor
Description
-----------
Refactored PCKS #11 PAL to remove circular dependency on pkcs11_mbedtls.c implementation.
Removed config for alternate C_Initialize.
Added PKCS11_PAL_Initialize API, to give PAL layer control over it's own initialization.

This resolves the MISRA violation raised by prvMbedTLSInitialize, as it can now be declared to be a static function.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.