### PR TITLE
Revert removal of sending second eI2CSendNoStopFlag iot_i2c_ioctl call

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_i2c.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2c.c
@@ -681,6 +681,10 @@ TEST( TEST_IOT_I2C, AFQP_IotI2CReadAsyncFailReadTwice )
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 
         /* read from i2c device */
+        lRetVal = iot_i2c_ioctl( xI2CHandle, eI2CSendNoStopFlag, NULL );
+        TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
+
+        /* read from i2c device */
         lRetVal = iot_i2c_read_async( xI2CHandle, ucBuffer, sizeof( ucBuffer ) );
         TEST_ASSERT_EQUAL( IOT_I2C_SUCCESS, lRetVal );
 


### PR DESCRIPTION
* The there are two eI2CSendNoStopFlag calls, one for the write and one for the read
  both are needed.

<!--- Revert removal of call to iot_i2c_ioctl with eI2CSendNoStopFlag --->

Description
-----------
<!--- The there are two eI2CSendNoStopFlag calls, one for the write and one for the read
  both are needed.  --->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.