### PR TITLE
Added #include "iot_test_common_io_internal.h" to test_iot_uart.c

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -32,6 +32,7 @@
 
 /* Driver model includes */
 #include "iot_uart.h"
+#include "iot_test_common_io_internal.h"
 
 /* FreeRTOS includes */
 #include "FreeRTOS.h"


### PR DESCRIPTION
* Needed for definition of IOT_TEST_COMMON_IO_UART_SUPPORTED_CANCEL

<!--- Added #include "iot_test_common_io_internal.h" to test_iot_uart.c   -->

Description
-----------
<!--- test_iot_uart.c uses IOT_TEST_COMMON_IO_UART_SUPPORTED_CANCEL to 
determine if test case AFQP_IotUARTCancel should be run.  IOT_TEST_COMMON_IO_UART_SUPPORTED_CANCEL is optionally defined in 
iot_test_common_io_internal.h and needs to be included.  -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.