### PR TITLE
Fixes to test_iot_gpio.c

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -97,6 +97,8 @@ TEST_GROUP( TEST_IOT_GPIO );
  */
 TEST_SETUP( TEST_IOT_GPIO )
 {
+    xtestIotGpioSemaphore = xSemaphoreCreateBinary();
+    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioSemaphore );
 }
 
 /*-----------------------------------------------------------*/
@@ -118,9 +120,6 @@ TEST_TEAR_DOWN( TEST_IOT_GPIO )
  */
 TEST_GROUP_RUNNER( TEST_IOT_GPIO )
 {
-    xtestIotGpioSemaphore = xSemaphoreCreateBinary();
-    TEST_ASSERT_NOT_EQUAL( NULL, xtestIotGpioSemaphore );
-
     RUN_TEST_CASE( TEST_IOT_GPIO, AFQP_IotGpioOpenClose );
     RUN_TEST_CASE( TEST_IOT_GPIO, AFQP_IotGpioOpenOpenClose );
     RUN_TEST_CASE( TEST_IOT_GPIO, AFQP_IotGpioOpenCloseClose );
@@ -414,7 +413,7 @@ TEST( TEST_IOT_GPIO, AFQP_IotGpioSpeed )
                 ulPerfCountFastDelta = 0xFFFFFFFF - ulPerfCount0 + ulPerfCount1 + 1;
             }
 
-            TEST_ASSERT_GREATER_THAN( ulPerfCountFastDelta, ulPerfCountSlowDelta );
+            TEST_ASSERT_GREATER_THAN( ulPerfCountSlowDelta, ulPerfCountFastDelta );
         }
     }
 

--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -112,11 +112,8 @@ TEST_TEAR_DOWN( TEST_IOT_GPIO )
     iot_gpio_close( xtestIotGpioHandleA );
     iot_gpio_close( xtestIotGpioHandleB );
 
-    if ( xtestIotGpioSemaphore != NULL )
-    {
-        vSemaphoreDelete(xtestIotGpioSemaphore);
-        xtestIotGpioSemaphore = NULL;
-    }
+    vSemaphoreDelete( xtestIotGpioSemaphore );
+    xtestIotGpioSemaphore = NULL;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -111,6 +111,12 @@ TEST_TEAR_DOWN( TEST_IOT_GPIO )
     /* Make sure resources are freed up */
     iot_gpio_close( xtestIotGpioHandleA );
     iot_gpio_close( xtestIotGpioHandleB );
+
+    if ( xtestIotGpioSemaphore != NULL )
+    {
+        vSemaphoreDelete(xtestIotGpioSemaphore);
+        xtestIotGpioSemaphore = NULL;
+    }
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Fix bugs in test_iot_gpio.c -->
Moved global semaphore creation to TEST_SETUP().
Added code to delete semaphore in TEST_TEAR_DOWN().
Fixed TEST_ASSERT_GREATER_THAN() in AFQP_IotGpioSpeed.

Description
-----------
<!--- Moved global semaphore creation to TEST_SETUP().
Added code to delete semaphore in TEST_TEAR_DOWN().
Fixed TEST_ASSERT_GREATER_THAN() in AFQP_IotGpioSpeed.
 --->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.