### PR TITLE
Fix/test iot tsensor

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_tsensor.c
+++ b/libraries/abstractions/common_io/test/test_iot_tsensor.c
@@ -568,7 +568,7 @@ TEST( TEST_IOT_TSENSOR, AFQP_IotTsensorCalibrationSuccess )
 
         if( lRetVal != IOT_TSENSOR_NOT_SUPPORTED )
         {
-            TEST_ASSERT_EQUAL( IOT_TSENSOR_SUCCESS, lRetVal );
+            TEST_ASSERT_EQUAL( IOT_TSENSOR_INVALID_VALUE, lRetVal );
         }
     }
 


### PR DESCRIPTION
…_INVALID_VALUE.

* In AFQP_IotTsensorCalibrationSuccess, there is call to iot_tsensor_ioctl() for
  sensor calibration.  The param is NULL but expect to return success.  It should
  expect invalid value as return code instead of success.

<!--- Title  -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.