### PR TITLE
Mix up in iot_test_common_io_internal.h between pwm and power conditi…

### DIFF
--- a/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
+++ b/libraries/abstractions/common_io/test/iot_test_common_io_internal.h
@@ -220,12 +220,12 @@
     extern uint32_t ulAssistedTestIotPwmInstance;     /* PWM Instance for assisted test */
 
 /**
- * Board specific Power config set
+ * Board specific PWM config set
  *
  * @param: testSet: number of config set to be test
  * @return None
  */
-    void SET_TEST_IOT_POWER_CONFIG( int testSet );
+    void SET_TEST_IOT_PWM_CONFIG( int testSet );
 #else /* if defined( IOT_TEST_COMMON_IO_PWM_SUPPORTED ) && ( IOT_TEST_COMMON_IO_PWM_SUPPORTED >= 1 ) */
     #define IOT_TEST_COMMON_IO_PWM_SUPPORTED    0
 #endif /* ifdef IOT_TEST_COMMON_IO_PWM_SUPPORTED */
@@ -328,7 +328,7 @@
 #endif
 
 /* Power */
-#if defined( IOT_TEST_COMMON_IO_PWM_SUPPORTED ) && ( IOT_TEST_COMMON_IO_PWM_SUPPORTED >= 1 )
+#if defined( IOT_TEST_COMMON_IO_POWER_SUPPORTED ) && ( IOT_TEST_COMMON_IO_POWER_SUPPORTED >= 1 )
     extern uint32_t ultestIotPowerDelay;               /* Delay used to wait for the DUT enter idle */
 
     extern uint32_t ultestIotPowerPcWakeThreshold;     /* Threshold (minimum idle Time required to enter PC Idle Mode */
@@ -342,14 +342,14 @@
     extern uint8_t * puctestIotPowerWakeupSources;     /* Array of wakeup sources, HW-dependent */
 
 /**
- * Board specific PWM config set
+ * Board specific Power config set
  *
  * @param: testSet: number of config set to be test
  * @return None
  */
-    void SET_TEST_IOT_PWM_CONFIG( int testSet );
+    void SET_TEST_IOT_POWER_CONFIG( int testSet );
 #else /* if defined( IOT_TEST_COMMON_IO_PWM_SUPPORTED ) && ( IOT_TEST_COMMON_IO_PWM_SUPPORTED >= 1 ) */
-    #define IOT_TEST_COMMON_IO_PWM_SUPPORTED    0
+    #define IOT_TEST_COMMON_IO_POWER_SUPPORTED    0
 #endif /* ifdef IOT_TEST_COMMON_IO_PWM_SUPPORTED */
 
 /* USB Device */


### PR DESCRIPTION
<!--- Title  -->
Fix conditional compile mixup in iot_test_common_io_internal.h.

Description
-----------
<!--- Describe your changes in detail -->
There looks like some confusion with conditional compiles for pwm and power.  Fixed them.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.