### PR TITLE
Fix: MQTT Keep Alive scheduling

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
@@ -383,15 +383,15 @@ static _mqttConnection_t * _createMqttConnection( bool awsIotMqttMode,
      * Adjust the user-provided keep-alive interval based on these requirements. */
     if( awsIotMqttMode == true )
     {
-        if( keepAliveSeconds < AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE )
+        if( keepAliveSeconds == 0 )
+        {
+            keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
+        }
+        else if( keepAliveSeconds < AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE )
         {
             keepAliveSeconds = AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE;
         }
         else if( keepAliveSeconds > AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE )
-        {
-            keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
-        }
-        else if( keepAliveSeconds == 0 )
         {
             keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
         }

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -722,16 +722,10 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
              * so a PINGREQ will be transmitted in the next execution. */
             pMqttConnection->nextKeepAliveMs = pMqttConnection->keepAliveMs;
 
-            /* Check if keep alive time is nonzero and greater than wait time. */
-            if( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS )
-            {
-                /* Subtract time taken for PINGRESP check. */
-                scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
-            }
-            else
-            {
-                EMPTY_ELSE_MARKER;
-            }
+            IotMqtt_Assert( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS );
+
+            /* Subtract time taken for PINGRESP check. */
+            scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
         }
         else
         {

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
@@ -187,7 +187,11 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     /* Check that keep alive is not too short. */
     if( adjustedKeepAliveSec != 0 )
     {
-        /* If wait time is too long, keep alive jobs will time out while waiting for PINGRESP. */
+        /* After sending a PINGREQ, we wait for IOT_MQTT_RESPONSE_WAIT_MS to
+         * receive the corresponding PINGRESP. If the PINGRESP is received within
+         * IOT_MQTT_RESPONSE_WAIT_MS, we schedule another job to send PINGREQ.
+         * If the IOT_MQTT_RESPONSE_WAIT_MS is longer than keep alive interval,
+         * we will fail to send PINGRESP on time. */
         if( ( adjustedKeepAliveSec * 1000 ) <= IOT_MQTT_RESPONSE_WAIT_MS )
         {
             IotLogError( "Keep alive interval %d ms must be longer than response wait time %d ms.",

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
@@ -42,6 +42,7 @@
 bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
 {
     IOT_FUNCTION_ENTRY( bool, true );
+    uint16_t adjustedKeepAliveSec = 0;
 
     /* Check for NULL. */
     if( pConnectInfo == NULL )
@@ -128,6 +129,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         EMPTY_ELSE_MARKER;
     }
 
+    adjustedKeepAliveSec = pConnectInfo->keepAliveSeconds;
+
     /* Check for compatibility with the AWS IoT MQTT service limits. */
     if( pConnectInfo->awsIotMqttMode == true )
     {
@@ -150,6 +153,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
             IotLogWarn( "AWS IoT does not support disabling keep-alive. Default keep-alive "
                         "of %d seconds will be used.",
                         AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE );
+
+            adjustedKeepAliveSec = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
         }
         else if( pConnectInfo->keepAliveSeconds < AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE )
         {
@@ -157,6 +162,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
                         "An interval of %d seconds will be used.",
                         AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE,
                         AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE );
+
+            adjustedKeepAliveSec = AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE;
         }
         else if( pConnectInfo->keepAliveSeconds > AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE )
         {
@@ -164,6 +171,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
                         "An interval of %d seconds will be used.",
                         AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE,
                         AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE );
+
+            adjustedKeepAliveSec = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
         }
         else
         {
@@ -176,12 +185,13 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     }
 
     /* Check that keep alive is not too short. */
-    if( pConnectInfo->keepAliveSeconds != 0 )
+    if( adjustedKeepAliveSec != 0 )
     {
-        if( ( pConnectInfo->keepAliveSeconds * 1000 ) <= IOT_MQTT_RESPONSE_WAIT_MS )
+        /* If wait time is too long, keep alive jobs will time out while waiting for PINGRESP. */
+        if( ( adjustedKeepAliveSec * 1000 ) <= IOT_MQTT_RESPONSE_WAIT_MS )
         {
             IotLogError( "Keep alive interval %d ms must be longer than response wait time %d ms.",
-                         pConnectInfo->keepAliveSeconds * 1000,
+                         adjustedKeepAliveSec * 1000,
                          IOT_MQTT_RESPONSE_WAIT_MS );
 
             IOT_SET_AND_GOTO_CLEANUP( false );

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c
@@ -175,6 +175,27 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         EMPTY_ELSE_MARKER;
     }
 
+    /* Check that keep alive is not too short. */
+    if( pConnectInfo->keepAliveSeconds != 0 )
+    {
+        if( ( pConnectInfo->keepAliveSeconds * 1000 ) <= IOT_MQTT_RESPONSE_WAIT_MS )
+        {
+            IotLogError( "Keep alive interval %d ms must be longer than response wait time %d ms.",
+                         pConnectInfo->keepAliveSeconds * 1000,
+                         IOT_MQTT_RESPONSE_WAIT_MS );
+
+            IOT_SET_AND_GOTO_CLEANUP( false );
+        }
+        else
+        {
+            EMPTY_ELSE_MARKER;
+        }
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
 

--- a/libraries/c_sdk/standard/mqtt/src/private/iot_mqtt_internal.h
+++ b/libraries/c_sdk/standard/mqtt/src/private/iot_mqtt_internal.h
@@ -271,6 +271,7 @@ typedef struct _mqttConnection
     IotListDouble_t subscriptionList;            /**< @brief Holds subscriptions associated with this connection. */
     IotMutex_t subscriptionMutex;                /**< @brief Grants exclusive access to the subscription list. */
 
+    uint64_t lastMessageTime;                    /**< @brief When the most recent message was transmitted. */
     bool keepAliveFailure;                       /**< @brief Failure flag for keep-alive operation. */
     uint32_t keepAliveMs;                        /**< @brief Keep-alive interval in milliseconds. Its max value (per spec) is 65,535,000. */
     uint32_t nextKeepAliveMs;                    /**< @brief Relative delay for next keep-alive job. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fixes a keep alive bug in MQTT when IOT_MQTT_RESPONSE_WAIT_MS is a significant fraction of keepAliveMs

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.