### PR TITLE
fix: MQTT test failure from #2064

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -779,10 +779,16 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
              * and Call 3 is KeepAliveMS. */
             pMqttConnection->nextKeepAliveMs = pMqttConnection->keepAliveMs;
 
-            IotMqtt_Assert( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS );
-
-            /* Subtract time taken for PINGRESP check. */
-            scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
+            /* Check if keep alive time is nonzero and greater than wait time. */
+            if( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS )
+            {
+                /* Subtract time taken for PINGRESP check. */
+                scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
+            }
+            else
+            {
+                EMPTY_ELSE_MARKER;
+            }
         }
         else
         {

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -779,16 +779,10 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
              * and Call 3 is KeepAliveMS. */
             pMqttConnection->nextKeepAliveMs = pMqttConnection->keepAliveMs;
 
-            /* Check if keep alive time is nonzero and greater than wait time. */
-            if( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS )
-            {
-                /* Subtract time taken for PINGRESP check. */
-                scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
-            }
-            else
-            {
-                EMPTY_ELSE_MARKER;
-            }
+            IotMqtt_Assert( pMqttConnection->keepAliveMs > IOT_MQTT_RESPONSE_WAIT_MS );
+
+            /* Subtract time taken for PINGRESP check. */
+            scheduleDelay = pMqttConnection->keepAliveMs - IOT_MQTT_RESPONSE_WAIT_MS;
         }
         else
         {

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -1364,8 +1364,7 @@ TEST( MQTT_Unit_API, KeepAlivePeriodic )
     IotMqttDisconnectReason_t expectedReason = IOT_MQTT_KEEP_ALIVE_TIMEOUT;
 
     /* An estimate for the amount of time this test requires. */
-    const uint32_t sleepTimeMs = ( KEEP_ALIVE_COUNT * SHORT_KEEP_ALIVE_MS ) +
-                                 ( IOT_MQTT_RESPONSE_WAIT_MS * KEEP_ALIVE_COUNT ) + 1500;
+    const uint32_t sleepTimeMs = ( ( 2 + KEEP_ALIVE_COUNT ) * SHORT_KEEP_ALIVE_MS ) + 1500;
 
     /* Print a newline so this test may log its status. */
     UNITY_PRINT_EOL();

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -74,7 +74,7 @@
  * @brief A short keep-alive interval to use for the keep-alive tests. It may be
  * shorter than the minimum 1 second specified by the MQTT spec.
  */
-#define SHORT_KEEP_ALIVE_MS         ( 100 )
+#define SHORT_KEEP_ALIVE_MS         ( IOT_MQTT_RESPONSE_WAIT_MS + 100 )
 
 /**
  * @brief The number of times the periodic keep-alive should run.
@@ -172,11 +172,6 @@ static void _incomingPingresp( void * pArgument )
     /* Silence warnings about unused parameters. */
     ( void ) pArgument;
 
-    /* This test will not work if the response wait time is too small. */
-    #if IOT_MQTT_RESPONSE_WAIT_MS < ( 2 * SHORT_KEEP_ALIVE_MS + 100 )
-    #error "IOT_MQTT_RESPONSE_WAIT_MS too small for keep-alive tests."
-    #endif
-
     static int32_t invokeCount = 0;
     static uint64_t lastInvokeTime = 0;
     uint64_t currentTime = IotClock_GetTimeMs();
@@ -184,8 +179,9 @@ static void _incomingPingresp( void * pArgument )
     /* Increment invoke count for this function. */
     invokeCount++;
 
-    /* Sleep to simulate the network round-trip time. */
-    IotClock_SleepMs( 2 * SHORT_KEEP_ALIVE_MS );
+    /* Sleep to simulate the network round-trip time. Should be less than
+     * the response wait time. */
+    IotClock_SleepMs( IOT_MQTT_RESPONSE_WAIT_MS / 2 );
 
     /* Respond with a PINGRESP. */
     if( invokeCount <= KEEP_ALIVE_COUNT )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fixes an MQTT KeepAlivePeriodic unit test failure introduced by #2064. The KeepAlivePeriodic Test had triggered an assert since the keep alive time used by the test was lower than the minimum IOT_MQTT_RESPONSE_WAIT_MS allowed. This increases the keep alive time used by the test to be within acceptable bounds.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.