### PR TITLE
PSoC64: add missing qprogram make target

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/application_code/cy_code/CY8CKIT-064S0S2-4343W.mk
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/application_code/cy_code/CY8CKIT-064S0S2-4343W.mk
@@ -212,6 +212,8 @@ CY_OPENOCD_PROGRAM_FLASH= -s ${CY_OPENOCD_DIR}/scripts \
                           -c "resume; reset; exit"
 
 program: build qprogram
+
+qprogram: memcalc
 	@echo;\
 	echo "Programming PSoC64 ... ";\
 	$(CY_OPENOCD_DIR)/bin/openocd $(CY_OPENOCD_PROGRAM_FLASH)

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/cy_code/CY8CKIT-064S0S2-4343W.mk
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/cy_code/CY8CKIT-064S0S2-4343W.mk
@@ -106,6 +106,8 @@ CY_OPENOCD_PROGRAM_FLASH= -s ${CY_OPENOCD_DIR}/scripts \
                           -c "resume; reset; exit"
 
 program: build qprogram
+
+qprogram: memcalc
 	@echo;\
 	echo "Programming PSoC64 ... ";\
 	$(CY_OPENOCD_DIR)/bin/openocd $(CY_OPENOCD_PROGRAM_FLASH)


### PR DESCRIPTION
make qprogram - skips the build step and programs the board

Signed-off-by: Andrei Narkevitch <ainh@cypress.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.