### PR TITLE
Change https echo server domain

### DIFF
--- a/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
+++ b/libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c
@@ -55,7 +55,7 @@
  * This address MUST NOT start with http:// or https://.
  */
 #ifndef IOT_TEST_HTTPS_SERVER_HOST_NAME
-    #define IOT_TEST_HTTPS_SERVER_HOST_NAME    "postman-echo.com"
+    #define IOT_TEST_HTTPS_SERVER_HOST_NAME    "freertos-ci.ddnsfree.com"
 #endif
 
 /**


### PR DESCRIPTION
Fix HTTPS failures on Nuvoton, TI and Infineon by running tests against an HTTPS server owned by the Lab Infra Team

Description
-----------
<!--- Describe your changes in detail -->
Changed code to use https echo server running on CI EC2 instance. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.