### PR TITLE
Fix issue related to WiFi scan and configure AP with SSID of maximum length on ESP32

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_wifi_config.h
@@ -58,8 +58,8 @@
 
 /**
  * @brief Max passphrase length
+ * Maximum allowed WPA2 passphrase length (per specification) is 63
  */
-// Maximum allowed WPA2 passphrase length (per specification) is 63
 #define wificonfigMAX_PASSPHRASE_LEN          ( 63 )
 
 /**

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_wifi_config.h
@@ -59,7 +59,8 @@
 /**
  * @brief Max passphrase length
  */
-#define wificonfigMAX_PASSPHRASE_LEN          ( 64 )
+// Maximum allowed WPA2 passphrase length (per specification) is 63
+#define wificonfigMAX_PASSPHRASE_LEN          ( 63 )
 
 /**
  * @brief Soft Access point SSID

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -245,9 +245,9 @@ void prvWifiConnect( void )
 
     /* Setup parameters. */
     xJoinAPParams.pcSSID = clientcredentialWIFI_SSID;
-    xJoinAPParams.ucSSIDLength = sizeof( clientcredentialWIFI_SSID );
+    xJoinAPParams.ucSSIDLength = strlen( clientcredentialWIFI_SSID );
     xJoinAPParams.pcPassword = clientcredentialWIFI_PASSWORD;
-    xJoinAPParams.ucPasswordLength = sizeof( clientcredentialWIFI_PASSWORD );
+    xJoinAPParams.ucPasswordLength = strlen( clientcredentialWIFI_PASSWORD );
     xJoinAPParams.xSecurity = clientcredentialWIFI_SECURITY;
 
     RETRY_EXPONENTIAL( eWiFiStatus = WIFI_ConnectAP( &( xJoinAPParams ) ),

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_wifi_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_wifi_config.h
@@ -58,8 +58,8 @@
 
 /**
  * @brief Max passphrase length
+ * Maximum allowed WPA2 passphrase length (per specification) is 63
  */
-// Maximum allowed WPA2 passphrase length (per specification) is 63
 #define wificonfigMAX_PASSPHRASE_LEN          ( 63 )
 
 /**

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_wifi_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_wifi_config.h
@@ -59,7 +59,8 @@
 /**
  * @brief Max passphrase length
  */
-#define wificonfigMAX_PASSPHRASE_LEN          ( 64 )
+// Maximum allowed WPA2 passphrase length (per specification) is 63
+#define wificonfigMAX_PASSPHRASE_LEN          ( 63 )
 
 /**
  * @brief Soft Access point SSID

--- a/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
@@ -562,7 +562,7 @@ WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
                 uint16_t num_aps = ucNumNetworks;
                 esp_wifi_scan_get_ap_records(&num_aps, ap_info);
                 for (int i = 0; i < num_aps; i++) {
-                    strlcpy(pxBuffer[i].cSSID, (const char *)ap_info[i].ssid, wificonfigMAX_SSID_LEN);
+                    strlcpy(pxBuffer[i].cSSID, (const char *)ap_info[i].ssid, wificonfigMAX_SSID_LEN + 1);
                     memcpy(pxBuffer[i].ucBSSID, ap_info[i].bssid, wificonfigMAX_BSSID_LEN);
                     pxBuffer[i].cRSSI = ap_info[i].rssi;
                     pxBuffer[i].cChannel = ap_info[i].primary;
@@ -1291,9 +1291,13 @@ WIFIReturnCode_t WIFI_ConfigureAP( const WIFINetworkParams_t * const pxNetworkPa
         }
 
         /* ssid/password is required */
-        strlcpy((char *) &wifi_config.ap.ssid, pxNetworkParams->pcSSID, pxNetworkParams->ucSSIDLength);
+        /* SSID can be a non NULL terminated string if ssid_len is specified.
+         * Hence, memcpy is used to support 32 character long SSID name.
+         */
+        memcpy((char *) &wifi_config.ap.ssid, pxNetworkParams->pcSSID, pxNetworkParams->ucSSIDLength);
+        wifi_config.ap.ssid_len = pxNetworkParams->ucSSIDLength;
         if (pxNetworkParams->xSecurity != eWiFiSecurityOpen) {
-            strlcpy((char *) &wifi_config.ap.password, pxNetworkParams->pcPassword, pxNetworkParams->ucPasswordLength);
+            strlcpy((char *) &wifi_config.ap.password, pxNetworkParams->pcPassword, pxNetworkParams->ucPasswordLength + 1);
         }
 
         ret = WIFI_SetSecurity(pxNetworkParams->xSecurity, &wifi_config.ap.authmode);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
strlcpy sets last byte to NULL. Hence, length of SSID to be copied should be (max length + 1).

Using `sizeof` operator to calculate string length also counts NULL termination character. Hence, use strlen to calculate length of SSID and Passphrase.

Fixes issue https://github.com/aws/amazon-freertos/issues/2067

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.