### PR TITLE
Fixed regression in PKCS #11 nxp due to logic error in PAL refactor.

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -284,7 +284,7 @@ CK_RV PKCS11_PAL_Initialize( void )
     CK_RV xResult = CKR_OK;
 
     /* Initialize flash storage. */
-    if( pdTRUE == mflash_init( g_cert_files, 1 ) )
+    if( pdFALSE == mflash_init( g_cert_files, 1 ) )
     {
         xResult = CKR_FUNCTION_FAILED;
     }


### PR DESCRIPTION
Fixed regression in PKCS #11 NXP due to logic error in PAL refactor.

Description
-----------
The  logic for a successful initialization in the NXP PAL was accidentally refactored to be the opposite of the intention.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.