### PR TITLE
PKCS #11 Warning Fix

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2104,6 +2104,7 @@ static CK_RV prvGetExistingKeyComponent( CK_OBJECT_HANDLE_PTR pxPalHandle,
     return xResult;
 }
 
+#if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 )
 /**
  * @brief Helper function for importing elliptic curve keys from
  * template using C_CreateObject.
@@ -2210,6 +2211,7 @@ static CK_RV prvCreateECKey( CK_ATTRIBUTE * pxTemplate,
 
     return xResult;
 }
+#endif
 
 /**
  * @brief Helper function for parsing RSA Private Key attribute templates
@@ -2355,6 +2357,8 @@ static CK_RV prvCreatePublicKey( CK_ATTRIBUTE * pxTemplate,
             /* coverity[misra_c_2012_rule_10_5_violation] */
             xResult = prvCreateECKey( pxTemplate, ulCount, pxObject, ( CK_BBOOL ) CK_FALSE );
         }
+    #else
+        ( void ) pxObject;
     #endif /* if ( pkcs11configSUPPRESS_ECDSA_MECHANISM != 1 ) */
     else
     {


### PR DESCRIPTION
PKCS #11 Warning Fix

Description
-----------
Fix warnings of unused functions and parameters when ECDSA is suppressed.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.