### PR TITLE
TCP_ECHO_CLIENT_DEMO app fix for CLang/IAR builds

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
@@ -77,8 +77,11 @@
 
 /* Provide a function to retrieve the serializer function pointers in the MQTT demo. */
 typedef struct IotMqttSerializer IotMqttSerializer_t;
-extern const IotMqttSerializer_t * demoGetMqttSerializer( void );
-#define IOT_DEMO_MQTT_SERIALIZER                demoGetMqttSerializer()
+
+#if defined (MQTT_DEMO_TYPE_ENABLED)
+    extern const IotMqttSerializer_t * demoGetMqttSerializer( void );
+    #define IOT_DEMO_MQTT_SERIALIZER                demoGetMqttSerializer()
+#endif
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"


### PR DESCRIPTION
- ARM CLang and IAR linkers have issues when
external demoGetMqttSerializer symbol is declared and
not defined (i.e. TCP_ECHO_CLIENT_DEMO application)

Signed-off-by: Andrei Narkevitch <ainh@cypress.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.