### PR TITLE
Fix Cypress makefiles include paths and defines (#2070)

### DIFF
--- a/vendors/cypress/WICED_SDK/apps/demo/aws_demo/aws_demo.mk
+++ b/vendors/cypress/WICED_SDK/apps/demo/aws_demo/aws_demo.mk
@@ -56,6 +56,7 @@ GLOBAL_INCLUDES +=  $(AMAZON_FREERTOS_PATH)demos/include \
                     $(AFR_THIRDPARTY_PATH)jsmn \
                     $(AFR_THIRDPARTY_PATH)pkcs11 \
                     $(AFR_THIRDPARTY_PATH)lwip/src/include/lwip \
+                    $(AFR_THIRDPARTY_PATH)mbedtls_config \
                     $(AFR_THIRDPARTY_PATH)mbedtls/include \
                     $(AFR_THIRDPARTY_PATH)mbedtls_utils \
                     $(AMAZON_FREERTOS_PATH)freertos_kernel/include \

--- a/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
+++ b/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
@@ -63,6 +63,7 @@ GLOBAL_INCLUDES +=  $(AMAZON_FREERTOS_PATH)tests/include \
                     $(AFR_THIRDPARTY_PATH)jsmn \
                     $(AFR_THIRDPARTY_PATH)pkcs11 \
                     $(AFR_THIRDPARTY_PATH)lwip/src/include/lwip \
+                    $(AFR_THIRDPARTY_PATH)mbedtls_config \
                     $(AFR_THIRDPARTY_PATH)mbedtls/include \
                     $(AFR_THIRDPARTY_PATH)mbedtls_utils \
                     $(AMAZON_FREERTOS_PATH)freertos_kernel/include \

--- a/vendors/cypress/WICED_SDK/libraries/aws/aws.mk
+++ b/vendors/cypress/WICED_SDK/libraries/aws/aws.mk
@@ -142,7 +142,7 @@ $(NAME)_SOURCES :=  $(AFR_FREERTOS_PLUS_AWS_PATH)greengrass/src/aws_greengrass_d
                     $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/ports/pkcs11/iot_pkcs11_pal.c   \
                     $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/ports/pkcs11/hw_poll.c
 
-$(NAME)_INCLUDES := $(AFR_C_SDK_STANDARD_PATH)mqtt/include \
+GLOBAL_INCLUDES := $(AFR_C_SDK_STANDARD_PATH)mqtt/include \
                     $(AFR_C_SDK_STANDARD_PATH)mqtt/include/types \
                     $(AFR_C_SDK_AWS_PATH)/shadow/include \
                     $(AFR_C_SDK_AWS_PATH)/shadow/include/types \
@@ -163,5 +163,5 @@ $(NAME)_INCLUDES := $(AFR_C_SDK_STANDARD_PATH)mqtt/include \
                     $(AFR_THIRDPARTY_PATH)mbedtls_utlils \
                     $(AFR_THIRDPARTY_PATH)unity/src
 
-$(NAME)_DEFINES := MBEDTLS_CONFIG_FILE="<aws_mbedtls_config.h>"\
-				   CONFIG_MEDTLS_USE_AFR_MEMORY
+GLOBAL_DEFINES := MBEDTLS_CONFIG_FILE="<aws_mbedtls_config.h>" \
+                  CONFIG_MEDTLS_USE_AFR_MEMORY


### PR DESCRIPTION
Fix Cypress makefile include paths and defines

Description
-----------
The AFQP_Verify test was failing on both of the cypress boards. The root issue was that it was using the default MbedTLS config file instead of the "aws_mbedtls_config.h" file.

Changes I made to fix this:
- Fixed the way that the include paths and defines are added in aws.mk.
- Added the path to the aws_mbedtls_config.h file to the aws_demo.mk and aws_test.mk files for consistency.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.