### PR TITLE
Add 1.4x MQTT API deprecation warning message for all supported toolc…

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
@@ -53,7 +53,7 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The 1.4x API defined in this file is on a deprecation path. We display
+ * @brief The 1.4.x API defined in this file is on a deprecation path. We display
  * a deprecation warning message in build outputs depending of all supported toolchains.
  *
  * This logic uses toolchain-specific macros to issue warning message with preprocessor

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
@@ -53,17 +53,8 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The 1.4x API defined in this file is on a deprecation path.
- * This macro represents the text to display as a warning message in builds
- * that include this file.
- */
-#define DEPRECATION_WARN                                          \
-    "1.4x MQTT compatability API is on the path of DEPRECATION. " \
-    "Please contact AWS for support."
-
-/**
- * @brief Display a deprecation warning message for the 1.4x compatibility API
- * in build outputs depending of all supported toolchains.
+ * @brief The 1.4x API defined in this file is on a deprecation path. We display
+ * a deprecation warning message in build outputs depending of all supported toolchains.
  *
  * This logic uses toolchain-specific macros to issue warning message with preprocessor
  * directives supported by the toolchain.
@@ -72,15 +63,15 @@
     #define STRINGISE_IMPL( x )    # x
     #define STRINGISE( x )         STRINGISE_IMPL( x )
     #define FILE_LINE_LINK    __FILE__ "(" STRINGISE( __LINE__ ) ") : "
-    #pragma message ( __FILE__ "(" STRINGISE( __LINE__ ) ") : WARNING: " DEPRECATION_WARN )
-#elif defined( __GNUC__ ) /* GCC compilers issue -Wcpp warning for #warning directive. */
-    #pragma message ( "WARNING:" DEPRECATION_WARN )
+    #pragma message ( FILE_LINE_LINK "WARNING: 1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
+#elif defined( __GNUC__ )
+    /* GCC compilers issue -Wcpp warning for #warning directive. */
+    #pragma message ( "WARNING: 1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
 #elif defined( __TI_COMPILER_VERSION__ )
-    #warn "1.4x MQTT API is on the path of DEPRECATION. Please contact AWS for support."
+    #warn "1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
 #else
-    /* IAR and Renesas toolchains do not perform macro replacement. */
-    /* Thus, we do not use DEPRECATION_WARN macro here. */
-    #warning "1.4x MQTT API is on the path of DEPRECATION. Please contact AWS for support."
+    /* IAR and Renesas toolchains support the #warning directive. */
+    #warning "1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
 #endif /* ifdef _MSC_VER */
 
 /**

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
@@ -62,16 +62,18 @@
 #ifdef _MSC_VER
     #define STRINGISE_IMPL( x )    # x
     #define STRINGISE( x )         STRINGISE_IMPL( x )
+    /* File and line number macros are added explicitly as MSVC does */
+    /* not add them for #pragma message directive. */
     #define FILE_LINE_LINK    __FILE__ "(" STRINGISE( __LINE__ ) ") : "
-    #pragma message ( FILE_LINE_LINK "WARNING: 1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
+    #pragma message ( FILE_LINE_LINK "WARNING: 1.4.x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
 #elif defined( __GNUC__ )
     /* GCC compilers issue -Wcpp warning for #warning directive. */
-    #pragma message ( "WARNING: 1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
+    #pragma message ( "WARNING: 1.4.x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support." )
 #elif defined( __TI_COMPILER_VERSION__ )
-    #warn "1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
-#else
+    #warn "1.4.x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
+#else /* ifdef _MSC_VER */
     /* IAR and Renesas toolchains support the #warning directive. */
-    #warning "1.4x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
+    #warning "1.4.x MQTT compatibility API is on the path of DEPRECATION. Please contact AWS for support."
 #endif /* ifdef _MSC_VER */
 
 /**

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c
@@ -53,6 +53,37 @@
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief The 1.4x API defined in this file is on a deprecation path.
+ * This macro represents the text to display as a warning message in builds
+ * that include this file.
+ */
+#define DEPRECATION_WARN                                          \
+    "1.4x MQTT compatability API is on the path of DEPRECATION. " \
+    "Please contact AWS for support."
+
+/**
+ * @brief Display a deprecation warning message for the 1.4x compatibility API
+ * in build outputs depending of all supported toolchains.
+ *
+ * This logic uses toolchain-specific macros to issue warning message with preprocessor
+ * directives supported by the toolchain.
+ */
+#ifdef _MSC_VER
+    #define STRINGISE_IMPL( x )    # x
+    #define STRINGISE( x )         STRINGISE_IMPL( x )
+    #define FILE_LINE_LINK    __FILE__ "(" STRINGISE( __LINE__ ) ") : "
+    #pragma message ( __FILE__ "(" STRINGISE( __LINE__ ) ") : WARNING: " DEPRECATION_WARN )
+#elif defined( __GNUC__ ) /* GCC compilers issue -Wcpp warning for #warning directive. */
+    #pragma message ( "WARNING:" DEPRECATION_WARN )
+#elif defined( __TI_COMPILER_VERSION__ )
+    #warn "1.4x MQTT API is on the path of DEPRECATION. Please contact AWS for support."
+#else
+    /* IAR and Renesas toolchains do not perform macro replacement. */
+    /* Thus, we do not use DEPRECATION_WARN macro here. */
+    #warning "1.4x MQTT API is on the path of DEPRECATION. Please contact AWS for support."
+#endif /* ifdef _MSC_VER */
+
+/**
  * @brief Converts FreeRTOS ticks to milliseconds.
  */
 #define mqttTICKS_TO_MS( xTicks )    ( xTicks * 1000 / configTICK_RATE_HZ )


### PR DESCRIPTION
Add a deprecation warning message for the 1.4x MQTT API for all supported toolchains

Description
-----------
As part of the deprecation path of 1.4x series of MQTT APIs, we will issue a build-time warning of deprecation. 
Note that `#warning` directive is not supported by all toolchains (as it is not part of the ISO C standard), thus, the logic uses toolchain-specific directives to support displaying the message on their respective build outputs.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.