### PR TITLE
OTA/ Start self test timer before job doc is requested.

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -725,6 +725,8 @@ static OTA_Err_t prvStartHandler( OTA_EventData_t * pxEventData )
     OTA_Err_t xReturn = kOTA_Err_None;
     OTA_EventMsg_t xEventMsg = { 0 };
 
+    /* Start self-test timer, if platform is in self-test. */
+    prvStartSelfTestTimer();
 
     /* Send event to OTA task to get job document. */
     xEventMsg.xEventId = eOTA_AgentEvent_RequestJobDocument;
@@ -746,7 +748,7 @@ static OTA_Err_t prvInSelfTestHandler( OTA_EventData_t * pxEventData )
     OTA_LOG_L1( "[%s] prvInSelfTestHandler, platform is in self-test.\r\n", OTA_METHOD_NAME );
 
     /* Check the platform's OTA update image state. It should also be in self test. */
-    if( prvStartSelfTestTimer() == pdTRUE )
+    if( prvInSelftest() == true )
     {
         /* Callback for application specific self-test. */
         xOTA_Agent.xPALCallbacks.xCompleteCallback( eOTA_JobEvent_StartTest );


### PR DESCRIPTION
<!--- Title -->
This fix starts the self-test timer before it receives the OTA job document.

Description
-----------
<!--- Describe your changes in detail -->
The fix helps in handling conditions where the OTA job is forced cancelled after it is started to allow device to reset and rollback.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.