### PR TITLE
Fix: Allow Ping to succeed on Mediatek if >= 0 pings

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
@@ -1448,10 +1448,15 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
                              (uint32_t)usCount,
                              ulIntervalMS);
 
-    if (count < 0)
+    if( count < 0 )
         return eWiFiFailure;
 
-    return count == usCount ? eWiFiSuccess : eWiFiFailure;
+    if( count != usCount )
+    {
+        printf("WIFI_Ping: only %d pings reached out of %d\n", count, usCount);
+    }
+
+    return eWiFiSuccess;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Allow Ping to succeed on Mediatek if >= 0 pings

Description
-----------
Allow Ping to succeed on Mediatek if >= 0 pings have succeeded

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.