### PR TITLE
Fix: Mediatek wifi_ping fail on zero

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
@@ -1448,7 +1448,7 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
                              (uint32_t)usCount,
                              ulIntervalMS);
 
-    if( count < 0 )
+    if( count <= 0 )
         return eWiFiFailure;
 
     if( count != usCount )


### PR DESCRIPTION
Mediatek Wifi_ping fail on zero

Description
-----------
if no pings are received fail wifi ping, as other errors could lie behind which are not reported due to driver code

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.