### PR TITLE
Fix: Nuvoton print wifi_ping errors

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/wifi/iot_wifi.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/wifi/iot_wifi.c
@@ -248,6 +248,7 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr, uint16_t usCount, uint32_t ulIn
 {
     WIFIReturnCode_t xWiFiRet = eWiFiFailure;
     uint32_t i;
+    int ret;
 
     if (pucIPAddr == NULL || usCount == 0) {
         return xWiFiRet;
@@ -255,11 +256,14 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr, uint16_t usCount, uint32_t ulIn
 
     if (xSemaphoreTake(xNuWiFi.xWifiSem, xSemaphoreWaitTicks) == pdTRUE) {
         for (i = 0 ; i < usCount ; i++) {
-            if (ESP_WIFI_Ping(&xNuWiFi.xWifiObject, pucIPAddr) == ESP_WIFI_STATUS_OK) {
+            ret = ESP_WIFI_Ping(&xNuWiFi.xWifiObject, pucIPAddr);
+            if (ret == ESP_WIFI_STATUS_OK) {
                 xWiFiRet = eWiFiSuccess;
                 if (i < usCount - 1) {
                     vTaskDelay(pdMS_TO_TICKS(ulIntervalMS));
                 }
+            } else {
+                configPRINTF("WIFI_Ping ESP_WIFI_Ping Not OK %d\n", ret);
             }
         }
         xSemaphoreGive(xNuWiFi.xWifiSem);


### PR DESCRIPTION
Nuvoton print wifi_ping errors

Description
-----------
It is hard to know what went wrong when Nuvoton wifi_ping fails, therefore, we are printing error codes when it does

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.