### PR TITLE
PKCS #11 Unit Tests - New Session Handles

### DIFF
--- a/tests/unit_test/linux/config_files/iot_pkcs11_config.h
+++ b/tests/unit_test/linux/config_files/iot_pkcs11_config.h
@@ -56,6 +56,12 @@
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
+ * @brief Maximum number of sessions that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_SESSIONS                           10
+
+/**
  * @brief Set to 1 if a PAL destroy object is implemented.
  *
  * If set to 0, no PAL destroy object is implemented, and this functionality


### PR DESCRIPTION
PKCS #11 Unit Tests - New Session Handles

Description
-----------

This commit updates the unit tests for iot_pkcs11_mbedtls.c after updating the session handle management to be
done with a static array and swapping to using static mutexes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.