### PR TITLE
Remove Amazon prefix from repository branding

### DIFF
--- a/libraries/abstractions/common_io/include/iot_usb_host.h
+++ b/libraries/abstractions/common_io/include/iot_usb_host.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS Common IO V0.1.0
+ * FreeRTOS Common IO V0.1.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_CloseSession.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_CloseSession.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_DigestFinal.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_DigestFinal.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_DigestInit.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_DigestInit.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_DigestUpdate.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_DigestUpdate.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_Finalize.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_Finalize.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_FindObjects.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_FindObjects.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_FindObjectsFinal.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_FindObjectsFinal.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_FindObjectsInit.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_FindObjectsInit.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_GenerateKeyPair.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_GenerateKeyPair.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_GenerateRandom.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_GenerateRandom.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_GetAttributeValue.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_GetAttributeValue.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_Initialize.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_Initialize.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_OpenSession.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_OpenSession.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_Sign.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_Sign.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_SignInit.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_SignInit.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_Verify.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_Verify.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_C_VerifyInit.c
+++ b/libraries/abstractions/pkcs11/test/MBT_C_VerifyInit.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_DigestMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_DigestMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_GenerationMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_GenerationMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_ObjectMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_ObjectMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_SessionMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_SessionMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_SignMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_SignMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/MBT_VerifyMachine.c
+++ b/libraries/abstractions/pkcs11/test/MBT_VerifyMachine.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11_globals.h
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11_globals.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS PKCS#11 V1.0.8
+ * FreeRTOS PKCS#11 V1.0.8
  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
+++ b/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS Secure Sockets V1.1.8
+ * FreeRTOS Secure Sockets V1.1.8
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/unit_test/linux/config_files/aws_secure_sockets_config.h
+++ b/tests/unit_test/linux/config_files/aws_secure_sockets_config.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS V1.1.4
+ * FreeRTOS V1.1.4
  * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/unit_test/linux/config_files/aws_wifi_config.h
+++ b/tests/unit_test/linux/config_files/aws_wifi_config.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS V1.4.8
+ * FreeRTOS V1.4.8
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/unit_test/linux/config_files/iot_ble_config.h
+++ b/tests/unit_test/linux/config_files/iot_ble_config.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS V1.4.2
+ * FreeRTOS V1.4.2
  * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -73,7 +73,7 @@ else()
 endif()
 
 # Provide an option to enable unit tests with mocking
-option(AFR_ENABLE_UNIT_TESTS "Build tests for Amazon FreeRTOS. Requires recompiling whole library." OFF)
+option(AFR_ENABLE_UNIT_TESTS "Build tests for FreeRTOS. Requires recompiling whole library." OFF)
 if (AFR_ENABLE_UNIT_TESTS)
      add_compile_definitions(AMAZON_FREERTOS_ENABLE_UNIT_TESTS)
      add_compile_definitions(IOT_BUILD_TESTS=1)

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_pkcs11_config.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS V1.1.4
+ * FreeRTOS V1.1.4
  * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_test_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/iot_test_pkcs11_config.h
@@ -1,5 +1,5 @@
 /*
- * Amazon FreeRTOS V1.1.4
+ * FreeRTOS V1.1.4
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -37,7 +37,7 @@
  * Each task consumes both stack and heap space, which may cause memory allocation
  * failures if too many tasks are created.
  */
-#define pkcs11testMULTI_THREAD_TASK_COUNT     ( 2 )
+#define pkcs11testMULTI_THREAD_TASK_COUNT             ( 2 )
 
 /**
  * @brief The number of iterations of the test that will run in multithread tests.
@@ -46,7 +46,7 @@
  * boards. Ensure that pkcs11testEVENT_GROUP_TIMEOUT is long enough to accommodate
  * all iterations of the loop.
  */
-#define pkcs11testMULTI_THREAD_LOOP_COUNT     ( 10 )
+#define pkcs11testMULTI_THREAD_LOOP_COUNT             ( 10 )
 
 /**
  * @brief
@@ -54,32 +54,32 @@
  * All tasks of the SignVerifyRoundTrip_MultitaskLoop test must finish within
  * this timeout, or the test will fail.
  */
-#define pkcs11testEVENT_GROUP_TIMEOUT_MS      ( pdMS_TO_TICKS( 1000000UL ) )
+#define pkcs11testEVENT_GROUP_TIMEOUT_MS              ( pdMS_TO_TICKS( 1000000UL ) )
 
 /**
  * @brief The index of the slot that should be used to open sessions for PKCS #11 tests.
  */
-#define pkcs11testSLOT_NUMBER                 ( 0 )
+#define pkcs11testSLOT_NUMBER                         ( 0 )
 
 /*
  * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testRSA_KEY_SUPPORT             ( 0 )
+#define pkcs11testRSA_KEY_SUPPORT                     ( 0 )
 
 /*
  * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testEC_KEY_SUPPORT              ( 1 )
+#define pkcs11testEC_KEY_SUPPORT                      ( 1 )
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */
-#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT  ( 0 )
+#define pkcs11testIMPORT_PRIVATE_KEY_SUPPORT          ( 0 )
 
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT    ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 1 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.
@@ -88,7 +88,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "Test Priv Key"
+#define pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS    "Test Priv Key"
 
 /**
  * @brief The PKCS #11 label for device public key.
@@ -97,7 +97,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "Test Pub TLS Key"
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     "Test Pub TLS Key"
 
 /**
  * @brief The PKCS #11 label for the device certificate.
@@ -106,7 +106,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Test Cert"
+#define pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS    "Test Cert"
 
 /**
  * @brief The PKCS #11 label for the object to be used for code verification.
@@ -117,7 +117,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_CODE_VERIFICATION_KEY            pkcs11configLABEL_CODE_VERIFICATION_KEY
+#define pkcs11testLABEL_CODE_VERIFICATION_KEY         pkcs11configLABEL_CODE_VERIFICATION_KEY
 
 /**
  * @brief The PKCS #11 label for Just-In-Time-Provisioning.
@@ -130,18 +130,18 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_JITP_CERTIFICATE                 pkcs11configLABEL_JITP_CERTIFICATE
+#define pkcs11testLABEL_JITP_CERTIFICATE              pkcs11configLABEL_JITP_CERTIFICATE
 
 /**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h
  */
-#define pkcs11testLABEL_ROOT_CERTIFICATE                 pkcs11configLABEL_ROOT_CERTIFICATE
+#define pkcs11testLABEL_ROOT_CERTIFICATE              pkcs11configLABEL_ROOT_CERTIFICATE
 
 /**
  * @brief The size of the stack used for multithread tests.
  */
-#define pkcs11testMULTI_TASK_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 8 ) 
+#define pkcs11testMULTI_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 8 )
 
 #endif /* _AWS_TEST_PKCS11_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/esp32_plus_ecc608a_devkitc.cmake
+++ b/vendors/espressif/boards/esp32/esp32_plus_ecc608a_devkitc.cmake
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------------------------
-# Amazon FreeRTOS Console metadata
+# FreeRTOS Console metadata
 # -------------------------------------------------------------------------------------------------
 afr_set_board_metadata(ID "ESP32-DevKitC-With-MCHP-ATECC608A")
 afr_set_board_metadata(DISPLAY_NAME "ESP32-DevKitC with ATECC608A")


### PR DESCRIPTION
Update remaining artifacts of **Amazon FreeRTOS** to just **FreeRTOS** as the repository brand name.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.