### PR TITLE
Update Cypress PSoC64 board name in MTB aws_demos project file.

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/Makefile
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/Makefile
@@ -39,7 +39,7 @@ CY_BUILD_LOCATION=$(abspath $(CY_BUILD_RELATIVE_LOCATION))
 ################################################################################
 
 # Target board/hardware
-TARGET=CY8CKIT-064S0S2-4343W
+TARGET=CY8CKIT_064S0S2_4343W
 
 # Name of application (used to derive name of final linked file).
 APPNAME=$(CY_AFR_BUILD)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The board name in Cypress aws_demos project file was not updated.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.