### PR TITLE
Increase the logging size for Xilinx Microzed

### DIFF
--- a/vendors/xilinx/boards/microzed/aws_demos/application_code/main.c
+++ b/vendors/xilinx/boards/microzed/aws_demos/application_code/main.c
@@ -53,7 +53,7 @@
 #include "aws_application_version.h"
 
 /* Logging Task Defines. */
-#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 64 )
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 128 )
 #define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
 
 /* Unit test defines. */

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -52,7 +52,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
  * then FreeRTOS_printf should be set to the function used to print out the
  * messages. */
-#define ipconfigHAS_PRINTF    1
+#define ipconfigHAS_PRINTF    0
 #if ( ipconfigHAS_PRINTF == 1 )
     #define FreeRTOS_printf( X )    configPRINTF( X )
 #endif

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -52,7 +52,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
  * then FreeRTOS_printf should be set to the function used to print out the
  * messages. */
-#define ipconfigHAS_PRINTF    0
+#define ipconfigHAS_PRINTF    1
 #if ( ipconfigHAS_PRINTF == 1 )
     #define FreeRTOS_printf( X )    configPRINTF( X )
 #endif


### PR DESCRIPTION
Description
-----------
I have tested locally that increasing the logging to 100 does not help the "Demo completed successfully" message to print, but increasing it to 128 does. Increasing the queue greater may cause issues with demos as memory is depleted. 

Every demo passes and run. 
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/63/
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/65/ - Shadow rerun

This change was needed in addition to the decrease in network statistic logs that were reduced by @htibosch a few weeks ago.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.