### PR TITLE
PKCS #11 PAL MISRA Fix

### DIFF
--- a/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
+++ b/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
@@ -97,8 +97,8 @@ CK_RV PKCS11_PAL_Initialize( void );
  */
 /* @[declare_pkcs11_pal_saveobject] */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize );
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize );
 /* @[declare_pkcs11_pal_saveobject] */
 
 /**
@@ -124,8 +124,8 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle );
  * Returns eInvalidHandle if unsuccessful.
  */
 /* @[declare_pkcs11_pal_findobject] */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength );
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength );
 /* @[declare_pkcs11_pal_findobject] */
 
 
@@ -153,9 +153,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 /* @[declare_pkcs11_pal_getobjectvalue] */
-BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      uint8_t ** ppucData,
-                                      uint32_t * pulDataSize,
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
                                       CK_BBOOL * pIsPrivate );
 /* @[declare_pkcs11_pal_getobjectvalue] */
 
@@ -168,8 +168,8 @@ BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
 /* @[declare_pkcs11_pal_getobjectvaluecleanup] */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucBuffer,
-                                       uint32_t ulBufferSize );
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize );
 /* @[declare_pkcs11_pal_getobjectvaluecleanup] */
 
 #endif /* IOT_PKCS11_PAL include guard. */

--- a/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
+++ b/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
@@ -162,14 +162,14 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 /**
  * @brief Cleanup after PKCS11_GetObjectValue().
  *
- * @param[in] pucBuffer      The buffer to free.
+ * @param[in] pucData       The buffer to free.
  *                          (*ppucData from PKCS11_PAL_GetObjectValue())
- * @param[in] ulBufferSize   The length of the buffer to free.
+ * @param[in] ulDatasize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
 /* @[declare_pkcs11_pal_getobjectvaluecleanup] */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize );
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize );
 /* @[declare_pkcs11_pal_getobjectvaluecleanup] */
 
 #endif /* IOT_PKCS11_PAL include guard. */

--- a/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
+++ b/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
@@ -116,7 +116,7 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle );
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
@@ -124,7 +124,7 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle );
  * Returns eInvalidHandle if unsuccessful.
  */
 /* @[declare_pkcs11_pal_findobject] */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength );
 /* @[declare_pkcs11_pal_findobject] */
 

--- a/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
+++ b/libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h
@@ -154,9 +154,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
  */
 /* @[declare_pkcs11_pal_getobjectvalue] */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      CK_BYTE_PTR * ppucData,
-                                      CK_ULONG_PTR pulDataSize,
-                                      CK_BBOOL * pIsPrivate );
+                                 CK_BYTE_PTR * ppucData,
+                                 CK_ULONG_PTR pulDataSize,
+                                 CK_BBOOL * pIsPrivate );
 /* @[declare_pkcs11_pal_getobjectvalue] */
 
 /**

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -1031,6 +1031,7 @@ static CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
 {
     CK_RV xResult = CKR_HOST_MEMORY;
     BaseType_t xGotSemaphore;
+
     xGotSemaphore = xSemaphoreTake( xP11Context.xObjectList.xMutex, portMAX_DELAY );
     /* See explanation in prvCheckValidSessionAndModule for this exception. */
     /* coverity[misra_c_2012_rule_10_5_violation] */

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
@@ -122,8 +122,8 @@ static void prvLabelToFilenameHandle( uint8_t * pcLabel, CK_OBJECT_HANDLE_PTR pH
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle ;
 
@@ -151,8 +151,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle ;
     
@@ -191,9 +191,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     uint32_t index, size ;
     cy_rslt_t res ;
@@ -254,8 +254,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     free(pucData) ;
 }

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
@@ -144,14 +144,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle ;
@@ -159,7 +159,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     if (cy_objstore_initialize(false, 1) != CY_RSLT_SUCCESS)
         return eInvalidHandle ;
 
-    prvLabelToFilenameHandle( pLabel, &xHandle );
+    prvLabelToFilenameHandle( pxLabel, &xHandle );
 
     if (cy_objstore_find_object(xHandle, NULL, NULL) != CY_RSLT_SUCCESS)
         return eInvalidHandle ;

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/pkcs11/iot_pkcs11_pal.c
@@ -254,8 +254,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     free(pucData) ;
 }

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -191,14 +191,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -209,7 +209,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+    prvLabelToFilenameHandle( pxLabel, &pcFileName, &xHandle );
 
     if (xHandle != CK_INVALID_HANDLE)
     {

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -340,8 +340,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     if( NULL != pucData )
     {

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -125,8 +125,8 @@ CK_RV PKCS11_PAL_Initialize( void )
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     wiced_result_t result = WICED_SUCCESS;
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -185,12 +185,6 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
     return xHandle;
 }
 
-
-CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate );
-    
 /**
 * @brief Translates a PKCS #11 label into an object handle.
 *
@@ -204,8 +198,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -255,9 +249,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     uint32_t len=0;
     wiced_result_t result = WICED_SUCCESS;
@@ -346,8 +340,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     if( NULL != pucData )
     {

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -64,6 +64,11 @@ enum eObjectHandles
     eAwsCodeSigningKey
 };
 
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate );
+
 /* Converts a label to its respective filename and handle. */
 void prvLabelToFilenameHandle( uint8_t * pcLabel,
                                char ** pcFileName,

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -196,14 +196,14 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -214,7 +214,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+    prvLabelToFilenameHandle( pxLabel, &pcFileName, &xHandle );
 
     if (xHandle != CK_INVALID_HANDLE)
     {

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -186,10 +186,6 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 }
 
 
-CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      CK_BYTE_PTR * ppucData,
-                                      CK_ULONG_PTR pulDataSize,
-                                      CK_BBOOL * pIsPrivate );
 /**
 * @brief Translates a PKCS #11 label into an object handle.
 *

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -345,8 +345,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     if( NULL != pucData )
     {

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -125,8 +125,8 @@ CK_RV PKCS11_PAL_Initialize( void )
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     wiced_result_t result = WICED_SUCCESS;
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -187,9 +187,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 
 
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate );
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate );
 /**
 * @brief Translates a PKCS #11 label into an object handle.
 *
@@ -203,8 +203,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -254,9 +254,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     uint32_t len=0;
     wiced_result_t result = WICED_SUCCESS;
@@ -345,8 +345,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     if( NULL != pucData )
     {

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/iot_pkcs11_pal.c
@@ -64,6 +64,11 @@ enum eObjectHandles
     eAwsCodeSigningKey
 };
 
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate );
+
 /* Converts a label to its respective filename and handle. */
 void prvLabelToFilenameHandle( uint8_t * pcLabel,
                                char ** pcFileName,

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/iot_pkcs11_config.h
@@ -61,19 +61,19 @@
  * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
  * attribute.
  */
-#define pkcs11configMAX_LABEL_LENGTH                       32
+#define pkcs11configMAX_LABEL_LENGTH                       32UL
 
 /**
  * @brief Maximum number of token objects that can be stored
  * by the PKCS #11 module.
  */
-#define pkcs11configMAX_NUM_OBJECTS                        6
+#define pkcs11configMAX_NUM_OBJECTS                        6UL
 
 /**
  * @brief Maximum number of sessions that can be stored
  * by the PKCS #11 module.
  */
-#define pkcs11configMAX_SESSIONS                           10
+#define pkcs11configMAX_SESSIONS                           10UL
 
 /**
  * @brief Set to 1 if a PAL destroy object is implemented.

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -376,8 +376,8 @@ done:
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -178,8 +178,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * @return The file handle of the object that was stored.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     initialize_nvs_partition();
 
@@ -223,8 +223,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pcLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -285,9 +285,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pcLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     initialize_nvs_partition();
 
@@ -376,8 +376,8 @@ done:
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/espressif/boards/esp32/ports/pkcs11/iot_pkcs11_pal.c
@@ -191,7 +191,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
                               &pcFileName,
                               &xHandle );
 
-    ESP_LOGD(TAG, "Writing file %s, %d bytes", pcFileName, ulDataSize);
+    ESP_LOGD(TAG, "Writing file %s, %d bytes", ( char * ) pcFileName, ( uint32_t ) ulDataSize);
     nvs_handle handle;
     esp_err_t err = nvs_open_from_partition(NVS_PART_NAME, NAMESPACE, NVS_READWRITE, &handle);
     if (err != ESP_OK) {
@@ -199,7 +199,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
         return eInvalidHandle;
     }
 
-    err = nvs_set_blob(handle, pcFileName, pucData, ulDataSize);
+    err = nvs_set_blob(handle, pcFileName, ( char * ) pucData, ( uint32_t ) ulDataSize);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "failed nvs set blob %d", err);
         nvs_close(handle);
@@ -223,7 +223,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -232,7 +232,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     initialize_nvs_partition();
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    prvLabelToFilenameHandle( pcLabel,
+    prvLabelToFilenameHandle( pxLabel,
                               &pcFileName,
                               &xHandle );
 

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
@@ -344,8 +344,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
@@ -195,13 +195,13 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    if( 0 == memcmp( pLabel,
+    if( 0 == memcmp( pxLabel,
                      &pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
                      sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ) ) )
     {
@@ -210,7 +210,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
             xHandle = eAwsDeviceCertificate;
         }
     }
-    else if( 0 == memcmp( pLabel,
+    else if( 0 == memcmp( pxLabel,
                           &pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
                           sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) ) )
     {
@@ -219,7 +219,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
             xHandle = eAwsDevicePrivateKey;
         }
     }
-    else if( 0 == memcmp( pLabel,
+    else if( 0 == memcmp( pxLabel,
                           &pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
                           sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ) ) )
     {
@@ -228,7 +228,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
             xHandle = eAwsDevicePublicKey;
         }
     }
-    else if( 0 == memcmp( pLabel,
+    else if( 0 == memcmp( pxLabel,
                           &pkcs11configLABEL_CODE_VERIFICATION_KEY,
                           sizeof( pkcs11configLABEL_CODE_VERIFICATION_KEY ) ) )
     {

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/iot_pkcs11_pal.c
@@ -105,8 +105,8 @@ static E_EEPROM_XMC4_t e_eeprom;
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     CK_ULONG ulFlashMark = pkcs11OBJECT_FLASH_OBJECT_PRESENT;
@@ -195,8 +195,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
@@ -267,9 +267,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV ulReturn = CKR_OK;
 
@@ -344,8 +344,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -336,8 +336,8 @@ static int32_t prvUploadPublicKey( char * pucLabel,
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
@@ -457,8 +457,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
@@ -544,9 +544,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
  * error.
  */
-BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      uint8_t ** ppucData,
-                                      uint32_t * pulDataSize,
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
                                       CK_BBOOL * pIsPrivate )
 {
     BaseType_t ulReturn = CKR_OK;
@@ -631,8 +631,8 @@ BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     vPortFree( pucData );

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -315,8 +315,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     if (pucData == NULL)
         return;

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -115,8 +115,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * @return The file handle of the object that was stored.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -162,8 +162,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pcLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -221,9 +221,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pcLabel,
 * error, CKR_ARGUMENTS_BAD for bad arguments.
 */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     char * pcFileName = NULL;
     int ret;
@@ -315,8 +315,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     if (pucData == NULL)
         return;

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/iot_pkcs11_pal.c
@@ -162,7 +162,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -170,7 +170,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     int ret;
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    prvLabelToFilenameHandle(pcLabel, &pcFileName, &xHandle);
+    prvLabelToFilenameHandle(pxLabel, &pcFileName, &xHandle);
 
     if (pcFileName == NULL) {
         /* TODO: Check what print function to use */

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -220,7 +220,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
@@ -228,7 +228,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
@@ -239,7 +239,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
 
     /* Converts a label to its respective filename and handle. */
 
-    prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+    prvLabelToFilenameHandle( pxLabel, &pcFileName, &xHandle );
 
     if( pcFileName != NULL )
     {

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -330,8 +330,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/iot_pkcs11_pal.c
@@ -188,9 +188,9 @@ CK_RV PKCS11_PAL_Initialize( void )
  * @return The object handle if successful.
  * eInvalidHandle = 0 if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR    pxLabel,
-                                        uint8_t             *pucData,
-                                        uint32_t            ulDataSize )
+CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     char                *pcFileName = NULL;
     CK_OBJECT_HANDLE    xHandle     = eInvalidHandle;
@@ -228,8 +228,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR    pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
     ( void ) usLength;
@@ -280,9 +280,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV       ulReturn        = CKR_OK;
     char        *pcFileName     = NULL;
@@ -330,8 +330,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -222,7 +222,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
@@ -230,7 +230,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -239,26 +239,26 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     const P11KeyConfig_t * P11ConfigFlashPtr = ( const P11KeyConfig_t * ) KVA0_TO_KVA1( PKCS11_CERTIFICATE_SECTION_START_ADDRESS );
 
     /* TODO: Check if object actually exists/has been created before returning. */
-    if( 0 == memcmp( pLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength )  )
+    if( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength )  )
     {
         xHandle = eAwsDeviceCertificate;
                 pCertFlash = &P11ConfigFlashPtr->xDeviceCertificate;
 
     }
-    else if( 0 == memcmp( pLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, usLength ) )
+    else if( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, usLength ) )
     {
         xHandle = eAwsDevicePrivateKey;
                 pCertFlash = &P11ConfigFlashPtr->xDeviceKey;
 
     }
-    else if( 0 == memcmp( pLabel, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, usLength ) )
+    else if( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, usLength ) )
     {
         /* Public and private key are stored together in same file. */
         xHandle = eAwsDevicePublicKey;
                 pCertFlash = &P11ConfigFlashPtr->xDeviceKey;
 
     }
-    else if( 0 == memcmp( pLabel, pkcs11configFILE_CODE_SIGN_PUBLIC_KEY, usLength ) )
+    else if( 0 == memcmp( pxLabel, pkcs11configFILE_CODE_SIGN_PUBLIC_KEY, usLength ) )
     {
         xHandle = eAwsCodeSigningKey;
                 pCertFlash = &P11ConfigFlashPtr->xCodeVerificationKey;

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -127,8 +127,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     uint32_t * pFlashDest, * pDataSrc;
     int rowIx, nRows;
@@ -230,8 +230,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     const P11CertData_t * pCertFlash = 0;
@@ -301,9 +301,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV xResult = CKR_OK;
     uint32_t certSize = 0;
@@ -363,8 +363,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c
@@ -363,8 +363,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
@@ -348,14 +348,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     uint8_t     *pucData = NULL;
@@ -367,7 +367,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     char * pcFileName = NULL;
 
     /* Converts a label to its respective filename and handle. */
-    prvLabelToFilenameHandle( pLabel,
+    prvLabelToFilenameHandle( pxLabel,
                               &pcFileName,
                               &xHandle );
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
@@ -465,8 +465,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/iot_pkcs11_pal.c
@@ -319,8 +319,8 @@ CK_RV PKCS11_PAL_Initialize( void )
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     char                *pcFileName = NULL;
     CK_OBJECT_HANDLE    xHandle     = eInvalidHandle;
@@ -355,8 +355,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     uint8_t     *pucData = NULL;
     uint32_t    dataSize = 0;  
@@ -409,9 +409,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 * error.
 */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
 
     CK_RV ulReturn = CKR_OK;
@@ -465,8 +465,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -164,14 +164,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -180,7 +180,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     size_t xFileLength = 0;
 
     /* Translate from the PKCS#11 label to local storage file name. */
-    prvLabelToFilenameHandle( pLabel, &pcFileName, &xHandle );
+    prvLabelToFilenameHandle( pxLabel, &pcFileName, &xHandle );
 
     /* Check if the file exists. */
     if( pdFALSE == mflash_read_file( pcFileName, &pFile, &xFileLength ) )

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -267,8 +267,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/iot_pkcs11_pal.c
@@ -135,8 +135,8 @@ void prvLabelToFilenameHandle( uint8_t * pcLabel,
  * @return The file handle of the object that was stored.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -171,8 +171,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * @return The object handle if operation was successful.
  * Returns eInvalidHandle if unsuccessful.
  */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -218,9 +218,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     char * pcFileName = NULL;
     CK_RV ulReturn = CKR_OK;
@@ -267,8 +267,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
@@ -344,8 +344,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 
 /*-----------------------------------------------------------*/
 
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
@@ -158,8 +158,8 @@ CK_RV PKCS11_PAL_Initialize( void )
 }
 
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     uint32_t ulStatus = 0;
     HANDLE hFile = INVALID_HANDLE_VALUE;
@@ -215,8 +215,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 /*-----------------------------------------------------------*/
 
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
     ( void ) usLength;
@@ -240,9 +240,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 /*-----------------------------------------------------------*/
 
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV ulReturn = CKR_OK;
     uint32_t ulDriverReturn = 0;
@@ -344,8 +344,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 
 /*-----------------------------------------------------------*/
 
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
@@ -215,7 +215,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 /*-----------------------------------------------------------*/
 
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
@@ -225,7 +225,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     char * pcFileName = NULL;
 
     /* Converts a label to its respective filename and handle. */
-    prvLabelToFilenameHandle( pLabel,
+    prvLabelToFilenameHandle( pxLabel,
                               &pcFileName,
                               &xHandle );
 

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
@@ -331,14 +331,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
@@ -349,7 +349,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
 
     for(i = 1; i < PKCS_OBJECT_HANDLES_NUM; i++)
     {
-        if(!strcmp((char *)&object_handle_dictionary[i], (char *)pLabel))
+        if(!strcmp((char *)&object_handle_dictionary[i], (char *)pxLabel))
         {
             if(pkcs_control_block_data_image.data.pkcs_data[i].status == PKCS_DATA_STATUS_REGISTERED)
             {

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
@@ -428,8 +428,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Avoid compiler warnings about unused variables. */
     R_INTERNAL_NOT_USED(pucData);

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c
@@ -199,8 +199,8 @@ void PKCS11_PAL_Initialize( void )
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     int i;
@@ -338,8 +338,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     /* Avoid compiler warnings about unused variables. */
     R_INTERNAL_NOT_USED(usLength);
@@ -385,9 +385,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 * error.
 */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV xReturn = CKR_FUNCTION_FAILED;
     CK_OBJECT_HANDLE xHandleStorage = xHandle;
@@ -428,8 +428,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Avoid compiler warnings about unused variables. */
     R_INTERNAL_NOT_USED(pucData);

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
@@ -649,8 +649,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
@@ -317,8 +317,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -519,8 +519,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
@@ -568,9 +568,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  */
 
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 
 {
     CK_RV ulReturn = CKR_OBJECT_HANDLE_INVALID;
@@ -649,8 +649,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) pucData;

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/iot_pkcs11_pal.c
@@ -511,7 +511,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
@@ -519,22 +519,22 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
 
-    if( ( 0 == memcmp( pLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength ) ) &&
+    if( ( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength ) ) &&
         ( ( P11KeyConfig.ulDeviceCertificateMark & pkcs11OBJECT_PRESENT_MASK ) == pkcs11OBJECT_PRESENT_MAGIC ) )
     {
         xHandle = eAwsDeviceCertificate;
     }
-    else if( ( 0 == memcmp( pLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, usLength ) ) &&
+    else if( ( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, usLength ) ) &&
              ( ( P11KeyConfig.ulDeviceKeyMark & pkcs11OBJECT_PRESENT_MASK ) == pkcs11OBJECT_PRESENT_MAGIC ) )
     {
         xHandle = eAwsDevicePrivateKey;
     }
-    else if( ( 0 == memcmp( pLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, usLength ) ) &&
+    else if( ( 0 == memcmp( pxLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, usLength ) ) &&
              ( ( P11KeyConfig.ulCodeSignKeyMark & pkcs11OBJECT_PRESENT_MASK ) == pkcs11OBJECT_PRESENT_MAGIC ) )
     {
         xHandle = eAwsCodeSigningKey;

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -419,7 +419,7 @@ CK_RV PKCS11_PAL_Initialize( void )
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -428,7 +428,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     SlFsFileInfo_t FsFileInfo = { 0 };
 
     /* Converts a label to its respective filename and handle. */
-    prvLabelToFilenameHandle( pLabel,
+    prvLabelToFilenameHandle( pxLabel,
                               &pcFileName,
                               &xHandle );
 

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -419,8 +419,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
@@ -471,10 +471,10 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * buffer could not be allocated, CKR_FUNCTION_FAILED for device driver
  * error.
  */
-BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      uint8_t ** ppucData,
-                                      uint32_t * pulDataSize,
-                                      CK_BBOOL * xIsPrivate )
+CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV ulReturn = CKR_OK;
     int32_t iReadBytes = 0;
@@ -559,8 +559,8 @@ BaseType_t PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;
@@ -586,8 +586,8 @@ void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     char * pcFileName = NULL;
     char * pcPemBuffer = NULL;

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -486,11 +486,11 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 
     if( xHandle == eAwsDevicePrivateKey )
     {
-        *xIsPrivate = CK_TRUE;
+        *pIsPrivate = CK_TRUE;
     }
     else
     {
-        *xIsPrivate = CK_FALSE;
+        *pIsPrivate = CK_FALSE;
     }
 
     if( pcFileName == NULL )

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/iot_pkcs11_pal.c
@@ -559,8 +559,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -73,14 +73,14 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * Port-specific object handle retrieval.
 *
 *
-* @param[in] pLabel         Pointer to the label of the object
+* @param[in] pxLabel         Pointer to the label of the object
 *                           who's handle should be found.
 * @param[in] usLength       The length of the label, in bytes.
 *
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = 0;

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -60,8 +60,8 @@ CK_RV PKCS11_PAL_Initialize( void )
 * @return The file handle of the object that was stored.
 */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-    uint8_t * pucData,
-    uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     CK_OBJECT_HANDLE xHandle = 0;
     return xHandle;
@@ -80,8 +80,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
 * @return The object handle if operation was successful.
 * Returns eInvalidHandle if unsuccessful.
 */
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-    uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = 0;
     return xHandle;
@@ -111,9 +111,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
 * error.
 */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-    uint8_t ** ppucData,
-    uint32_t * pulDataSize,
-    CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV xReturn = CKR_OK;
     return xReturn;
@@ -128,8 +128,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-    uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     
 }

--- a/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/vendor/boards/board/ports/pkcs11/iot_pkcs11_pal.c
@@ -128,8 +128,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 * @param[in] ulDataSize    The length of the buffer to free.
 *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
 */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     
 }

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -324,8 +324,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
-                                       CK_ULONG ulBufferSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
+                                       CK_ULONG ulDataSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -120,8 +120,8 @@ CK_RV PKCS11_PAL_Initialize( void )
  * eInvalidHandle = 0 if unsuccessful.
  */
 CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
-                                        uint8_t * pucData,
-                                        uint32_t ulDataSize )
+                                        CK_BYTE_PTR pucData,
+                                        CK_ULONG ulDataSize )
 {
     static FIL fil;
     FRESULT Res;
@@ -175,8 +175,8 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
-                                        uint8_t usLength )
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+                                        CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     uint8_t * pcFileName = NULL;
@@ -230,9 +230,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                 uint8_t ** ppucData,
-                                 uint32_t * pulDataSize,
-                                 CK_BBOOL * pIsPrivate )
+                                      CK_BYTE_PTR * ppucData,
+                                      CK_ULONG_PTR pulDataSize,
+                                      CK_BBOOL * pIsPrivate )
 {
     CK_RV ulReturn = CKR_OK;
     FRESULT Res;
@@ -324,8 +324,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
  * @param[in] ulDataSize    The length of the buffer to free.
  *                          (*pulDataSize from PKCS11_PAL_GetObjectValue())
  */
-void PKCS11_PAL_GetObjectValueCleanup( uint8_t * pucData,
-                                       uint32_t ulDataSize )
+void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucBuffer,
+                                       CK_ULONG ulBufferSize )
 {
     /* Unused parameters. */
     ( void ) ulDataSize;

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/iot_pkcs11_pal.c
@@ -167,7 +167,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Port-specific object handle retrieval.
  *
  *
- * @param[in] pLabel         Pointer to the label of the object
+ * @param[in] pxLabel         Pointer to the label of the object
  *                           who's handle should be found.
  * @param[in] usLength       The length of the label, in bytes.
  *
@@ -175,7 +175,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
  * Returns eInvalidHandle if unsuccessful.
  */
 
-CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
+CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
@@ -184,7 +184,7 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
     FRESULT Res;
 
     /* Converts a label to its respective filename and handle. */
-    prvLabelToFilenameHandle( pLabel,
+    prvLabelToFilenameHandle( pxLabel,
                               &pcFileName,
                               &xHandle );
 


### PR DESCRIPTION
PKCS #11 PAL MISRA Update

Description
-----------
This commit fixes some of the MISRA errors caused by the PKCS #11 PAL API. It makes most functions use the PKCS #11 data types, as well as reduces the amount of casting being done in the PKCS #11 stack by as much as possible.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.