### PR TITLE
Make each config of a CBMC proof have unique name

### DIFF
--- a/tools/cbmc/proofs/make_configuration_directories.py
+++ b/tools/cbmc/proofs/make_configuration_directories.py
@@ -125,13 +125,18 @@ def process(folder, files):
                 """))
             LOGGER.error("The offending entry is %s", config)
             return
-        new_config_folder = os.path.join(folder, "config_" + configname)
+
+        new_entry = "%s__config_%s" % (json_content["ENTRY"], configname)
+
+        new_config_folder = os.path.join(folder, new_entry)
         pathlib.Path(new_config_folder).mkdir(exist_ok=True, parents=True)
         harness_copied = False
         for file in files:
             if file.endswith("harness.c"):
-                shutil.copy(os.path.join(folder, file),
-                            os.path.join(new_config_folder, file))
+                shutil.copy(
+                    os.path.join(folder, file),
+                    os.path.join(
+                        new_config_folder, "%s_harness.c" % new_entry))
                 harness_copied = True
 
         if not harness_copied:
@@ -146,6 +151,9 @@ def process(folder, files):
             current_config["EXPECTED"] = config["EXPECTED"]
         else:
             current_config["EXPECTED"] = True
+
+        current_config["ENTRY"] = new_entry
+
         with open(os.path.join(new_config_folder, "Makefile.json"),
                   "w") as output_file:
             json.dump(current_config, output_file, indent=2)


### PR DESCRIPTION
Some CBMC proofs are built in several different 'configurations'. Prior
to this commit, the name of each of these configurations was the same as
the name of the original proof. This meant that CI would sometimes write
the proof artifacts of each of these configurations on top of each
other, since the artifacts are saved under a folder whose name is based
on the name of the proof.

This commit fixes this so that each configuration of each proof has a
unique name, formed by joining the name of the configuration to the name
of the proof with a double underscore---for example,
TaskIncrementTick__config_default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.