### PR TITLE
FreeRTOS+TCP Set xDataLength before calculating checksum

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -874,6 +874,9 @@ NetworkBufferDescriptor_t xTempBuffer;
 		usPacketIdentifier++;
 		pxIPHeader->usFragmentOffset = 0U;
 
+		/* Important: tell NIC driver how many bytes must be sent. */
+		pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;
+
 		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
 		{
 			/* calculate the IP header checksum, in case the driver won't do that. */
@@ -898,9 +901,6 @@ NetworkBufferDescriptor_t xTempBuffer;
 			pxNetworkBuffer->pxNextBuffer = NULL;
 		}
 		#endif
-
-		/* Important: tell NIC driver how many bytes must be sent. */
-		pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;
 
 		/* Fill in the destination MAC addresses. */
 		( void ) memcpy( &( pxEthernetHeader->xDestinationAddress ),


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Since the big PR #2015, it can happen that the TCP checksum for an outgoing packet is not set correctly, because it sees a length error. I just found this out while testing with the WinSim projects.

The function `usGenerateProtocolChecksum()` has recently become stricter: it also checks the the total length is at least the sum of the Ethernet header, plus the length field found in the IPv4 header (see code below ).

I propose the following change, symbolically in `FreeRTOS_TCP_IP.c`:
~~~c
+    pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;

     /* calculate the TCP checksum for an outgoing packet. */
     usGenerateProtocolChecksum( pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );

-    pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;
~~~

The length error was detected here in `usGenerateProtocolChecksum()`:
~~~c
    usLength = pxIPPacket->xIPHeader.usLength;
    usLength = FreeRTOS_ntohs( usLength );
    if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
    {
        usChecksum = ipINVALID_LENGTH;
        location = 3;
        goto error_exit;
    }
~~~
The problem would only occur on platforms that do not have checksum offloading like WinSim.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.