### PR TITLE
Use configPRINTF instead of directly using logging API

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -100,14 +100,14 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @brief Macro for logging in PKCS #11.
  *
  */
-#define PKCS11_PRINT( X )            vLoggingPrintf X
+#define PKCS11_PRINT( X )            configPRINTF( X )
 
 /**
  * @ingroup pkcs11_macros
  * @brief Macro for logging warnings in PKCS #11.
  *
  */
-#define PKCS11_WARNING_PRINT( X )    /* vLoggingPrintf X */
+#define PKCS11_WARNING_PRINT( X )    /* configPRINTF( X ) */
 
 /**
  * @ingroup pkcs11_macros

--- a/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
+++ b/libraries/freertos_plus/standard/crypto/src/iot_crypto.c
@@ -25,7 +25,6 @@
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
-#include "FreeRTOSIPConfig.h"
 #include "iot_crypto.h"
 
 /* mbedTLS includes. */
@@ -50,7 +49,7 @@
 
 
 
-#define CRYPTO_PRINT( X )    vLoggingPrintf X
+#define CRYPTO_PRINT( X )    configPRINTF( X )
 
 /**
  * @brief Internal signature verification context structure

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -137,7 +137,7 @@ typedef struct TLSContext
 #define TLS_HANDSHAKE_STARTED        ( 1 )
 #define TLS_HANDSHAKE_SUCCESSFUL     ( 2 )
 
-#define TLS_PRINT( X )    vLoggingPrintf X
+#define TLS_PRINT( X )    configPRINTF( X )
 
 /*-----------------------------------------------------------*/
 

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -59,8 +59,8 @@
 #include <string.h>
 #include <limits.h>
 
-#define PKCS11_PRINT( X )            vLoggingPrintf X
-#define PKCS11_WARNING_PRINT( X )    /* vLoggingPrintf X */
+#define PKCS11_PRINT( X )            configPRINTF( X )
+#define PKCS11_WARNING_PRINT( X )    /* configPRINTF( X ) */
 
 #define pkcs11NO_OPERATION            ( ( CK_MECHANISM_TYPE ) 0xFFFFFFFFF )
 

--- a/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
+++ b/vendors/pc/boards/windows/ports/pkcs11/iot_pkcs11_pal.c
@@ -35,7 +35,6 @@
 /*-----------------------------------------------------------*/
 
 #include "FreeRTOS.h"
-#include "FreeRTOSIPConfig.h"
 #include "iot_pkcs11.h"
 #include "iot_pkcs11_config.h"
 
@@ -58,7 +57,7 @@
  * @brief PKCS #11 logging macro.
  *
  */
-#define PKCS11_PAL_PRINT( X )    vLoggingPrintf X
+#define PKCS11_PAL_PRINT( X )    configPRINTF( X )
 
 /**
  * @ingroup pkcs11_enums


### PR DESCRIPTION
Use configPRINTF instead of directly using logging API

Description
-----------
Use configPRINTF instead of directly using logging API. This allows using a logging mechanism that is configurable, as well as removing the dependency on vLoggingPrintf.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.