### PR TITLE
Fix ES_WIFI_Ping to correctly differentiate Ping Success and Timeout

### DIFF
--- a/vendors/st/stm32l475_discovery/BSP/Components/es_wifi/es_wifi.c
+++ b/vendors/st/stm32l475_discovery/BSP/Components/es_wifi/es_wifi.c
@@ -1549,10 +1549,10 @@ ES_WIFI_Status_t ES_WIFI_Ping(ES_WIFIObject_t *Obj, uint8_t *address, uint16_t c
            * numValuesRead will not be 5 and it will be detected as timeout.
            */
           numValuesRead = sscanf((char*)Obj->CmdData, "\r\n%hhu.%hhu.%hhu.%hhu,%lu", &ipAddress[0],
-                                                                      &ipAddress[1],
-                                                                      &ipAddress[2],
-                                                                      &ipAddress[3],
-                                                                      &timeout);
+                                                                                     &ipAddress[1],
+                                                                                     &ipAddress[2],
+                                                                                     &ipAddress[3],
+                                                                                     &timeout);
           if(numValuesRead == 5 &&
              ipAddress[0] == address[0] &&
              ipAddress[1] == address[1] &&


### PR DESCRIPTION
Description
-----------
The Inventek module returns one of the following as ping response:

```
Success - \r\nIP0.IP1.IP2.IP3,RTT\r\nOK\r\n>
Timeout - \r\nIP0.IP1.IP2.IP3,Timeout\r\nOK\r\n>
```

Where IP0..IP3 are the octacts of the IP address pinged and RTT is the round trip time.

```
Example success response - \r\n8.8.8.8,48\r\nOK\r\n>
Example timeout response - \r\n192.168.1.1,Timeout\r\nOK\r\n>
```

Earlier the function just relied on the presence of `\r\nOK\r\n>` to detect success which is present in both the success and the timeout response. As a result, it incorrectly detected timeout as success.
This change adds additional parsing to ensure that success and timeout responses are differentiated correctly.

Testing
--------
* Tested pinging Google DNS server (8.8.8.8) and `ES_WIFI_Ping` returns `ES_WIFI_STATUS_OK`.
* Tested pinging a non-existent IP address and `ES_WIFI_Ping` returns `ES_WIFI_STATUS_TIMEOUT`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.