### PR TITLE
Fix: psoc64 metadata mode fix & Add a delay to psoc64 test project

### DIFF
--- a/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
@@ -754,37 +754,39 @@ function(cy_kit_generate)
         target_include_directories(AFR::kernel::mcu_port INTERFACE
             "${MCUBOOT_DIR}/mcuboot_header"
         )
-            
-        if(CY_TFM_PSA)
-            # TFM uses a different linker script and signing tool
-            # see next if() section after endif(CY_ALTERNATE_APP)
-        else()
-            # non-TFM signing
+        
+        if(NOT AFR_METADATA_MODE)
+            if(CY_TFM_PSA)
+                # TFM uses a different linker script and signing tool
+                # see next if() section after endif(CY_ALTERNATE_APP)
+            else()
+                # non-TFM signing
 
-            #------------------------------------------------------------
-            # Create our script filename in this scope
-            set(SIGN_SCRIPT_FILE_NAME           "sign_${AFR_TARGET_APP_NAME}.sh")
-            set(SIGN_SCRIPT_FILE_PATH           "${CMAKE_BINARY_DIR}/${SIGN_SCRIPT_FILE_NAME}")
-            set(SIGN_SCRIPT_FILE_PATH_TMP       "${CMAKE_BINARY_DIR}/tmp/${SIGN_SCRIPT_FILE_NAME}")
-            set(CY_OUTPUT_FILE_PATH             "${CMAKE_BINARY_DIR}/${AFR_TARGET_APP_NAME}")
-            set(CY_OUTPUT_FILE_PATH_ELF         "${CY_OUTPUT_FILE_PATH}.elf")
-            set(CY_OUTPUT_FILE_PATH_HEX         "${CY_OUTPUT_FILE_PATH}.hex")
-            set(CY_OUTPUT_FILE_PATH_SIGNED_HEX  "${CY_OUTPUT_FILE_PATH}.signed.hex")
-            set(CY_OUTPUT_FILE_NAME_BIN         "${AFR_TARGET_APP_NAME}.bin")
-            set(CY_OUTPUT_FILE_PATH_BIN         "${CY_OUTPUT_FILE_PATH}.bin")
-            set(CY_OUTPUT_FILE_PATH_TAR         "${CY_OUTPUT_FILE_PATH}.tar")
-            set(CY_OUTPUT_FILE_PATH_WILD        "${CY_OUTPUT_FILE_PATH}.*")
-            set(CY_COMPONENTS_JSON_NAME         "components.json")
-            set(CY_OUTPUT_FILE_NAME_TAR         "${AFR_TARGET_APP_NAME}.tar")
+                #------------------------------------------------------------
+                # Create our script filename in this scope
+                set(SIGN_SCRIPT_FILE_NAME           "sign_${AFR_TARGET_APP_NAME}.sh")
+                set(SIGN_SCRIPT_FILE_PATH           "${CMAKE_BINARY_DIR}/${SIGN_SCRIPT_FILE_NAME}")
+                set(SIGN_SCRIPT_FILE_PATH_TMP       "${CMAKE_BINARY_DIR}/tmp/${SIGN_SCRIPT_FILE_NAME}")
+                set(CY_OUTPUT_FILE_PATH             "${CMAKE_BINARY_DIR}/${AFR_TARGET_APP_NAME}")
+                set(CY_OUTPUT_FILE_PATH_ELF         "${CY_OUTPUT_FILE_PATH}.elf")
+                set(CY_OUTPUT_FILE_PATH_HEX         "${CY_OUTPUT_FILE_PATH}.hex")
+                set(CY_OUTPUT_FILE_PATH_SIGNED_HEX  "${CY_OUTPUT_FILE_PATH}.signed.hex")
+                set(CY_OUTPUT_FILE_NAME_BIN         "${AFR_TARGET_APP_NAME}.bin")
+                set(CY_OUTPUT_FILE_PATH_BIN         "${CY_OUTPUT_FILE_PATH}.bin")
+                set(CY_OUTPUT_FILE_PATH_TAR         "${CY_OUTPUT_FILE_PATH}.tar")
+                set(CY_OUTPUT_FILE_PATH_WILD        "${CY_OUTPUT_FILE_PATH}.*")
+                set(CY_COMPONENTS_JSON_NAME         "components.json")
+                set(CY_OUTPUT_FILE_NAME_TAR         "${AFR_TARGET_APP_NAME}.tar")
 
-            # creates the script to call imgtool.py to sign the image
-            config_cy_mcuboot_sign_script("${CMAKE_BINARY_DIR}")
+                # creates the script to call imgtool.py to sign the image
+                config_cy_mcuboot_sign_script("${CMAKE_BINARY_DIR}")
 
-            add_custom_command(
-                TARGET "${AFR_TARGET_APP_NAME}" POST_BUILD
-                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-                COMMAND "${SIGN_SCRIPT_FILE_PATH}"
-                )
+                add_custom_command(
+                    TARGET "${AFR_TARGET_APP_NAME}" POST_BUILD
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                    COMMAND "${SIGN_SCRIPT_FILE_PATH}"
+                    )
+            endif()
         endif()
     else()
         target_include_directories(${AFR_TARGET_APP_NAME} PUBLIC
@@ -793,7 +795,7 @@ function(cy_kit_generate)
     endif(OTA_SUPPORT)
         
 
-    if(CY_TFM_PSA)
+    if(CY_TFM_PSA AND (NOT AFR_METADATA_MODE))
         set(CY_AWS_ELF  "${CMAKE_BINARY_DIR}/aws.elf")
         set(CY_CM0_IMG "${CMAKE_BINARY_DIR}/cm0.hex")
         set(CY_CM4_IMG "${CMAKE_BINARY_DIR}/cm4.hex")

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
@@ -237,6 +237,9 @@ int main( void )
                      ucMACAddress );
 #endif /* CY_USE_FREERTOS_TCP */
 
+    /* Add 20s delay to let serial port establish a connection to PC before starting the tests */
+    vTaskDelay( pdMS_TO_TICKS( 1000 ) * 20 );
+
     /* Start the scheduler.  Initialization that requires the OS to be running,
      * including the Wi-Fi initialization, is performed in the RTOS daemon task
      * startup hook. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
1. Remove the cypress tools from dependency when AFR_METADATA_MODE is enabled.
2. Add 20s delay to the start of test program, so that the board have enough time to establish a serial connection to our test infra PC before the test program starts to output data to serial port. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.