### PR TITLE
Fix SPI baud change and default config on ST

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
@@ -57,6 +57,8 @@ typedef struct IotSPIDescriptor
 } IotSPIDescriptor_t;
 /*-----------------------------------------------------------*/
 
+extern uint32_t SystemCoreClock;
+
 static SPI_HandleTypeDef xSpiHandleMap[] =
 {
     {
@@ -279,7 +281,26 @@ int32_t iot_spi_ioctl( IotSPIHandle_t const pxSPIPeripheral,
                             break;
                     }
 
-                    LL_SPI_SetBaudRatePrescaler( pxSpi->Instance, ( ( IotSPIMasterConfig_t * ) pvBuffer )->ulFreq );
+                    uint32_t sysClkTmp = SystemCoreClock;
+                    uint32_t preScaler = 0;
+                    uint8_t divisor = 0;
+
+                    while( sysClkTmp > ( ( IotSPIMasterConfig_t * ) pvBuffer )->ulFreq )
+                    {
+                        divisor++;
+                        sysClkTmp = ( sysClkTmp >> 1 );
+
+                        if( divisor >= 7 )
+                        {
+                            break;
+                        }
+                    }
+
+                    preScaler = ( ( ( divisor & 0x4 ) == 0 ) ? 0x0 : SPI_CR1_BR_2 ) |
+                                ( ( ( divisor & 0x2 ) == 0 ) ? 0x0 : SPI_CR1_BR_1 ) |
+                                ( ( ( divisor & 0x1 ) == 0 ) ? 0x0 : SPI_CR1_BR_0 );
+
+                    LL_SPI_SetBaudRatePrescaler( pxSpi->Instance, preScaler );
                     lError = IOT_SPI_SUCCESS;
                     pxSPIPeripheral->xConfig = *( IotSPIMasterConfig_t * ) pvBuffer;
                 }

--- a/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
@@ -305,15 +305,10 @@ int32_t iot_spi_ioctl( IotSPIHandle_t const pxSPIPeripheral,
                     uint32_t preScaler = 0;
                     uint8_t divisor = 0;
 
-                    while( sysClkTmp > ( ( IotSPIMasterConfig_t * ) pvBuffer )->ulFreq )
+                    while( ( sysClkTmp > ( ( IotSPIMasterConfig_t * ) pvBuffer )->ulFreq ) && ( divisor < 7 ) )
                     {
                         divisor++;
                         sysClkTmp = ( sysClkTmp >> 1 );
-
-                        if( divisor >= 7 )
-                        {
-                            break;
-                        }
                     }
 
                     preScaler = ( ( ( divisor & 0x4 ) == 0 ) ? 0x0 : SPI_CR1_BR_2 ) |

--- a/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/common_io/iot_spi.c
@@ -154,29 +154,47 @@ static const STM32_SPI_HalContext_t xSpiContexts[] =
 
 static IotSPIDescriptor_t xSpi1 =
 {
-    .pxSpiContext  = &xSpiContexts[ 0 ],
-    .xConfig       = { 0 },
-    .xSpiCallback  = NULL,
-    .pvUserContext = NULL,
-    .sOpened       = IOT_SPI_CLOSED,
+    .pxSpiContext     = &xSpiContexts[ 0 ],
+    .xConfig          =
+    {
+        .ulFreq       = 0,
+        .eMode        = eSPIMode0,
+        .eSetBitOrder = eSPIMSBFirst,
+        .ucDummyValue = 0
+    },
+    .xSpiCallback     = NULL,
+    .pvUserContext    = NULL,
+    .sOpened          = IOT_SPI_CLOSED,
 };
 
 static IotSPIDescriptor_t xSpi2 =
 {
-    .pxSpiContext  = &xSpiContexts[ 1 ],
-    .xConfig       = { 0 },
-    .xSpiCallback  = NULL,
-    .pvUserContext = NULL,
-    .sOpened       = IOT_SPI_CLOSED,
+    .pxSpiContext     = &xSpiContexts[ 1 ],
+    .xConfig          =
+    {
+        .ulFreq       = 0,
+        .eMode        = eSPIMode0,
+        .eSetBitOrder = eSPIMSBFirst,
+        .ucDummyValue = 0
+    },
+    .xSpiCallback     = NULL,
+    .pvUserContext    = NULL,
+    .sOpened          = IOT_SPI_CLOSED,
 };
 
 static IotSPIDescriptor_t xSpi3 =
 {
-    .pxSpiContext  = &xSpiContexts[ 2 ],
-    .xConfig       = { 0 },
-    .xSpiCallback  = NULL,
-    .pvUserContext = NULL,
-    .sOpened       = IOT_SPI_CLOSED,
+    .pxSpiContext     = &xSpiContexts[ 2 ],
+    .xConfig          =
+    {
+        .ulFreq       = 0,
+        .eMode        = eSPIMode0,
+        .eSetBitOrder = eSPIMSBFirst,
+        .ucDummyValue = 0
+    },
+    .xSpiCallback     = NULL,
+    .pvUserContext    = NULL,
+    .sOpened          = IOT_SPI_CLOSED,
 };
 /*-----------------------------------------------------------*/
 
@@ -201,6 +219,8 @@ IotSPIHandle_t iot_spi_open( int32_t lSpiInstance )
             else
             {
                 xHandle->sOpened = IOT_SPI_OPENED;
+
+                xHandle->xConfig.ulFreq = ( SystemCoreClock >> 1 ); /* Default prescaler is 2 and freq = clock / prescaler */
             }
         }
         else


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Baud fix: The low level LL_SPI_SetBaudRatePrescaler requires a prescaler parameter instead of the raw frequency. So we need to calculate the prescaler based on the system clock and desired frequency.

Default config fix: when open, the frequency should be calculated to the default one which is system clock divided by the default prescaler - 2.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.