### PR TITLE
Re-enable CBC for connecting to Greengrass.

### DIFF
--- a/libraries/3rdparty/mbedtls_config/aws_mbedtls_config.h
+++ b/libraries/3rdparty/mbedtls_config/aws_mbedtls_config.h
@@ -600,7 +600,7 @@
  *
  * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
  */
-//#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CBC
 
 /**
  * \def MBEDTLS_CIPHER_MODE_CFB


### PR DESCRIPTION
Renable CBC for connecting to Greengrass.

Description
-----------
Since we only enable TLS 1.2 there was no overlapping cipher suites supported by the client and the Greengrass core.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.