### PR TITLE
PKCS 11 Unit Tests

### DIFF
--- a/libraries/abstractions/pkcs11/utest/project.yml
+++ b/libraries/abstractions/pkcs11/utest/project.yml
@@ -18,6 +18,7 @@
     uint32:   UINT32
     int8:     INT8
     bool:     UINT8
+    CK_ULONG_PTR: UINT32*
   :includes:        # This will add these includes to each mock.
     - <stdbool.h>
     - <stdint.h>


### PR DESCRIPTION
PKCS 11 Unit Tests


Description
-----------
Sync up unit tests with latest PKCS #11 changes. Add last 0.4% of line coverage. The main changes getting synced here are the data type changes in the PKCS #11 PAL.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.