### PR TITLE
Add PKCS #11 to PSA shim as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 	path = libraries/3rdparty/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git
 	branch = mbedtls-2.16.6
+[submodule "libraries/abstractions/pkcs11/psa"]
+	path = libraries/abstractions/pkcs11/psa
+	url = https://github.com/Linaro/freertos-pkcs11-psa.git


### PR DESCRIPTION
Add PKCS #11 to PSA shim as a submodule.

Description
-----------
Add PKCS #11 to PSA shim as a submodule. Note it is not yet in the build system or tested.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.