### PR TITLE
FreeRTOS+TCP : print resource statistics routine

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
@@ -304,6 +304,12 @@ BaseType_t FreeRTOS_IsNetworkUp( void );
 	UBaseType_t uxGetMinimumIPQueueSpace( void );
 #endif
 
+#if ( ipconfigHAS_PRINTF != 0 )
+	extern void vPrintResourceStats( void );
+#else
+	#define vPrintResourceStats()	do {} while( ipFALSE_BOOL )
+#endif
+
 /*
  * Defined in FreeRTOS_Sockets.c
  * //_RB_ Don't think this comment is correct.  If this is for internal use only it should appear after all the public API functions and not start with FreeRTOS_.

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -1196,10 +1196,6 @@ uint32_t ul;
 
 static void prvEMACHandlerTask( void *pvParameters )
 {
-UBaseType_t uxLastMinBufferCount = 0;
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-UBaseType_t uxLastMinQueueSpace = 0;
-#endif
 UBaseType_t uxCurrentCount;
 BaseType_t xResult;
 const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
@@ -1210,15 +1206,11 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 	for( ;; )
 	{
 		xResult = 0;
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+
+		/* Call a function that monitors resources: the amount of free network
+		buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+		for more detailed comments. */
+		vPrintResourceStats();
 
 		if( xTXDescriptorSemaphore != NULL )
 		{
@@ -1232,19 +1224,6 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			}
 
 		}
-
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
 		if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
 		{

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -44,14 +44,6 @@ enum if_state_t {
 static const char *TAG = "NetInterface";
 volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 
-/* protect the function declaration itself instead of using
-   #if everywhere.                                        */
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvPrintResourceStats();    
-#else
-    #define prvPrintResourceStats()
-#endif
-
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     static BaseType_t xMACAdrInitialized = pdFALSE;
@@ -86,7 +78,10 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
         }
     }
 
-    prvPrintResourceStats();
+	/* Call a function that monitors resources: the amount of free network
+	buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+	for more detailed comments. */
+	vPrintResourceStats();
     
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
@@ -115,7 +110,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-    prvPrintResourceStats();
+    vPrintResourceStats();
 
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");
@@ -145,50 +140,3 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
         return ESP_FAIL;
     }
 }
-
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvPrintResourceStats()
-    {
-        static UBaseType_t uxLastMinBufferCount = 0u;
-        static UBaseType_t uxCurrentBufferCount = 0u;
-        static size_t uxMinLastSize = 0uL;
-        size_t uxMinSize;
-
-        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
-
-        if( uxLastMinBufferCount != uxCurrentBufferCount )
-        {
-            /* The logging produced below may be helpful
-             * while tuning +TCP: see how many buffers are in use. */
-            uxLastMinBufferCount = uxCurrentBufferCount;
-            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
-        }
-
-        uxMinSize = xPortGetMinimumEverFreeHeapSize();
-
-        if( uxMinLastSize != uxMinSize )
-        {
-            uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
-        }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                static UBaseType_t uxLastMinQueueSpace = 0;
-                UBaseType_t uxCurrentCount = 0u;
-
-                uxCurrentCount = uxGetMinimumIPQueueSpace();
-
-                if( uxLastMinQueueSpace != uxCurrentCount )
-                {
-                    /* The logging produced below may be helpful
-                     * while tuning +TCP: see how many buffers are in use. */
-                    uxLastMinQueueSpace = uxCurrentCount;
-                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-    }
-#endif /* ( ipconfigHAS_PRINTF != 0 ) */
-/*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In some of the network interfaces for FreeRTOS+TCP, there is static function `prvMonitorResources()` that produces warnings as soon as these resources drop:

- The amount of heap available
- The number of network buffers
- The free space in the IP-task queue

This method of logging would produce too much information.

In this PR I added a global function `vPrintResourceStats()` to `FreeRTOS_IP.c`, so it can be used by any FreeRTOS+TCP project.

Changes compared to the earlier `prvMonitorResources()`:

- There won't be logging about the amount of heap as long as there is plenty (`ipMONITOR_MAX_HEAP`, default 1 MByte)
- There will only be logging about the heap as soon as the amount has dropped at least 10% (configurable).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.