### PR TITLE
Re-enable encrypt then MAC for CBC now that CBC is re-enabled.

### DIFF
--- a/libraries/3rdparty/mbedtls_config/aws_mbedtls_config.h
+++ b/libraries/3rdparty/mbedtls_config/aws_mbedtls_config.h
@@ -1343,7 +1343,7 @@
  *
  * Comment this macro to disable support for Encrypt-then-MAC
  */
-//#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
 
 /** \def MBEDTLS_SSL_EXTENDED_MASTER_SECRET
  *


### PR DESCRIPTION
Re-enable encrypt then MAC for CBC now that CBC is re-enabled.

Description
-----------
Re-enable encrypt then MAC for CBC now that CBC is re-enabled. 

CBC was re-enabled in https://github.com/aws/amazon-freertos/pull/2153 for Greengrass, which needed this algorithm for TLS 1.2.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.