### PR TITLE
Add a testcase for token property of a public key template when generating a key pair

### DIFF
--- a/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
+++ b/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
@@ -3168,6 +3168,7 @@ void test_pkcs11_C_GenerateKeyPairECDSALockFail( void )
     CK_ATTRIBUTE xPublicKeyTemplate[] =
     {
         { CKA_KEY_TYPE,  &xKeyType,         sizeof( xKeyType )                           },
+        { CKA_TOKEN,     &xTrue,            sizeof( xTrue )                              },
         { CKA_VERIFY,    &xTrue,            sizeof( xTrue )                              },
         { CKA_EC_PARAMS, xEcParams,         sizeof( xEcParams )                          },
         { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
@@ -3303,7 +3304,8 @@ void test_pkcs11_C_GenerateKeyPairBadArgs( void )
         { CKA_KEY_TYPE,  &xKeyType,         sizeof( xKeyType )                           },
         { CKA_VERIFY,    &xTrue,            sizeof( xTrue )                              },
         { CKA_EC_PARAMS, xEcParams,         sizeof( xEcParams )                          },
-        { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) }
+        { CKA_LABEL,     pucPublicKeyLabel, strlen( ( const char * ) pucPublicKeyLabel ) },
+        { CKA_TOKEN,     &xTrue,            sizeof( xTrue )                              }
     };
 
     CK_ATTRIBUTE xPrivateKeyTemplate[] =
@@ -3373,6 +3375,14 @@ void test_pkcs11_C_GenerateKeyPairBadArgs( void )
                                  &xPubKeyHandle, &xPrivKeyHandle );
     TEST_ASSERT_EQUAL( CKR_TEMPLATE_INCONSISTENT, xResult );
     xPublicKeyTemplate[ 0 ].pValue = &xKeyType;
+
+    xPublicKeyTemplate[ 4 ].pValue = &xFalse;
+    xResult = C_GenerateKeyPair( xSession, &xMechanism, xPublicKeyTemplate,
+                                 sizeof( xPublicKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                 xPrivateKeyTemplate, sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                 &xPubKeyHandle, &xPrivKeyHandle );
+    TEST_ASSERT_EQUAL( CKR_TEMPLATE_INCONSISTENT, xResult );
+    xPublicKeyTemplate[ 4 ].pValue = &xTrue;
 
     prvCommonDeinitStubs();
 }


### PR DESCRIPTION
Add a testcase for token property of a public key template when generating a key pair

Description
-----------
This is a testcase for catching an error that was made when refactoring the pkcs mbedtls layer. The API says that if specified, a public key's CKA_TOKEN type should have a value of "True" but this check was accidentally removed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.