### PR TITLE
Add check for token to be true when generating a public key.

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -4130,6 +4130,19 @@ static CK_RV prvCheckGenerateKeyPairPublicTemplate( CK_ATTRIBUTE ** ppxLabel,
             *pulAttributeMap |= VERIFY_IN_TEMPLATE;
             break;
 
+        case ( CKA_TOKEN ):
+            ( void ) memcpy( &xBool, pxAttribute->pValue, sizeof( CK_BBOOL ) );
+
+            /* See explanation in prvCheckValidSessionAndModule for this exception. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
+            if( xBool != ( CK_BBOOL ) CK_TRUE )
+            {
+                PKCS11_PRINT( ( "ERROR: Generating public keys that are false for attribute CKA_TOKEN is not supported. \r\n" ) );
+                xResult = CKR_TEMPLATE_INCONSISTENT;
+            }
+
+            break;
+
         default:
             xResult = CKR_TEMPLATE_INCONSISTENT;
             break;


### PR DESCRIPTION
Add check for token to be true when generating a public key.

Description
-----------
This fixes a regression that occurred when refactoring. This adds a check for the token property of a generated public key.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.