### PR TITLE
OTA: Handle new job document after resuming 

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -2052,8 +2052,18 @@ static OTA_FileContext_t * prvParseJobDoc( const char * pcJSON,
                 /* C->pucJobName is guaranteed to be zero terminated. */
                 if( strcmp( ( char * ) xOTA_Agent.pcOTA_Singleton_ActiveJobName, ( char * ) C->pucJobName ) != 0 )
                 {
-                    OTA_LOG_L1( "[%s] Busy with existing job. Ignoring.\r\n", OTA_METHOD_NAME );
-                    eErr = eOTA_JobParseErr_BusyWithExistingJob;
+                    OTA_LOG_L1( "[%s] New job document received,aborting current job.\r\n", OTA_METHOD_NAME );
+
+                    /* Abort the current job. */
+                    ( void ) xOTA_Agent.xPALCallbacks.xSetPlatformImageState( xOTA_Agent.ulServerFileID, eOTA_ImageState_Aborted );
+                    ( void ) prvOTA_Close( &xOTA_Agent.pxOTA_Files[ xOTA_Agent.ulFileIndex ] );
+
+                    /* Set new active job name. */
+                    vPortFree( xOTA_Agent.pcOTA_Singleton_ActiveJobName );
+                    xOTA_Agent.pcOTA_Singleton_ActiveJobName = C->pucJobName;
+                    C->pucJobName = NULL;
+
+                    eErr = eOTA_JobParseErr_None;
                 }
                 else
                 { /* The same job is being reported so update the url. */

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h
@@ -245,7 +245,7 @@ typedef struct ota_agent_context
     uint8_t pcThingName[ otaconfigMAX_THINGNAME_LEN + 1U ]; /* Thing name + zero terminator. */
     void * pvConnectionContext;                             /* Connection context for control and data plane. */
     OTA_FileContext_t pxOTA_Files[ OTA_MAX_FILES ];         /* Static array of OTA file structures. */
-    uint32_t ulFileIndex;                                   /* Static array of OTA file structures. */
+    uint32_t ulFileIndex;                                   /* Index of current file in the array. */
     uint32_t ulServerFileID;                                /* Variable to store current file ID passed down */
     uint8_t * pcOTA_Singleton_ActiveJobName;                /* The currently active job name. We only allow one at a time. */
     uint8_t * pcClientTokenFromJob;                         /* The clientToken field from the latest update job. */


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
The change handles the situation when OTA Agent is suspended , existing job is cancelled and new job is queued and the OTA Agent resumes. The existing job is aborted and new job execution is initiated. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.