### PR TITLE
Bump version of portmacro. h

### DIFF
--- a/tests/unit_test/linux/config_files/portmacro.h
+++ b/tests/unit_test/linux/config_files/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202006.00
+ * FreeRTOS V202007.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/unit_test/linux/config_files/portmacro.h
+++ b/tests/unit_test/linux/config_files/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202007.00
+ * FreeRTOS V202006.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -240,7 +240,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
     #ifdef __cplusplus
-}
+        }
     #endif
 
 #endif /* PORTMACRO_H */

--- a/tests/unit_test/linux/config_files/portmacro.h
+++ b/tests/unit_test/linux/config_files/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202006.00
+ * FreeRTOS V202007.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -240,7 +240,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
     #ifdef __cplusplus
-        }
+}
     #endif
 
 #endif /* PORTMACRO_H */


### PR DESCRIPTION
Bump version of `portmacro.h` file under `tests/` missed in #2183 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.