### PR TITLE
Fix OTA disconnect and cancel E2E test

### DIFF
--- a/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_cancel_update.py
+++ b/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_disconnect_cancel_update.py
@@ -76,6 +76,9 @@ class OtaTestDisconnectCancelUpdate(OtaTestCase):
         self._otaProject.buildProject()
         # Start an OTA Update.
         otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig, [self._protocol])
+        # Prepare another image to be updated later
+        self._otaProject.setApplicationVersion(0, 9, 2)
+        self._otaProject.buildProject()
 
         # Wait until the job is in progress.
         thing_name = self._otaAwsAgent._iotThing.thing_name
@@ -112,8 +115,6 @@ class OtaTestDisconnectCancelUpdate(OtaTestCase):
             iot_client.cancel_job_execution(jobId=f'AFR_OTA-{otaUpdateId}', thingName=thing_name, force=True)
 
             # Do another OTA update, this should succeed.
-            self._otaProject.setApplicationVersion(0, 9, 2)
-            self._otaProject.buildProject()
             otaUpdateId = self._otaAwsAgent.quickCreateOtaUpdate(self._otaConfig, [self._protocol])
             return self.getTestResultAfterOtaUpdateCompletion(otaUpdateId)
         else:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
We should prepare the image at the beginning and immediately create another update after cancel the current one to make sure device is getting the new job doc after it resumes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.