### PR TITLE
Fix: PSoC64 Cmake file for AFR_METADATA_MODE

### DIFF
--- a/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
@@ -138,6 +138,10 @@ function(cy_kit_generate)
     # is BLE supported?
     string(FIND "${ARG_DEFINES}" "CY_BLE_SUPPORTED" check_ble_supported)
     if (NOT ("${check_ble_supported}" STREQUAL "-1"))
+       # Add BLE when generating metadata for Build Combination and OCW.
+       if ("${AFR_METADATA_MODE}" STREQUAL "1")
+          set(CY_BLE_SUPPORTED 1)           
+       endif()
        # BLE is only supported for arm-gcc
        if ("${AFR_TOOLCHAIN}" STREQUAL "arm-gcc")
           set(CY_BLE_SUPPORTED 1)

--- a/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
@@ -929,6 +929,6 @@ function(cy_kit_generate)
             )
         endif(OTA_SUPPORT)
 
-    endif(CY_TFM_PSA)
+    endif(CY_TFM_PSA AND (NOT AFR_METADATA_MODE))
 
 endfunction(cy_kit_generate)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
BLE was explicitly excluded from build if the compiler is not arm-gcc (the psoc64 BLE port currently only works with arm-gcc). This cause a problem when generating the build combinations / metadata. AFR_METADATA_MODE only runs the cmake in configuration stage without compilier definded. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.