### PR TITLE
Sync Single Echo Client demo tasks

### DIFF
--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -424,9 +424,14 @@ static void prvEchoClientTask( void * pvParameters )
         vTaskDelay( echoLOOP_DELAY );
     }
     
-    /* Increment the global synchronisation variable to show
+    /* Safely increment the global synchronisation variable to show
      * that this task has finished. */
-    SyncCounter++;
+    taskENTER_CRITICAL();
+    {
+        SyncCounter++;
+    }
+    taskEXIT_CRITICAL();
+    
 
     /* Wait to be Deleted by the parent task. */
     while ( pdTRUE )

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -167,7 +167,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     BaseType_t xX;
     BaseType_t TaskCompleteCounter;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
-    
+
     /* Unused parameters */
     ( void ) awsIotMqttMode;
     ( void ) pIdentifier;
@@ -182,12 +182,12 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     for( xX = 0; xX < echoNUM_ECHO_CLIENTS; xX++ )
     {
         snprintf( cNameBuffer, echoMAX_TASK_NAME_LENGTH, "Echo%ld", ( long int ) xX );
-        xTaskCreate( prvEchoClientTask,             /* The function that implements the task. */
-                     cNameBuffer,                   /* Just a text name for the task to aid debugging. */
-                     democonfigDEMO_STACKSIZE,      /* The stack size is defined in FreeRTOSIPConfig.h. */
-                     ( void * ) xX,                 /* The task parameter, not used in this case. */
-                     democonfigDEMO_PRIORITY,       /* The priority assigned to the task is defined in FreeRTOSConfig.h. */
-                     NULL );                        /* The task handle is not used. */
+        xTaskCreate( prvEchoClientTask,        /* The function that implements the task. */
+                     cNameBuffer,              /* Just a text name for the task to aid debugging. */
+                     democonfigDEMO_STACKSIZE, /* The stack size is defined in FreeRTOSIPConfig.h. */
+                     ( void * ) xX,            /* The task parameter, not used in this case. */
+                     democonfigDEMO_PRIORITY,  /* The priority assigned to the task is defined in FreeRTOSConfig.h. */
+                     NULL );                   /* The task handle is not used. */
     }
 
     /* Wait for all tasks to finish. */
@@ -198,7 +198,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
 
         /* Increment the task completion counter variable. */
         TaskCompleteCounter++;
-    }  
+    }
 
     /* Return Success. */
     return EXIT_SUCCESS;
@@ -253,7 +253,7 @@ static void prvEchoClientTask( void * pvParameters )
                                                             configECHO_SERVER_ADDR3 );
 
     /* Create lMaxConnectionCount distinct connections to the echo server. */
-    for( lConnectionCount = 0; lConnectionCount < lMaxConnectionCount ; lConnectionCount++ )
+    for( lConnectionCount = 0; lConnectionCount < lMaxConnectionCount; lConnectionCount++ )
     {
         /* Create a TCP socket. */
         xSocket = SOCKETS_Socket( SOCKETS_AF_INET, SOCKETS_SOCK_STREAM, SOCKETS_IPPROTO_TCP );
@@ -425,10 +425,10 @@ static void prvEchoClientTask( void * pvParameters )
          * congested. */
         vTaskDelay( echoLOOP_DELAY );
     }
-    
+
     /* Notify the parent task about completion. */
     xSemaphoreGive( EchoSingleSemaphore );
-    
+
     /* Allow the task to delete itself. */
     vTaskDelete( NULL );
 }

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -429,7 +429,7 @@ static void prvEchoClientTask( void * pvParameters )
     /* Notify the parent task about completion. */
     xSemaphoreGive( EchoSingleSemaphore );
 
-    /* Allow the task to delete itself. */
+    /* Delete self. */
     vTaskDelete( NULL );
 }
 /*-----------------------------------------------------------*/

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -168,6 +168,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     BaseType_t SyncCounter;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
     TaskHandle_t EchoTaskHandles[ echoNUM_ECHO_CLIENTS ];
+    
     /* Unused parameters */
     ( void ) awsIotMqttMode;
     ( void ) pIdentifier;

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -167,8 +167,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     BaseType_t xX;
     BaseType_t TaskCompleteCounter;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
-    TaskHandle_t EchoTaskHandles[ echoNUM_ECHO_CLIENTS ];
-
+    
     /* Unused parameters */
     ( void ) awsIotMqttMode;
     ( void ) pIdentifier;
@@ -188,7 +187,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
                      democonfigDEMO_STACKSIZE,      /* The stack size is defined in FreeRTOSIPConfig.h. */
                      ( void * ) xX,                 /* The task parameter, not used in this case. */
                      democonfigDEMO_PRIORITY,       /* The priority assigned to the task is defined in FreeRTOSConfig.h. */
-                     &EchoTaskHandles[ xX ] );      /* The task handle is not used. */
+                     NULL );                        /* The task handle is not used. */
     }
 
     /* Wait for all tasks to finish. */


### PR DESCRIPTION
Description
-----------
Thanks to the issue: https://github.com/aws/amazon-freertos/issues/2172, a race condition in tasks (parent and child) was found in TCP_Echo_Single demo.
As the issue points out, the parent task finishes before the child (echo) task(s) and therefore the demo finishes even before the echo-client has a chance to connect to the echo server.

This PR rectifies the aforementioned race condition by making the parent task wait using Semaphores.
+ The child (echo) tasks were designed as a `for( ; ; )` and were not getting cleaned up after the demo. This PR addresses that as well. The iterations are limited by a certain amount and the parent task cleans up the child tasks after their completion.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.