### PR TITLE
Add text for Cypress64 board qualification to ChangeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added new OTA config for allowing downgrade and version update. This is provided for testing purpose and configuration is disabled by default.
 
 #### Cypress
-- New Board: The <b>CY8CKIT_064S0S2_4343W<b> board is now qualified with FreeRTOS.
+- New Board: The <b>CY8CKIT_064S0S2_4343W</b> board is now qualified with FreeRTOS.
 
 #### Espressif
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - OTA Demo is updated to check for MQTT disconnect, suspend OTA operations and try reconnecting with exponential delay and jitter. After successful connection the demo resumes OTA Agent operations.
 - Added new OTA config for allowing downgrade and version update. This is provided for testing purpose and configuration is disabled by default.
 
+#### Cypress
+- New Board: The <b>CY8CKIT_064S0S2_4343W<b> board is now qualified with FreeRTOS.
+
 #### Espressif
 
 - New Board: <b>ESP32-WROOM-32SE</b> is now qualified with FreeRTOS. It was previously supported in Preview mode.


### PR DESCRIPTION
Add Cypress 64 board qualification text to **CHANGELOG.md** which is in scope for the **202007.00** release


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.