### PR TITLE
Re-name FreeRTOS with FreeRTOS AWS Reference Integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Change Log for FreeRTOS
+# Change Log for FreeRTOS AWS Reference Integrations
 
 ## 202007.00 7/14/2020
+
+#### Product Name Change
+- The repository brand name has been changed from `FreeRTOS` to `FreeRTOS AWS Reference Integrations`.
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# FreeRTOS AWS Reference Integrations
+
 ## Cloning
 This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring in dependent components.
 


### PR DESCRIPTION
**Re-brand the repository product from `FreeRTOS` to `FreeRTOS AWS Reference Integrations`**

The **FreeRTOS** product brand will be represented by the [FreeRTOS/FreeRTOS](github.com/FreeRTOS/FreeRTOS) repository and freertos.org website.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.