### PR TITLE
Refactor Key Size Macros

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -171,7 +171,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @note The largest RSA private key is used because EC keys are smaller and
  * the RSA public key is smaller.
  */
-#define pkcs11_MAX_PRIVATE_KEY_DER_SIZE    pkcs11_PRIVATE_RSA_2048_SIZE
+#define pkcs11_MAX_PRIVATE_KEY_DER_SIZE    pkcs11_PRIVATE_RSA_2048_DER_SIZE
 
 /**
  * @ingroup pkcs11_macros

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -61,7 +61,6 @@
 
 /**
  * @brief Default EC operations to ON.
- *
  */
 #ifndef pkcs11configSUPPRESS_ECDSA_MECHANISM
     #define pkcs11configSUPPRESS_ECDSA_MECHANISM    0
@@ -105,60 +104,51 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
 /**
  * @ingroup pkcs11_macros
  * @brief Macro for logging warnings in PKCS #11.
- *
  */
 #define PKCS11_WARNING_PRINT( X )    /* configPRINTF( X ) */
 
 /**
  * @ingroup pkcs11_macros
  * @brief Indicates that no PKCS #11 operation is underway for given session.
- *
  */
-#define pkcs11NO_OPERATION                  ( ( CK_MECHANISM_TYPE ) -1 )
+#define pkcs11NO_OPERATION                      ( ( CK_MECHANISM_TYPE ) -1 )
 
 /**
  * @ingroup pkcs11_macros
  * @brief size of a prime256v1 EC private key in bytes, when encoded in DER.
- *
- *
  */
-#define pkcs11_PRIVATE_EC_PRIME_256_SIZE    160
+#define pkcs11_PRIVATE_EC_PRIME_256_DER_SIZE    160
 
 /**
  * @ingroup pkcs11_macros
  * @brief size of a prime256v1 EC public key in bytes, when encoded in DER.
- *
  */
-#define pkcs11_PUBLIC_EC_PRIME_256_SIZE     100
+#define pkcs11_PUBLIC_EC_PRIME_256_DER_SIZE     100
 
 /**
  * @ingroup pkcs11_macros
  * @brief size of a 2048 bit RSA public key in bytes, when encoded in DER.
- *
- *
  */
-#define pkcs11_PUBLIC_RSA_2048_SIZE         300
+#define pkcs11_PUBLIC_RSA_2048_DER_SIZE         300
 
 /**
  * @ingroup pkcs11_macros
  * @brief size of a 2048 bit RSA private key in bytes, in DER encoding.
- *
  */
-#define pkcs11_PRIVATE_RSA_2048_SIZE        1200
+#define pkcs11_PRIVATE_RSA_2048_DER_SIZE        1200
 
 /**
  * @ingroup pkcs11_macros
  * @brief Max size of an EC public key in bytes, in DER encoding.
  */
-#define EC_MAX_PUBLIC_KEY_SIZE              pkcs11_PUBLIC_EC_PRIME_256_SIZE
+#define EC_MAX_PUBLIC_KEY_DER_SIZE              pkcs11_PUBLIC_EC_PRIME_256_DER_SIZE
 
 
 /**
  * @ingroup pkcs11_macros
  * @brief Max size of an EC private key in bytes, in DER encoding.
- *
  */
-#define EC_MAX_LENGTH_KEY      pkcs11_PRIVATE_EC_PRIME_256_SIZE
+#define EC_KEY_MAX_DER_SIZE        pkcs11_PRIVATE_EC_PRIME_256_DER_SIZE
 
 /**
  * @ingroup pkcs11_macros
@@ -167,7 +157,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  *
  * @note The largest RSA public key is used because EC keys are smaller.
  */
-#define MAX_PUBLIC_KEY_SIZE    pkcs11_PUBLIC_RSA_2048_SIZE
+#define MAX_PUBLIC_KEY_DER_SIZE    pkcs11_PUBLIC_RSA_2048_DER_SIZE
 
 
 /**
@@ -181,12 +171,11 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @note The largest RSA private key is used because EC keys are smaller and
  * the RSA public key is smaller.
  */
-#define MAX_LENGTH_KEY                pkcs11_PRIVATE_RSA_2048_SIZE
+#define MAX_PRIVATE_KEY_DER_SIZE      pkcs11_PRIVATE_RSA_2048_SIZE
 
 /**
  * @ingroup pkcs11_macros
  * @brief The size of the buffer malloc'ed for the exported public key in C_GenerateKeyPair.
- *
  */
 #define pkcs11KEY_GEN_MAX_DER_SIZE    200
 
@@ -219,7 +208,6 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @brief PKCS #11 object container.
  *
  * Maps a PKCS #11 object handle to it's label.
- *
  */
 typedef struct P11Object_t
 {
@@ -247,7 +235,6 @@ typedef struct P11ObjectList_t
 /**
  * @ingroup pkcs11_datatypes
  * @brief PKCS #11 Module Object
- *
  */
 typedef struct P11Struct_t
 {
@@ -373,9 +360,7 @@ static CK_BBOOL prvOperationActive( const P11Session_t * pxSession )
 
 /*
  * PKCS#11 module implementation.
- */
-
-/**
+ *
  * @functions_page{pkcs11_mbedtls,PKCS #11 mbedTLS, PKCS #11 mbedTLS}
  * @functions_brief{PKCS #11 mbedTLS implementation}
  * - @function_name{pkcs11_mbedtls_function_c_initialize}
@@ -566,7 +551,6 @@ static CK_RV prvMbedTLS_Initialize( void )
 
 /**
  * @brief Searches a template for the CKA_CLASS attribute.
- *
  */
 static CK_RV prvGetObjectClass( const CK_ATTRIBUTE * pxTemplate,
                                 CK_ULONG ulCount,
@@ -593,7 +577,6 @@ static CK_RV prvGetObjectClass( const CK_ATTRIBUTE * pxTemplate,
 
 /**
  * @brief Parses attribute values for a certificate.
- *
  */
 static CK_RV prvCertAttParse( CK_ATTRIBUTE * pxAttribute,
                               CK_CERTIFICATE_TYPE * pxCertificateType,
@@ -665,7 +648,6 @@ static CK_RV prvCertAttParse( CK_ATTRIBUTE * pxAttribute,
 
 /**
  * @brief Parses attribute values for a RSA Key.
- *
  */
 static CK_RV prvRsaKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
                                 const mbedtls_pk_context * pxMbedContext )
@@ -774,7 +756,6 @@ static CK_RV prvRsaKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
 
 /**
  * @brief Parses attribute values for a private EC Key.
- *
  */
 static CK_RV prvEcPrivKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
                                    const mbedtls_pk_context * pxMbedContext )
@@ -819,7 +800,6 @@ static CK_RV prvEcPrivKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
 
 /**
  * @brief Parses attribute values for a public EC Key.
- *
  */
 static CK_RV prvEcPubKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
                                   const mbedtls_pk_context * pxMbedContext )
@@ -865,7 +845,6 @@ static CK_RV prvEcPubKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
 
 /**
  * @brief Parses attribute values for an EC Key.
- *
  */
 static CK_RV prvEcKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
                                const mbedtls_pk_context * pxMbedContext,
@@ -1027,7 +1006,6 @@ static void prvFindObjectInListByHandle( CK_OBJECT_HANDLE xAppHandle,
  * @warning This does not delete the object from NVM.
  *
  * @param[in] xAppHandle     Application handle of the object to be deleted.
- *
  */
 static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xAppHandle )
 {
@@ -1146,7 +1124,6 @@ static CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
 
 /**
  * @brief Save a DER formatted key in the PKCS #11 PAL.
- *
  */
 static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
                                  CK_OBJECT_HANDLE_PTR pxObject,
@@ -1164,26 +1141,29 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
 
     if( ( xKeyType == CKK_EC ) && ( xIsPrivate == ( CK_BBOOL ) CK_TRUE ) )
     {
-        ulDerBufSize = EC_MAX_LENGTH_KEY;
+        ulDerBufSize = EC_KEY_MAX_DER_SIZE;
     }
     else if( ( xKeyType == CKK_EC ) && ( xIsPrivate == ( CK_BBOOL ) CK_FALSE ) )
     {
-        ulDerBufSize = EC_MAX_PUBLIC_KEY_SIZE;
+        ulDerBufSize = EC_MAX_PUBLIC_KEY_DER_SIZE;
     }
     else if( ( xKeyType == CKK_RSA ) && ( xIsPrivate == ( CK_BBOOL ) CK_TRUE ) )
     {
-        ulDerBufSize = MAX_LENGTH_KEY;
+        ulDerBufSize = MAX_PRIVATE_KEY_DER_SIZE;
     }
     else if( ( xKeyType == CKK_RSA ) && ( xIsPrivate == ( CK_BBOOL ) CK_FALSE ) )
     {
-        ulDerBufSize = MAX_PUBLIC_KEY_SIZE;
+        ulDerBufSize = MAX_PUBLIC_KEY_DER_SIZE;
     }
     else
     {
         xResult = CKR_ARGUMENTS_BAD;
     }
 
-    pxDerKey = pvPortMalloc( ulDerBufSize );
+    if( xResult == CKR_OK )
+    {
+        pxDerKey = pvPortMalloc( ulDerBufSize );
+    }
 
     if( pxDerKey == NULL )
     {
@@ -2060,7 +2040,6 @@ static CK_RV prvCreateCertificate( CK_ATTRIBUTE * pxTemplate,
  * @param[out] pxKeyType pointer to key type.
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
- *
  */
 static void prvGetKeyType( CK_KEY_TYPE * pxKeyType,
                            const CK_ATTRIBUTE * pxTemplate,
@@ -2089,7 +2068,6 @@ static void prvGetKeyType( CK_KEY_TYPE * pxKeyType,
  * @param[out] ppxLabel pointer to label.
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
- *
  */
 static void prvGetLabel( CK_ATTRIBUTE ** ppxLabel,
                          CK_ATTRIBUTE * pxTemplate,
@@ -2197,7 +2175,6 @@ static CK_RV prvGetExistingKeyComponent( CK_OBJECT_HANDLE_PTR pxPalHandle,
  * @param[in] ulCount length of templates array.
  * @param[in] pxObject PKCS #11 object handle.
  * @param[in] xIsPrivate boolean indicating whether the key is private or public.
- *
  */
 static CK_RV prvCreateECKey( CK_ATTRIBUTE * pxTemplate,
                              CK_ULONG ulCount,
@@ -2303,7 +2280,6 @@ static CK_RV prvCreateECKey( CK_ATTRIBUTE * pxTemplate,
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
  * @param[in] pxObject PKCS #11 object handle.
- *
  */
 static CK_RV prvCreateRsaPrivateKey( CK_ATTRIBUTE * pxTemplate,
                                      CK_ULONG ulCount,
@@ -2373,7 +2349,6 @@ static CK_RV prvCreateRsaPrivateKey( CK_ATTRIBUTE * pxTemplate,
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
  * @param[in] pxObject PKCS #11 object handle.
- *
  */
 static CK_RV prvCreatePrivateKey( CK_ATTRIBUTE * pxTemplate,
                                   CK_ULONG ulCount,
@@ -2418,7 +2393,6 @@ static CK_RV prvCreatePrivateKey( CK_ATTRIBUTE * pxTemplate,
  * @param[in] pxTemplate templates to search for a key in.
  * @param[in] ulCount length of templates array.
  * @param[in] pxObject PKCS #11 object handle.
- *
  */
 static CK_RV prvCreatePublicKey( CK_ATTRIBUTE * pxTemplate,
                                  CK_ULONG ulCount,

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -141,14 +141,14 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @ingroup pkcs11_macros
  * @brief Max size of an EC public key in bytes, in DER encoding.
  */
-#define EC_MAX_PUBLIC_KEY_DER_SIZE              pkcs11_PUBLIC_EC_PRIME_256_DER_SIZE
+#define pkcs11_MAX_EC_PUBLIC_KEY_DER_SIZE       pkcs11_PUBLIC_EC_PRIME_256_DER_SIZE
 
 
 /**
  * @ingroup pkcs11_macros
  * @brief Max size of an EC private key in bytes, in DER encoding.
  */
-#define EC_KEY_MAX_DER_SIZE        pkcs11_PRIVATE_EC_PRIME_256_DER_SIZE
+#define pkcs11_MAX_EC_PRIVATE_KEY_DER_SIZE    pkcs11_PRIVATE_EC_PRIME_256_DER_SIZE
 
 /**
  * @ingroup pkcs11_macros
@@ -157,7 +157,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  *
  * @note The largest RSA public key is used because EC keys are smaller.
  */
-#define MAX_PUBLIC_KEY_DER_SIZE    pkcs11_PUBLIC_RSA_2048_DER_SIZE
+#define pkcs11_MAX_PUBLIC_KEY_DER_SIZE        pkcs11_PUBLIC_RSA_2048_DER_SIZE
 
 
 /**
@@ -171,13 +171,13 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @note The largest RSA private key is used because EC keys are smaller and
  * the RSA public key is smaller.
  */
-#define MAX_PRIVATE_KEY_DER_SIZE      pkcs11_PRIVATE_RSA_2048_SIZE
+#define pkcs11_MAX_PRIVATE_KEY_DER_SIZE    pkcs11_PRIVATE_RSA_2048_SIZE
 
 /**
  * @ingroup pkcs11_macros
  * @brief The size of the buffer malloc'ed for the exported public key in C_GenerateKeyPair.
  */
-#define pkcs11KEY_GEN_MAX_DER_SIZE    200
+#define pkcs11KEY_GEN_MAX_DER_SIZE         200
 
 /**
  * @ingroup pkcs11_macros
@@ -185,23 +185,23 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  *
  * @note that this implementation does not have a concept of "slots" so this number is arbitrary.
  */
-#define pkcs11SLOT_ID                 1
+#define pkcs11SLOT_ID                      1
 
 /**
  * @ingroup pkcs11_macros
  * @brief Private defines for checking that attribute templates are complete.
  */
-#define LABEL_IN_TEMPLATE             ( 1U )           /**< Bit set for label in template. */
-#define PRIVATE_IN_TEMPLATE           ( 1U << 1 )      /**< Bit set for private key in in template. */
-#define SIGN_IN_TEMPLATE              ( 1U << 2 )      /**< Bit set for sign in template. */
-#define EC_PARAMS_IN_TEMPLATE         ( 1U << 3 )      /**< Bit set for EC params in template. */
-#define VERIFY_IN_TEMPLATE            ( 1U << 4 )      /**< Bit set for verify in template. */
+#define LABEL_IN_TEMPLATE                  ( 1U )      /**< Bit set for label in template. */
+#define PRIVATE_IN_TEMPLATE                ( 1U << 1 ) /**< Bit set for private key in in template. */
+#define SIGN_IN_TEMPLATE                   ( 1U << 2 ) /**< Bit set for sign in template. */
+#define EC_PARAMS_IN_TEMPLATE              ( 1U << 3 ) /**< Bit set for EC params in template. */
+#define VERIFY_IN_TEMPLATE                 ( 1U << 4 ) /**< Bit set for verify in template. */
 
 /**
  * @ingroup pkcs11_macros
  * @brief Macro to signify an invalid PKCS #11 key type.
  */
-#define PKCS11_INVALID_KEY_TYPE       ( ( CK_KEY_TYPE ) 0xFFFFFFFFUL )
+#define PKCS11_INVALID_KEY_TYPE            ( ( CK_KEY_TYPE ) 0xFFFFFFFFUL )
 
 /**
  * @ingroup pkcs11_datatypes
@@ -1132,7 +1132,7 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
                                  CK_BBOOL xIsPrivate )
 {
     CK_RV xResult = CKR_OK;
-    CK_BYTE_PTR pxDerKey;
+    CK_BYTE_PTR pxDerKey = NULL;
     int32_t lDerKeyLength = 0;
     uint32_t ulActualKeyLength = 0;
     int32_t lCompare = 0;
@@ -1141,19 +1141,19 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
 
     if( ( xKeyType == CKK_EC ) && ( xIsPrivate == ( CK_BBOOL ) CK_TRUE ) )
     {
-        ulDerBufSize = EC_KEY_MAX_DER_SIZE;
+        ulDerBufSize = pkcs11_MAX_EC_PRIVATE_KEY_DER_SIZE;
     }
     else if( ( xKeyType == CKK_EC ) && ( xIsPrivate == ( CK_BBOOL ) CK_FALSE ) )
     {
-        ulDerBufSize = EC_MAX_PUBLIC_KEY_DER_SIZE;
+        ulDerBufSize = pkcs11_MAX_EC_PUBLIC_KEY_DER_SIZE;
     }
     else if( ( xKeyType == CKK_RSA ) && ( xIsPrivate == ( CK_BBOOL ) CK_TRUE ) )
     {
-        ulDerBufSize = MAX_PRIVATE_KEY_DER_SIZE;
+        ulDerBufSize = pkcs11_MAX_PRIVATE_KEY_DER_SIZE;
     }
     else if( ( xKeyType == CKK_RSA ) && ( xIsPrivate == ( CK_BBOOL ) CK_FALSE ) )
     {
-        ulDerBufSize = MAX_PUBLIC_KEY_DER_SIZE;
+        ulDerBufSize = pkcs11_MAX_PUBLIC_KEY_DER_SIZE;
     }
     else
     {

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1487,6 +1487,13 @@ static const char cValidECDSAPrivateKey[] =
     "Kk9GzFk9ChthHFsx+T7UFithbYWtRf0Zww==\n"
     "-----END EC PRIVATE KEY-----";
 
+/* Valid ECDSA public key. */
+static const char cValidECDSAPublicKey[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzghp+QstUhOmzKBGEL7uBjsaBbya\n"
+    "NTMLXKLSW78+bdoP9bKTOrqiKk9GzFk9ChthHFsx+T7UFithbYWtRf0Zww==\n"
+    "-----END PUBLIC KEY-----";
+
 /* Valid ECDSA certificate. */
 static const char cValidECDSACertificate[] =
     "-----BEGIN CERTIFICATE-----\n"
@@ -1522,8 +1529,8 @@ void prvProvisionCredentialsWithKeyImport( CK_OBJECT_HANDLE_PTR pxPrivateKeyHand
         xCurrentCredentials = eNone;
 
         xResult = xProvisionPublicKey( xGlobalSession,
-                                       ( uint8_t * ) cValidECDSAPrivateKey,
-                                       sizeof( cValidECDSAPrivateKey ),
+                                       ( uint8_t * ) cValidECDSAPublicKey,
+                                       sizeof( cValidECDSAPublicKey ),
                                        CKK_EC,
                                        ( uint8_t * ) pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
                                        pxPublicKeyHandle );
@@ -1659,8 +1666,8 @@ TEST( Full_PKCS11_EC, AFQP_CreateObjectDestroyObjectKeys )
     TEST_ASSERT_NOT_EQUAL_MESSAGE( 0, xPrivateKeyHandle, "Invalid object handle returned for EC private key." );
 
     xResult = xProvisionPublicKey( xGlobalSession,
-                                   ( uint8_t * ) cValidECDSAPrivateKey,
-                                   sizeof( cValidECDSAPrivateKey ),
+                                   ( uint8_t * ) cValidECDSAPublicKey,
+                                   sizeof( cValidECDSAPublicKey ),
                                    CKK_EC,
                                    ( uint8_t * ) pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
                                    &xPublicKeyHandle );
@@ -1699,7 +1706,7 @@ TEST( Full_PKCS11_EC, AFQP_CreateObjectDestroyObjectCertificates )
         TEST_ASSERT_NOT_EQUAL_MESSAGE( 0, xJITPCertificateHandle, "Invalid object handle returned for EC JITP certificate." );
 
         xResult = xProvisionPublicKey( xGlobalSession,
-                                       ( uint8_t * ) cValidECDSAPrivateKey,
+                                       ( uint8_t * ) cValidECDSAPublicKey,
                                        sizeof( cValidECDSAPrivateKey ),
                                        CKK_EC,
                                        pkcs11configLABEL_CODE_VERIFICATION_KEY,


### PR DESCRIPTION
Refactor Key Size Macros

Description
-----------
Fix TODO for writing a key to DER.
Added size specific macros for the keys currently supported by the stack.
Use smallest possible buffer for converting keys to DER.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.