### PR TITLE
Address some PKCS #11 TODOs

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -166,8 +166,11 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  *
  * @note This length needs to be updated if using a different curve.
  *
+ * To summarize:
+ * 32 points of 2 bytes each + 1 point length byte, 1 length byte, and
+ * 1 type (uncompressed) byte
  */
-#define pkcs11EC_POINT_LENGTH                 67
+#define pkcs11EC_POINT_LENGTH                 ( ( 32 * 2 ) + 1 + 1 + 1 )
 
 /**
  * @ingroup pkcs11_macros
@@ -2629,7 +2632,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
     mbedtls_pk_type_t xKeyType;
     const mbedtls_ecp_keypair * pxKeyPair;
     CK_KEY_TYPE xPkcsKeyType = ( CK_KEY_TYPE ) ~0UL;
-    CK_OBJECT_CLASS xClass;
+    CK_OBJECT_CLASS xClass = ~0UL;
     CK_BYTE_PTR pxObjectValue = NULL;
     CK_ULONG ulLength = 0;
     const CK_BYTE ucP256Oid[] = pkcs11DER_ENCODED_OID_P256;
@@ -2702,7 +2705,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
         }
         else
         {
-            /* Could not determine the object class." */
+            xResult = CKR_OBJECT_HANDLE_INVALID;
         }
     }
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -1244,12 +1244,12 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
          * It must be removed so that we can read the private
          * key back at a later time. */
         uint8_t emptyPubKey[ 6 ] = { 0xa1, 0x04, 0x03, 0x02, 0x00, 0x00 };
-        lCompare = memcmp( &pxDerKey[ ulDerBufSize - 6 ], emptyPubKey, 6 );
+        lCompare = memcmp( &pxDerKey[ ulDerBufSize - 6UL ], emptyPubKey, 6 );
 
         if( ( lCompare == 0 ) && ( ulActualKeyLength >= 6UL ) )
         {
             /* Do not write the last 6 bytes to key storage. */
-            pxDerKey[ ulDerBufSize - lDerKeyLength + 1 ] -= ( uint8_t ) 6;
+            pxDerKey[ ulDerBufSize - ( uint32_t ) lDerKeyLength + 1UL ] -= ( uint8_t ) 6;
             ulActualKeyLength -= 6UL;
         }
     }
@@ -1257,7 +1257,7 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
     if( xResult == CKR_OK )
     {
         xPalHandle = PKCS11_PAL_SaveObject( pxLabel,
-                                            pxDerKey + ( ulDerBufSize - lDerKeyLength ),
+                                            pxDerKey + ( ulDerBufSize - ( uint32_t ) lDerKeyLength ),
                                             ulActualKeyLength );
 
         if( xPalHandle == CK_INVALID_HANDLE )

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -167,7 +167,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @note This length needs to be updated if using a different curve.
  *
  */
-#define pkcs11EC_POINT_LENGTH    67
+#define pkcs11EC_POINT_LENGTH                 67
 
 /**
  * @ingroup pkcs11_macros

--- a/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
+++ b/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
@@ -1661,12 +1661,9 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
 
     /* EC Params Case */
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     mbedtls_pk_init_CMockIgnore();
     mbedtls_x509_crt_init_CMockIgnore();
-    mbedtls_pk_parse_key_IgnoreAndReturn( 1 );
-    mbedtls_pk_parse_public_key_IgnoreAndReturn( 1 );
-    mbedtls_x509_crt_parse_IgnoreAndReturn( 1 );
+    mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
     PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
     mbedtls_pk_free_CMockIgnore();
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
@@ -1679,7 +1676,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     xTemplate.pValue = NULL;
     xTemplate.ulValueLen = 0;
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
@@ -1690,7 +1686,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     xTemplate.pValue = &ulPoint;
     xTemplate.ulValueLen = sizeof( ulPoint );
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
     TEST_ASSERT_EQUAL( ulKnownPoint, ulPoint );
@@ -1699,7 +1694,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     xTemplate.ulValueLen = sizeof( ulPoint );
 
     mbedtls_ecp_tls_write_point_IgnoreAndReturn( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
 
@@ -1707,7 +1701,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     xTemplate.pValue = &ulPoint;
     xTemplate.ulValueLen = sizeof( ulPoint );
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
 
@@ -1716,7 +1709,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     /* Unknown attribute. */
     xTemplate.type = CKA_MODULUS;
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
 
@@ -1725,7 +1717,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     xTemplate.pValue = NULL;
     xTemplate.ulValueLen = 0;
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
@@ -1734,7 +1725,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
     xTemplate.pValue = &xPrivateKeyClass;
 
-    PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
     TEST_ASSERT_EQUAL( sizeof( xPrivateKeyClass ), xTemplate.ulValueLen );
@@ -1749,7 +1739,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
     PKCS11_PAL_GetObjectValue_ReturnThruPtr_pulDataSize( &ulLength );
     mbedtls_pk_parse_key_IgnoreAndReturn( 1 );
-    mbedtls_pk_parse_public_key_IgnoreAndReturn( 0 );
+    mbedtls_pk_parse_public_key_ExpectAnyArgsAndReturn( 0 );
     xResult = C_GetAttributeValue( xSession, xObjectPub, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
     TEST_ASSERT_EQUAL( 1, xTemplate.ulValueLen );


### PR DESCRIPTION
Address some PKCS #11 TODOs

Description
-----------
* Added check to see if the parsed buffer was a certificate.
* Added macro for magic number for the EC point used in EC public keys.
* Determined byte size of an EC signature on the prime256v1 curve.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.