### PR TITLE
Update PKCS #11 unit tests

### DIFF
--- a/libraries/abstractions/pkcs11/utest/CMakeLists.txt
+++ b/libraries/abstractions/pkcs11/utest/CMakeLists.txt
@@ -25,6 +25,7 @@ cmake_minimum_required (VERSION 3.13)
                 "${3rdparty_dir}/mbedtls/include/mbedtls/ecdsa.h"
                 "${3rdparty_dir}/mbedtls_utils/mbedtls_error.h"
                 "${3rdparty_dir}/mbedtls/include/mbedtls/pk.h"
+                "${3rdparty_dir}/mbedtls/include/mbedtls/x509_crt.h"
                 "${standard_dir}/utils/include/iot_pki_utils.h"
         )
 

--- a/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
+++ b/libraries/abstractions/pkcs11/utest/iot_pkcs11_mbedtls_utest.c
@@ -39,6 +39,7 @@
 #include "mock_entropy.h"
 #include "mock_sha256.h"
 #include "mock_pk.h"
+#include "mock_x509_crt.h"
 #include "mock_ecp.h"
 #include "mock_ecdsa.h"
 #include "mock_rsa.h"
@@ -1617,8 +1618,10 @@ void test_pkcs11_C_GetAttributeValueCert( void )
     /* Get Certificate value. */
     PKCS11_PAL_GetObjectValue_IgnoreAndReturn( CKR_OK );
     mbedtls_pk_init_CMockIgnore();
+    mbedtls_x509_crt_init_CMockIgnore();
     mbedtls_pk_parse_key_IgnoreAndReturn( 1 );
     mbedtls_pk_parse_public_key_IgnoreAndReturn( 1 );
+    mbedtls_x509_crt_parse_IgnoreAndReturn( 0 );
     PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
     mbedtls_pk_free_CMockIgnore();
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xCertificateTemplate, ulCount );
@@ -1660,8 +1663,10 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     /* EC Params Case */
     PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
     mbedtls_pk_init_CMockIgnore();
+    mbedtls_x509_crt_init_CMockIgnore();
     mbedtls_pk_parse_key_IgnoreAndReturn( 1 );
     mbedtls_pk_parse_public_key_IgnoreAndReturn( 1 );
+    mbedtls_x509_crt_parse_IgnoreAndReturn( 1 );
     PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
     mbedtls_pk_free_CMockIgnore();
     xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
@@ -1796,6 +1801,7 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
 
     PKCS11_PAL_GetObjectValue_IgnoreAndReturn( CKR_OK );
     mbedtls_pk_init_CMockIgnore();
+    mbedtls_x509_crt_init_CMockIgnore();
     mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
     PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
     mbedtls_pk_free_CMockIgnore();


### PR DESCRIPTION
Update PKCS #11 unit tests

Description
-----------
Update PKCS #11 unit tests to account for x509 parsing in C_GetAttributeValue.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.