### PR TITLE
FreeRTOS+TCP : print resource statistics routine (#2164)

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h
@@ -304,6 +304,12 @@ BaseType_t FreeRTOS_IsNetworkUp( void );
 	UBaseType_t uxGetMinimumIPQueueSpace( void );
 #endif
 
+#if ( ipconfigHAS_PRINTF != 0 )
+	extern void vPrintResourceStats( void );
+#else
+	#define vPrintResourceStats()	do {} while( ipFALSE_BOOL )
+#endif
+
 /*
  * Defined in FreeRTOS_Sockets.c
  * //_RB_ Don't think this comment is correct.  If this is for internal use only it should appear after all the public API functions and not start with FreeRTOS_.

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -1196,10 +1196,6 @@ uint32_t ul;
 
 static void prvEMACHandlerTask( void *pvParameters )
 {
-UBaseType_t uxLastMinBufferCount = 0;
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-UBaseType_t uxLastMinQueueSpace = 0;
-#endif
 UBaseType_t uxCurrentCount;
 BaseType_t xResult;
 const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
@@ -1210,15 +1206,11 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 	for( ;; )
 	{
 		xResult = 0;
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+
+		/* Call a function that monitors resources: the amount of free network
+		buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+		for more detailed comments. */
+		vPrintResourceStats();
 
 		if( xTXDescriptorSemaphore != NULL )
 		{
@@ -1232,19 +1224,6 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 			}
 
 		}
-
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
 		if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
 		{

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -85,7 +85,7 @@
  * the size of the stack used by the idle task - but allow this to be overridden in
  * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
+	#define configEMAC_TASK_STACK_SIZE ( 4 * configMINIMAL_STACK_SIZE )
 #endif
 
 #if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
@@ -107,10 +107,6 @@ static BaseType_t prvGMACWaitLS( TickType_t xMaxTime );
  * A deferred interrupt handler for all MAC/DMA interrupt sources.
  */
 static void prvEMACHandlerTask( void * pvParameters );
-
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources( void );
-#endif
 
 /*-----------------------------------------------------------*/
 
@@ -332,141 +328,90 @@ BaseType_t xGetPhyLinkStatus( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources()
-    {
-        static UBaseType_t uxLastMinBufferCount = 0u;
-        static size_t uxMinLastSize = 0uL;
-        UBaseType_t uxCurrentBufferCount;
-        size_t uxMinSize;
-
-        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
-
-        if( uxLastMinBufferCount != uxCurrentBufferCount )
-        {
-            /* The logging produced below may be helpful
-             * while tuning +TCP: see how many buffers are in use. */
-            uxLastMinBufferCount = uxCurrentBufferCount;
-            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                               uxGetNumberOfFreeNetworkBuffers(),
-                               uxCurrentBufferCount ) );
-        }
-
-        uxMinSize = xPortGetMinimumEverFreeHeapSize();
-
-        if( uxMinLastSize != uxMinSize )
-        {
-            uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
-        }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                static UBaseType_t uxLastMinQueueSpace = 0;
-                UBaseType_t uxCurrentCount = 0u;
-
-                uxCurrentCount = uxGetMinimumIPQueueSpace();
-
-                if( uxLastMinQueueSpace != uxCurrentCount )
-                {
-                    /* The logging produced below may be helpful
-                     * while tuning +TCP: see how many buffers are in use. */
-                    uxLastMinQueueSpace = uxCurrentCount;
-                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-    }
-#endif /* ( ipconfigHAS_PRINTF != 0 ) */
-/*-----------------------------------------------------------*/
-
-static void prvEMACHandlerTask( void * pvParameters )
+static void prvEMACHandlerTask( void *pvParameters )
 {
-    TimeOut_t xPhyTime;
-    TickType_t xPhyRemTime;
-    BaseType_t xResult = 0;
-    uint32_t xStatus;
-    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+TimeOut_t xPhyTime;
+TickType_t xPhyRemTime;
+BaseType_t xResult = 0;
+uint32_t xStatus;
+const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
-    /* Remove compiler warnings about unused parameters. */
-    ( void ) pvParameters;
+	/* Remove compiler warnings about unused parameters. */
+	( void ) pvParameters;
 
-    /* A possibility to set some additional task properties like calling
-     * portTASK_USES_FLOATING_POINT() */
-    iptraceEMAC_TASK_STARTING();
+	/* A possibility to set some additional task properties like calling
+	portTASK_USES_FLOATING_POINT() */
+	iptraceEMAC_TASK_STARTING();
 
-    vTaskSetTimeOutState( &xPhyTime );
-    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+	vTaskSetTimeOutState( &xPhyTime );
+	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-    for( ; ; )
-    {
-        #if ( ipconfigHAS_PRINTF != 0 )
-            {
-                prvMonitorResources();
-            }
-        #endif /* ipconfigHAS_PRINTF != 0 ) */
+	for( ;; )
+	{
+		/* Call a function that monitors resources: the amount of free network
+		buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+		for more detailed comments. */
+		vPrintResourceStats();
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
-        {
-            /* No events to process now, wait for the next. */
-            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-        }
+		if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
+		{
+			/* No events to process now, wait for the next. */
+			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
-            xResult = emacps_check_rx( &xEMACpsif );
-        }
+		if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
+			xResult = emacps_check_rx( &xEMACpsif );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
-            emacps_check_tx( &xEMACpsif );
-        }
+		if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
+			emacps_check_tx( &xEMACpsif );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
-            emacps_check_errors( &xEMACpsif );
-        }
+		if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
+			emacps_check_errors( &xEMACpsif );
+		}
 
-        if( xResult > 0 )
-        {
-            /* A packet was received. No need to check for the PHY status now,
-             * but set a timer to check it later on. */
-            vTaskSetTimeOutState( &xPhyTime );
-            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-            xResult = 0;
+		if( xResult > 0 )
+		{
+			/* A packet was received. No need to check for the PHY status now,
+			but set a timer to check it later on. */
+			vTaskSetTimeOutState( &xPhyTime );
+			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			xResult = 0;
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+			{
+				/* Indicate that the Link Status is high, so that
+				xNetworkInterfaceOutput() can send packets. */
+				ulPHYLinkStatus |= niBMSR_LINK_STATUS;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
+			}
+		}
+		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+		{
+			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
-            {
-                /* Indicate that the Link Status is high, so that
-                 * xNetworkInterfaceOutput() can send packets. */
-                ulPHYLinkStatus |= niBMSR_LINK_STATUS;
-                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
-            }
-        }
-        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-        {
-            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
+			{
+				ulPHYLinkStatus = xStatus;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
+			}
 
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
-            {
-                ulPHYLinkStatus = xStatus;
-                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
-            }
-
-            vTaskSetTimeOutState( &xPhyTime );
-
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
-            {
-                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-            }
-            else
-            {
-                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-            }
-        }
-    }
+			vTaskSetTimeOutState( &xPhyTime );
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			}
+			else
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+			}
+		}
+	}
 }
 /*-----------------------------------------------------------*/

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -44,14 +44,6 @@ enum if_state_t {
 static const char *TAG = "NetInterface";
 volatile static uint32_t xInterfaceState = INTERFACE_DOWN;
 
-/* protect the function declaration itself instead of using
-   #if everywhere.                                        */
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvPrintResourceStats();    
-#else
-    #define prvPrintResourceStats()
-#endif
-
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     static BaseType_t xMACAdrInitialized = pdFALSE;
@@ -86,7 +78,10 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBu
         }
     }
 
-    prvPrintResourceStats();
+	/* Call a function that monitors resources: the amount of free network
+	buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+	for more detailed comments. */
+	vPrintResourceStats();
     
     if (xReleaseAfterSend == pdTRUE) {
         vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
@@ -115,7 +110,7 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-    prvPrintResourceStats();
+    vPrintResourceStats();
 
     if( eConsiderFrameForProcessing( buffer ) != eProcessBuffer ) {
         ESP_LOGD(TAG, "Dropping packet");
@@ -145,50 +140,3 @@ esp_err_t wlanif_input(void *netif, void *buffer, uint16_t len, void *eb)
         return ESP_FAIL;
     }
 }
-
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvPrintResourceStats()
-    {
-        static UBaseType_t uxLastMinBufferCount = 0u;
-        static UBaseType_t uxCurrentBufferCount = 0u;
-        static size_t uxMinLastSize = 0uL;
-        size_t uxMinSize;
-
-        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
-
-        if( uxLastMinBufferCount != uxCurrentBufferCount )
-        {
-            /* The logging produced below may be helpful
-             * while tuning +TCP: see how many buffers are in use. */
-            uxLastMinBufferCount = uxCurrentBufferCount;
-            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
-        }
-
-        uxMinSize = xPortGetMinimumEverFreeHeapSize();
-
-        if( uxMinLastSize != uxMinSize )
-        {
-            uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
-        }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                static UBaseType_t uxLastMinQueueSpace = 0;
-                UBaseType_t uxCurrentCount = 0u;
-
-                uxCurrentCount = uxGetMinimumIPQueueSpace();
-
-                if( uxLastMinQueueSpace != uxCurrentCount )
-                {
-                    /* The logging produced below may be helpful
-                     * while tuning +TCP: see how many buffers are in use. */
-                    uxLastMinQueueSpace = uxCurrentCount;
-                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-    }
-#endif /* ( ipconfigHAS_PRINTF != 0 ) */
-/*-----------------------------------------------------------*/


### PR DESCRIPTION
Port #2164 logging frequency of FreeRTOS+TCP stack to `release-candidate`

Description
-----------
Too much logging from network stack was inhibiting logging messages of demos to be printed, causing CI to detect false failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.