### PR TITLE
Fix: Enable BLE in Cypress PSoC64 MTB demo project.

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/Makefile
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/Makefile
@@ -26,6 +26,9 @@
 # Choose between "aws_demos" and "aws_tests"
 CY_AFR_BUILD=aws_demos
 
+# BLE support
+BLE_SUPPORT=1
+
 # Root location of AFR directory
 CY_AFR_ROOT=../../../../..
 
@@ -96,6 +99,9 @@ INCLUDES=
 
 # Add additional defines to the build process (without a leading -D).
 DEFINES=CYBSP_WIFI_CAPABLE CY_RTOS_AWARE CY_RETARGET_IO_CONVERT_LF_TO_CRLF CY_USE_LWIP CY_TFM_PSA_SUPPORTED CONFIG_MEDTLS_USE_AFR_MEMORY MBEDTLS_CONFIG_FILE=\"aws_mbedtls_config.h\" TFM_MULTI_CORE_MULTI_CLIENT_CALL
+
+# Add BLE defines
+DEFINES+=CY_BLE_SUPPORTED
 
 # Select softfp or hardfp floating point. Default is softfp. 
 VFP_SELECT=


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
To fix BLE_GATT_SERVER demo build error in build combination test.
https://amazon-freertos-ci.corp.amazon.com/view/5-Build_Combinations/job/Build_Combinations/job/Build_All_Combinations/437/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.