### PR TITLE
PKCS #11 TODOs

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3799,7 +3799,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
     {
         if( pdTRUE == xSemaphoreTake( pxSession->xVerifyMutex, portMAX_DELAY ) )
         {
-            if( ( pxSession->xSignKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xSignKeyHandle != hKey ) )
+            if( ( pxSession->xVerifyKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xVerifyKeyHandle != hKey ) )
             {
                 mbedtls_pk_free( &pxSession->xVerifyKey );
 

--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -3473,9 +3473,10 @@ CK_DECLARE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE hSession,
         {
             if( ( pxSession->xSignKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xSignKeyHandle != hKey ) )
             {
+                pxSession->xSignKeyHandle = CK_INVALID_HANDLE;
                 mbedtls_pk_free( &pxSession->xSignKey );
-
                 mbedtls_pk_init( &pxSession->xSignKey );
+
                 lMbedTLSResult = mbedtls_pk_parse_key( &pxSession->xSignKey, pulKeyData, ulKeyDataLength, NULL, 0 );
 
                 if( lMbedTLSResult != 0 )
@@ -3485,7 +3486,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE hSession,
                     PKCS11_PRINT( ( "%s \r\n",
                                     mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
                     xResult = CKR_KEY_HANDLE_INVALID;
-                    pxSession->xSignKeyHandle = CK_INVALID_HANDLE;
                 }
                 else
                 {
@@ -3801,8 +3801,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
         {
             if( ( pxSession->xVerifyKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xVerifyKeyHandle != hKey ) )
             {
+                pxSession->xVerifyKeyHandle = CK_INVALID_HANDLE;
                 mbedtls_pk_free( &pxSession->xVerifyKey );
-
                 mbedtls_pk_init( &pxSession->xVerifyKey );
 
                 if( 0 != mbedtls_pk_parse_public_key( &pxSession->xVerifyKey, pucKeyData, ulKeyDataLength ) )
@@ -3811,7 +3811,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
                     {
                         PKCS11_PRINT( ( "ERROR: Unable to parse public key for verification. \r\n" ) );
                         xResult = CKR_KEY_HANDLE_INVALID;
-                        pxSession->xVerifyKeyHandle = CK_INVALID_HANDLE;
                     }
                     else
                     {


### PR DESCRIPTION
PKCS #11 TODOs

Description
-----------
This commit address the last of the TODOs in iot_pkcs11_mbedtls.c
* Removed a TODO refactor comment as it was vague.
* Added a variable to track whether the sign and verify key is the same as the last operation, saving key parse operations.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.