### PR TITLE
OTA: Support force cancellation of in progress Job

### DIFF
--- a/libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h
+++ b/libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h
@@ -162,7 +162,8 @@ typedef enum
     eOTA_JobParseErr_ZeroFileSize,        /* Job document specified a zero sized file. This is not allowed. */
     eOTA_JobParseErr_NonConformingJobDoc, /* The job document failed to fulfill the model requirements. */
     eOTA_JobParseErr_BadModelInitParams,  /* There was an invalid initialization parameter used in the document model. */
-    eOTA_JobParseErr_NoContextAvailable   /* There wasn't an OTA context available. */
+    eOTA_JobParseErr_NoContextAvailable,  /* There wasn't an OTA context available. */
+    eOTA_JobParseErr_NoActiveJobs,        /* No active jobs are available in the service. */
 } OTA_JobParseErr_t;
 
 

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1454,7 +1454,13 @@ static bool prvOTA_Close( OTA_FileContext_t * const C )
 
     bool bResult = false;
 
-    OTA_LOG_L1( "[%s] Context->0x%p\r\n", OTA_METHOD_NAME, C );
+    OTA_LOG_L2( "[%s] Context->0x%p\r\n", OTA_METHOD_NAME, C );
+
+    /* Cleanup related to selected protocol. */
+    if( xOTA_DataInterface.prvCleanup != NULL )
+    {
+        ( void ) xOTA_DataInterface.prvCleanup( &xOTA_Agent );
+    }
 
     if( C != NULL )
     {

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h
@@ -205,10 +205,11 @@ enum
  * size, attributes, etc. The following value specifies the number of parameters
  * that are included in the job document model although some may be optional. */
 
-#define OTA_NUM_JOB_PARAMS              ( 19 ) /* Number of parameters in the job document. */
+#define OTA_NUM_JOB_PARAMS              ( 20 ) /* Number of parameters in the job document. */
 
 /* Keys in OTA job doc . */
 #define OTA_JSON_CLIENT_TOKEN_KEY       "clientToken"
+#define OTA_JSON_TIMESTAMP_KEY          "timestamp"
 #define OTA_JSON_EXECUTION_KEY          "execution"
 #define OTA_JSON_JOB_ID_KEY             "jobId"
 #define OTA_JSON_STATUS_DETAILS_KEY     "statusDetails"
@@ -249,6 +250,7 @@ typedef struct ota_agent_context
     uint32_t ulServerFileID;                                /* Variable to store current file ID passed down */
     uint8_t * pcOTA_Singleton_ActiveJobName;                /* The currently active job name. We only allow one at a time. */
     uint8_t * pcClientTokenFromJob;                         /* The clientToken field from the latest update job. */
+    uint32_t ulTimestampFromJob;                            /* Timestamp received from the latest job document. */
     TimerHandle_t pvSelfTestTimer;                          /* The self-test response expected timer. */
     TimerHandle_t xRequestTimer;                            /* The request timer associated with this OTA context. */
     QueueHandle_t xOTA_EventQueue;                          /* Event queue for communicating with the OTA Agent task. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This change adds supports for handling force cancellation of an in-progress OTA job from the service. This will abort the existing download and fetches the next job document from service and begins processing if available.

This change also includes getting the timestamp from job document and identifying a job document received does not have any execution data.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.