### PR TITLE
UDP: Add ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS compile time constant

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
@@ -314,11 +314,7 @@ from the FreeRTOSIPConfig.h configuration header file. */
 #endif
 
 #ifndef ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND
-	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND	1
-#endif
-
-#ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
-	#define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS	0
+	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND 1
 #endif
 
 #ifndef ipconfigUDP_TIME_TO_LIVE

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
@@ -314,7 +314,11 @@ from the FreeRTOSIPConfig.h configuration header file. */
 #endif
 
 #ifndef ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND
-	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND 1
+	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND	1
+#endif
+
+#ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
+	#define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS	0
 #endif
 
 #ifndef ipconfigUDP_TIME_TO_LIVE

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -1685,8 +1685,6 @@ uint8_t ucProtocol;
 		{
 			/* The size of the IP-header is larger than 20 bytes.
 			The extra space is used for IP-options. */
-			#if( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 )
-			{
 			/* All structs of headers expect a IP header size of 20 bytes
 			 * IP header options were included, we'll ignore them and cut them out. */
 			const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -67,6 +67,11 @@ a constant. */
 #define	ipFIRST_MULTI_CAST_IPv4		0xE0000000UL
 #define	ipLAST_MULTI_CAST_IPv4		0xF0000000UL
 
+/* The first byte in the IPv4 header combines the IP version (4) with
+with the length of the IP header. */
+#define	ipIPV4_VERSION_HEADER_LENGTH_MIN	0x45U
+#define	ipIPV4_VERSION_HEADER_LENGTH_MAX	0x4FU
+	
 /* Time delay between repeated attempts to initialise the network hardware. */
 #ifndef ipINITIALISATION_RETRY_DELAY
 	#define ipINITIALISATION_RETRY_DELAY	( pdMS_TO_TICKS( 3000U ) )
@@ -1545,9 +1550,10 @@ eFrameProcessingResult_t eReturn = eProcessBuffer;
 				/* Can not handle, fragmented packet. */
 				eReturn = eReleaseBuffer;
 			}
-			/* 0x45 means: IPv4 with an IP header of 5 x 4 = 20 bytes
-			 * 0x47 means: IPv4 with an IP header of 7 x 4 = 28 bytes */
-			else if( ( pxIPHeader->ucVersionHeaderLength < 0x45U ) || ( pxIPHeader->ucVersionHeaderLength > 0x4FU ) )
+			/* Test if the length of the IP-header is between 20 and 60 bytes,
+			and if the IP-version is 4. */
+			else if( ( pxIPHeader->ucVersionHeaderLength < ipIPV4_VERSION_HEADER_LENGTH_MIN ) ||
+					 ( pxIPHeader->ucVersionHeaderLength > ipIPV4_VERSION_HEADER_LENGTH_MAX ) )
 			{
 				/* Can not handle, unknown or invalid header version. */
 				eReturn = eReleaseBuffer;
@@ -1677,15 +1683,18 @@ uint8_t ucProtocol;
 	{
 		if( uxHeaderLength > ipSIZE_OF_IPv4_HEADER )
 		{
+			/* The size of the IP-header is larger than 20 bytes.
+			The extra space is used for IP-options. */
+			#if( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 )
+			{
 			/* All structs of headers expect a IP header size of 20 bytes
-			 * IP header options were included, we'll ignore them and cut them out
-			 * Note: IP options are mostly use in Multi-cast protocols */
+			 * IP header options were included, we'll ignore them and cut them out. */
 			const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;
-			/* From: the previous start of UDP/ICMP/TCP data */
+			/* From: the previous start of UDP/ICMP/TCP data. */
 			const uint8_t *pucSource = ( const uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + uxHeaderLength ] );
-			/* To: the usual start of UDP/ICMP/TCP data at offset 20 from IP header */
+			/* To: the usual start of UDP/ICMP/TCP data at offset 20 (decimal ) from IP header. */
 			uint8_t *pucTarget = ( uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + ipSIZE_OF_IPv4_HEADER ] );
-			/* How many: total length minus the options and the lower headers */
+			/* How many: total length minus the options and the lower headers. */
 			const size_t  xMoveLen = pxNetworkBuffer->xDataLength - ( optlen + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ETH_HEADER );
 
 			( void ) memmove( pucTarget, pucSource, xMoveLen );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -1681,6 +1681,7 @@ uint8_t ucProtocol;
 
 	if( eReturn == eProcessBuffer )
 	{
+		/* Are there IP-options. */
 		if( uxHeaderLength > ipSIZE_OF_IPv4_HEADER )
 		{
 			/* The size of the IP-header is larger than 20 bytes.

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -125,11 +125,9 @@ events are posted to the network event queue. */
 handled.  The value is chosen simply to be easy to spot when debugging. */
 #define ipUNHANDLED_PROTOCOL		0x4321U
 
-/* Returned to indicate a valid checksum. */
+/* Returned to indicate a valid checksum when the checksum does not need to be
+calculated. */
 #define ipCORRECT_CRC				0xffffU
-
-/* Returned to indicate incorrect checksum. */
-#define ipWRONG_CRC					0x0000U
 
 /* Returned as the (invalid) checksum when the length of the data being checked
 had an invalid length. */
@@ -2031,18 +2029,8 @@ BaseType_t location = 0;
 	}
 	else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
 	{
-		#if( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 )
-		{
-			/* Sender hasn't set the checksum, drop the packet because
-			ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS is not set. */
-			usChecksum = ipWRONG_CRC;
-		}
-		#else
-		{
-			/* Sender hasn't set the checksum, no use to calculate it. */
-			usChecksum = ipCORRECT_CRC;
-		}
-		#endif
+		/* Sender hasn't set the checksum, no use to calculate it. */
+		usChecksum = ipCORRECT_CRC;
 		location = 8;
 		goto error_exit;
 	}

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c
@@ -125,9 +125,11 @@ events are posted to the network event queue. */
 handled.  The value is chosen simply to be easy to spot when debugging. */
 #define ipUNHANDLED_PROTOCOL		0x4321U
 
-/* Returned to indicate a valid checksum when the checksum does not need to be
-calculated. */
+/* Returned to indicate a valid checksum. */
 #define ipCORRECT_CRC				0xffffU
+
+/* Returned to indicate incorrect checksum. */
+#define ipWRONG_CRC					0x0000U
 
 /* Returned as the (invalid) checksum when the length of the data being checked
 had an invalid length. */
@@ -2029,8 +2031,18 @@ BaseType_t location = 0;
 	}
 	else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
 	{
-		/* Sender hasn't set the checksum, no use to calculate it. */
-		usChecksum = ipCORRECT_CRC;
+		#if( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 )
+		{
+			/* Sender hasn't set the checksum, drop the packet because
+			ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS is not set. */
+			usChecksum = ipWRONG_CRC;
+		}
+		#else
+		{
+			/* Sender hasn't set the checksum, no use to calculate it. */
+			usChecksum = ipCORRECT_CRC;
+		}
+		#endif
 		location = 8;
 		goto error_exit;
 	}


### PR DESCRIPTION
<!--- Title -->

UDP: Add ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS compile time constant
-----------

Description
-----------
In compliance with the UDP protocol specification the FreeRTOS+TCP stack currently processes UDP packets that have their checksum field set to 0.  This update introduces a new compile time constant `ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS` that defaults to 0.  The TCP/IP stack will drop UDP packets that have their checksum field set to zero unless that constant is set to 1.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.