### PR TITLE
Fix Nuvoton Ethernet Build by updating tinycbor path in project file

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
@@ -374,7 +374,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot;  CONFIG_MEDTLS_USE_AFR_MEMORY RVDS_ARMCM4_NUC4xx __little_endian__=1 NDEBUG M487_ETH_DEMO</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/tinycbor;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -2506,42 +2506,42 @@
 					</Files>
 				</Group>
 				<Group>
-					<GroupName>libraries/3rdparty/tinycbor/</GroupName>
+					<GroupName>libraries/3rdparty/tinycbor/src/</GroupName>
 					<Files>
 						<File>
 							<FileName>cborpretty.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborpretty.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborpretty_stdio.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborpretty_stdio.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty_stdio.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborencoder.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborencoder.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborencoder_close_container_checked.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborencoder_close_container_checked.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborerrorstrings.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborerrorstrings.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborerrorstrings.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborparser.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborparser.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborparser.c</FilePath>
 						</File>
 						<File>
 							<FileName>cborparser_dup_string.c</FileName>
 							<FileType>1</FileType>
-							<FilePath>../../../../../libraries/3rdparty/tinycbor/cborparser_dup_string.c</FilePath>
+							<FilePath>../../../../../libraries/3rdparty/tinycbor/src/cborparser_dup_string.c</FilePath>
 						</File>
 					</Files>
 				</Group>


### PR DESCRIPTION
Fix **Nuvoton Ethernet Build failure** by updating path to `tinycbor` files in project file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.