### PR TITLE
Count only A records in DNS resolution logic

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1182,7 +1182,7 @@ uint16_t usType = 0U;
 		{
 			const uint16_t usCount = ( uint16_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
 
-			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( x < usCount ); x++ )
+			for( x = 0U; x < pxDNSMessageHeader->usAnswers; x++ )
 			{
 			BaseType_t xDoAccept;
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1206,9 +1206,9 @@ uint16_t usType = 0U;
 		if( ( pxDNSMessageHeader->usFlags & dnsRX_FLAGS_MASK ) == dnsEXPECTED_RX_FLAGS )
 		{
 			const uint16_t usCount = ( uint16_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
-			uint16_t ulNumARecordsStored = 0;
+			uint16_t usNumARecordsStored = 0;
 
-			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( ulNumARecordsStored < usCount ); x++ )
+			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( usNumARecordsStored < usCount ); x++ )
 			{
                 BaseType_t xDoAccept;
 
@@ -1287,7 +1287,7 @@ uint16_t usType = 0U;
 							if( xDoStore != pdFALSE )
 							{
 								( void ) prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
-                                ulNumARecordsStored++;    /* Track # of A records stored */
+                                usNumARecordsStored++;    /* Track # of A records stored */
 							}
 
 							FreeRTOS_inet_ntop( FREERTOS_AF_INET, ( const void * ) &( ulIPAddress ), cBuffer, sizeof( cBuffer ) );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1206,10 +1206,11 @@ uint16_t usType = 0U;
 		if( ( pxDNSMessageHeader->usFlags & dnsRX_FLAGS_MASK ) == dnsEXPECTED_RX_FLAGS )
 		{
 			const uint16_t usCount = ( uint16_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
+			uint16_t ulNumARecordsStored = 0;
 
-			for( x = 0U; x < pxDNSMessageHeader->usAnswers; x++ )
+			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( ulNumARecordsStored < usCount ); x++ )
 			{
-			BaseType_t xDoAccept;
+                BaseType_t xDoAccept;
 
 				uxResult = prvSkipNameField( pucByte,
 											 uxSourceBytesRemaining );
@@ -1286,6 +1287,7 @@ uint16_t usType = 0U;
 							if( xDoStore != pdFALSE )
 							{
 								( void ) prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
+                                ulNumARecordsStored++;    /* Track # of A records stored */
 							}
 
 							FreeRTOS_inet_ntop( FREERTOS_AF_INET, ( const void * ) &( ulIPAddress ), cBuffer, sizeof( cBuffer ) );

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1210,7 +1210,7 @@ uint16_t usType = 0U;
 
 			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( usNumARecordsStored < usCount ); x++ )
 			{
-                BaseType_t xDoAccept;
+				BaseType_t xDoAccept;
 
 				uxResult = prvSkipNameField( pucByte,
 											 uxSourceBytesRemaining );
@@ -1287,7 +1287,7 @@ uint16_t usType = 0U;
 							if( xDoStore != pdFALSE )
 							{
 								( void ) prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
-                                usNumARecordsStored++;    /* Track # of A records stored */
+								usNumARecordsStored++;    /* Track # of A records stored */
 							}
 
 							FreeRTOS_inet_ntop( FREERTOS_AF_INET, ( const void * ) &( ulIPAddress ), cBuffer, sizeof( cBuffer ) );


### PR DESCRIPTION
<!--- Title -->
Correct DNS resolution logic

Description
-----------
<!--- Describe your changes in detail -->
The DNS resolution logic should only count A records (which are stored) when determining whether or not to stop processing records.  Previously the logic was counting all records (e.g. CNAME) in this logic.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.