### PR TITLE
Fix GreenGrass Discovery demo failure in Nuvoton Ethernet board

### DIFF
--- a/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
@@ -173,7 +173,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
                 if( returnCode != SOCKETS_ERROR_NONE )
                 {
-                    ggdconfigPRINT( "SOCKETS_Connect call failed: ServerAddress=%d, Port=%d, ReturnCode=%d\r\n",
+                    ggdconfigPRINT( "SOCKETS_Connect call failed: ServerAddress=%lu, Port=%u, ReturnCode=%d\r\n",
                                     xServerAddress.ulAddress, xServerAddress.usPort, returnCode );
                     GGD_SecureConnect_Disconnect( pxSocket );
                     xStatus = pdFAIL;

--- a/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
@@ -65,6 +65,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
     size_t xURLLength;
     BaseType_t xIsIPAddress;
     BaseType_t xStatus;
+    int32_t returnCode;
 
     configASSERT( pxHostAddressData != NULL );
     configASSERT( pxSocket != NULL );
@@ -130,26 +131,35 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
             if( pxHostAddressData->pcCertificate != NULL )
             {
-                if( SOCKETS_SetSockOpt( *pxSocket,
-                                        0,
-                                        SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE,
-                                        pxHostAddressData->pcCertificate,
-                                        ( size_t ) pxHostAddressData->ulCertificateSize )
-                    != SOCKETS_ERROR_NONE )
+                /* Override TLS trust store with server certificate. */
+                returnCode = SOCKETS_SetSockOpt( *pxSocket,
+                                                 0,
+                                                 SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE,
+                                                 pxHostAddressData->pcCertificate,
+                                                 ( size_t ) pxHostAddressData->ulCertificateSize );
+
+                if( returnCode != SOCKETS_ERROR_NONE )
                 {
+                    ggdconfigPRINT( "Failure in SOCKET_SetSockOpt call for overriding TLS trust store: "
+                                    "ReturnCode=%d\r\n", returnCode );
                     xStatus = pdFAIL;
                 }
             }
 
             if( xIsIPAddress == pdFALSE )
             {
-                if( SOCKETS_SetSockOpt( *pxSocket,
-                                        0,
-                                        SOCKETS_SO_SERVER_NAME_INDICATION,
-                                        pxHostAddressData->pcHostAddress,
-                                        ( size_t ) 1 + xURLLength )
-                    != SOCKETS_ERROR_NONE )
+                /* Enable use of SNI in TLS. */
+                returnCode = SOCKETS_SetSockOpt( *pxSocket,
+                                                 0,
+                                                 SOCKETS_SO_SERVER_NAME_INDICATION,
+                                                 pxHostAddressData->pcHostAddress,
+                                                 ( size_t ) 1 + xURLLength );
+
+                if( returnCode != SOCKETS_ERROR_NONE )
                 {
+                    ggdconfigPRINT( "Failure in SOCKET_SetSockOpt call for enabling TLS SNI: "
+                                    "ServerHost=%.*s, ReturnCode=%d\r\n",
+                                    xURLLength, pxHostAddressData->pcHostAddress, returnCode );
                     xStatus = pdFAIL;
                 }
             }
@@ -157,11 +167,14 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
             /* Establish the TCP connection. */
             if( pdPASS == xStatus )
             {
-                if( ( SOCKETS_Connect( *pxSocket,
-                                       &xServerAddress,
-                                       ( uint32_t ) sizeof( xServerAddress ) )
-                      != SOCKETS_ERROR_NONE ) )
+                returnCode = SOCKETS_Connect( *pxSocket,
+                                              &xServerAddress,
+                                              ( uint32_t ) sizeof( xServerAddress ) );
+
+                if( returnCode != SOCKETS_ERROR_NONE )
                 {
+                    ggdconfigPRINT( "SOCKETS_Connect call failed: ServerAddress=%d, Port=%d, ReturnCode=%d\r\n",
+                                    xServerAddress.ulAddress, xServerAddress.usPort, returnCode );
                     GGD_SecureConnect_Disconnect( pxSocket );
                     xStatus = pdFAIL;
                 }

--- a/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
@@ -109,7 +109,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
             if( xServerAddress.ulAddress == 0u )
             {
-                ggdconfigPRINT( "ERROR! Failed to resolve host address: Address=%.*s",
+                ggdconfigPRINT( "ERROR! Failed to resolve host address: ServerHost=%.*s",
                                 xURLLength, pxHostAddressData->pcHostAddress );
             }
 

--- a/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
+++ b/libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c
@@ -106,6 +106,13 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
             xServerAddress.usPort = SOCKETS_htons( pxHostAddressData->usPort );
             xServerAddress.ulAddress =
                 SOCKETS_GetHostByName( pxHostAddressData->pcHostAddress );
+
+            if( xServerAddress.ulAddress == 0u )
+            {
+                ggdconfigPRINT( "ERROR! Failed to resolve host address: Address=%.*s",
+                                xURLLength, pxHostAddressData->pcHostAddress );
+            }
+
             xServerAddress.ucSocketDomain = SOCKETS_AF_INET;
 
             /* Set send timeout for the socket. */
@@ -140,7 +147,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
                 if( returnCode != SOCKETS_ERROR_NONE )
                 {
-                    ggdconfigPRINT( "Failure in SOCKET_SetSockOpt call for overriding TLS trust store: "
+                    ggdconfigPRINT( "ERROR! Failure in SOCKET_SetSockOpt call for overriding TLS trust store: "
                                     "ReturnCode=%d\r\n", returnCode );
                     xStatus = pdFAIL;
                 }
@@ -157,7 +164,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
                 if( returnCode != SOCKETS_ERROR_NONE )
                 {
-                    ggdconfigPRINT( "Failure in SOCKET_SetSockOpt call for enabling TLS SNI: "
+                    ggdconfigPRINT( "ERROR! Failure in SOCKET_SetSockOpt call for enabling TLS SNI: "
                                     "ServerHost=%.*s, ReturnCode=%d\r\n",
                                     xURLLength, pxHostAddressData->pcHostAddress, returnCode );
                     xStatus = pdFAIL;
@@ -173,7 +180,7 @@ BaseType_t GGD_SecureConnect_Connect( const GGD_HostAddressData_t * pxHostAddres
 
                 if( returnCode != SOCKETS_ERROR_NONE )
                 {
-                    ggdconfigPRINT( "SOCKETS_Connect call failed: ServerAddress=%lu, Port=%u, ReturnCode=%d\r\n",
+                    ggdconfigPRINT( "ERROR! SOCKETS_Connect call failed: ServerAddress=%lu, Port=%u, ReturnCode=%d\r\n",
                                     xServerAddress.ulAddress, xServerAddress.usPort, returnCode );
                     GGD_SecureConnect_Disconnect( pxSocket );
                     xStatus = pdFAIL;

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -143,7 +143,7 @@ void vLoggingPrintf( const char * pcFormat,
                      ... );
 
 /* Map the FreeRTOS printf() to the logging task printf. */
-#define configPRINTF( x )          printf x //vLoggingPrintf x
+#define configPRINTF( x )          vLoggingPrintf x
 
 /* Non-format version thread-safe print */
 #define configPRINT( X )                  vLoggingPrint( X )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -152,7 +152,7 @@ void vLoggingPrintf( const char * pcFormat,
 
 /* Sets the length of the buffers into which logging messages are written - so
  * also defines the maximum length of each log message. */
-#define configLOGGING_MAX_MESSAGE_LENGTH            80
+#define configLOGGING_MAX_MESSAGE_LENGTH            128
 
 /* Set to 1 to prepend each log message with a message number, the task name,
  * and a time stamp. */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -200,7 +200,7 @@ extern uint32_t numaker_ulRand(void);
  * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
  * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
  * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
-#define ipconfigINCLUDE_FULL_INET_ADDR                 0
+#define ipconfigINCLUDE_FULL_INET_ADDR                 1
 
 /* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
  * are available to the IP stack.  The total number of network buffers is limited

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -47,7 +47,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * out the debugging messages. */
 #define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    #define FreeRTOS_debug_printf( X )    vLoggingPrintf( X )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif
 
 /* Set to 1 to print out non debugging messages, for example the output of the

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -45,9 +45,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF   0 //1
+#define ipconfigHAS_DEBUG_PRINTF    0 /*1 */
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    #define FreeRTOS_debug_printf( X )    vLoggingPrintf( X )//configPRINTF( X )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif
 
 /* Set to 1 to print out non debugging messages, for example the output of the
@@ -118,7 +118,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * number generation is performed via this macro to allow applications to use their
  * own random number generation method.  For example, it might be possible to
  * generate a random number by sampling noise on an analogue input. */
-extern uint32_t numaker_ulRand(void);
+extern uint32_t numaker_ulRand( void );
 #define ipconfigRAND32()    numaker_ulRand()
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
@@ -206,7 +206,7 @@ extern uint32_t numaker_ulRand(void);
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         5//16
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         5 /*16 */
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -45,7 +45,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    0 /*1 */
+#define ipconfigHAS_DEBUG_PRINTF    0
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif
@@ -206,7 +206,7 @@ extern uint32_t numaker_ulRand( void );
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         5 /*16 */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         5
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can


### PR DESCRIPTION
### Fix 3 bugs in Nuvoton Vendor configurations:

#### Bug 1: Log messages printed in CI demo runs are mangled. 

A logging task is present to serialize calls to `printf` to ensure that messages from different tasks are not mangled. This requires that all the messages are printed using `vLoggingPrint` and `vLoggingPrintf` which will pass all the messages serially to the logging task. An incorrectly defined `configPRINTF` was causing `printf` to be called directly from multiple tasks resulting in mangled messages. This PR address it by defining  `configPRINTF` to  `vLoggingPrintf`.

#### Bug 2: Incorrect mapping of `FreeRTOS_debug_printf` macro.

`FreeRTOS_debug_printf` macro is called with double parentheses from the codebase and the expectation is that one set of parentheses will be removed when defining it to `vLoggingPrintf`:
```c
#define FreeRTOS_debug_printf( x ) vLoggingPrintf x
```
It was incorrectly defined to `vLoggingPrintf(x)` resulting in build errors when `ipconfigHAS_DEBUG_PRINTF` was defined to 1. This PR fixes it by defining it to  `configPRINTF(x)` which in-turn removes the extra parentheses:
```c
#define FreeRTOS_debug_printf( x ) configPRINTF(x)
#define configPRINTF(x) vLoggingPrintf x
```

#### Bug 3: Greengrass Demo failure in Nuvoton Ethernet board.

Greengrass demo first finds the Grreengrass Core and then connects to it over MQTT. The demo was able to successfully find the core but was failing to connect to it. The reason was the Greengrass Core's address was a public IP and the `FreeRTOS_gethostbyname` was failing to successfully convert it to a uint32_t. The reason is that `FreeRTOS_gethostbyname` requires `FreeRTOS_inet_addr` to be able to handle IP addresses - it was not available because `ipconfigINCLUDE_FULL_INET_ADDR` was defined to 0. This PR address it by defining `ipconfigINCLUDE_FULL_INET_ADDR` to 1.

----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.