### PR TITLE
Updates to Changelog/ReadMe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change Log for FreeRTOS AWS Reference Integrations
 
-## 202007.00 7/14/2020
+## 202007.00 
 
-#### Product Name Change
-- The repository brand name has been changed from `FreeRTOS` to `FreeRTOS AWS Reference Integrations`.
+#### Contents
+- This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 202007.00 July 2020
 
-#### Contents
+### Content
 - This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  These reference integrations are pre-integrated FreeRTOS projects ported to microcontroller-based evaluation boards that demonstrate end-to-end connectivity to AWS IoT.
+This repository contains the `FreeRTOS AWS Reference Integrations', which are pre-integrated FreeRTOS projects that demonstrate connectivity with AWS IoT.  The repository contains projects for many different microcontroller evaluation boards.
 
 ## 202007.00 July 2020
 
@@ -7,9 +7,9 @@ This repository contains the `FreeRTOS AWS Reference Integrations' based on Free
 
 #### Over the Air Update V1.2.0
 
-- Added feature to suspend and resume over-the-air updates (OTA) Agent using new APIs. This allows OTA Agent to resume download after suspending it for any tasks like re-establishing MQTT connection. 
-- Updated OTA demo to suspend OTA operations when the MQTT connection disconnects and try to reconnect with exponential delay and jitter.  After successful connection the demo resumes OTA operations.
-- Added a new OTA config for allowing downgrade and version update. This is provided for testing purpose and configuration is disabled by default.
+- Updated the over-the-air (OTA) agent with the ability to pause and resume an in-progress update.
+- Updated the OTA demo to demonstrate how to suspent an in-progress OTA update should the MQTT connection disconnect, then resume the same update when the MQTT connection reconnects.  In line with best practice, the reconnect logic uses an exponential backoff and jitter algorithm to prevent the MQTT server getting overwhelmed with connection requests if a fleet of devices get dicsonnected and then attmpt to reconnect at the same time.
+- For testing purposes only, it is now posible to use the OTA agent to downgrade a version number or revert to an older version.  This new functionality is disabled by default.
 
 #### New Board: Cypress PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit 
 - New Board: The <b>Cypress PSoC 64</b> board is now qualified with FreeRTOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  
+This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  These reference integrations are pre-integrated FreeRTOS projects ported to microcontroller-based evaluation boards that demonstrate end-to-end connectivity to AWS IoT.
 
 ## 202007.00 July 2020
 
@@ -7,19 +7,17 @@ This repository contains the `FreeRTOS AWS Reference Integrations' based on Free
 
 #### Over the Air Update V1.2.0
 
-- Added feature to suspend and resume OTA Agent using new APIs provided. This allows OTA Agent to resume download after suspending it for any tasks like re-establishing MQTT connection. 
-- OTA Demo is updated to check for MQTT disconnect, suspend OTA operations and try reconnecting with exponential delay and jitter. After successful connection the demo resumes OTA Agent operations.
-- Added new OTA config for allowing downgrade and version update. This is provided for testing purpose and configuration is disabled by default.
+- Added feature to suspend and resume over-the-air updates (OTA) Agent using new APIs. This allows OTA Agent to resume download after suspending it for any tasks like re-establishing MQTT connection. 
+- Updated OTA demo to suspend OTA operations when the MQTT connection disconnects and try to reconnect with exponential delay and jitter.  After successful connection the demo resumes OTA operations.
+- Added a new OTA config for allowing downgrade and version update. This is provided for testing purpose and configuration is disabled by default.
 
-#### Cypress
-- New Board: The <b>CY8CKIT_064S0S2_4343W</b> board is now qualified with FreeRTOS.
+#### New Board: Cypress PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit 
+- New Board: The <b>Cypress PSoC 64</b> board is now qualified with FreeRTOS.
 
-#### Espressif
+#### New Board: ESP32-WROOM-32SE
 
-- New Board: <b>ESP32-WROOM-32SE</b> is now qualified with FreeRTOS. It was previously supported in Preview mode.
-- Support OTA data over HTTP together with BLE on ESP32 when SPIRAM is enabled.
-- Added ESP-IDF component for WiFi provisioning in SoftAP mode. This allows WiFi provisioning of devices through a web-server running on the device and a provisioning mobile application to enter WiFi credentials onto the device for provisioning. This requires use of lwIP as the networking stack.
-
+- New Board: <b>ESP32-WROOM-32SE</b> is now available in the FreeRTOS Console.  
+- 
 ### Updates
 
 #### FreeRTOS+POSIX Utils V1.2.0
@@ -28,13 +26,13 @@ This repository contains the `FreeRTOS AWS Reference Integrations' based on Free
 
 #### MQTT Client Library V2.2.0
 
-- Improvements in Keep-Alive mechanism : MQTT protocol requires PING requests to be sent  when the connection is idle. This update will  stop sending PING requests when connection is not idle. Earlier, the client library would sometimes disconnect the connection during OTA, when traffic is heavy, due to timeout for server PING response. This update fixes the disconnect issue during OTA.
+- Improved the Keep-Alive mechanism: The MQTT library will not send PING requests when connection is not idle, which fixes a disconnect issue during OTA. In prior versions, MQTT would sometimes disconnect during OTA due to timeouts for server PING response.
 - Bug fix for Keep-Alive interval: The MQTT library was incorrectly sending PING requests at intervals greater than the keep alive period sent in the CONNECT request. This change fixes the problem.
 
 #### Secure Sockets LwIP V1.2.0
 
 - Fix invalid memory access - ss_ctx_t context is shared and sent to a user callback. If the socket is closed and subsequently freed during callback execution, the callback can potentially access the invalid context.
-- Add fixes for potential invalid memory accesses, at one place by validating socket handle before de-referencing, and at another place by freeing memory only if it had been previously allocated.
+- Fix two separate issues for potential invalid memory access., at one place by validating socket handle before de-referencing, and at another place by freeing memory only if it had been previously allocated.
 
 #### PKCS#11 V2.1.0
 
@@ -50,8 +48,8 @@ This repository contains the `FreeRTOS AWS Reference Integrations' based on Free
 #### Bluetooth Low Energy Management Library V2.1.0
 
 - Added new API IotBle_SetDeviceName() to set the BLE device name at runtime.
-- Made fixes to IotBle_On() and IotBle_Off() APIs.
-- Accommodate larger-than-expected writes to RXLargeMesg Gatt Characteristic.
+- Fixed IotBle_On() and IotBle_Off() APIs.
+- Accommodate larger-than-expected writes to RXLargeMesg Gatt characteristic.
 
 #### FreeRTOS+TCP V2.2.0
 
@@ -64,10 +62,12 @@ This repository contains the `FreeRTOS AWS Reference Integrations' based on Free
 
 #### Over the Air Update V1.2.0
 
-- Fixed an issue for when an OTA job is force cancelled when its related download is in progress. It was caused due to the self-start timer starting after the OTA job document is received. The fix makes the self-start timer start when the OTA agent on the device starts, before receiving the OTA job.
+- Fixed an issue encountered when an OTA job is force cancelled while the related download is in progress. It was caused due to the self-start timer starting after the OTA job document is received. The fix starts the self-start timer when the OTA agent on the device starts.  
 
 #### Espressif
 
+- Support OTA via HTTP over the BLE channel for ESP32 (when SPIRAM is enabled).
+- Added ESP-IDF component for WiFi provisioning in SoftAP mode. This allows provisioning devices with Wi-Fi credentials via a web-server running on the device and a provisioning mobile application.  This mode requires the use of lwIP as the networking stack. 
 - Replaced ESP-IDF code to be a submodule pointer to the official ESP-IDF repository.
 - Updated LwIP as the default networking stack. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This repository contains the `FreeRTOS AWS Reference Integrations', which are pr
 #### Over the Air Update V1.2.0
 
 - Updated the over-the-air (OTA) agent with the ability to pause and resume an in-progress update.
-- Updated the OTA demo to demonstrate how to suspent an in-progress OTA update should the MQTT connection disconnect, then resume the same update when the MQTT connection reconnects.  In line with best practice, the reconnect logic uses an exponential backoff and jitter algorithm to prevent the MQTT server getting overwhelmed with connection requests if a fleet of devices get dicsonnected and then attmpt to reconnect at the same time.
-- For testing purposes only, it is now posible to use the OTA agent to downgrade a version number or revert to an older version.  This new functionality is disabled by default.
+- Updated the OTA demo to demonstrate how to suspend an in-progress OTA update should the MQTT connection disconnect, then resume the same update when the MQTT connection reconnects. In line with best practice, the reconnect logic uses an exponential backoff and jitter algorithm to prevent the MQTT server getting overwhelmed with connection requests if a fleet of devices get disconnected and then attempt to reconnect at the same time.
+- For testing purposes only, it is now possible to use the OTA agent to downgrade a version number or revert to an older version.  This new functionality is disabled by default.
 
 #### New Board: Cypress PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit 
 - New Board: The <b>Cypress PSoC 64</b> board is now qualified with FreeRTOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for FreeRTOS AWS Reference Integrations
 
-## 202007.00 
+## 202007.00 July 2020
 
 #### Contents
 - This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# Change Log for FreeRTOS AWS Reference Integrations
+# Change Log
+This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  
 
 ## 202007.00 July 2020
-
-### Content
-- This repository contains the `FreeRTOS AWS Reference Integrations' based on FreeRTOS.  
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-This repository contains the `FreeRTOS AWS Reference Integrations', which are pre-integrated FreeRTOS projects that demonstrate connectivity with AWS IoT.  The repository contains projects for many different microcontroller evaluation boards.
+This repository contains the `FreeRTOS AWS Reference Integrations`, which are pre-integrated FreeRTOS projects that demonstrate connectivity with AWS IoT.  The repository contains projects for many different microcontroller evaluation boards.
 
 ## 202007.00 July 2020
 
@@ -32,7 +32,7 @@ This repository contains the `FreeRTOS AWS Reference Integrations', which are pr
 #### Secure Sockets LwIP V1.2.0
 
 - Fix invalid memory access - ss_ctx_t context is shared and sent to a user callback. If the socket is closed and subsequently freed during callback execution, the callback can potentially access the invalid context.
-- Fix two separate issues for potential invalid memory access., at one place by validating socket handle before de-referencing, and at another place by freeing memory only if it had been previously allocated.
+- Fix two separate issues for potential invalid memory access; at one place by validating socket handle before de-referencing, and at another place by freeing memory only if it had been previously allocated.
 
 #### PKCS#11 V2.1.0
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,18 @@ The following MCU boards are supported for FreeRTOS:
 11. **Cypress CYW43907** - [Cypress CYW943907AEVAL1F Evaluation Kit](https://www.cypress.com/documentation/development-kitsboards/cyw943907aeval1f-evaluation-kit)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_43.html)
     * IDE: [WICED Studio](https://community.cypress.com/community/wiced-wifi)
-12. **Marvell MW320** - [Marvell MW320 AWS IoT Starter Kit](https://www.marvell.com/microcontrollers/aws-iot-starter-kit/)
+12. **Cypress PSoC64** - [PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit](https://www.cypress.com/cy8ckit-064S0S2-4343W)
+    * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_psoc64.html)
+    * IDE: [ModusToolbox](https://www.cypress.com/products/modustoolbox-software-environment)
+13. **Marvell MW320** - [Marvell MW320 AWS IoT Starter Kit](https://www.marvell.com/microcontrollers/aws-iot-starter-kit/)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_marvell320.html)
-13. **Marvell MW322** - [Marvell MW322 AWS IoT Starter Kit](https://www.marvell.com/microcontrollers/aws-iot-starter-kit/)
+14. **Marvell MW322** - [Marvell MW322 AWS IoT Starter Kit](https://www.marvell.com/microcontrollers/aws-iot-starter-kit/)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_marvell322.html)
-14. **Nordic nRF52840 DK** - [nRF52840 DK Development kit](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK/)
+15. **Nordic nRF52840 DK** - [nRF52840 DK Development kit](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK/)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_nordic.html)  
-15. **Nuvoton** - [NuMaker-IoT-M487](https://direct.nuvoton.com/en/numaker-iot-m487)
+16. **Nuvoton** - [NuMaker-IoT-M487](https://direct.nuvoton.com/en/numaker-iot-m487)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting-started-nuvoton-m487.html)
-16. **Windows Simulator** - To evaluate FreeRTOS without using MCU-based hardware, you can use the Windows Simulator.
+17. **Windows Simulator** - To evaluate FreeRTOS without using MCU-based hardware, you can use the Windows Simulator.
     * Requirements: Microsoft Windows 7 or newer, with at least a dual core and a hard-wired Ethernet connection
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_windows.html)
     * IDE: [Visual Studio Community Edition](https://www.visualstudio.com/downloads/)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following MCU boards are supported for FreeRTOS:
 11. **Cypress CYW43907** - [Cypress CYW943907AEVAL1F Evaluation Kit](https://www.cypress.com/documentation/development-kitsboards/cyw943907aeval1f-evaluation-kit)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_43.html)
     * IDE: [WICED Studio](https://community.cypress.com/community/wiced-wifi)
-12. **Cypress PSoC64** - [PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit](https://www.cypress.com/cy8ckit-064S0S2-4343W)
+12. **Cypress PSoC 64** - [PSoC 64 Standard Secure AWS Wi-Fi Bluetooth Pioneer Kit](https://www.cypress.com/cy8ckit-064S0S2-4343W)
     * [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_psoc64.html)
     * IDE: [ModusToolbox](https://www.cypress.com/products/modustoolbox-software-environment)
 13. **Marvell MW320** - [Marvell MW320 AWS IoT Starter Kit](https://www.marvell.com/microcontrollers/aws-iot-starter-kit/)

--- a/vendors/cypress/MTB/ota/README.md
+++ b/vendors/cypress/MTB/ota/README.md
@@ -1,4 +1,4 @@
-# PSoC64 OTA Updates
+# PSoC 64 OTA Updates
 
 PSoC® 64 devices have passed all of the required FreeRTOS qualification tests. However, the optional OTA feature implemented in the PSoC 64 Standard Secure AWS firmware library is still pending evaluation. The OTA feature as-implemented currently passes all of the OTA qualification tests except [“aws_ota_test_case_rollback_if_unable_to_connect_after_update.py”](https://github.com/aws/amazon-freertos/tree/202007.00/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_rollback_if_unable_to_connect_after_update.py). 
 

--- a/vendors/cypress/MTB/ota/README.md
+++ b/vendors/cypress/MTB/ota/README.md
@@ -4,4 +4,4 @@ PSoC® 64 devices have passed all of the required FreeRTOS qualification tests. 
 
 When a successfully validated OTA image is applied to a device using the PSoC64 Standard Secure AWS MCU, and the device is unable to communicate with AWS IoT Core, the device will not be able to automatically rollback to the original known good image. This may result in the device being unreachable from AWS IoT Core for any further updates. This functionality is still under development by the Cypress team. 
 
-For more information, please refer to OTA Updates with AWS and the CY8CKIT-064S0S2-4343W Kit  If you have further questions or need technical support, please contact the Cypress Developer Community.
+For more information, please refer to [OTA Updates with AWS and the CY8CKIT-064S0S2-4343W Kit](https://community.cypress.com/docs/DOC-20063).  If you have further questions or need technical support, please contact the [Cypress Developer Community](https://community.cypress.com/community/software-forums/modustoolbox-amazon-freertos-sdk).

--- a/vendors/cypress/MTB/ota/README.md
+++ b/vendors/cypress/MTB/ota/README.md
@@ -2,6 +2,6 @@
 
 PSoC® 64 devices have passed all of the required FreeRTOS qualification tests. However, the optional OTA feature implemented in the PSoC 64 Standard Secure AWS firmware library is still pending evaluation. The OTA feature as-implemented currently passes all of the OTA qualification tests except [“aws_ota_test_case_rollback_if_unable_to_connect_after_update.py”](https://github.com/aws/amazon-freertos/tree/202007.00/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_rollback_if_unable_to_connect_after_update.py). 
 
-When a successfully validated OTA image is applied to a device using the PSoC64 Standard Secure AWS MCU and the device is unable to communicate with AWS IoT Core, the device will not be able to automatically rollback to the original known good image. This may result in the device being unreachable from AWS IoT Core for any further updates. This functionality is still under development by the Cypress team. 
+When a successfully validated OTA image is applied to a device using the PSoC64 Standard Secure AWS MCU, and the device is unable to communicate with AWS IoT Core, the device will not be able to automatically rollback to the original known good image. This may result in the device being unreachable from AWS IoT Core for any further updates. This functionality is still under development by the Cypress team. 
 
 For more information, please refer to OTA Updates with AWS and the CY8CKIT-064S0S2-4343W Kit  If you have further questions or need technical support, please contact the Cypress Developer Community.

--- a/vendors/cypress/MTB/ota/README.md
+++ b/vendors/cypress/MTB/ota/README.md
@@ -1,0 +1,7 @@
+# PSoC64 OTA Updates
+
+PSoC® 64 devices have passed all of the required FreeRTOS qualification tests. However, the optional OTA feature implemented in the PSoC 64 Standard Secure AWS firmware library is still pending evaluation. The OTA feature as-implemented currently passes all of the OTA qualification tests except [“aws_ota_test_case_rollback_if_unable_to_connect_after_update.py”](https://github.com/aws/amazon-freertos/tree/202007.00/tools/ota_e2e_tests/aws_ota_test/aws_ota_test_case_rollback_if_unable_to_connect_after_update.py). 
+
+When a successfully validated OTA image is applied to a device using the PSoC64 Standard Secure AWS MCU and the device is unable to communicate with AWS IoT Core, the device will not be able to automatically rollback to the original known good image. This may result in the device being unreachable from AWS IoT Core for any further updates. This functionality is still under development by the Cypress team. 
+
+For more information, please refer to OTA Updates with AWS and the CY8CKIT-064S0S2-4343W Kit  If you have further questions or need technical support, please contact the Cypress Developer Community.


### PR DESCRIPTION
Updates to various docs for the release.

Description
-----------
1. Update top-level ReadMe to include the PSoC64 (several links are not live yet)
2. Update top-level Changelog to call out FreeRTOS AWS Reference Integrations and removed the release date, to be replaced with release month instead.  
3. Added the Cypress OTA ReadMe - (several links are not live yet)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.