### PR TITLE
Update flash offset align check

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -488,7 +488,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
+        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
+            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -571,7 +572,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
+        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
+            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -660,7 +662,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) )
+        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
+            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -329,12 +329,18 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashReadInfo )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /*
-         * Check the flash size, block size, sector size and flash size
+         * Check the flash size, block size, sector size and page size
          */
         TEST_ASSERT_NOT_EQUAL( 0, pxFlashInfo->ulPageSize );
         TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulPageSize, pxFlashInfo->ulSectorSize );
         TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulSectorSize, pxFlashInfo->ulBlockSize );
         TEST_ASSERT_GREATER_OR_EQUAL( pxFlashInfo->ulBlockSize, pxFlashInfo->ulFlashSize );
+
+        /* Make sure the flash size, block size, sector size and page size are the power of 2 */
+        TEST_ASSERT_EQUAL( 0, pxFlashInfo->ulPageSize & ( pxFlashInfo->ulPageSize - 1 ) );
+        TEST_ASSERT_EQUAL( 0, pxFlashInfo->ulSectorSize & ( pxFlashInfo->ulSectorSize - 1 ) );
+        TEST_ASSERT_EQUAL( 0, pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) );
+        TEST_ASSERT_EQUAL( 0, pxFlashInfo->ulFlashSize & ( pxFlashInfo->ulFlashSize - 1 ) );
     }
 
     /* Close flash handle */
@@ -488,8 +494,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
-            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
+        if( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -572,8 +577,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
-            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
+        if( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -662,8 +666,7 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
-            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
+        if( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -488,8 +488,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocks )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
-            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
+        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
+            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -572,8 +572,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedAddress )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
-            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
+        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
+            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )
@@ -662,8 +662,8 @@ TEST( TEST_IOT_FLASH, AFQP_IotFlashEraseFlashBlocksUnAlignedSize )
         TEST_ASSERT_NOT_EQUAL( NULL, pxFlashInfo );
 
         /* Make sure the offset is aligned to BlockSize */
-        if( ( ultestIotFlashStartOffset == ( ultestIotFlashStartOffset & pxFlashInfo->ulBlockSize ) ) || 
-            ( 0 == ( ultestIotFlashStartOffset % pxFlashInfo->ulBlockSize ) ) )
+        if ( ( ( ultestIotFlashStartOffset & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0 ) &&
+            ( pxFlashInfo->ulBlockSize != 0 ) && ( ( pxFlashInfo->ulBlockSize & ( pxFlashInfo->ulBlockSize - 1 ) ) == 0) )
         {
             /* If Erase asyc is supported, register a callback */
             if( pxFlashInfo->ucAsyncSupported )


### PR DESCRIPTION
<!--- Title -->
Update flash offset align check

Description
-----------
<!--- Describe your changes in detail -->

There is flash start offset align check condition in unit test case of test_iot_flash.c 
I think it assumes the flash start offset is less than block size. 
If the flash start offset is set to the even multiple of the block size, the block size alignment check fails. 
For example, 

- pxFlashInfo->ulBlockSize = 0x10000 (64K) 

- ultestIotFlashStartOffset = 2 * pxFlashInfo->ulBlockSize

- Then the alignment check fails. 

This update extends the alignment check condition to support the flash start offset larger than the block size. 


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.