### PR TITLE
Ota/rollback selftest job force cancellation

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -951,7 +951,7 @@ static OTA_Err_t prvProcessJobHandler( OTA_EventData_t * pxEventData )
         /*
          * If the platform is not in the self_test state, initiate file download.
          */
-        if( OTA_GetImageState() != eOTA_ImageState_Testing )
+        if( prvInSelftest() == false )
         {
             /* Init data interface routines */
             xReturn = prvSetDataInterface( &xOTA_DataInterface, xOTA_Agent.pxOTA_Files[ xOTA_Agent.ulFileIndex ].pucProtocols );

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -948,29 +948,44 @@ static OTA_Err_t prvProcessJobHandler( OTA_EventData_t * pxEventData )
     }
     else
     {
-        /* Init data interface routines */
-        xReturn = prvSetDataInterface( &xOTA_DataInterface, xOTA_Agent.pxOTA_Files[ xOTA_Agent.ulFileIndex ].pucProtocols );
-
-        if( xReturn == kOTA_Err_None )
+        /*
+         * If the platform is not in the self_test state, initiate file download.
+         */
+        if( OTA_GetImageState() != eOTA_ImageState_Testing )
         {
-            OTA_LOG_L1( "[%s] Setting OTA data inerface.\r\n", OTA_METHOD_NAME );
+            /* Init data interface routines */
+            xReturn = prvSetDataInterface( &xOTA_DataInterface, xOTA_Agent.pxOTA_Files[ xOTA_Agent.ulFileIndex ].pucProtocols );
 
-            /* Received a valid context so send event to request file blocks. */
-            xEventMsg.xEventId = eOTA_AgentEvent_CreateFile;
-
-            /*Send the event to OTA Agent task. */
-            if( !OTA_SignalEvent( &xEventMsg ) )
+            if( xReturn == kOTA_Err_None )
             {
-                xReturn = kOTA_Err_EventQueueSendFailed;
+                OTA_LOG_L1( "[%s] Setting OTA data inerface.\r\n", OTA_METHOD_NAME );
+
+                /* Received a valid context so send event to request file blocks. */
+                xEventMsg.xEventId = eOTA_AgentEvent_CreateFile;
+
+                /*Send the event to OTA Agent task. */
+                if( !OTA_SignalEvent( &xEventMsg ) )
+                {
+                    xReturn = kOTA_Err_EventQueueSendFailed;
+                }
+            }
+            else
+            {
+                /*
+                 * Failed to set the data interface so abort the OTA.If there is a valid job id,
+                 * then a job status update will be sent.
+                 */
+                ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, xReturn );
             }
         }
         else
         {
             /*
-             * Failed to set the data interface so abort the OTA.If there is a valid job id,
-             * then a job status update will be sent.
+             * Received a job that is not in self-test but platform is, so reboot the device to allow
+             * roll back to previous image.
              */
-            ( void ) prvSetImageStateWithReason( eOTA_ImageState_Aborted, xReturn );
+            OTA_LOG_L1( "[%s] Platform is in self-test but job is not, rebooting !  \r\n", OTA_METHOD_NAME );
+            ( void ) xOTA_Agent.xPALCallbacks.xResetDevice( xOTA_Agent.ulServerFileID );
         }
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Use the platform get state function instead of the OTA Agent get state. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.