### PR TITLE
OTA: Use platform get state function in processjobhandler

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -951,7 +951,7 @@ static OTA_Err_t prvProcessJobHandler( OTA_EventData_t * pxEventData )
         /*
          * If the platform is not in the self_test state, initiate file download.
          */
-        if( OTA_GetImageState() != eOTA_ImageState_Testing )
+        if( prvInSelftest() == false )
         {
             /* Init data interface routines */
             xReturn = prvSetDataInterface( &xOTA_DataInterface, xOTA_Agent.pxOTA_Files[ xOTA_Agent.ulFileIndex ].pucProtocols );


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This change uses the platform image state function instead of OTA image state. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.