### PR TITLE
Hygiene changes for new macros in FreeRTOS+TCP config defaults

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
@@ -317,20 +317,22 @@ from the FreeRTOSIPConfig.h configuration header file. */
 	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND	1
 #endif
 
-
+/* Configuration to control whether packets with IP options,
+ * received over the network, should be passed up to the 
+ * software stack OR should be dropped.
+ * Value of 0 of causes packets with IP options to be dropped
+ * while value of 1 passes them up the stack.
+ */
 #ifndef ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS
 	#define ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS	1
 #endif
 
-#ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
-	#define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS	0
-#endif
-
-
-#ifndef ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS
-	#define ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS	1
-#endif
-
+/* Configuration to control whether IP packets with 
+ * checksum value of zero should be passed up the software
+ * stack OR should be dropped.
+ * Value of 0 of causes zero checksum packets to be dropped
+ * while value of 1 passes them up the stack.
+ */
 #ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
 	#define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS	0
 #endif

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h
@@ -320,18 +320,21 @@ from the FreeRTOSIPConfig.h configuration header file. */
 /* Configuration to control whether packets with IP options,
  * received over the network, should be passed up to the 
  * software stack OR should be dropped.
- * Value of 0 of causes packets with IP options to be dropped
- * while value of 1 passes them up the stack.
+ * If set to 1, the stack accepts IP packets that contain IP options, but does
+ * not process the options (IP options are not supported).
+ * If set to 0, the stack will drop IP packets that contain IP options.
  */
 #ifndef ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS
 	#define ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS	1
 #endif
 
-/* Configuration to control whether IP packets with 
+/* Configuration to control whether UDP packets with 
  * checksum value of zero should be passed up the software
  * stack OR should be dropped.
- * Value of 0 of causes zero checksum packets to be dropped
- * while value of 1 passes them up the stack.
+ * If set to 1, the stack will accept UDP packets that have their checksum 
+ * value set to 0.
+ * If set to 0, the stack will drop UDP packets that have their checksum value
+ * set to 0.
  */
 #ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
 	#define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS	0


### PR DESCRIPTION
* Remove duplication of default config definition for `ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS` and `ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS`
* Add helpful documentation for explaining utility of macros


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.