### PR TITLE
Correct error reporting in demo

### DIFF
--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -56,7 +56,7 @@
 #include "aws_demo_config.h"
 
 /* Dimensions the buffer used to generate the task name. */
-#define echoMAX_TASK_NAME_LENGTH    8
+#define echoMAX_TASK_NAME_LENGTH        8
 
 /* Maximum connection count. */
 #define echoMAXIMUM_CONNECTION_COUNT    10
@@ -211,6 +211,7 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     }
 
     xX = 0;
+
     /* Count the number of successes. */
     while( xX < echoNUM_ECHO_CLIENTS )
     {
@@ -218,8 +219,8 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
     }
 
     /* Calculate the percentage of successful connections across all connections. */
-    SuccessPercent = ( (float)SuccessfulConnections / ( echoNUM_ECHO_CLIENTS * echoMAX_LOOP_COUNT * echoMAXIMUM_CONNECTION_COUNT ) );
-    
+    SuccessPercent = ( ( float ) SuccessfulConnections / ( echoNUM_ECHO_CLIENTS * echoMAX_LOOP_COUNT * echoMAXIMUM_CONNECTION_COUNT ) );
+
     if( SuccessPercent > echoSUCCESS_THRESHOLD )
     {
         /* Number of successful connections more than threshold. Return Success. */

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -387,6 +387,7 @@ static void prvEchoClientTask( void * pvParameters )
                         ulTxRxCycles[ xInstance ]++;
                         configPRINTF( ( "Received correct string from echo server.\r\n" ) );
 
+                        /* Increment success count. */
                         xSuccess[ xInstance ]++;
                     }
                     else
@@ -394,13 +395,12 @@ static void prvEchoClientTask( void * pvParameters )
                         /* The received string did not match the transmitted
                          * string. */
                         ulTxRxFailures[ xInstance ]++;
-
                         configPRINTF( ( "ERROR - Received incorrect string from echo server.\r\n" ) );
                         break;
                     }
                 }
                 else if( xReceivedBytes == -pdFREERTOS_ERRNO_ENOTCONN )
-                {                        
+                {
                     /* The connection got closed. */
                     break;
                 }

--- a/demos/tcp/aws_tcp_echo_client_single_task.c
+++ b/demos/tcp/aws_tcp_echo_client_single_task.c
@@ -58,6 +58,15 @@
 /* Dimensions the buffer used to generate the task name. */
 #define echoMAX_TASK_NAME_LENGTH    8
 
+/* Maximum connection count. */
+#define echoMAXIMUM_CONNECTION_COUNT    10
+
+/* Maximum Loop count. */
+#define echoMAX_LOOP_COUNT              10
+
+/* The threshold to declare this demo as successful. Range: 0 - 1. */
+#define echoSUCCESS_THRESHOLD           0.95
+
 /* Sanity check the configuration constants required by this demo are
  * present. */
 #if !defined( configECHO_SERVER_ADDR0 ) || !defined( configECHO_SERVER_ADDR1 ) || !defined( configECHO_SERVER_ADDR2 ) || !defined( configECHO_SERVER_ADDR3 )
@@ -156,7 +165,7 @@ static char cTxBuffers[ echoNUM_ECHO_CLIENTS ][ echoBUFFER_SIZES ],
 
 /* Create a semaphore to sync all Echo task(s). */
 static SemaphoreHandle_t EchoSingleSemaphore;
-
+BaseType_t xSuccess[ echoNUM_ECHO_CLIENTS ];
 
 int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
                                           const char * pIdentifier,
@@ -165,8 +174,9 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
                                           const IotNetworkInterface_t * pNetworkInterface )
 {
     BaseType_t xX;
-    BaseType_t TaskCompleteCounter;
+    BaseType_t TaskCompleteCounter, SuccessfulConnections = 0;
     char cNameBuffer[ echoMAX_TASK_NAME_LENGTH ];
+    float SuccessPercent = 0;
 
     /* Unused parameters */
     ( void ) awsIotMqttMode;
@@ -200,8 +210,26 @@ int vStartTCPEchoClientTasks_SingleTasks( bool awsIotMqttMode,
         TaskCompleteCounter++;
     }
 
-    /* Return Success. */
-    return EXIT_SUCCESS;
+    xX = 0;
+    /* Count the number of successes. */
+    while( xX < echoNUM_ECHO_CLIENTS )
+    {
+        SuccessfulConnections += xSuccess[ xX++ ];
+    }
+
+    /* Calculate the percentage of successful connections across all connections. */
+    SuccessPercent = ( (float)SuccessfulConnections / ( echoNUM_ECHO_CLIENTS * echoMAX_LOOP_COUNT * echoMAXIMUM_CONNECTION_COUNT ) );
+    
+    if( SuccessPercent > echoSUCCESS_THRESHOLD )
+    {
+        /* Number of successful connections more than threshold. Return Success. */
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        /* Number of successful connections less than threshold. Return Failure. */
+        return EXIT_FAILURE;
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -210,7 +238,7 @@ static void prvEchoClientTask( void * pvParameters )
     Socket_t xSocket;
 /*_RB_ struct convention is for this not to be typedef'ed, so 'struct' is required. */ SocketsSockaddr_t xEchoServerAddress;
     int32_t lLoopCount = 0UL;
-    const int32_t lMaxLoopCount = 10;
+    const int32_t lMaxLoopCount = echoMAX_LOOP_COUNT;
     volatile uint32_t ulTxCount = 0UL;
     BaseType_t xReceivedBytes, xReturned, xInstance;
     BaseType_t xTransmitted, xStringLength;
@@ -218,7 +246,7 @@ static void prvEchoClientTask( void * pvParameters )
     char * pcReceivedString;
     TickType_t xTimeOnEntering;
     BaseType_t lConnectionCount;
-    const BaseType_t lMaxConnectionCount = 10;
+    const BaseType_t lMaxConnectionCount = echoMAXIMUM_CONNECTION_COUNT;
 
     #if ( ipconfigUSE_TCP_WIN == 1 )
         WinProperties_t xWinProps;
@@ -358,18 +386,21 @@ static void prvEchoClientTask( void * pvParameters )
                         /* The echo reply was received without error. */
                         ulTxRxCycles[ xInstance ]++;
                         configPRINTF( ( "Received correct string from echo server.\r\n" ) );
+
+                        xSuccess[ xInstance ]++;
                     }
                     else
                     {
                         /* The received string did not match the transmitted
                          * string. */
                         ulTxRxFailures[ xInstance ]++;
+
                         configPRINTF( ( "ERROR - Received incorrect string from echo server.\r\n" ) );
                         break;
                     }
                 }
                 else if( xReceivedBytes == -pdFREERTOS_ERRNO_ENOTCONN )
-                {
+                {                        
                     /* The connection got closed. */
                     break;
                 }


### PR DESCRIPTION
Description
-----------
The TCP echo demo erroneously reported success even when the connection had failed. This PR rectifies the error with the demo returning success/failure depending on the actual statistics of the connections.
The user can choose the threshold for the number of failures before the demo will be deemed to have failed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.