### PR TITLE
Fix precompiler if should be ifdef in ota agent

### DIFF
--- a/libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h
+++ b/libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h
@@ -405,7 +405,7 @@ typedef struct OTA_FileContext
     {
         int32_t lFileHandle;    /*!< Device internal file pointer or handle.
                                  * File type is handle after file is open for write. */
-        #if WIN32
+        #ifdef WIN32
             FILE * pxFile;      /*!< File type is stdio FILE structure after file is open for write. */
         #endif
         uint8_t * pucFile;      /*!< File type is RAM/Flash image pointer after file is open for write. */


### PR DESCRIPTION
Fix precompiler if should be ifdef in ota agent

Description
-----------
Just very minor change, this fails with stricter compilation settings otherwise:

```
aws_iot_ota_agent.h:408:13: error: "WIN32" is not defined, evaluates to 0 [-Werror=undef]
         #if WIN32
             ^~~~~
cc1: all warnings being treated as errors
```

Checklist:
----------
- [  ] I have tested my changes. No regression in existing tests.
- [  ] My code is Linted.
(didn't take the effort, i assume very much both are still true, also couldn't find doc to quickly run tests and lint, should be some cmake targets? pointers appreciated if necessary :/ ) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.