### PR TITLE
MISRA compliance changes in FreeRTOS_Sockets{.c/.h}

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
@@ -217,7 +217,7 @@ typedef struct xSOCKET *Socket_t;
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/FreeRTOS_TCP_API_Functions.html
  */
 Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol );
-int32_t FreeRTOS_recvfrom( const Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, socklen_t *pxSourceAddressLength );
+int32_t FreeRTOS_recvfrom( const Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, const socklen_t *pxSourceAddressLength );
 int32_t FreeRTOS_sendto( Socket_t xSocket, const void *pvBuffer, size_t uxTotalDataLength, BaseType_t xFlags, const struct freertos_sockaddr *pxDestinationAddress, socklen_t xDestinationAddressLength );
 BaseType_t FreeRTOS_bind( Socket_t xSocket, struct freertos_sockaddr const * pxAddress, socklen_t xAddressLength );
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
@@ -217,12 +217,12 @@ typedef struct xSOCKET *Socket_t;
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/FreeRTOS_TCP_API_Functions.html
  */
 Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol );
-int32_t FreeRTOS_recvfrom( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, socklen_t *pxSourceAddressLength );
+int32_t FreeRTOS_recvfrom( const Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, socklen_t *pxSourceAddressLength );
 int32_t FreeRTOS_sendto( Socket_t xSocket, const void *pvBuffer, size_t uxTotalDataLength, BaseType_t xFlags, const struct freertos_sockaddr *pxDestinationAddress, socklen_t xDestinationAddressLength );
 BaseType_t FreeRTOS_bind( Socket_t xSocket, struct freertos_sockaddr const * pxAddress, socklen_t xAddressLength );
 
 /* function to get the local address and IP port */
-size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+size_t FreeRTOS_GetLocalAddress( const Socket_t xSocket, struct freertos_sockaddr *pxAddress );
 
 #if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
 	/* Returns true if an UDP socket exists bound to mentioned port number. */
@@ -231,7 +231,7 @@ size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxA
 
 #if ipconfigUSE_TCP == 1
 
-BaseType_t FreeRTOS_connect( Socket_t xClientSocket, struct freertos_sockaddr *pxAddress, socklen_t xAddressLength );
+BaseType_t FreeRTOS_connect( Socket_t xClientSocket, const struct freertos_sockaddr *pxAddress, socklen_t xAddressLength );
 BaseType_t FreeRTOS_listen( Socket_t xSocket, BaseType_t xBacklog );
 BaseType_t FreeRTOS_recv( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags );
 BaseType_t FreeRTOS_send( Socket_t xSocket, const void *pvBuffer, size_t uxDataLength, BaseType_t xFlags );
@@ -253,18 +253,18 @@ BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr
 #if( ipconfigUSE_TCP == 1 )
 
 	/* returns pdTRUE if TCP socket is connected */
-	BaseType_t FreeRTOS_issocketconnected( Socket_t xSocket );
+	BaseType_t FreeRTOS_issocketconnected( const Socket_t xSocket );
 
 	/* returns the actual size of MSS being used */
-	BaseType_t FreeRTOS_mss( Socket_t xSocket );
+	BaseType_t FreeRTOS_mss( const Socket_t xSocket );
 
 #endif
 
-/* for internal use only: return the connection status */
-BaseType_t FreeRTOS_connstatus( Socket_t xSocket );
+/* For internal use only: return the connection status. */
+BaseType_t FreeRTOS_connstatus( const Socket_t xSocket );
 
 /* Returns the number of bytes that may be added to txStream */
-BaseType_t FreeRTOS_maywrite( Socket_t xSocket );
+BaseType_t FreeRTOS_maywrite( const Socket_t xSocket );
 
 /*
  * Two helper functions, mostly for testing
@@ -272,9 +272,9 @@ BaseType_t FreeRTOS_maywrite( Socket_t xSocket );
  * tx_space returns the free space in the Tx buffer
  */
 #if( ipconfigUSE_TCP == 1 )
-	BaseType_t FreeRTOS_rx_size( Socket_t xSocket );
-	BaseType_t FreeRTOS_tx_space( Socket_t xSocket );
-	BaseType_t FreeRTOS_tx_size( Socket_t xSocket );
+	BaseType_t FreeRTOS_rx_size( const Socket_t xSocket );
+	BaseType_t FreeRTOS_tx_space( const Socket_t xSocket );
+	BaseType_t FreeRTOS_tx_size( const Socket_t xSocket );
 #endif
 
 /* Returns the number of outstanding bytes in txStream. */
@@ -382,7 +382,7 @@ const char *FreeRTOS_inet_ntop4( const void *pvSource, char *pcDestination, sock
  * For the web server: borrow the circular Rx buffer for inspection
  * HTML driver wants to see if a sequence of 13/10/13/10 is available
  */
-const struct xSTREAM_BUFFER *FreeRTOS_get_rx_buf( Socket_t xSocket );
+const struct xSTREAM_BUFFER *FreeRTOS_get_rx_buf( const Socket_t xSocket );
 
 void FreeRTOS_netstat( void );
 

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c
@@ -781,8 +781,6 @@ EventBits_t xEventBits = ( EventBits_t ) 0;
 				the received data can be copied, but a pointer that must be set to
 				point to the buffer in which the received data has already been
 				placed. */
-				/* 9079: (Note -- conversion from pointer to void to pointer to other type [MISRA 2012 Rule 11.5, advisory]) */
-				/* 9087: (Note -- cast performed between a pointer to object type and a pointer to a different object type [MISRA 2012 Rule 11.3, required]) */
 				*( ( void** ) pvBuffer ) = ipPOINTER_CAST( void *, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ) );
 			}
 

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/jitp/config_files/FreeRTOSIPConfig.h
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/jitp/config_files/FreeRTOSIPConfig.h
@@ -121,7 +121,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/wifi_scanner/config_files/FreeRTOSIPConfig.h
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/wifi_scanner/config_files/FreeRTOSIPConfig.h
@@ -121,7 +121,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -134,7 +134,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -134,7 +134,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -142,7 +142,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -136,7 +136,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -142,7 +142,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -136,7 +136,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -139,7 +139,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -132,7 +132,7 @@ extern uint32_t ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS     ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS     ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -138,7 +138,7 @@ extern int rand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -138,7 +138,7 @@ extern int rand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -140,7 +140,7 @@ extern uint32_t numaker_ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -140,7 +140,7 @@ extern uint32_t numaker_ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -131,7 +131,7 @@ extern UBaseType_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -131,7 +131,7 @@ extern UBaseType_t uxRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ uint32_t ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ uint32_t ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ uint32_t ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ uint32_t ulRand(void);
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -131,7 +131,7 @@ extern UBaseType_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -131,7 +131,7 @@ extern UBaseType_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -128,7 +128,7 @@ free) the network buffers are themselves blocked waiting for a network buffer.
 ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
 milliseconds can be converted to a time in ticks by dividing the time in
 milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
 address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -128,7 +128,7 @@ free) the network buffers are themselves blocked waiting for a network buffer.
 ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
 milliseconds can be converted to a time in ticks by dividing the time in
 milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
 address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -129,7 +129,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -123,7 +123,7 @@ extern uint32_t ulRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -142,7 +142,7 @@ extern uint32_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 20000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 20000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSIPConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSIPConfig.h
@@ -136,7 +136,7 @@ extern uint32_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 20000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 20000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If


### PR DESCRIPTION
Description
-----------
This PR adds changes related to MISRA correction in FreeRTOS_Socket.c files.
Some corrections required code rework which has been done and tested Using Full_TCP test suite, Full_TCP_Extended and Full_FreeRTOS_TCP test suite.

Remaining MISRA warnings are regarding:
- Pointer conversions which are essential to map data buffers to various structs.
- Use of #includes after some c-code. These #includes are used in "packing" the structs.
- Use of Unions.

Note to reviewers: GitHub has difficulty figuring out the block and indentation changes. While reviewing please enable the option `"Hide whitespace changes"` in settings or [click here](https://github.com/aws/amazon-freertos/pull/2298/files?diff=split&w=1).


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.