### PR TITLE
MISRA changes FreeRTOS_TCP_IP.c

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
@@ -401,6 +401,7 @@ socket events. */
 		(right) = tmp; \
 	} while ( ipFALSE_BOOL )
 
+/* WARNING: Do NOT use this macro when the array was received as a parameter. */
 #ifndef ARRAY_SIZE
 	#define ARRAY_SIZE(x)	( ( BaseType_t ) ( sizeof( x ) / sizeof( ( x )[ 0 ] ) ) )
 #endif

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.0
+ * FreeRTOS+TCP V2.2.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -1689,7 +1689,7 @@ BaseType_t xResize;
 	{
 		/* Network buffers are created with a fixed size and can hold the largest
 		MTU. */
-		lNeeded = ipTOTAL_ETHERNET_FRAME_SIZE;
+		lNeeded = ( uint32_t ) ipTOTAL_ETHERNET_FRAME_SIZE;
 		/* and therefore, the buffer won't be too small.
 		Only ask for a new network buffer in case none was supplied. */
 		if( pxNetworkBuffer == NULL )

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1142,8 +1142,6 @@ uint32_t ulInitialSequenceNumber = 0;
 static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
 {
 size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
-
-/* Map the ethernet buffer onto the ProtocolHeader_t struct for easy access to the fields. */
 const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
 	&( pxNetworkBuffer->pucEthernetBuffer[ uxTCPHeaderOffset ] ) );
 const TCPHeader_t * pxTCPHeader;

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.2.1
+ * FreeRTOS+TCP V2.3.0
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -703,7 +703,7 @@ BaseType_t xDoRelease = xReleaseAfterSend;
 EthernetHeader_t *pxEthernetHeader;
 uint32_t ulFrontSpace, ulSpace, ulSourceAddress, ulWinSize;
 const TCPWindow_t *pxTCPWindow;
-NetworkBufferDescriptor_t *pxNetworkBuffer = pxDescriptor;	/* To avoid error: "function parameter modified [MISRA 2012 Rule 17.8, advisory]" */
+NetworkBufferDescriptor_t *pxNetworkBuffer = pxDescriptor;
 NetworkBufferDescriptor_t xTempBuffer;
 /* For sending, a pseudo network buffer will be used, as explained above. */
 
@@ -713,11 +713,11 @@ NetworkBufferDescriptor_t xTempBuffer;
 
 		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
 		{
-			xTempBuffer.pxNextBuffer = NULL;
+			pxNetworkBuffer->pxNextBuffer = NULL;
 		}
 		#endif
-		xTempBuffer.pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
-		xTempBuffer.xDataLength = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
+		pxNetworkBuffer->pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
+		pxNetworkBuffer->xDataLength = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
 		xDoRelease = pdFALSE;
 	}
 
@@ -739,6 +739,7 @@ NetworkBufferDescriptor_t xTempBuffer;
 	if( pxNetworkBuffer != NULL )
 	#endif
 	{
+		/* Map the buffer onto a TCPPacket_t struct for easy access to the fields. */
 		pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 		pxIPHeader = &pxTCPPacket->xIPHeader;
 		pxEthernetHeader = &pxTCPPacket->xEthernetHeader;
@@ -1045,7 +1046,8 @@ uint32_t ulInitialSequenceNumber = 0;
 	uint16_t usLength;
 
 		/* The MAC-address of the peer (or gateway) has been found,
-		now prepare the initial TCP packet and some fields in the socket. */
+		 * now prepare the initial TCP packet and some fields in the socket. Map
+		 * the buffer onto the TCPPacket_t struct to easily access it's field. */
 		pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxSocket->u.xTCP.xPacket.u.ucLastPacket );
 		pxIPHeader = &pxTCPPacket->xIPHeader;
 
@@ -1159,43 +1161,47 @@ uint8_t ucLength;
 	if( pxTCPHeader->ucTCPOffset <= ( 5U << 4U ) )
 	{
 		/* Avoid integer underflow in computation of ucLength. */
-		return;
 	}
-	ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
-	uxOptionsLength = ( size_t ) ucLength;
-	if( pxNetworkBuffer->xDataLength > uxOptionOffset )
+	else
 	{
-		/* Validate options size calculation. */
-		if( ( pxNetworkBuffer->xDataLength > uxOptionOffset ) &&
-			( uxOptionsLength <= ( pxNetworkBuffer->xDataLength - uxOptionOffset ) ) )
+		ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
+		uxOptionsLength = ( size_t ) ucLength;
+		if( pxNetworkBuffer->xDataLength > uxOptionOffset )
 		{
-			if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_SYN ) != ( uint8_t ) 0U )
+			/* Validate options size calculation. */
+			if( ( pxNetworkBuffer->xDataLength > uxOptionOffset ) &&
+				( uxOptionsLength <= ( pxNetworkBuffer->xDataLength - uxOptionOffset ) ) )
 			{
-				xHasSYNFlag = pdTRUE;
-			}
-			else
-			{
-				xHasSYNFlag = pdFALSE;
-			}
-			/* The length check is only necessary in case the option data are
-			corrupted, we don't like to run into invalid memory and crash. */
-			for( ;; )
-			{
-				if( uxOptionsLength == 0U )
+				if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_SYN ) != ( uint8_t ) 0U )
 				{
-					/* coverity[break_stmt] : Break statement terminating the loop */
-					break;
+					xHasSYNFlag = pdTRUE;
 				}
-				uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
-				if( uxResult == 0UL )
+				else
 				{
-					break;
+					xHasSYNFlag = pdFALSE;
 				}
-				uxOptionsLength -= uxResult;
-				pucPtr = &( pucPtr[ uxResult ] );
+				/* The length check is only necessary in case the option data are
+				corrupted, we don't like to run into invalid memory and crash. */
+				for( ;; )
+				{
+					if( uxOptionsLength == 0U )
+					{
+						/* coverity[break_stmt] : Break statement terminating the loop */
+						break;
+					}
+					uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
+					if( uxResult == 0UL )
+					{
+						break;
+					}
+					uxOptionsLength -= uxResult;
+					pucPtr = &( pucPtr[ uxResult ] );
+				}
 			}
 		}
 	}
+
+	return;
 }
 /*-----------------------------------------------------------*/
 
@@ -1209,23 +1215,23 @@ size_t uxRemainingOptionsBytes = uxTotalLength;
 uint8_t ucLen;
 size_t uxIndex = 0U;
 TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
+BaseType_t xReturn = pdFALSE;
 
 	if( pucPtr[ 0U ] == tcpTCP_OPT_END )
 	{
 		/* End of options. */
-		return 0U;
+		uxIndex = 0U;
 	}
-	if( pucPtr[ 0U ] == tcpTCP_OPT_NOOP )
+	else if( pucPtr[ 0U ] == tcpTCP_OPT_NOOP )
 	{
 		/* NOP option, inserted to make the length a multiple of 4. */
-		return 1U;
+		uxIndex = 1U;
 	}
-
-	/* Any other well-formed option must be at least two bytes: the option
-	type byte followed by a length byte. */
-	if( uxRemainingOptionsBytes < 2U )
+	else if( uxRemainingOptionsBytes < 2U )
 	{
-		return 0U;
+		/* Any other well-formed option must be at least two bytes: the option
+		type byte followed by a length byte. */
+		uxIndex = 0U;
 	}
 #if( ipconfigUSE_TCP_WIN != 0 )
 	else if( pucPtr[ 0 ] == tcpTCP_OPT_WSOPT )
@@ -1234,15 +1240,18 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 		/* Confirm that the option fits in the remaining buffer space. */
 		if( ( uxRemainingOptionsBytes < tcpTCP_OPT_WSOPT_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_WSOPT_LEN ) )
 		{
-			return 0U;
+			uxIndex = 0U;
 		}
-		/* Option is only valid in SYN phase. */
-		if( xHasSYNFlag != 0 )
+		else
 		{
-			pxSocket->u.xTCP.ucPeerWinScaleFactor = pucPtr[ 2 ];
-			pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
+			/* Option is only valid in SYN phase. */
+			if( xHasSYNFlag != 0 )
+			{
+				pxSocket->u.xTCP.ucPeerWinScaleFactor = pucPtr[ 2 ];
+				pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
+			}
+			uxIndex = tcpTCP_OPT_WSOPT_LEN;
 		}
-		uxIndex = tcpTCP_OPT_WSOPT_LEN;
 	}
 #endif	/* ipconfigUSE_TCP_WIN */
 	else if( pucPtr[ 0 ] == tcpTCP_OPT_MSS )
@@ -1250,44 +1259,55 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 		/* Confirm that the option fits in the remaining buffer space. */
 		if( ( uxRemainingOptionsBytes < tcpTCP_OPT_MSS_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_MSS_LEN ) )
 		{
-			return 0U;
+			uxIndex = 0U;
 		}
-
-		/* An MSS option with the correct option length.  FreeRTOS_htons()
-		is not needed here because usChar2u16() already returns a host
-		endian number. */
-		uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
-
-		if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
+		else
 		{
-			/* Perform a basic check on the the new MSS. */
-			if( uxNewMSS == 0U )
+			/* An MSS option with the correct option length.  FreeRTOS_htons()
+			is not needed here because usChar2u16() already returns a host
+			endian number. */
+			uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
+
+			if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
 			{
-				return 0U;
+				/* Perform a basic check on the the new MSS. */
+				if( uxNewMSS == 0U )
+				{
+					uxIndex = 0U;
+
+					/* Return Condition found. */
+					xReturn = pdTRUE;
+				}
+				else
+				{
+					FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
+				}
 			}
 
-			FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
-		}
-
-		if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
-		{
-			/* our MSS was bigger than the MSS of the other party: adapt it. */
-			pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
-			if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
+			/* If a 'return' condition has not been found. */
+			if( xReturn == pdFALSE )
 			{
-				/* The peer advertises a smaller MSS than this socket was
-				using.  Use that as well. */
-				FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
-				pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-			}
-			pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
-			pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
-			pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
-			pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-			pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-		}
+				if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
+				{
+					/* our MSS was bigger than the MSS of the other party: adapt it. */
+					pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
+					if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
+					{
+						/* The peer advertises a smaller MSS than this socket was
+						using.  Use that as well. */
+						FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
+						pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+					}
+					pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
+					pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
+					pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
+					pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
+					pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+				}
 
-		uxIndex = tcpTCP_OPT_MSS_LEN;
+				uxIndex = tcpTCP_OPT_MSS_LEN;
+			}
+		}
 	}
 	else
 	{
@@ -1299,32 +1319,34 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 			/* If the length field is too small or too big, the options are
 			 * malformed, don't process them further.
 			 */
-			return 0U;
+			uxIndex = 0U;
 		}
-
-		#if( ipconfigUSE_TCP_WIN == 1 )
+		else
 		{
-			/* Selective ACK: the peer has received a packet but it is missing
-			 * earlier packets. At least this packet does not need retransmission
-			 * anymore. ulTCPWindowTxSack( ) takes care of this administration.
-			 */
-			if( pucPtr[ 0U ] == tcpTCP_OPT_SACK_A )
+			#if( ipconfigUSE_TCP_WIN == 1 )
 			{
-				ucLen -= 2U;
-				uxIndex += 2U;
-
-				while( ucLen >= ( uint8_t ) 8U )
+				/* Selective ACK: the peer has received a packet but it is missing
+				 * earlier packets. At least this packet does not need retransmission
+				 * anymore. ulTCPWindowTxSack( ) takes care of this administration.
+				 */
+				if( pucPtr[ 0U ] == tcpTCP_OPT_SACK_A )
 				{
-					prvReadSackOption( pucPtr, uxIndex, pxSocket );
-					uxIndex += 8U;
-					ucLen -= 8U;
-				}
-				/* ucLen should be 0 by now. */
-			}
-		}
-		#endif	/* ipconfigUSE_TCP_WIN == 1 */
+					ucLen -= 2U;
+					uxIndex += 2U;
 
-		uxIndex += ( size_t ) ucLen;
+					while( ucLen >= ( uint8_t ) 8U )
+					{
+						prvReadSackOption( pucPtr, uxIndex, pxSocket );
+						uxIndex += 8U;
+						ucLen -= 8U;
+					}
+					/* ucLen should be 0 by now. */
+				}
+			}
+			#endif	/* ipconfigUSE_TCP_WIN == 1 */
+
+			uxIndex += ( size_t ) ucLen;
+		}
 	}
 	return uxIndex;
 }
@@ -1660,14 +1682,14 @@ static NetworkBufferDescriptor_t *prvTCPBufferResize( const FreeRTOS_Socket_t *p
 	int32_t lDataLen, UBaseType_t uxOptionsLength )
 {
 NetworkBufferDescriptor_t *pxReturn;
-int32_t lNeeded;
+uint32_t lNeeded;
 BaseType_t xResize;
 
 	if( xBufferAllocFixedSize != pdFALSE )
 	{
 		/* Network buffers are created with a fixed size and can hold the largest
 		MTU. */
-		lNeeded = ( int32_t ) ipTOTAL_ETHERNET_FRAME_SIZE;
+		lNeeded = ipTOTAL_ETHERNET_FRAME_SIZE;
 		/* and therefore, the buffer won't be too small.
 		Only ask for a new network buffer in case none was supplied. */
 		if( pxNetworkBuffer == NULL )
@@ -1683,11 +1705,11 @@ BaseType_t xResize;
 	{
 		/* Network buffers are created with a variable size. See if it must
 		grow. */
-		lNeeded = FreeRTOS_max_int32( ( int32_t ) sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ),
-			ipNUMERIC_CAST( int32_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + lDataLen );
+		lNeeded = FreeRTOS_max_uint32( ( uint32_t ) sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ),
+			ipNUMERIC_CAST( uint32_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + lDataLen );
 		/* In case we were called from a TCP timer event, a buffer must be
 		created.  Otherwise, test 'xDataLength' of the provided buffer. */
-		if( ( pxNetworkBuffer == NULL ) || ( pxNetworkBuffer->xDataLength < (size_t)lNeeded ) )
+		if( ( pxNetworkBuffer == NULL ) || ( pxNetworkBuffer->xDataLength < (size_t) lNeeded ) )
 		{
 			xResize = pdTRUE;
 		}
@@ -1702,7 +1724,7 @@ BaseType_t xResize;
 		/* The caller didn't provide a network buffer or the provided buffer is
 		too small.  As we must send-out a data packet, a buffer will be created
 		here. */
-		pxReturn = pxGetNetworkBufferWithDescriptor( ( uint32_t ) lNeeded, 0U );
+		pxReturn = pxGetNetworkBufferWithDescriptor( ( size_t ) lNeeded, 0U );
 
 		if( pxReturn != NULL )
 		{
@@ -1792,6 +1814,9 @@ int32_t lStreamPos;
 			{
 				*ppxNetworkBuffer = pxNewBuffer;
 				pucEthernetBuffer = pxNewBuffer->pucEthernetBuffer;
+
+				/* Map the byte stream onto ProtocolHeaders_t struct for easy
+				 * access to the fields. */
 				pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
 
 				pucSendData = &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ] );
@@ -2137,6 +2162,8 @@ const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *
 	&( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 const TCPHeader_t *pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
 int32_t lLength, lTCPHeaderLength, lReceiveLength, lUrgentLength;
+
+/* Map the buffer onto an IPHeader_t struct for easy access to fields. */
 const IPHeader_t *pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 const size_t xIPHeaderLength = ipSIZE_OF_IPv4_HEADER;
 uint16_t usLength;
@@ -2353,13 +2380,13 @@ uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
 BaseType_t xSendLength = 0;
 
 	/* Either expect a ACK or a SYN+ACK. */
-	uint16_t usExpect = ( uint16_t ) tcpTCP_FLAG_ACK;
+	uint8_t usExpect = tcpTCP_FLAG_ACK;
 	if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
 	{
-		usExpect |= ( uint16_t ) tcpTCP_FLAG_SYN;
+		usExpect |= tcpTCP_FLAG_SYN;
 	}
 
-	if( ipNUMERIC_CAST( uint16_t, ucTCPFlags & 0x17U ) != usExpect )
+	if( ( ucTCPFlags & 0x17U ) != usExpect )
 	{
 		/* eSYN_RECEIVED: flags 0010 expected, not 0002. */
 		/* eSYN_RECEIVED: flags ACK  expected, not SYN. */
@@ -2952,7 +2979,7 @@ static BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t *pxNe
 #else
 	{
 		TCPPacket_t *pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-		const BaseType_t xSendLength = ( BaseType_t )
+		const UBaseType_t xSendLength = ( UBaseType_t )
 			( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
 
 		pxTCPPacket->xTCPHeader.ucTCPFlags = ucTCPFlags;
@@ -3013,6 +3040,8 @@ BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t *pxDescriptor )
 {
 /* Function might modify the parameter. */
 NetworkBufferDescriptor_t *pxNetworkBuffer = pxDescriptor;
+
+/* Map the buffer onto a ProtocolHeaders_t struct for easy access to the fields. */
 const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
 	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 FreeRTOS_Socket_t *pxSocket;
@@ -3031,209 +3060,210 @@ const IPHeader_t *pxIPHeader;
 	/* Check for a minimum packet size. */
 	if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
 	{
-		return pdFAIL;
-	}
-
-	pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-	ulLocalIP = FreeRTOS_htonl( pxIPHeader->ulDestinationIPAddress );
-	ulRemoteIP = FreeRTOS_htonl( pxIPHeader->ulSourceIPAddress );
-
-	/* Find the destination socket, and if not found: return a socket listing to
-	the destination PORT. */
-	pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, xLocalPort, ulRemoteIP, xRemotePort );
-
-	if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == pdFALSE ) )
-	{
-		/* A TCP messages is received but either there is no socket with the
-		given port number or the there is a socket, but it is in one of these
-		non-active states:  eCLOSED, eCLOSE_WAIT, eFIN_WAIT_2, eCLOSING, or
-		eTIME_WAIT. */
-
-		FreeRTOS_debug_printf( ( "TCP: No active socket on port %d (%lxip:%d)\n", xLocalPort, ulRemoteIP, xRemotePort ) );
-
-		/* Send a RST to all packets that can not be handled.  As a result
-		the other party will get a ECONN error.  There are two exceptions:
-		1) A packet that already has the RST flag set.
-		2) A packet that only has the ACK flag set.
-		A packet with only the ACK flag set might be the last ACK in
-	 	a three-way hand-shake that closes a connection. */
-		if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_ACK ) &&
-			( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U ) )
-		{
-			( void ) prvTCPSendReset( pxNetworkBuffer );
-		}
-
-		/* The packet can't be handled. */
 		xResult = pdFAIL;
 	}
 	else
 	{
-		pxSocket->u.xTCP.ucRepCount = 0U;
+		pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+		ulLocalIP = FreeRTOS_htonl( pxIPHeader->ulDestinationIPAddress );
+		ulRemoteIP = FreeRTOS_htonl( pxIPHeader->ulSourceIPAddress );
 
-		if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+		/* Find the destination socket, and if not found: return a socket listing to
+		the destination PORT. */
+		pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, xLocalPort, ulRemoteIP, xRemotePort );
+
+		if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == pdFALSE ) )
 		{
-			/* The matching socket is in a listening state.  Test if the peer
-			has set the SYN flag. */
-			if( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_SYN )
-			{
-				/* What happens: maybe after a reboot, a client doesn't know the
-				connection had gone.  Send a RST in order to get a new connect
-				request. */
-				#if( ipconfigHAS_DEBUG_PRINTF == 1 )
-				{
-				FreeRTOS_debug_printf( ( "TCP: Server can't handle flags: %s from %lxip:%u to port %u\n",
-					prvTCPFlagMeaning( ( UBaseType_t ) ucTCPFlags ), ulRemoteIP, xRemotePort, xLocalPort ) );
-				}
-				#endif /* ipconfigHAS_DEBUG_PRINTF */
+			/* A TCP messages is received but either there is no socket with the
+			given port number or the there is a socket, but it is in one of these
+			non-active states:  eCLOSED, eCLOSE_WAIT, eFIN_WAIT_2, eCLOSING, or
+			eTIME_WAIT. */
 
-				if( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U )
-				{
-					( void ) prvTCPSendReset( pxNetworkBuffer );
-				}
-				xResult = pdFAIL;
-			}
-			else
-			{
-				/* prvHandleListen() will either return a newly created socket
-				(if bReuseSocket is false), otherwise it returns the current
-				socket which will later get connected. */
-				pxSocket = prvHandleListen( pxSocket, pxNetworkBuffer );
+			FreeRTOS_debug_printf( ( "TCP: No active socket on port %d (%lxip:%d)\n", xLocalPort, ulRemoteIP, xRemotePort ) );
 
-				if( pxSocket == NULL )
-				{
-					xResult = pdFAIL;
-				}
+			/* Send a RST to all packets that can not be handled.  As a result
+			the other party will get a ECONN error.  There are two exceptions:
+			1) A packet that already has the RST flag set.
+			2) A packet that only has the ACK flag set.
+			A packet with only the ACK flag set might be the last ACK in
+	 		a three-way hand-shake that closes a connection. */
+			if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_ACK ) &&
+				( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U ) )
+			{
+				( void ) prvTCPSendReset( pxNetworkBuffer );
 			}
-		}	/* if( pxSocket->u.xTCP.ucTCPState == eTCP_LISTEN ). */
+
+			/* The packet can't be handled. */
+			xResult = pdFAIL;
+		}
 		else
 		{
-			/* This is not a socket in listening mode. Check for the RST
-			flag. */
-			if( ( ucTCPFlags & tcpTCP_FLAG_RST ) != 0U )
-			{
-				FreeRTOS_debug_printf( ( "TCP: RST received from %lxip:%u for %u\n", ulRemoteIP, xRemotePort, xLocalPort ) );
+			pxSocket->u.xTCP.ucRepCount = 0U;
 
-				/* Implement https://tools.ietf.org/html/rfc5961#section-3.2. */
-				if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+			if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+			{
+				/* The matching socket is in a listening state.  Test if the peer
+				has set the SYN flag. */
+				if( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_SYN )
 				{
-					/* Per the above RFC, "In the SYN-SENT state ... the RST is
-					acceptable if the ACK field acknowledges the SYN." */
-					if( ulAckNumber == ( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber + 1UL ) )
+					/* What happens: maybe after a reboot, a client doesn't know the
+					connection had gone.  Send a RST in order to get a new connect
+					request. */
+					#if( ipconfigHAS_DEBUG_PRINTF == 1 )
 					{
-						vTCPStateChange( pxSocket, eCLOSED );
+					FreeRTOS_debug_printf( ( "TCP: Server can't handle flags: %s from %lxip:%u to port %u\n",
+						prvTCPFlagMeaning( ( UBaseType_t ) ucTCPFlags ), ulRemoteIP, xRemotePort, xLocalPort ) );
 					}
+					#endif /* ipconfigHAS_DEBUG_PRINTF */
+
+					if( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U )
+					{
+						( void ) prvTCPSendReset( pxNetworkBuffer );
+					}
+					xResult = pdFAIL;
 				}
 				else
 				{
-					/* Check whether the packet matches the next expected sequence number. */
-					if( ulSequenceNumber == pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber )
+					/* prvHandleListen() will either return a newly created socket
+					(if bReuseSocket is false), otherwise it returns the current
+					socket which will later get connected. */
+					pxSocket = prvHandleListen( pxSocket, pxNetworkBuffer );
+
+					if( pxSocket == NULL )
 					{
-						vTCPStateChange( pxSocket, eCLOSED );
+						xResult = pdFAIL;
 					}
-					/* Otherwise, check whether the packet is within the receive window. */
-					else if( ( ulSequenceNumber > pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber ) &&
-							 ( ulSequenceNumber < ( pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber +
-												  pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) ) )
+				}
+			}	/* if( pxSocket->u.xTCP.ucTCPState == eTCP_LISTEN ). */
+			else
+			{
+				/* This is not a socket in listening mode. Check for the RST
+				flag. */
+				if( ( ucTCPFlags & tcpTCP_FLAG_RST ) != 0U )
+				{
+					FreeRTOS_debug_printf( ( "TCP: RST received from %lxip:%u for %u\n", ulRemoteIP, xRemotePort, xLocalPort ) );
+
+					/* Implement https://tools.ietf.org/html/rfc5961#section-3.2. */
+					if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
 					{
-						/* Send a challenge ACK. */
-						( void ) prvTCPSendChallengeAck( pxNetworkBuffer );
+						/* Per the above RFC, "In the SYN-SENT state ... the RST is
+						acceptable if the ACK field acknowledges the SYN." */
+						if( ulAckNumber == ( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber + 1UL ) )
+						{
+							vTCPStateChange( pxSocket, eCLOSED );
+						}
 					}
 					else
 					{
-						/* Nothing. */
+						/* Check whether the packet matches the next expected sequence number. */
+						if( ulSequenceNumber == pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber )
+						{
+							vTCPStateChange( pxSocket, eCLOSED );
+						}
+						/* Otherwise, check whether the packet is within the receive window. */
+						else if( ( ulSequenceNumber > pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber ) &&
+								 ( ulSequenceNumber < ( pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber +
+													  pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) ) )
+						{
+							/* Send a challenge ACK. */
+							( void ) prvTCPSendChallengeAck( pxNetworkBuffer );
+						}
+						else
+						{
+							/* Nothing. */
+						}
 					}
+
+					/* Otherwise, do nothing. In any case, the packet cannot be handled. */
+					xResult = pdFAIL;
 				}
+				else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
+				{
+					/* SYN flag while this socket is already connected. */
+					FreeRTOS_debug_printf( ( "TCP: SYN unexpected from %lxip:%u\n", ulRemoteIP, xRemotePort ) );
 
-				/* Otherwise, do nothing. In any case, the packet cannot be handled. */
-				xResult = pdFAIL;
-			}
-			else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
-			{
-				/* SYN flag while this socket is already connected. */
-				FreeRTOS_debug_printf( ( "TCP: SYN unexpected from %lxip:%u\n", ulRemoteIP, xRemotePort ) );
-
-				/* The packet cannot be handled. */
-				xResult = pdFAIL;
-			}
-			else
-			{
-				/* Update the copy of the TCP header only (skipping eth and IP
-				headers).  It might be used later on, whenever data must be sent
-				to the peer. */
-				const BaseType_t lOffset = ipNUMERIC_CAST( BaseType_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) );
-				( void ) memcpy( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ),
-								 &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ),
-								 ipSIZE_OF_TCP_HEADER );
+					/* The packet cannot be handled. */
+					xResult = pdFAIL;
+				}
+				else
+				{
+					/* Update the copy of the TCP header only (skipping eth and IP
+					headers).  It might be used later on, whenever data must be sent
+					to the peer. */
+					const UBaseType_t lOffset = ipNUMERIC_CAST( UBaseType_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) );
+					( void ) memcpy( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ),
+									 &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ),
+									 ipSIZE_OF_TCP_HEADER );
+				}
 			}
 		}
-	}
 
-	if( xResult != pdFAIL )
-	{
-	uint16_t usWindow;
-
-		/* pxSocket is not NULL when xResult != pdFAIL. */
-		configASSERT( pxSocket != NULL );
-		/* Touch the alive timers because we received a message	for this
-		socket. */
-		prvTCPTouchSocket( pxSocket );
-
-		/* Parse the TCP option(s), if present. */
-		/* _HT_ : if we're in the SYN phase, and peer does not send a MSS option,
-		then we MUST assume an MSS size of 536 bytes for backward compatibility. */
-
-		/* When there are no TCP options, the TCP offset equals 20 bytes, which is stored as
-		the number 5 (words) in the higher nibble of the TCP-offset byte. */
-		if( ( pxProtocolHeaders->xTCPHeader.ucTCPOffset & tcpTCP_OFFSET_LENGTH_BITS ) > tcpTCP_OFFSET_STANDARD_LENGTH )
+		if( xResult != pdFAIL )
 		{
-			prvCheckOptions( pxSocket, pxNetworkBuffer );
-		}
+		uint16_t usWindow;
 
-		usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
-		pxSocket->u.xTCP.ulWindowSize = (uint32_t ) usWindow;
-		#if( ipconfigUSE_TCP_WIN == 1 )
-		{
-			/* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
-			segment itself is never scaled. */
-			if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
+			/* pxSocket is not NULL when xResult != pdFAIL. */
+			configASSERT( pxSocket != NULL );
+			/* Touch the alive timers because we received a message	for this
+			socket. */
+			prvTCPTouchSocket( pxSocket );
+
+			/* Parse the TCP option(s), if present. */
+			/* _HT_ : if we're in the SYN phase, and peer does not send a MSS option,
+			then we MUST assume an MSS size of 536 bytes for backward compatibility. */
+
+			/* When there are no TCP options, the TCP offset equals 20 bytes, which is stored as
+			the number 5 (words) in the higher nibble of the TCP-offset byte. */
+			if( ( pxProtocolHeaders->xTCPHeader.ucTCPOffset & tcpTCP_OFFSET_LENGTH_BITS ) > tcpTCP_OFFSET_STANDARD_LENGTH )
 			{
-				pxSocket->u.xTCP.ulWindowSize =
-					( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
+				prvCheckOptions( pxSocket, pxNetworkBuffer );
 			}
-		}
-		#endif /* ipconfigUSE_TCP_WIN */
 
-		/* In prvTCPHandleState() the incoming messages will be handled
-		depending on the current state of the connection. */
-		if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
-		{
-			/* prvTCPHandleState() has sent a message, see if there are more to
-			be transmitted. */
+			usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
+			pxSocket->u.xTCP.ulWindowSize = (uint32_t ) usWindow;
 			#if( ipconfigUSE_TCP_WIN == 1 )
 			{
-				( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+				/* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
+				segment itself is never scaled. */
+				if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
+				{
+					pxSocket->u.xTCP.ulWindowSize =
+						( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
+				}
 			}
 			#endif /* ipconfigUSE_TCP_WIN */
-		}
 
-		if( pxNetworkBuffer != NULL )
-		{
-			/* We must check if the buffer is unequal to NULL, because the
-			socket might keep a reference to it in case a delayed ACK must be
-			sent. */
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			#ifndef _lint
-			/* Clear pointers that are freed. */
-			pxNetworkBuffer = NULL;
-			#endif
-		}
+			/* In prvTCPHandleState() the incoming messages will be handled
+			depending on the current state of the connection. */
+			if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
+			{
+				/* prvTCPHandleState() has sent a message, see if there are more to
+				be transmitted. */
+				#if( ipconfigUSE_TCP_WIN == 1 )
+				{
+					( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+				}
+				#endif /* ipconfigUSE_TCP_WIN */
+			}
 
-		/* And finally, calculate when this socket wants to be woken up. */
-		( void ) prvTCPNextTimeout ( pxSocket );
-		/* Return pdPASS to tell that the network buffer is 'consumed'. */
-		xResult = pdPASS;
+			if( pxNetworkBuffer != NULL )
+			{
+				/* We must check if the buffer is unequal to NULL, because the
+				socket might keep a reference to it in case a delayed ACK must be
+				sent. */
+				vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+				#ifndef _lint
+				/* Clear pointers that are freed. */
+				pxNetworkBuffer = NULL;
+				#endif
+			}
+
+			/* And finally, calculate when this socket wants to be woken up. */
+			( void ) prvTCPNextTimeout ( pxSocket );
+			/* Return pdPASS to tell that the network buffer is 'consumed'. */
+			xResult = pdPASS;
+		}
 	}
-
 	/* pdPASS being returned means the buffer has been consumed. */
 	return xResult;
 }
@@ -3241,6 +3271,7 @@ const IPHeader_t *pxIPHeader;
 
 static FreeRTOS_Socket_t *prvHandleListen( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer )
 {
+/* Cast the byte stream onto a TCPPacket_t struct for easy access to the fields. */
 const TCPPacket_t * pxTCPPacket = ipPOINTER_CAST( const TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 FreeRTOS_Socket_t *pxReturn = NULL;
 uint32_t ulInitialSequenceNumber;
@@ -3307,6 +3338,7 @@ uint32_t ulInitialSequenceNumber;
 
 	if( ( ulInitialSequenceNumber != 0U ) && ( pxReturn != NULL ) )
 	{
+	/* Map the byte stream onto the ProtocolHeaders_t for easy access to the fields. */
 	const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
 		&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/WWD/wwd_FreeRTOS_systick.h
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/FreeRTOS/WWD/wwd_FreeRTOS_systick.h
@@ -45,7 +45,7 @@ extern "C"
 {
 #endif
 
-#define SYSTICK_FREQUENCY  (1000)
+#define SYSTICK_FREQUENCY  (1000U)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/vendors/cypress/WICED_SDK/WICED/RTOS/NoOS/WWD/wwd_rtos.h
+++ b/vendors/cypress/WICED_SDK/WICED/RTOS/NoOS/WWD/wwd_rtos.h
@@ -60,7 +60,7 @@ extern "C"
 /*
  * The number of system ticks per second
  */
-#define SYSTICK_FREQUENCY  (1000)
+#define SYSTICK_FREQUENCY  (1000U)
 
 /******************************************************
  *             Structures

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/FreeRTOSConfig.h
@@ -139,7 +139,7 @@ extern void vAssertCalled( const char * pcFile,
 #define configUSE_IDLE_HOOK							1
 #define configUSE_TICK_HOOK							1
 #define configCPU_CLOCK_HZ							( 100000000 )
-#define configTICK_RATE_HZ							( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ							( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES						( 7 )
 #define configMINIMAL_STACK_SIZE					( ( unsigned short ) 130 )
 #define configTOTAL_HEAP_SIZE						( ( size_t ) ( 300 * 1024 ) )

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/FreeRTOSConfig.h
@@ -68,7 +68,7 @@ extern void vLoggingPrint( const char * pcMessage );
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 130 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 192U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 10 )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/FreeRTOSConfig.h
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 250 * 1024 ) )
 #define configAPPLICATION_ALLOCATED_HEAP           1

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  
+#define configTICK_RATE_HZ                         ( 1000U )                  
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 250 * 1024 ) )
 #define configAPPLICATION_ALLOCATED_HEAP           1

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/FreeRTOSConfig.h
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  
+#define configTICK_RATE_HZ                         ( 1000U )                  
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 250 * 1024 ) )
 #define configAPPLICATION_ALLOCATED_HEAP           1

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  
+#define configTICK_RATE_HZ                         ( 1000U )                  
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 250 * 1024 ) )
 #define configAPPLICATION_ALLOCATED_HEAP           1

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/FreeRTOSConfig.h
@@ -47,7 +47,7 @@
 #define configUSE_TICK_HOOK			0
 /* #define configCPU_CLOCK_HZ			( ( unsigned long ) 200000000 ) */
 #define configCPU_CLOCK_HZ              	( board_cpu_freq( ) )
-#define configTICK_RATE_HZ			( ( portTickType ) 1000 )
+#define configTICK_RATE_HZ			( ( portTickType ) 1000U )
 #define configMAX_PRIORITIES			( 7 )
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 256 )
 /* #define configTOTAL_HEAP_SIZE		( ( size_t ) ( 72 * 1024 ) ) */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/FreeRTOSConfig.h
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_TICK_HOOK		0
 /* #define configCPU_CLOCK_HZ		( ( unsigned long ) 200000000 ) */
 #define configCPU_CLOCK_HZ           ( board_cpu_freq( ) )
-#define configTICK_RATE_HZ		( ( portTickType ) 1000 )
+#define configTICK_RATE_HZ		( ( portTickType ) 1000U )
 #define configMAX_PRIORITIES		(  7 )
 #define configMINIMAL_STACK_SIZE	( ( unsigned short ) 256 )
 /* #define configTOTAL_HEAP_SIZE		( ( size_t ) ( 72 * 1024 ) ) */

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSConfig.h
@@ -71,7 +71,7 @@ extern uint32_t SystemCoreClock;
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 
 #define configMAX_PRIORITIES                       ( 20 )
-#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #if MTK_WIFI_OS_MM_OPTION == 2
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 135U * 1024U ) )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
@@ -58,7 +58,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 
 #define configMAX_PRIORITIES                       ( 20 )
-#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 256 )
 #if MTK_WIFI_OS_MM_OPTION == 2
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 135U * 1024U ) )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h
@@ -51,7 +51,7 @@
 #define configUSE_TICKLESS_IDLE                    0
 #define configCPU_CLOCK_HZ                         ( 200000000UL )
 #define configPERIPHERAL_CLOCK_HZ                  ( 100000000UL )
-#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                       ( 10UL )
 #define configMINIMAL_STACK_SIZE                   ( 512 )
 #define configISR_STACK_SIZE                       ( 512 )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
 #define configUSE_TICKLESS_IDLE                    0
 #define configCPU_CLOCK_HZ                         ( 200000000UL )
 #define configPERIPHERAL_CLOCK_HZ                  ( 100000000UL )
-#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                         ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                       ( 10UL )
 #define configMINIMAL_STACK_SIZE                   ( 512 )
 #define configISR_STACK_SIZE                       ( 512 )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/FreeRTOSConfig.h
@@ -44,7 +44,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configTICK_RATE_HZ                         ( 1000U )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/FreeRTOSConfig.h
@@ -46,7 +46,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configTICK_RATE_HZ                         ( 1000U )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/FreeRTOSConfig.h
@@ -62,7 +62,7 @@
 #define configUSE_TICKLESS_IDLE                                                   0
 #define configUSE_TICKLESS_IDLE_SIMPLE_DEBUG                                      1 /* See into vPortSuppressTicksAndSleep source code for explanation */
 #define configCPU_CLOCK_HZ                                                        ( SystemCoreClock )
-#define configTICK_RATE_HZ                                                        100
+#define configTICK_RATE_HZ                                                        100U
 #define configMAX_PRIORITIES                                                      ( 15 )
 #define configMINIMAL_STACK_SIZE                                                  ( 600 )
 #define configTOTAL_HEAP_SIZE                                                     ( 175000 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/FreeRTOSConfig.h
@@ -62,7 +62,7 @@
 #define configUSE_TICKLESS_IDLE                                                   0
 #define configUSE_TICKLESS_IDLE_SIMPLE_DEBUG                                      1 /* See into vPortSuppressTicksAndSleep source code for explanation */
 #define configCPU_CLOCK_HZ                                                        ( SystemCoreClock )
-#define configTICK_RATE_HZ                                                        100
+#define configTICK_RATE_HZ                                                        100U
 #define configMAX_PRIORITIES                                                      ( 15 )
 #define configMINIMAL_STACK_SIZE                                                  ( 600 )
 #define configTOTAL_HEAP_SIZE                                                     ( 175000 )

--- a/vendors/nordic/nRF5_SDK_15.2.0/external/freertos/config/FreeRTOSConfig.h
+++ b/vendors/nordic/nRF5_SDK_15.2.0/external/freertos/config/FreeRTOSConfig.h
@@ -60,7 +60,7 @@
 #define configUSE_TICKLESS_IDLE                                                   0
 #define configUSE_TICKLESS_IDLE_SIMPLE_DEBUG                                      1 /* See into vPortSuppressTicksAndSleep source code for explanation */
 #define configCPU_CLOCK_HZ                                                        ( SystemCoreClock )
-#define configTICK_RATE_HZ                                                        1024
+#define configTICK_RATE_HZ                                                        1024U
 #define configMAX_PRIORITIES                                                      ( 3 )
 #define configMINIMAL_STACK_SIZE                                                  ( 60 )
 #define configTOTAL_HEAP_SIZE                                                     ( 4096 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 119 * 1024 ) )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
@@ -55,7 +55,7 @@
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 100 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 247 * 512 ) )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
@@ -55,7 +55,7 @@
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 90 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 100 * 1024 ) )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSConfig.h
@@ -57,7 +57,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 140 * 1024 ) )    /* 140 Kbytes. */

--- a/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/FreeRTOSConfig.h
@@ -44,7 +44,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configTICK_RATE_HZ                         ( 1000U )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/FreeRTOSConfig.h
@@ -46,7 +46,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configTICK_RATE_HZ                         ( 1000U )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 512 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 256U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 12 )

--- a/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 512 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 256U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 12 )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 90 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 60 * 1024 ) )

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_TICKLESS_IDLE                      0
 #define configUSE_DAEMON_TASK_STARTUP_HOOK           1
 #define configCPU_CLOCK_HZ                           ( SystemCoreClock )
-#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                           ( ( TickType_t ) 1000U )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
 #define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 78 * 1024 ) )    /* 78 Kbytes. */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
@@ -55,7 +55,7 @@
 #define configUSE_TIME_SLICING                   0
 #define configUSE_IDLE_HOOK                      0
 #define configUSE_TICK_HOOK                      0
-#define configTICK_RATE_HZ                       ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                       ( ( TickType_t ) 1000U )
 #define configMINIMAL_STACK_SIZE                 ( ( unsigned short ) 90 )
 #define configTOTAL_HEAP_SIZE                    ( ( size_t ) ( 92160 ) )
 #define configMAX_TASK_NAME_LEN                  ( 12 )

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSConfig.h
@@ -53,7 +53,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_TIME_SLICING                   0
 #define configUSE_IDLE_HOOK                      1
 #define configUSE_TICK_HOOK                      0
-#define configTICK_RATE_HZ                       ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                       ( ( TickType_t ) 1000U )
 #define configMINIMAL_STACK_SIZE                 ( ( unsigned short ) 256 )
 #define configTOTAL_HEAP_SIZE                    ( ( size_t ) ( 92160 ) )
 #define configMAX_TASK_NAME_LEN                  ( 12 )

--- a/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/FreeRTOSConfig.h
@@ -49,7 +49,7 @@
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/FreeRTOSConfig.h
@@ -52,7 +52,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PREEMPTION                       1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
 #define configMAX_TASK_NAME_LEN                    ( 15 )

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/FreeRTOSConfig.h
@@ -55,7 +55,7 @@
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configUSE_TICKLESS_IDLE					0
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 //#define configPERIPHERAL_CLOCK_HZ  				( 33333000UL )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 200 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 4 * 1024 * 1024 ) )

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/FreeRTOSConfig.h
@@ -58,7 +58,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #define configUSE_TICKLESS_IDLE					0
 #define configMAX_PRIORITIES                       ( 7 )
-#define configTICK_RATE_HZ                         ( 1000 )
+#define configTICK_RATE_HZ                         ( 1000U )
 //#define configPERIPHERAL_CLOCK_HZ  				( 33333000UL )
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 200 )
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 4 * 1024 * 1024 ) )


### PR DESCRIPTION
Description
-----------
This PR adds changes related to MISRA correction in FreeRTOS_TCP_IP.c file along with config files.
Some corrections required code rework which has been done and tested Using Full_TCP test suite, Full_TCP_Extended and Full_FreeRTOS_TCP test suite.

Remaining MISRA warnings are regarding:

- Pointer conversions which are essential to map data buffers to various structs.
- Use of #includes after some c-code. These #includes are used in "packing" the structs.
- Use of Unions.

Note to reviewers: GitHub has difficulty figuring out the block and indentation changes. While reviewing please enable the option `"Hide whitespace changes"` in settings or [click here](https://github.com/aws/amazon-freertos/pull/2301/files?diff=split&w=1).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.