### PR TITLE
Fix memory leak in pkcs11 implementation.

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2903,6 +2903,9 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
 
         /* Free the mbedTLS structure used to parse the key. */
         mbedtls_pk_free( &xKeyContext );
+
+        /* Free the mbedTLS structure used to parse the certificate. */
+        mbedtls_x509_crt_free( &xMbedX509Context );
     }
 
     return xResult;


### PR DESCRIPTION
Fix memory leak in pkcs11 implementation.

Description
-----------
The x509 certificate context used to parse an object to determine if it was an x509 certificate was never free'd after use.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.