### PR TITLE
MISRA compliance changes in FreeRTOS_TCP_WIN.c

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c
@@ -86,7 +86,7 @@
 #endif /* configUSE_TCP_WIN */
 /*-----------------------------------------------------------*/
 
-extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere );
+static void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere );
 
 /*
  * All TCP sockets share a pool of segment descriptors (TCPSegment_t)
@@ -302,7 +302,7 @@ static portINLINE uint32_t ulTimerGetAge( const TCPTimer_t *pxTimer )
 }
 /*-----------------------------------------------------------*/
 
-void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere )
+static void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere )
 {
 	/* Insert a new list item into pxList, it does not sort the list,
 	but it puts the item just before xListEnd, so it will be the last item
@@ -372,7 +372,6 @@ void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem
 
 		/* Find a segment with a given sequence number in the list of received
 		segments. */
-
 		pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xRxSegments ) );
 
 		for( pxIterator  = listGET_NEXT( pxEnd );


### PR DESCRIPTION
Description
-----------
This PR adds changes related to MISRA correction in FreeRTOS_TCP_WIN.c files.
Some corrections required code rework which has been done and tested Using Full_TCP test suite, Full_TCP_Extended and Full_FreeRTOS_TCP test suite.

Remaining MISRA warnings are regarding:
- Pointer conversions which are essential to map data buffers to various structs.
- Use of #includes after some c-code. These #includes are used in "packing" the structs.
- Use of Unions.

Note to reviewers: GitHub has difficulty figuring out the block and indentation changes. While reviewing please enable the option `"Hide whitespace changes"` in settings or [click here](https://github.com/aws/amazon-freertos/pull/2303/files?diff=split&w=1).


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.