### PR TITLE
Espressif CMake ENV Variables

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -25,6 +25,13 @@ if(AFR_METADATA_MODE)
     set(PYTHON_DEPS_CHECKED 1)
 endif()
 
+if(DEFINED ENV{IDF_PATH})
+    message("WARNING: IDF_PATH environment variable is not cleared. 
+    If CMake is generating an error, consider clearing the IDF_PATH environment 
+    variable, and generating a clean build. This message can be ignored if 
+    CMake was successful.")
+endif()
+
 
 
 set(esp_idf_dir "${AFR_VENDORS_DIR}/espressif/esp-idf")


### PR DESCRIPTION
Espressif CMake ENV Variables

Description
-----------
Add warning message to help user debug environment variable related build issues with Espressif CMake. If IDF_PATH is defined as an Environment variable when trying to generate a build folder, the error messages are unclear and hard to debug.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.