### PR TITLE
ble-wifi-proxy/provisioning: Receive/Handle error codes from phone

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
@@ -45,7 +45,7 @@ typedef enum IotBleDataTransferChannelEvent
     IOT_BLE_DATA_TRANSFER_CHANNEL_DATA_RECEIVED, /**< Event invoked when the last chunk of a large object or a small packet is received on the channel. */
     IOT_BLE_DATA_TRANSFER_CHANNEL_DATA_SENT,     /**< Event invoked after the last chunk of data stream is sent over the channel. */
     IOT_BLE_DATA_TRANSFER_CHANNEL_CLOSED,        /**< Event invoked when the channel is closed. */
-    IOT_BLE_DATA_TRANSFER_CHANNEL_ERROR_UPDATED  /**< Event invoked when error status bits is overwritten */
+    IOT_BLE_DATA_TRANSFER_CHANNEL_PEER_ERROR     /**< Event invoked when error status bits is overwritten */
 } IotBleDataTransferChannelEvent_t;
 
 /**

--- a/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
@@ -168,4 +168,3 @@ uint8_t IotBleDataTransfer_GetPeerError( IotBleDataTransferChannel_t * pChannel 
 
 
 #endif /* IOT_BLE_DATA_TRANSFER_H */
-

--- a/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_data_transfer.h
@@ -44,7 +44,8 @@ typedef enum IotBleDataTransferChannelEvent
     IOT_BLE_DATA_TRANSFER_CHANNEL_OPENED = 0,    /**< Indicates if the channel is opened and ready to read or write data. */
     IOT_BLE_DATA_TRANSFER_CHANNEL_DATA_RECEIVED, /**< Event invoked when the last chunk of a large object or a small packet is received on the channel. */
     IOT_BLE_DATA_TRANSFER_CHANNEL_DATA_SENT,     /**< Event invoked after the last chunk of data stream is sent over the channel. */
-    IOT_BLE_DATA_TRANSFER_CHANNEL_CLOSED         /**< Event invoked when the channel is closed. */
+    IOT_BLE_DATA_TRANSFER_CHANNEL_CLOSED,        /**< Event invoked when the channel is closed. */
+    IOT_BLE_DATA_TRANSFER_CHANNEL_ERROR_UPDATED  /**< Event invoked when error status bits is overwritten */
 } IotBleDataTransferChannelEvent_t;
 
 /**
@@ -158,4 +159,13 @@ void IotBleDataTransfer_Reset( IotBleDataTransferChannel_t * pChannel );
  */
 bool IotBleDataTransfer_Cleanup( void );
 
+/**
+ * @brief Retrieve the current error code reported by Data Transfer peer.
+ *
+ * @return uint8_t a 7-bit error code set by peer
+ */
+uint8_t IotBleDataTransfer_GetPeerError( IotBleDataTransferChannel_t * pChannel );
+
+
 #endif /* IOT_BLE_DATA_TRANSFER_H */
+

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -573,7 +573,7 @@ static void _ControlCharCallback( IotBleAttributeEvent_t * pEventParam )
 
                 if( pService->channel.callback != NULL )
                 {
-                    pService->channel.callback( IOT_BLE_DATA_TRANSFER_CHANNEL_ERROR_UPDATED, &pService->channel, pService->channel.pContext );
+                    pService->channel.callback( IOT_BLE_DATA_TRANSFER_CHANNEL_PEER_ERROR, &pService->channel, pService->channel.pContext );
                 }
             }
 

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -1285,4 +1285,3 @@ uint8_t IotBleDataTransfer_GetPeerError( IotBleDataTransferChannel_t * pChannel 
         return 0u;
     }
 }
-

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_data_transfer.c
@@ -174,18 +174,6 @@ typedef enum IotBleDataTransferAttributes
 } IotBleDataTransferAttributes_t;
 
 /**
- * Control characteristic is used to signify when when the phone is/isn't ready to connect.
- * The phone also uses it to communicate any failure codes to the mcu device
- */
-typedef enum IotBleDataTransferStatus
-{
-    IOT_BLE_DATA_TRANSFER_NOT_READY,
-    IOT_BLE_DATA_TRANSFER_READY,
-    IOT_BLE_DATA_TRANSFER_REMOTE_AUTH_FAIL,
-    IOT_BLE_DATA_TRANSFER_REMOTE_AUTH_PASS
-} IotBleDataTransferStatus_t;
-
-/**
  * @brief Structure used to represent a data channel buffer.
  */
 typedef struct IotBleDataChannelBuffer

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
@@ -98,11 +98,11 @@ static void _callback( IotBleDataTransferChannelEvent_t event,
                     break;
 
                 case BLE_PEER_EMPTY_MQTT_CLIENT_ID:
-                    IotLogError( "BLE Peer: invalid MQTT Client ID" );
+                    IotLogError( "BLE Peer: Invalid MQTT Client ID. For demos, please check clientcredentialIOT_THING_NAME" );
                     break;
 
                 case BLE_PEER_EMPTY_BROKER_ENDPOINT:
-                    IotLogError( "BLE Peer: invalid broker endpoint" );
+                    IotLogError( "BLE Peer: Invalid broker endpoint. For demos, please check clientcredentialMQTT_BROKER_ENDPOINT" );
                     break;
 
                 default:

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
@@ -64,7 +64,8 @@ typedef enum
     BLE_PEER_NO_ERROR,
     BLE_PEER_DISCONNECTED_ERROR,
     BLE_PEER_EMPTY_BROKER_ENDPOINT,
-    BLE_PEER_EMPTY_MQTT_CLIENT_ID
+    BLE_PEER_EMPTY_MQTT_CLIENT_ID,
+    BLE_PEER_COGNITO_AUTH_FAIL
 } BleNetworkError_t;
 
 static void _callback( IotBleDataTransferChannelEvent_t event,
@@ -84,7 +85,7 @@ static void _callback( IotBleDataTransferChannelEvent_t event,
             pBleConnection->pCallback( pBleConnection, pBleConnection->pContext );
             break;
 
-        case IOT_BLE_DATA_TRANSFER_CHANNEL_ERROR_UPDATED:
+        case IOT_BLE_DATA_TRANSFER_CHANNEL_PEER_ERROR:
 
             /* Currently only used for logging, but could short-circuit failure here.
              * At time of writing, such error events could occur but operations would only fail LATER,
@@ -103,6 +104,10 @@ static void _callback( IotBleDataTransferChannelEvent_t event,
 
                 case BLE_PEER_EMPTY_BROKER_ENDPOINT:
                     IotLogError( "BLE Peer: Invalid broker endpoint. For demos, please check clientcredentialMQTT_BROKER_ENDPOINT" );
+                    break;
+
+                case BLE_PEER_COGNITO_AUTH_FAIL:
+                    IotLogError( "BLE Peer: Cognito authentication failed. Please review policies and app cognito settings" );
                     break;
 
                 default:

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_network_ble.c
@@ -235,4 +235,3 @@ IotNetworkError_t IotNetworkBle_Destroy( void * pConnection )
 
     return IOT_NETWORK_SUCCESS;
 }
-


### PR DESCRIPTION
**Description:**
New API call `IotBleDataTransfer_GetPeerError` which reports the current 7-bit error status reported by the phone. 
There's also a new event `IOT_BLE_DATA_TRANSFER_CHANNEL_ERROR_UPDATED` which invokes user callback installed from `IotBleDataTransfer_SetCallback`. This new event is used in ble-network layer to log errors that the phone (peer) encountered, such as incorrect mqtt credentials.

There is [a companion PR](https://github.com/aws/amazon-freertos-ble-android-sdk/pull/28) in `amazon-freertos-ble-android-sdk` which adds mechanism for phone to send over these error codes. This PR does not functionally require the companion PR and existing functionality is retained without it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have tested my changes. No regression in existing tests.
- [X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.