### PR TITLE
Add all common-io peripherals to CMake build system

### DIFF
--- a/libraries/abstractions/common_io/CMakeLists.txt
+++ b/libraries/abstractions/common_io/CMakeLists.txt
@@ -6,9 +6,27 @@ set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
+        "${inc_dir}/iot_adc.h"
+        "${inc_dir}/iot_battery.h"
+        "${inc_dir}/iot_efuse.h"
+        "${inc_dir}/iot_flash.h"
+        "${inc_dir}/iot_gpio.h"
+        "${inc_dir}/iot_hw.h"
         "${inc_dir}/iot_i2c.h"
-        "${inc_dir}/iot_uart.h"
+        "${inc_dir}/iot_i2s.h"
+        "${inc_dir}/iot_perfcounter.h"
+        "${inc_dir}/iot_power.h"
+        "${inc_dir}/iot_pwm.h"
+        "${inc_dir}/iot_reset.h"
+        "${inc_dir}/iot_rtc.h"
+        "${inc_dir}/iot_sdio.h"
         "${inc_dir}/iot_spi.h"
+        "${inc_dir}/iot_timer.h"
+        "${inc_dir}/iot_tsensor.h"
+        "${inc_dir}/iot_uart.h"
+        "${inc_dir}/iot_usb_device.h"
+        "${inc_dir}/iot_usb_host.h"
+        "${inc_dir}/iot_watchdog.h"
 )
 
 afr_module_include_dirs(
@@ -28,9 +46,24 @@ afr_module_sources(
     INTERFACE
         "${test_dir}/iot_test_common_io_internal.h"
         "${test_dir}/iot_test_common_io.c"
+        "${test_dir}/test_iot_adc.c"
+        "${test_dir}/test_iot_battery.c"
+        "${test_dir}/test_iot_efuse.c"
+        "${test_dir}/test_iot_flash.c"
+        "${test_dir}/test_iot_gpio.c"
         "${test_dir}/test_iot_i2c.c"
-        "${test_dir}/test_iot_uart.c"
+        "${test_dir}/test_iot_i2s.c"
+        "${test_dir}/test_iot_perfcounter.c"
+        "${test_dir}/test_iot_power.c"
+        "${test_dir}/test_iot_pwm.c"
+        "${test_dir}/test_iot_reset.c"
+        "${test_dir}/test_iot_rtc.c"
+        "${test_dir}/test_iot_sdio.c"
         "${test_dir}/test_iot_spi.c"
+        "${test_dir}/test_iot_timer.c"
+        "${test_dir}/test_iot_tsensor.c"
+        "${test_dir}/test_iot_uart.c"
+        "${test_dir}/test_iot_watchdog.c"
 )
 
 afr_module_include_dirs(

--- a/libraries/abstractions/common_io/test/iot_test_common_io.c
+++ b/libraries/abstractions/common_io/test/iot_test_common_io.c
@@ -57,6 +57,14 @@ TEST_GROUP_RUNNER( Common_IO )
     size_t i = 0;
 
     /* These already used loop back tests which require minimum of two pins */
+    #ifdef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_PERFCOUNTER_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_PERFCOUNTER );
+        }
+    #endif
+
     #ifdef IOT_TEST_COMMON_IO_GPIO_SUPPORTED
         for( i = 1; i < IOT_TEST_COMMON_IO_GPIO_SUPPORTED; i++ )
         {
@@ -113,11 +121,11 @@ TEST_GROUP_RUNNER( Common_IO )
         }
     #endif
 
-    #ifdef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
-        for( i = 0; i < IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED; i++ )
+    #ifdef IOT_TEST_COMMON_IO_TIMER_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_TIMER_SUPPORTED; i++ )
         {
-            SET_TEST_IOT_PERFCOUNTER_CONFIG( i );
-            RUN_TEST_GROUP( TEST_IOT_PERFCOUNTER );
+            SET_TEST_IOT_TIMER_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_TIMER );
         }
     #endif
 
@@ -126,14 +134,6 @@ TEST_GROUP_RUNNER( Common_IO )
         {
             SET_TEST_IOT_FLASH_CONFIG( i );
             RUN_TEST_GROUP( TEST_IOT_FLASH );
-        }
-    #endif
-
-    #ifdef IOT_TEST_COMMON_IO_TIMER_SUPPORTED
-        for( i = 0; i < IOT_TEST_COMMON_IO_TIMER_SUPPORTED; i++ )
-        {
-            SET_TEST_IOT_TIMER_CONFIG( i );
-            RUN_TEST_GROUP( TEST_IOT_TIMER );
         }
     #endif
 

--- a/libraries/abstractions/common_io/test/iot_test_common_io.c
+++ b/libraries/abstractions/common_io/test/iot_test_common_io.c
@@ -56,7 +56,6 @@ TEST_GROUP_RUNNER( Common_IO )
 {
     size_t i = 0;
 
-    /* These already used loop back tests which require minimum of two pins */
     #ifdef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
         for( i = 0; i < IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED; i++ )
         {
@@ -65,6 +64,7 @@ TEST_GROUP_RUNNER( Common_IO )
         }
     #endif
 
+    /* These already used loop back tests which require minimum of two pins */
     #ifdef IOT_TEST_COMMON_IO_GPIO_SUPPORTED
         for( i = 1; i < IOT_TEST_COMMON_IO_GPIO_SUPPORTED; i++ )
         {

--- a/libraries/abstractions/common_io/test/iot_test_common_io.c
+++ b/libraries/abstractions/common_io/test/iot_test_common_io.c
@@ -88,4 +88,116 @@ TEST_GROUP_RUNNER( Common_IO )
             RUN_TEST_GROUP( TEST_IOT_SPI );
         }
     #endif
+
+    #ifdef IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_WATCHDOG_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_WATCHDOG_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_WATCHDOG );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_RTC_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_RTC_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_RTC_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_RTC );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_RESET_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_RESET_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_RESET_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_RESET );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_PERFCOUNTER_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_PERFCOUNTER_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_PERFCOUNTER );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_FLASH_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_FLASH_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_FLASH_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_FLASH );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_TIMER_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_TIMER_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_TIMER_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_TIMER );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_ADC_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_ADC_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_ADC_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_ADC );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_PWM_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_PWM_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_PWM_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_PWM );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_I2S_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_I2S_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_I2S_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_I2S );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_EFUSE_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_EFUSE_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_EFUSE_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_EFUSE );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_SDIO_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_SDIO_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_SDIO_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_SDIO );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_TEMP_SENSOR_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_TEMP_SENSOR_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_TSENSOR );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_POWER_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_POWER_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_POWER_CONFIG( i );
+            RUN_TEST_GROUP( TEST_IOT_POWER );
+        }
+    #endif
+
+    #ifdef IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED
+        for( i = 0; i < IOT_TEST_COMMON_IO_USB_DEVICE_SUPPORTED; i++ )
+        {
+            SET_TEST_IOT_USB_DEVICE_CONFIG( i );
+            /* No tests currently. */
+        }
+    #endif
 }


### PR DESCRIPTION
Add all common-io peripherals to CMake build system

Description
-----------
Since the CMake now only tries to link supported peripheral symbols, all the tests and header files can be added to the build.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.