### PR TITLE
Fix CMake Board Path's Command

### DIFF
--- a/vendors/renesas/manifest.cmake
+++ b/vendors/renesas/manifest.cmake
@@ -4,4 +4,4 @@ set(
     CACHE INTERNAL "Supported boards list."
 )
 
-set(AFR_MANIFEST_BOARD_DIR "boards")
+set(AFR_MANIFEST_BOARD_DIR "rx_mcu_boards/boards")


### PR DESCRIPTION
Fix CMake Board Path's Command

Description
-----------
The Renesas manifest file is not in the root of the vendor directory, and causes an error when earching for vendor paths.

To reproduce:
Before merging this commit
` cmake -P tools/cmake/afr_board_paths.cmake`

Expected Output:
cmake_supported_boards.yml created

Actual Output:
CMake Error at tools/cmake/afr_board_paths.cmake:19 (include):
  include could not find load file:

/Users/lundinc/Documents/amazon-freertos/vendors/renesas/manifest.cmake

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.