### PR TITLE
NimBLE AFR: Set flags field only in advertisement data and not in scan response

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gap.c
@@ -570,8 +570,11 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
      *     o Discoverability in forthcoming advertisement (general)
      *     o BLE-only (BR/EDR unsupported).
      */
-    fields.flags = BLE_HS_ADV_F_DISC_GEN |
-                   BLE_HS_ADV_F_BREDR_UNSUP;
+    if ( !pxParams->bSetScanRsp )
+    {
+        fields.flags = BLE_HS_ADV_F_DISC_GEN |
+                       BLE_HS_ADV_F_BREDR_UNSUP;
+    }
 
     if( pxParams->ulAppearance )
     {


### PR DESCRIPTION
<!--- Title -->

Description
-----------

- Have added if-check to avoid filling `FLAGS` field in scan response data.
- Previous to this PR, `FLAGS` were potentially getting set twice. Once in advertisement data and second time in scan response data. To avoid duplication, added this check.   
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.