### PR TITLE
Add OTA port for rx65n-rsk to CMake files

### DIFF
--- a/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/CMakeLists.txt
+++ b/vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/CMakeLists.txt
@@ -239,6 +239,21 @@ target_link_libraries(
     INTERFACE AFR::secure_sockets_freertos_plus_tcp
 )
 
+# OTA
+afr_mcu_port(ota)
+target_sources(
+    AFR::ota::mcu_port
+    INTERFACE "${rx65nrsk_ports_dir}/ota/aws_ota_pal.c"
+)
+target_link_libraries(
+    AFR::ota::mcu_port
+    INTERFACE
+        AFR::crypto
+        AFR::pkcs11
+        AFR::ota_mqtt
+        AFR::ota_http
+)
+
 # -------------------------------------------------------------------------------------------------
 # FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Update the rx65n-rsk CMake file to include the ota port

Description
-----------
Added a reference to the preexisting aws_ota_pal.c file in the rx65n-rsk CMake File

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.