### PR TITLE
Port unit tests from MQTT v4_beta2 library using unified workspace

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -6,6 +6,7 @@ if (AFR_ENABLE_UNIT_TESTS)
     add_subdirectory(freertos_plus/standard/utils/)
     add_subdirectory(abstractions/pkcs11/)
     add_subdirectory(c_sdk/standard/ble)
+    add_subdirectory(c_sdk/standard/mqtt_v2)
     return()
 endif()
 

--- a/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
@@ -3,7 +3,7 @@ set(ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
 set(MODULES_DIR "${ROOT_DIR}/libraries")
 set(PLATFORM_DIR "${ROOT_DIR}/platform")
 set(LOGGING_INCLUDE_DIRS "${ROOT_DIR}/demos/logging-stack")
-include(mqttFilePaths.cmake)
+include(${MODULES_DIR}/standard/mqtt/mqttFilePaths.cmake)
 
 if(AFR_ENABLE_UNIT_TESTS)
     add_subdirectory("${MODULES_DIR}/standard/mqtt/utest" libraries/standard/mqtt_v2/utest)
@@ -22,15 +22,14 @@ afr_set_lib_metadata(IS_VISIBLE "true")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    PUBLIC
+    INTERFACE
         ${MQTT_SOURCES}
 )
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    PUBLIC
+    INTERFACE
         ${MQTT_INCLUDE_PUBLIC_DIRS}
-    PRIVATE
         ${MQTT_INCLUDE_PRIVATE_DIRS}
         ${PLATFORM_INCLUDE_DIR}
 )

--- a/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
@@ -1,9 +1,12 @@
-set(CSDK_ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
-set(MODULES_DIR "${CSDK_ROOT_DIR}/libraries")
+# Set CSDK CMake variables for mqttFilePaths.cmake 
+set(ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
+set(MODULES_DIR "${ROOT_DIR}/libraries")
+set(PLATFORM_DIR "${ROOT_DIR}/platform")
+set(LOGGING_INCLUDE_DIRS "${ROOT_DIR}/demos/logging-stack")
 include(mqttFilePaths.cmake)
 
 if(AFR_ENABLE_UNIT_TESTS)
-    add_subdirectory(utest)
+    add_subdirectory("${MODULES_DIR}/standard/mqtt/utest" libraries/standard/mqtt_v2/utest)
     return()
 endif()
 
@@ -29,4 +32,5 @@ afr_module_include_dirs(
         ${MQTT_INCLUDE_PUBLIC_DIRS}
     PRIVATE
         ${MQTT_INCLUDE_PRIVATE_DIRS}
+        ${PLATFORM_INCLUDE_DIR}
 )

--- a/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(CSDK_ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
+set(MODULES_DIR "${CSDK_ROOT_DIR}/libraries")
+include(mqttFilePaths.cmake)
+
 if(AFR_ENABLE_UNIT_TESTS)
     add_subdirectory(utest)
     return()
@@ -12,10 +16,6 @@ afr_set_lib_metadata(DISPLAY_NAME "MQTTv2")
 afr_set_lib_metadata(CATEGORY "Connectivity")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
-
-set(CSDK_ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
-set(MODULES_DIR "${CSDK_ROOT_DIR}/libraries")
-include(mqttFilePaths.cmake)
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}

--- a/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(AFR_ENABLE_UNIT_TESTS)
+    add_subdirectory(utest)
+    return()
+endif()
+
 afr_module(NAME "mqtt_v2" INTERFACE)
 
 afr_set_lib_metadata(ID "mqtt_v2")
@@ -8,23 +13,20 @@ afr_set_lib_metadata(CATEGORY "Connectivity")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 
-set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
-set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
-set(test_dir "${CMAKE_CURRENT_LIST_DIR}/utest")
+set(CSDK_ROOT_DIR "${AFR_ROOT_DIR}/../aws-iot-device-sdk-embedded-C")
+set(MODULES_DIR "${CSDK_ROOT_DIR}/libraries")
+include(mqttFilePaths.cmake)
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    INTERFACE
-         "${src_dir}/mqtt.c"
-         "${src_dir}/mqtt_lightweight.c"
-         "${src_dir}/mqtt_state.c"
-         "${src_dir}"
+    PUBLIC
+        ${MQTT_SOURCES}
 )
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${inc_dir}"
+    PUBLIC
+        ${MQTT_INCLUDE_PUBLIC_DIRS}
+    PRIVATE
+        ${MQTT_INCLUDE_PRIVATE_DIRS}
 )
-
-

--- a/libraries/c_sdk/standard/mqtt_v2/mqttFilePaths.cmake
+++ b/libraries/c_sdk/standard/mqtt_v2/mqttFilePaths.cmake
@@ -13,8 +13,7 @@ set( MQTT_SOURCES
 
 # MQTT library Public Include directories.
 set( MQTT_INCLUDE_PUBLIC_DIRS
-     "${MODULES_DIR}/standard/mqtt/include"
-     "${MODULES_DIR}/standard/utilities/include" )
+     "${MODULES_DIR}/standard/mqtt/include" )
 
 # MQTT library Private Include directories.
 set( MQTT_INCLUDE_PRIVATE_DIRS

--- a/libraries/c_sdk/standard/mqtt_v2/mqttFilePaths.cmake
+++ b/libraries/c_sdk/standard/mqtt_v2/mqttFilePaths.cmake
@@ -13,7 +13,8 @@ set( MQTT_SOURCES
 
 # MQTT library Public Include directories.
 set( MQTT_INCLUDE_PUBLIC_DIRS
-     "${MODULES_DIR}/standard/mqtt/include" )
+     "${MODULES_DIR}/standard/mqtt/include"
+     "${MODULES_DIR}/standard/utilities/include" )
 
 # MQTT library Private Include directories.
 set( MQTT_INCLUDE_PRIVATE_DIRS

--- a/libraries/c_sdk/standard/mqtt_v2/utest/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/utest/CMakeLists.txt
@@ -1,4 +1,3 @@
-include("../mqttFilePaths.cmake")
 project ("mqtt unit test")
 cmake_minimum_required (VERSION 3.13)
 
@@ -68,6 +67,7 @@ create_real_library(${real_name}
 list(APPEND utest_link_list
             -l${mock_name}
             lib${real_name}.a
+            libutils.so
         )
 
 list(APPEND utest_dep_list
@@ -87,6 +87,7 @@ create_test(${utest_name}
 set(utest_link_list "")
 list(APPEND utest_link_list
                 lib${real_name}.a
+                libutils.so
         )
 
 # mqtt_state_utest
@@ -107,6 +108,7 @@ set(utest_source "${project_name}_lightweight_utest.c")
 set(utest_link_list "")
 list(APPEND utest_link_list
             lib${real_name}.a
+            libutils.so
         )
 
 create_test(${utest_name}

--- a/libraries/c_sdk/standard/mqtt_v2/utest/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt_v2/utest/CMakeLists.txt
@@ -1,3 +1,4 @@
+include("../mqttFilePaths.cmake")
 project ("mqtt unit test")
 cmake_minimum_required (VERSION 3.13)
 
@@ -67,7 +68,6 @@ create_real_library(${real_name}
 list(APPEND utest_link_list
             -l${mock_name}
             lib${real_name}.a
-            libutils.so
         )
 
 list(APPEND utest_dep_list
@@ -87,7 +87,6 @@ create_test(${utest_name}
 set(utest_link_list "")
 list(APPEND utest_link_list
                 lib${real_name}.a
-                libutils.so
         )
 
 # mqtt_state_utest
@@ -108,7 +107,6 @@ set(utest_source "${project_name}_lightweight_utest.c")
 set(utest_link_list "")
 list(APPEND utest_link_list
             lib${real_name}.a
-            libutils.so
         )
 
 create_test(${utest_name}

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -39,7 +39,7 @@ function(create_test test_name
     foreach(dependency IN LISTS dep_list)
         add_dependencies(${test_name} ${dependency})
     endforeach()
-    target_link_libraries(${test_name} -lgcov)
+    target_link_libraries(${test_name} -lgcov -lunity)
 
     target_link_directories(${test_name}  PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/lib


### PR DESCRIPTION
Port unit tests from MQTT v4_beta2 library using unified workspace 

Description
-----------
By utilizing the existing CMake files from CSDK repo, only a single CMakeLists.txt file is created in order to call AFR-specific CMake functions to build the MQTT v4_beta2 library.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.