### PR TITLE
Add Mbed TLS macros to the LPC54018 bootloader project

### DIFF
--- a/projects/nxp/lpc54018iotmodule/iar/bootloader/spifi_bootloader.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/bootloader/spifi_bootloader.ewp
@@ -215,6 +215,8 @@
                 <debug>1</debug>
                 <option>
                     <name>CCDefines</name>
+                    <state>MBEDTLS_CONFIG_FILE=&quot;aws_mbedtls_config.h&quot;</state>
+                    <state>CONFIG_MEDTLS_USE_AFR_MEMORY</state>
                     <state>DEBUG</state>
                     <state>XIP_IMAGE</state>
                     <state>CPU_LPC54018</state>

--- a/projects/nxp/lpc54018iotmodule/iar/bootloader/spifi_bootloader.ewp
+++ b/projects/nxp/lpc54018iotmodule/iar/bootloader/spifi_bootloader.ewp
@@ -362,6 +362,8 @@
                     <state>$PROJ_DIR$\..\..\..\..\..\freertos_kernel\portable\IAR\ARM_CM4F</state>
                     <state>$PROJ_DIR$\..\..\..\..\..\freertos_kernel\include</state>
                     <state>$PROJ_DIR$\..\..\..\..\..\libraries\3rdparty\mbedtls\include</state>
+                    <state>$PROJ_DIR$\..\..\..\..\..\libraries\3rdparty\mbedtls_utils</state>
+                    <state>$PROJ_DIR$\..\..\..\..\..\libraries\3rdparty\mbedtls_config</state>
                     <state>$PROJ_DIR$\..\..\..\..\..\libraries\3rdparty\jsmn</state>
                     <state>$PROJ_DIR$\..\..\..\..\..\libraries\3rdparty\pkcs11</state>
                     <state>$PROJ_DIR$\..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls</state>


### PR DESCRIPTION
Add Mbed TLS macros to the LPC54018 bootloader project

Description
-----------
* Add the MBEDTLS_CONFIG_FILE and CONFIG_MEDTLS_USE_AFR_MEMORY macros
* Add the directory of the AWS Mbed TLS config file to the include path
* Add the Mbed TLS utility directory to the include path

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.