### PR TITLE
OTA bug fix

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1304,7 +1304,6 @@ static OTA_Err_t prvResumeHandler( OTA_EventData_t * pxEventData )
 static OTA_Err_t prvJobNotificationHandler( OTA_EventData_t * pxEventData )
 {
     ( void ) pxEventData;
-    OTA_Err_t xErr = kOTA_Err_Uninitialized;
     OTA_EventMsg_t xEventMsg = { 0 };
 
     /*  We receieved job notification so stop the data request timer. */

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -2651,7 +2651,13 @@ static void prvAgentShutdownCleanup( void )
         xOTA_Agent.xRequestTimer = NULL;
     }
 
-    /* Cleanup related to selected protocol. */
+    /* Control plane cleanup related to selected protocol. */
+    if( xOTA_ControlInterface.prvCleanup != NULL )
+    {
+        ( void ) xOTA_ControlInterface.prvCleanup( &xOTA_Agent );
+    }
+
+    /* Data plane cleanup related to selected protocol. */
     if( xOTA_DataInterface.prvCleanup != NULL )
     {
         ( void ) xOTA_DataInterface.prvCleanup( &xOTA_Agent );

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c
@@ -74,6 +74,7 @@ void prvSetControlInterface( OTA_ControlInterface_t * pxControlInterface )
     #if ( configENABLED_CONTROL_PROTOCOL == OTA_CONTROL_OVER_MQTT )
         pxControlInterface->prvRequestJob = prvRequestJob_Mqtt;
         pxControlInterface->prvUpdateJobStatus = prvUpdateJobStatus_Mqtt;
+        pxControlInterface->prvCleanup = prvCleanupControl_Mqtt;
     #else
     #error "Enable MQTT control as control operations are only supported over MQTT."
     #endif
@@ -97,7 +98,7 @@ OTA_Err_t prvSetDataInterface( OTA_DataInterface_t * pxDataInterface,
                     pxDataInterface->prvInitFileTransfer = prvInitFileTransfer_Mqtt;
                     pxDataInterface->prvRequestFileBlock = prvRequestFileBlock_Mqtt;
                     pxDataInterface->prvDecodeFileBlock = prvDecodeFileBlock_Mqtt;
-                    pxDataInterface->prvCleanup = prvCleanup_Mqtt;
+                    pxDataInterface->prvCleanup = prvCleanupData_Mqtt;
 
                     OTA_LOG_L1( "[%s] Data interface is set to MQTT.\r\n", OTA_METHOD_NAME );
 
@@ -112,7 +113,7 @@ OTA_Err_t prvSetDataInterface( OTA_DataInterface_t * pxDataInterface,
                     pxDataInterface->prvInitFileTransfer = _AwsIotOTA_InitFileTransfer_HTTP;
                     pxDataInterface->prvRequestFileBlock = _AwsIotOTA_RequestDataBlock_HTTP;
                     pxDataInterface->prvDecodeFileBlock = _AwsIotOTA_DecodeFileBlock_HTTP;
-                    pxDataInterface->prvCleanup = _AwsIotOTA_Cleanup_HTTP;
+                    pxDataInterface->prvCleanup = _AwsIotOTA_CleanupData_HTTP;
 
                     OTA_LOG_L1( "[%s] Data interface is set to HTTP.\r\n", OTA_METHOD_NAME );
 

--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h
@@ -54,6 +54,7 @@ typedef struct
                                         OTA_JobStatus_t eStatus,
                                         int32_t lReason,
                                         int32_t lSubReason );
+    OTA_Err_t ( * prvCleanup )( OTA_AgentContext_t * pAgentCtx );
 } OTA_ControlInterface_t;
 
 /**

--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -1170,9 +1170,9 @@ OTA_Err_t _AwsIotOTA_DecodeFileBlock_HTTP( uint8_t * pMessageBuffer,
 }
 
 
-OTA_Err_t _AwsIotOTA_Cleanup_HTTP( OTA_AgentContext_t * pAgentCtx )
+OTA_Err_t _AwsIotOTA_CleanupData_HTTP( OTA_AgentContext_t * pAgentCtx )
 {
-    IotLogDebug( "Invoking _AwsIotOTA_Cleanup_HTTP" );
+    IotLogDebug( "Invoking _AwsIotOTA_CleanupData_HTTP" );
 
     /* Unused parameters. */
     ( void ) pAgentCtx;

--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h
@@ -43,6 +43,6 @@ OTA_Err_t _AwsIotOTA_DecodeFileBlock_HTTP( uint8_t * pMessageBuffer,
                                            uint8_t ** pPayload,
                                            size_t * pPayloadSize );
 
-OTA_Err_t _AwsIotOTA_Cleanup_HTTP( OTA_AgentContext_t * pxAgentCtx );
+OTA_Err_t _AwsIotOTA_CleanupData_HTTP( OTA_AgentContext_t * pxAgentCtx );
 
 #endif /* ifndef __AWS_OTA_HTTP__H__ */

--- a/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
+++ b/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
@@ -224,12 +224,14 @@ static bool prvUnSubscribeFromDataStream( const OTA_AgentContext_t * pxAgentCtx 
 
     IotMqttSubscription_t xUnSub;
 
+    xUnSub.qos = IOT_MQTT_QOS_0;
+
     bool bResult = false;
     char pcOTA_RxStreamTopic[ OTA_MAX_TOPIC_LEN ];
 
-    xUnSub.qos = IOT_MQTT_QOS_0;
+    const OTA_FileContext_t * pFileContext = &( pxAgentCtx->pxOTA_Files[ pxAgentCtx->ulFileIndex ] );
 
-    if( pxAgentCtx != NULL )
+    if( ( pxAgentCtx != NULL ) && ( pFileContext != NULL ) && ( pFileContext->pucStreamName != NULL ) )
     {
         /* Try to build the dynamic data stream topic and un-subscribe from it. */
 
@@ -237,7 +239,7 @@ static bool prvUnSubscribeFromDataStream( const OTA_AgentContext_t * pxAgentCtx 
                                                           sizeof( pcOTA_RxStreamTopic ),
                                                           pcOTA_StreamData_TopicTemplate,
                                                           pxAgentCtx->pcThingName,
-                                                          ( const char * ) pxAgentCtx->pxOTA_Files[ 0 ].pucStreamName );
+                                                          ( const char * ) pFileContext->pucStreamName );
 
         if( ( xUnSub.topicFilterLength > 0U ) && ( xUnSub.topicFilterLength < sizeof( pcOTA_RxStreamTopic ) ) )
         {
@@ -759,6 +761,7 @@ OTA_Err_t prvInitFileTransfer_Mqtt( OTA_AgentContext_t * pxAgentCtx )
     OTA_Err_t xResult = kOTA_Err_PublishFailed;
     char pcOTA_RxStreamTopic[ OTA_MAX_TOPIC_LEN ];
     IotMqttSubscription_t xOTAUpdateDataSubscription;
+    const OTA_FileContext_t * pFileContext = &( pxAgentCtx->pxOTA_Files[ pxAgentCtx->ulFileIndex ] );
 
     memset( &xOTAUpdateDataSubscription, 0, sizeof( xOTAUpdateDataSubscription ) );
     xOTAUpdateDataSubscription.qos = IOT_MQTT_QOS_0;
@@ -769,7 +772,7 @@ OTA_Err_t prvInitFileTransfer_Mqtt( OTA_AgentContext_t * pxAgentCtx )
                                                                           sizeof( pcOTA_RxStreamTopic ),
                                                                           pcOTA_StreamData_TopicTemplate,
                                                                           pxAgentCtx->pcThingName,
-                                                                          ( const char * ) pxAgentCtx->pxOTA_Files->pucStreamName );
+                                                                          ( const char * ) pFileContext->pucStreamName );
 
     if( ( xOTAUpdateDataSubscription.topicFilterLength > 0U ) && ( xOTAUpdateDataSubscription.topicFilterLength < sizeof( pcOTA_RxStreamTopic ) ) )
     {

--- a/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
+++ b/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
@@ -935,15 +935,24 @@ OTA_Err_t prvDecodeFileBlock_Mqtt( uint8_t * pucMessageBuffer,
 }
 
 /*
- * Perform any cleanup operations required like unsubscribing from
- * job topics.
+ * Perform any cleanup operations required for control plane.
  */
-OTA_Err_t prvCleanup_Mqtt( OTA_AgentContext_t * pxAgentCtx )
+OTA_Err_t prvCleanupControl_Mqtt( OTA_AgentContext_t * pxAgentCtx )
 {
-    DEFINE_OTA_METHOD_NAME( "prvCleanup_Mqtt" );
+    DEFINE_OTA_METHOD_NAME( "prvCleanupControl_Mqtt" );
 
     /* Unsubscribe from job notification topics. */
     prvUnSubscribeFromJobNotificationTopic( pxAgentCtx );
+
+    return kOTA_Err_None;
+}
+
+/*
+ * Perform any cleanup operations required for data plane.
+ */
+OTA_Err_t prvCleanupData_Mqtt( OTA_AgentContext_t * pxAgentCtx )
+{
+    DEFINE_OTA_METHOD_NAME( "prvCleanupData_Mqtt" );
 
     /* Unsubscribe from data stream topics. */
     prvUnSubscribeFromDataStream( pxAgentCtx );

--- a/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
+++ b/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c
@@ -231,7 +231,7 @@ static bool prvUnSubscribeFromDataStream( const OTA_AgentContext_t * pxAgentCtx 
 
     const OTA_FileContext_t * pFileContext = &( pxAgentCtx->pxOTA_Files[ pxAgentCtx->ulFileIndex ] );
 
-    if( ( pxAgentCtx != NULL ) && ( pFileContext != NULL ) && ( pFileContext->pucStreamName != NULL ) )
+    if( ( pFileContext != NULL ) && ( pFileContext->pucStreamName != NULL ) )
     {
         /* Try to build the dynamic data stream topic and un-subscribe from it. */
 

--- a/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h
+++ b/libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h
@@ -96,7 +96,7 @@ OTA_Err_t prvDecodeFileBlock_Mqtt( uint8_t * pucMessageBuffer,
                                    size_t * pxPayloadSize );
 
 /**
- * @brief Cleanup related to OTA over MQTT.
+ * @brief Cleanup related to OTA control plane over MQTT.
  *
  * This function perfroms cleanup by unsubscribing from any topics that were
  * subscribed for performing OTA over MQTT.
@@ -106,7 +106,20 @@ OTA_Err_t prvDecodeFileBlock_Mqtt( uint8_t * pucMessageBuffer,
  * @return The OTA error code. See OTA Agent error codes information in aws_iot_ota_agent.h.
  */
 
-OTA_Err_t prvCleanup_Mqtt( OTA_AgentContext_t * pxAgentCtx );
+OTA_Err_t prvCleanupControl_Mqtt( OTA_AgentContext_t * pxAgentCtx );
+
+/**
+ * @brief Cleanup related to OTA data plane over MQTT.
+ *
+ * This function perfroms cleanup by unsubscribing from any topics that were
+ * subscribed for performing OTA over MQTT.
+ *
+ * @param[in] pxAgentCtx The OTA agent context.
+ *
+ * @return The OTA error code. See OTA Agent error codes information in aws_iot_ota_agent.h.
+ */
+
+OTA_Err_t prvCleanupData_Mqtt( OTA_AgentContext_t * pxAgentCtx );
 
 /**
  * @brief Update job status over MQTT.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Address 2 issues:
- Separate data plane and control plane cleanup. We don't want to unsubscribe from job notification topic after OTA data transfer complete.
- Check if the stream name is null when unsubscribe from stream topic in MQTT data plane.

test is now passing: https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/ota_tests_ide/job/espressif/job/esp32_devkitc-make/68/console

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.