### PR TITLE
solve the reset issue by return error if the WINC driver is closed

### DIFF
--- a/vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c
+++ b/vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c
@@ -437,6 +437,9 @@ uint32_t WDRV_EXT_DataSend(uint16_t segSize, uint8_t *p_segData)
 {
     int8_t ret;
 
+    if (!s_isInitComplete)
+        return WDRV_ERROR;
+
     if (gp_wdrv_cfg->networkType == WDRV_NETWORK_TYPE_SOFT_AP) 
     {
         ret = wilc1000_eth_data_send(p_segData, segSize, AP_INTERFACE);


### PR DESCRIPTION
PICMZEF MQTT demo project reset issue

Description
-----------
MQTT Demo completes and after a few seconds later a reset is observed from the console logs 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.