### PR TITLE
Quarantine part of WiFi tests

### DIFF
--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -690,6 +690,10 @@ TEST_SETUP( Quarantine_WiFi )
 
 TEST_TEAR_DOWN( Quarantine_WiFi )
 {
+}
+
+TEST_GROUP_RUNNER( Quarantine_WiFi )
+{
     /* Happy path tests. */
     RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiOnOff );
     RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiMode );

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -624,7 +624,6 @@ static void prvSetupWiFiTests( void )
         ( "End of WiFi Networks\r\n" ) );
 
     vTaskDelay( testwifiCONNECTION_DELAY );
-
 }
 
 /* Unity TEST initializations. */
@@ -710,7 +709,6 @@ TEST_TEAR_DOWN( Quarantine_WiFi )
     /* Stability tests. */
     RUN_TEST_CASE( Quarantine_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks );
     RUN_TEST_CASE( Quarantine_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks );
-
 }
 
 /**

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -596,10 +596,7 @@ static void prvFinishWiFiTesting( void )
     }
 }
 
-/* Unity TEST initializations. */
-TEST_GROUP( Full_WiFi );
-
-TEST_SETUP( Full_WiFi )
+static void prvSetupWiFiTests( void )
 {
     int32_t lI = 0;
     int8_t cScanSize = 10;
@@ -627,6 +624,15 @@ TEST_SETUP( Full_WiFi )
         ( "End of WiFi Networks\r\n" ) );
 
     vTaskDelay( testwifiCONNECTION_DELAY );
+
+}
+
+/* Unity TEST initializations. */
+TEST_GROUP( Full_WiFi );
+
+TEST_SETUP( Full_WiFi )
+{
+    prvSetupWiFiTests();
 }
 
 TEST_TEAR_DOWN( Full_WiFi )
@@ -635,22 +641,6 @@ TEST_TEAR_DOWN( Full_WiFi )
 
 TEST_GROUP_RUNNER( Full_WiFi )
 {
-    /* Happy path tests. */
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiOnOff );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiMode );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiConnectionLoop );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiNetworkAddGetDelete );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiPowerManagementMode )
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiGetIP );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiGetMAC );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiGetHostIP );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiScan );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiReset );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiPing );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiIsConnected );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiConnectMultipleAP );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WiFiOnOffLoop );
-
     /* Null parameter tests. */
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_GetMode_NullParameters );
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_GetIP_NullParameters );
@@ -676,10 +666,6 @@ TEST_GROUP_RUNNER( Full_WiFi )
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_ConnectAP_MaxSSIDLengthExceeded );
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_ConnectAP_MaxPasswordLengthExceeded );
 
-    /* Stability tests. */
-    RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks );
-    RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks );
-
     #if ( testwifiENABLE_CONFIGURE_AP_TESTS == 1 )
         RUN_TEST_CASE( Full_WiFi, AFQP_WiFiConfigureAP );
         RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_ConfigureAP_NullParameters );
@@ -693,10 +679,45 @@ TEST_GROUP_RUNNER( Full_WiFi )
 }
 
 /**
+ * Test group for quarantined WiFi tests.
+ */
+TEST_GROUP( Quarantine_WiFi );
+
+
+TEST_SETUP( Quarantine_WiFi )
+{
+    prvSetupWiFiTests();
+}
+
+TEST_TEAR_DOWN( Quarantine_WiFi )
+{
+    /* Happy path tests. */
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiOnOff );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiMode );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiConnectionLoop );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiNetworkAddGetDelete );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiPowerManagementMode )
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiGetIP );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiGetMAC );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiGetHostIP );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiScan );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiReset );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiPing );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiIsConnected );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiConnectMultipleAP );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WiFiOnOffLoop );
+
+    /* Stability tests. */
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks );
+    RUN_TEST_CASE( Quarantine_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks );
+
+}
+
+/**
  * @brief Turn the Wi-Fi off then on in a loop and verify success. The Wi-Fi
  * should be ON after this test is finished.
  */
-TEST( Full_WiFi, AFQP_WiFiOnOffLoop )
+TEST( Quarantine_WiFi, AFQP_WiFiOnOffLoop )
 {
     char cBuffer[ 256 ];
     int16_t sBufferLength = 256;
@@ -730,7 +751,7 @@ TEST( Full_WiFi, AFQP_WiFiOnOffLoop )
  * @brief A single happy path case of turning the Wi-Fi off, on, then connecting
  * to the AP and disconnecting. Verify API results.
  */
-TEST( Full_WiFi, AFQP_WiFiOnOff )
+TEST( Quarantine_WiFi, AFQP_WiFiOnOff )
 {
     WIFINetworkParams_t xNetworkParams = { 0 };
     WIFIReturnCode_t xWiFiStatus;
@@ -766,7 +787,7 @@ TEST( Full_WiFi, AFQP_WiFiOnOff )
  * @brief Call WIFI_GetMode() and WIFI_SetMode() with each of the available
  * Wi-Fi modes; verify the API return status.
  */
-TEST( Full_WiFi, AFQP_WiFiMode )
+TEST( Quarantine_WiFi, AFQP_WiFiMode )
 {
     WIFIDeviceMode_t xWiFiDeviceMode;
     WIFIReturnCode_t xWiFiStatus;
@@ -833,7 +854,7 @@ TEST( Full_WiFi, AFQP_WIFI_SetMode_InvalidMode )
  * @brief Connect and disconnect the wireless AP testwifiCONNECTION_LOOP_TIMES
  * and verify the return status each time.
  */
-TEST( Full_WiFi, AFQP_WiFiConnectionLoop )
+TEST( Quarantine_WiFi, AFQP_WiFiConnectionLoop )
 {
     WIFINetworkParams_t xNetworkParams = { 0 };
     WIFIReturnCode_t xWiFiStatus;
@@ -876,7 +897,7 @@ TEST( Full_WiFi, AFQP_WiFiConnectionLoop )
 /**
  * @brief Exercise WIFI_GetIP() and verify the return status.
  */
-TEST( Full_WiFi, AFQP_WiFiGetIP )
+TEST( Quarantine_WiFi, AFQP_WiFiGetIP )
 {
     uint8_t ucIPAddr[ 4 ];
     WIFIReturnCode_t xWiFiStatus;
@@ -925,7 +946,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetIP_NullParameters )
  * The MAC address returned is checked to be non-zero. Checking for manufacturer
  * addresses given the unknown set of network interface vendors is infeasible.
  */
-TEST( Full_WiFi, AFQP_WiFiGetMAC )
+TEST( Quarantine_WiFi, AFQP_WiFiGetMAC )
 {
     uint8_t ucMacAddressVal[ testwifiMAC_ADDRESS_LENGTH ];
     WIFIReturnCode_t xWiFiStatus;
@@ -974,7 +995,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetMAC_NullParameters )
 /**
  * @brief Exercise WIFI_GetHostIP and verify the return status.
  */
-TEST( Full_WiFi, AFQP_WiFiGetHostIP )
+TEST( Quarantine_WiFi, AFQP_WiFiGetHostIP )
 {
     uint8_t ucIPAddr[ 4 ];
     WIFIReturnCode_t xWiFiStatus;
@@ -1082,7 +1103,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_DomainNameLengthExceeded )
 /**
  * @brief Exercise WIFI_Scan() and verify the return status.
  */
-TEST( Full_WiFi, AFQP_WiFiScan )
+TEST( Quarantine_WiFi, AFQP_WiFiScan )
 {
     WIFIScanResult_t xScanResults[ testwifiMAX_SCAN_NUMBER ];
     WIFIReturnCode_t xWiFiStatus;
@@ -1116,7 +1137,7 @@ TEST( Full_WiFi, AFQP_WIFI_Scan_NullParameters )
  * @brief Single test of adding a Wi-Fi network, getting it, then delete it;
  * verify the return status.
  */
-TEST( Full_WiFi, AFQP_WiFiNetworkAddGetDelete )
+TEST( Quarantine_WiFi, AFQP_WiFiNetworkAddGetDelete )
 {
     WIFINetworkProfile_t xNetworkProfile;
     WIFIReturnCode_t xWiFiStatus;
@@ -1289,7 +1310,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGetNonExistingNetwork )
 /**
  * @brief Call WIFI_NetworkGet() over the maximum network save number.
  */
-TEST( Full_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks )
+TEST( Quarantine_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks )
 {
     WIFIReturnCode_t xWiFiStatus;
     WIFINetworkProfile_t xNetworkProfile;
@@ -1319,7 +1340,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkGet_GetManyNetworks )
  * checked. Instead only the network returned on success is checked to be
  * correct.
  */
-TEST( Full_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks )
+TEST( Quarantine_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks )
 {
     WIFIReturnCode_t xWiFiStatus;
     WIFINetworkProfile_t xNetworkProfile;
@@ -1389,7 +1410,7 @@ TEST( Full_WiFi, AFQP_WIFI_NetworkAdd_AddManyNetworks )
  * @brief Exercise the WIFI_SetPMMode() and WIFI_GetPMMode() APIs for each of
  * the available modes and verify the return status.
  */
-TEST( Full_WiFi, AFQP_WiFiPowerManagementMode )
+TEST( Quarantine_WiFi, AFQP_WiFiPowerManagementMode )
 {
     WIFIPMMode_t xPMMode;
     WIFIReturnCode_t xWiFiStatus;
@@ -1641,7 +1662,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConfigureAP_MaxPasswordLengthExceeded )
 /**
  * @brief Exercise WIFI_Reset and verify a success.
  */
-TEST( Full_WiFi, AFQP_WiFiReset )
+TEST( Quarantine_WiFi, AFQP_WiFiReset )
 {
     WIFIReturnCode_t xWiFiStatus;
 
@@ -1652,7 +1673,7 @@ TEST( Full_WiFi, AFQP_WiFiReset )
 /**
  * @brief Exercise WIFI_Ping() and verify a success.
  */
-TEST( Full_WiFi, AFQP_WiFiPing )
+TEST( Quarantine_WiFi, AFQP_WiFiPing )
 {
     WIFIReturnCode_t xWiFiStatus;
     uint32_t ulPingAddress = testwifiPING_ADDRESS;
@@ -1684,7 +1705,7 @@ TEST( Full_WiFi, AFQP_WIFI_Ping_NullParameters )
  * @brief Test WIFI_IsConnected() after calling WIFI_ConnectAP() and
  * WIFI_DisconnectAP() and verify success.
  */
-TEST( Full_WiFi, AFQP_WiFiIsConnected )
+TEST( Quarantine_WiFi, AFQP_WiFiIsConnected )
 {
     WIFINetworkParams_t xNetworkParams = { 0 };
     BaseType_t xIsConnected;
@@ -1917,7 +1938,7 @@ TEST( Full_WiFi, AFQP_WIFI_ConnectAP_MaxPasswordLengthExceeded )
  * credentials defined in this test over and over and verify we are still
  * connected.
  */
-TEST( Full_WiFi, AFQP_WiFiConnectMultipleAP )
+TEST( Quarantine_WiFi, AFQP_WiFiConnectMultipleAP )
 {
     BaseType_t xIsConnected;
     BaseType_t xMaxRetries = 6;

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -68,6 +68,7 @@ static void RunTests( void )
      * first tests in this function. */
     #if ( testrunnerFULL_WIFI_ENABLED == 1 )
         RUN_TEST_GROUP( Full_WiFi );
+        RUN_TEST_GROUP( Quarantine_WiFi );
     #endif
 
     #if ( testrunnerFULL_TASKPOOL_ENABLED == 1 )


### PR DESCRIPTION
Quarantine part of WiFi tests to a different group

Description
-----------
Some of the WiFi tests are not adding value today: they don't test the result of API being qualified, or fails intermittently without enough error information for debugging.
Quarantine those tests for now to a `Quarantine_WiFi` group until they are fixed and restored.
 
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.