### PR TITLE
Transport code implementation + demo

### DIFF
--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -102,6 +102,8 @@
     #define DEMO_entryFUNCTION             RunHttpsSyncUploadDemo
 #elif defined( CONFIG_HTTPS_ASYNC_UPLOAD_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             RunHttpsAsyncUploadDemo
+#elif defined( CONFIG_MQTT_TRANSPORT_DEMO_ENABLED )
+    #define DEMO_entryFUNCTION             RunMQTTTransportDemo
 #else /* if defined( CONFIG_MQTT_DEMO_ENABLED ) */
 /* if no demo was defined there will be no entry point defined and we will not be able to run the demo */
     #error "No demo to run. One demo should be enabled"

--- a/demos/mqtt_transport/CMakeLists.txt
+++ b/demos/mqtt_transport/CMakeLists.txt
@@ -1,0 +1,18 @@
+# C SDK MQTT demo
+afr_demo_module(mqtt_transport)
+
+afr_set_demo_metadata(ID "MQTT_TRANSPORT_DEMO")
+afr_set_demo_metadata(DESCRIPTION "An example that demonstrates the MQTT transport layer")
+afr_set_demo_metadata(DISPLAY_NAME "MQTT Transport Hello World")
+
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_transport.c"
+)
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        AFR::mqtt_ble
+)
+

--- a/demos/mqtt_transport/CMakeLists.txt
+++ b/demos/mqtt_transport/CMakeLists.txt
@@ -10,6 +10,15 @@ afr_module_sources(
     INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_transport.c"
 )
+
+afr_module_include_dirs(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        .
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${AFR_MODULES_C_SDK_DIR}/standard/logging_stack/
+)
+
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE

--- a/demos/mqtt_transport/CMakeLists.txt
+++ b/demos/mqtt_transport/CMakeLists.txt
@@ -14,7 +14,6 @@ afr_module_sources(
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
     INTERFACE
-        .
         ${CMAKE_CURRENT_LIST_DIR}
         ${AFR_MODULES_C_SDK_DIR}/standard/logging_stack/
 )

--- a/demos/mqtt_transport/demo_config.h
+++ b/demos/mqtt_transport/demo_config.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef DEMO_CONFIG_H_
+#define DEMO_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for DEMO.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the Demo. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "DEMO"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_DEBUG
+#endif
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+#endif /* ifndef DEMO_CONFIG_H */

--- a/demos/mqtt_transport/mqtt_config.h
+++ b/demos/mqtt_transport/mqtt_config.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MQTT_CONFIG_H_
+#define MQTT_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for MQTT.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for MQTT.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+#include "logging_stack.h"
+/************ End of logging configuration ****************/
+
+/* Set network context to socket (int). */
+#include "iot_ble_data_transfer.h"
+typedef IotBleDataTransferChannel_t * NetworkContext_t;
+
+#endif /* ifndef MQTT_CONFIG_H_ */

--- a/demos/mqtt_transport/mqtt_demo_transport.c
+++ b/demos/mqtt_transport/mqtt_demo_transport.c
@@ -45,9 +45,6 @@
 #include <sys/types.h>
 
 
-
-/************ End of logging configuration ****************/
-
 /**
  * @brief The first characters in the client identifier. A timestamp is appended
  * to this prefix to create a unique client identifer.
@@ -249,7 +246,6 @@ static MQTTStatus_t demoInitChannel( void )
     if( status != MQTTSuccess )
     {
         LogError( ( "Something went wrong in initializing the demo" ) );
-        status = MQTTServerRefused;
     }
 
     return status;

--- a/demos/mqtt_transport/mqtt_demo_transport.c
+++ b/demos/mqtt_transport/mqtt_demo_transport.c
@@ -1,0 +1,821 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Include demo_config.h first for logging and other configuration */
+#include "demo_config.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "iot_ble_mqtt_transport.h"
+#include "iot_ble_data_transfer.h"
+#include "iot_ble_config_defaults.h"
+#include "platform/iot_clock.h"
+
+/* Standard includes. */
+#include <stdlib.h>
+#include <string.h>
+
+/* POSIX socket includes. */
+#include <netdb.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+
+
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The first characters in the client identifier. A timestamp is appended
+ * to this prefix to create a unique client identifer.
+ *
+ * This prefix is also used to generate topic names and topic filters used in this
+ * demo.
+ */
+#define CLIENT_IDENTIFIER_PREFIX             "iotdemo"
+
+/**
+ * @brief The maximum length the demo will use for client identifier.
+ */
+#define CLIENT_IDENTIFIER_MAX_LENGTH         12U
+
+/**
+ * @brief The topic the demo will subscribe and publish to.
+ */
+#define MQTT_EXAMPLE_TOPIC                   "iotdemo/test/abc"
+
+/**
+ * @brief The size of the buffer in bytes passed to the transport code to hold streaming data.
+ */
+#define STATIC_BUFFER_SIZE                   200U
+
+/**
+ * @brief The MQTT message published in this example.
+ */
+#define MQTT_EXAMPLE_MESSAGE                 "Hello MQTT World!"
+
+/**
+ * @brief Keep alive period in seconds for MQTT connection.
+ */
+#define MQTT_KEEP_ALIVE_PERIOD_SECONDS       5U
+
+/**
+ * @brief Number of time network receive will be attempted
+ * if it fails due to transportTimeout.
+ */
+#define MQTT_MAX_RECV_ATTEMPTS               100U
+
+/**
+ * @brief Delay between two demo iterations.
+ */
+#define MQTT_DEMO_ITERATION_DELAY_SECONDS    5U
+
+#define HIGH_BYTE_MASK                       0xF0U
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Callback for the demo, handles events when the data channel is first opened
+ * and when data is received by the channel.
+ */
+static void demoCallback( IotBleDataTransferChannelEvent_t event,
+                          IotBleDataTransferChannel_t * pChannel,
+                          void * context );
+
+/**
+ * @brief Initializes the demo, including calling the init function for the transport layer
+ * and initializing the BLE channel.
+ */
+static MQTTStatus_t demoInitChannel( void );
+
+
+/**
+ * @brief Generate and return monotonically increasing packet identifier.
+ *
+ * @return The next PacketId.
+ *
+ * @note This function is not thread safe.
+ */
+static uint16_t getNextPacketIdentifier( void );
+
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Packet Identifier generated when Subscribe request was sent to the broker;
+ * it is used to match received Subscribe ACK to the transmitted SUBSCRIBE request.
+ */
+static uint16_t subscribePacketIdentifier;
+
+/**
+ * @brief Packet Identifier generated when Unsubscribe request was sent to the broker;
+ * it is used to match received Unsubscribe response to the transmitted unsubscribe
+ * request.
+ */
+static uint16_t unsubscribePacketIdentifier;
+
+/**
+ * @brief Network context structure to store the data channel.
+ */
+static NetworkContext_t pContext;
+
+/**
+ * @brief Flag to mark if the channel has been disconnected at all
+ */
+static volatile bool channelActive = true;
+
+
+/*-----------------------------------------------------------*/
+
+static void demoCallback( IotBleDataTransferChannelEvent_t event,
+                          IotBleDataTransferChannel_t * pChannel,
+                          void * context )
+{
+    /* Unused parameters. */
+    ( void ) pChannel;
+    ( void ) context;
+
+    /* Event to see when the data channel is ready to receive data. */
+    if( event == IOT_BLE_DATA_TRANSFER_CHANNEL_OPENED )
+    {
+        IotSemaphore_Post( &pContext.isReady );
+    }
+
+    /* Event for when data is received over the channel. */
+    else if( event == IOT_BLE_DATA_TRANSFER_CHANNEL_DATA_RECEIVED )
+    {
+        IotBleMqttTransportAcceptData( &pContext );
+    }
+
+    /* Event for when channel is closed. */
+    else if( event == IOT_BLE_DATA_TRANSFER_CHANNEL_CLOSED )
+    {
+        channelActive = false;
+    }
+
+    else
+    {
+        /* Empty else, MISRA 2012 15.7 */
+    }
+}
+
+
+static MQTTStatus_t demoInitChannel( void )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    /* Must initialize the channel, pContext must contain the buffer and buf size at this point. */
+    IotBleMqttTransportInit( &pContext );
+
+    /* Open is a handshake proceture, so we need to wait until it is ready to use. */
+    pContext.pChannel = IotBleDataTransfer_Open( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_MQTT );
+
+    if( pContext.pChannel != NULL )
+    {
+        if( IotSemaphore_Create( &pContext.isReady, 0, 1 ) == true )
+        {
+            ( void ) IotBleDataTransfer_SetCallback( pContext.pChannel, demoCallback, NULL );
+
+            if( IotSemaphore_TimedWait( &pContext.isReady, IOT_BLE_MQTT_CREATE_CONNECTION_WAIT_MS ) == true )
+            {
+                LogInfo( ( "The channel was initialized successfully" ) );
+
+                status = MQTTSuccess;
+            }
+            else
+            {
+                LogError( ( "The BLE Connection timed out" ) );
+                status = MQTTServerRefused;
+            }
+        }
+        else
+        {
+            LogError( ( "Could not create network connection semaphore." ) );
+            status = MQTTNoMemory;
+        }
+    }
+
+    if( status != MQTTSuccess )
+    {
+        LogError( ( "Something went wrong in initializing the demo" ) );
+        status = MQTTServerRefused;
+    }
+
+    return status;
+}
+
+
+static uint16_t getNextPacketIdentifier( void )
+{
+    static uint16_t packetId = 1;
+
+    /* Since ID can never be 0, we traverse odd numbers */
+    packetId += 2U;
+
+    return packetId;
+}
+
+static MQTTStatus_t getNewData( const MQTTFixedBuffer_t * buf,
+                                MQTTPacketInfo_t * incomingPacket )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    size_t receiveAttempts = 0;
+    uint8_t bufferIndex = 0;
+    uint32_t bytesReturned = 0;
+    size_t bytesToRead = 0;
+
+    do
+    {
+        taskYIELD();
+        result = MQTT_GetIncomingPacketTypeAndLength( IotBleMqttTransportReceive, &pContext, incomingPacket );
+        receiveAttempts++;
+    } while( ( receiveAttempts < MQTT_MAX_RECV_ATTEMPTS ) && ( result != MQTTSuccess ) );
+
+    assert( result == MQTTSuccess );
+
+    receiveAttempts = 0;
+    bytesToRead = incomingPacket->remainingLength;
+
+    /* Now receive the remaining packet into statically allocated buffer. */
+    do
+    {
+        bytesReturned = ( size_t ) IotBleMqttTransportReceive( &pContext, &buf->pBuffer[ bufferIndex ], bytesToRead );
+        receiveAttempts++;
+
+        /* We are guaranteed to read up to the amount of requested bytes.
+         * Update the amount of bytes still needed if we read less than requested.
+         * Adjust the buffer index to write coniguously in memory. */
+        if( bytesReturned <= bytesToRead )
+        {
+            bufferIndex += bytesReturned;
+            bytesToRead -= bytesReturned;
+        }
+
+        taskYIELD();
+    } while( ( receiveAttempts < MQTT_MAX_RECV_ATTEMPTS ) && ( bytesToRead > 0U ) );
+
+    incomingPacket->pRemainingData = buf->pBuffer;
+
+    return result;
+}
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t createMQTTConnectionWithBroker( const MQTTFixedBuffer_t * buf )
+{
+    MQTTConnectInfo_t mqttConnectInfo;
+    size_t remainingLength;
+    size_t packetSize;
+    MQTTStatus_t result;
+    MQTTPacketInfo_t incomingPacket;
+    size_t status;
+    char demoClientIdentifier[ CLIENT_IDENTIFIER_MAX_LENGTH ];
+    uint16_t packetId = 0;
+    bool sessionPresent = false;
+
+    LogDebug( ( "Trying to send a connect packet to the server" ) );
+
+    /* Many fields not used in this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &mqttConnectInfo, 0x00, sizeof( mqttConnectInfo ) );
+
+    /* Start with a clean session i.e. direct IoT Core to discard any
+     * previous session data. Also, establishing a connection with clean session
+     * will ensure that the broker does not store any data when this client
+     * gets disconnected. */
+    mqttConnectInfo.cleanSession = true;
+
+    /* Generate the payload for the PUBLISH. */
+    status = ( size_t ) snprintf( demoClientIdentifier,
+                                  CLIENT_IDENTIFIER_MAX_LENGTH,
+                                  CLIENT_IDENTIFIER_PREFIX "%u",
+                                  ( uint16_t ) IotClock_GetTimeMs() );
+
+    LogInfo( ( "Generated client identifier is %s", demoClientIdentifier ) );
+
+    /* The client identifier is used to uniquely identify this MQTT client to
+     * IoT Core. In a production device the identifier can be something
+     * unique, such as a device serial number. */
+    mqttConnectInfo.pClientIdentifier = demoClientIdentifier;
+    mqttConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( demoClientIdentifier );
+
+    /* Set MQTT keep-alive period. It is the responsibility of the application to ensure
+     * that the interval between Control Packets being sent does not exceed the Keep Alive value.
+     * In the absence of sending any other Control Packets, the Client MUST send a PINGREQ Packet. */
+    mqttConnectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_PERIOD_SECONDS;
+
+    /* Get size requirement for the connect packet */
+    result = MQTT_GetConnectPacketSize( &mqttConnectInfo, NULL, &remainingLength, &packetSize );
+
+    /* Serialize MQTT connect packet into the provided buffer. */
+    result = MQTT_SerializeConnect( &mqttConnectInfo, NULL, packetSize, buf );
+    assert( result == MQTTSuccess );
+
+    /* Send the serialized connect packet to IoT Core */
+    status = ( size_t ) IotBleMqttTransportSend( &pContext, ( void * ) buf->pBuffer, packetSize );
+    assert( status == packetSize );
+
+    LogDebug( ( "Successfully sent a connect packet to the server" ) );
+    LogDebug( ( "Waiting for a connection acknowledgement from the server" ) );
+
+    /* Reset all fields of the incoming packet structure. */
+    ( void ) memset( ( void * ) &incomingPacket, 0x00, sizeof( MQTTPacketInfo_t ) );
+
+    status = getNewData( buf, &incomingPacket );
+
+    /* Deserialize the received packet to make sure the content of the CONNACK
+     * is valid. Note that the packetId is not present in the connection ack. */
+    result = MQTT_DeserializeAck( &incomingPacket, &packetId, &sessionPresent );
+
+    LogDebug( ( "Successfully received a connack packet" ) );
+
+    if( result != MQTTSuccess )
+    {
+        LogError( ( "Connection with IoT Core failed.\r\n" ) );
+    }
+    else
+    {
+        LogInfo( ( "Successfully connected with IoT Core\r\n" ) );
+    }
+
+    return result;
+}
+
+
+static void mqttSubscribeToTopic( const MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    MQTTSubscribeInfo_t mqttSubscription[ 1 ];
+    size_t remainingLength = 0;
+    size_t packetSize = 0;
+    size_t status = 0;
+
+    LogDebug( ( "Trying to send a subscribe packet to the server" ) );
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Some fields not used by this demo so start with everything as 0. */
+    ( void ) memset( ( void * ) &mqttSubscription, 0x00, sizeof( mqttSubscription ) );
+
+    /* Subscribe to the MQTT_EXAMPLE_TOPIC topic filter. This example subscribes to
+     * only one topic and uses QOS0. */
+    mqttSubscription[ 0 ].qos = MQTTQoS0;
+    mqttSubscription[ 0 ].pTopicFilter = MQTT_EXAMPLE_TOPIC;
+    mqttSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( MQTT_EXAMPLE_TOPIC );
+
+    result = MQTT_GetSubscribePacketSize( mqttSubscription,
+                                          sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                          &remainingLength, &packetSize );
+
+    assert( result == MQTTSuccess );
+
+    subscribePacketIdentifier = getNextPacketIdentifier();
+
+    /* Serialize subscribe into statically allocated buffer. */
+    result = MQTT_SerializeSubscribe( mqttSubscription,
+                                      sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                      subscribePacketIdentifier,
+                                      remainingLength,
+                                      buf );
+    assert( result == MQTTSuccess );
+
+    /* Send Subscribe request to the broker. */
+    status = ( size_t ) IotBleMqttTransportSend( &pContext, buf->pBuffer, packetSize );
+    assert( status == packetSize );
+
+    LogDebug( ( "Successfully sent subscribe packet to the server" ) );
+}
+
+
+static void mqttUnsubscribeFromTopic( const MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    MQTTSubscribeInfo_t mqttSubscription[ 1 ];
+    size_t remainingLength = 0;
+    size_t packetSize = 0;
+    size_t status = 0;
+
+    LogDebug( ( "Trying to send an unsubscribe packet to the server" ) );
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &mqttSubscription, 0x00, sizeof( mqttSubscription ) );
+
+    /* Unsubscribe to the MQTT_EXAMPLE_TOPIC topic filter. */
+    mqttSubscription[ 0 ].qos = MQTTQoS0;
+    mqttSubscription[ 0 ].pTopicFilter = MQTT_EXAMPLE_TOPIC;
+    mqttSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( MQTT_EXAMPLE_TOPIC );
+
+    result = MQTT_GetUnsubscribePacketSize( mqttSubscription,
+                                            sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                            &remainingLength,
+                                            &packetSize );
+    assert( result == MQTTSuccess );
+
+    /* Get next unique packet identifier */
+    unsubscribePacketIdentifier = getNextPacketIdentifier();
+
+    result = MQTT_SerializeUnsubscribe( mqttSubscription,
+                                        sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                        unsubscribePacketIdentifier,
+                                        remainingLength,
+                                        buf );
+    assert( result == MQTTSuccess );
+
+    /* Send Unsubscribe request to the broker. */
+    status = ( size_t ) IotBleMqttTransportSend( &pContext, buf->pBuffer, packetSize );
+    assert( status == packetSize );
+
+    LogDebug( ( "Successfully sent an unsubscribe packet to the server" ) );
+}
+
+
+static void mqttKeepAlive( const MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    int32_t status = 0;
+    size_t packetSize = 0;
+
+    LogDebug( ( "Trying to send a ping request packet to the server" ) );
+
+    /* Calculate PING request size. */
+    result = MQTT_GetPingreqPacketSize( &packetSize );
+
+    assert( packetSize > 0U );
+
+    result = MQTT_SerializePingreq( buf );
+    assert( result == MQTTSuccess );
+
+    /* Send Ping Request to the broker. */
+    status = IotBleMqttTransportSend( &pContext, buf->pBuffer, packetSize );
+    assert( status == ( int32_t ) packetSize );
+
+    LogDebug( ( "Successfully sent a ping request packet to the server" ) );
+}
+
+
+static void mqttDisconnect( const MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    int32_t status = 0;
+    size_t packetSize = 0;
+
+    LogDebug( ( "Trying to send a disconnect packet to the server" ) );
+
+    result = MQTT_GetDisconnectPacketSize( &packetSize );
+
+    assert( packetSize > 0U );
+
+    result = MQTT_SerializeDisconnect( buf );
+    assert( result == MQTTSuccess );
+
+    /* Send disconnect packet to the broker */
+    status = IotBleMqttTransportSend( &pContext, buf->pBuffer, packetSize );
+    assert( status == ( int32_t ) packetSize );
+
+    LogDebug( ( "Successfully sent a disconnect packet to the server" ) );
+}
+
+
+static void mqttPublishToTopic( const MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result;
+    MQTTPublishInfo_t mqttPublishInfo;
+    size_t remainingLength = 0;
+    size_t packetSize = 0;
+    uint16_t subPacketId = 0;
+    size_t bytesSent = 0;
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    LogDebug( ( "Trying to send a publish packet to the server" ) );
+
+    /* Some fields not used by this demo so start with everything as 0. */
+    ( void ) memset( ( void * ) &mqttPublishInfo, 0x00, sizeof( mqttPublishInfo ) );
+
+    /* This demo uses QOS0 */
+    mqttPublishInfo.qos = MQTTQoS0;
+    mqttPublishInfo.retain = false;
+    mqttPublishInfo.pTopicName = MQTT_EXAMPLE_TOPIC;
+    mqttPublishInfo.topicNameLength = ( uint16_t ) strlen( MQTT_EXAMPLE_TOPIC );
+    mqttPublishInfo.pPayload = MQTT_EXAMPLE_MESSAGE;
+    mqttPublishInfo.payloadLength = strlen( MQTT_EXAMPLE_MESSAGE );
+    mqttPublishInfo.dup = false;
+
+    /* Find out length of Publish packet size. */
+    result = MQTT_GetPublishPacketSize( &mqttPublishInfo, &remainingLength, &packetSize );
+    assert( result == MQTTSuccess );
+
+    subPacketId = getNextPacketIdentifier();
+
+    /* Serialize MQTT Publish packet header. The publish message payload will
+     * be sent directly in order to avoid copying it into the buffer.
+     * QOS0 does not make use of packet identifier, therefore value of 0 is used */
+    result = MQTT_SerializePublish( &mqttPublishInfo,
+                                    subPacketId,
+                                    remainingLength,
+                                    buf );
+    assert( result == MQTTSuccess );
+
+    bytesSent = ( size_t ) IotBleMqttTransportSend( &pContext, buf->pBuffer, packetSize );
+
+    assert( bytesSent == ( size_t ) packetSize );
+
+    LogDebug( ( "Successfully sent a publish packet to the server" ) );
+}
+
+
+static void mqttProcessResponse( const MQTTPacketInfo_t * pIncomingPacket,
+                                 const uint16_t packetId )
+{
+    switch( pIncomingPacket->type & HIGH_BYTE_MASK )
+    {
+        case MQTT_PACKET_TYPE_SUBACK:
+            LogDebug( ( "Subscribed to the topic %s.\r\n", MQTT_EXAMPLE_TOPIC ) );
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            assert( subscribePacketIdentifier == packetId );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBACK:
+            LogDebug( ( "Unsubscribed from the topic %s.\r\n", MQTT_EXAMPLE_TOPIC ) );
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            assert( unsubscribePacketIdentifier == packetId );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGRESP:
+            LogDebug( ( "Ping Response successfully received.\r\n" ) );
+            break;
+
+        /* Any other packet type is invalid. */
+        default:
+            LogWarn( ( "mqttProcessResponse() called with unknown packet type:(%u).",
+                       ( uint8_t ) pIncomingPacket->type ) );
+            break;
+    }
+}
+
+
+static void mqttProcessIncomingPublish( const MQTTPublishInfo_t * pPubInfo,
+                                        const uint16_t packetId )
+{
+    assert( pPubInfo != NULL );
+
+    /* Since this example does not make use of QOS1 or QOS2,
+     * packet identifier is not required. */
+    ( void ) packetId;
+
+    /* Verify the received publish is for the topic we have subscribed to. */
+    if( ( pPubInfo->topicNameLength == strlen( MQTT_EXAMPLE_TOPIC ) ) &&
+        ( 0 == strncmp( MQTT_EXAMPLE_TOPIC, pPubInfo->pTopicName, pPubInfo->topicNameLength ) ) )
+    {
+        LogInfo( ( "Incoming Publish Topic Name: %.*s matches subscribed topic.\n",
+                   pPubInfo->topicNameLength,
+                   pPubInfo->pTopicName ) );
+        LogInfo( ( "Incoming Publish Message : %.*s\n",
+                   pPubInfo->payloadLength,
+                   ( char * ) pPubInfo->pPayload ) );
+    }
+    else
+    {
+        LogError( ( "Incoming Publish Topic Name: %.*s does not match subscribed topic. \n",
+                    pPubInfo->topicNameLength,
+                    pPubInfo->pTopicName ) );
+    }
+}
+
+
+static void mqttProcessIncomingPacket( MQTTFixedBuffer_t * buf )
+{
+    MQTTStatus_t result = MQTTSuccess;
+    MQTTPacketInfo_t incomingPacket;
+    MQTTPublishInfo_t publishInfo;
+    uint16_t responsePacketId = 0;
+    bool sessionPresent = false;
+
+    LogDebug( ( "Trying to receive an incoming packet" ) );
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    ( void ) memset( ( void * ) &incomingPacket, 0x00, sizeof( MQTTPacketInfo_t ) );
+
+    result = getNewData( buf, &incomingPacket );
+
+    if( ( incomingPacket.type & HIGH_BYTE_MASK ) == MQTT_PACKET_TYPE_PUBLISH )
+    {
+        result = MQTT_DeserializePublish( &incomingPacket, &responsePacketId, &publishInfo );
+        assert( result == MQTTSuccess );
+        LogDebug( ( "Incoming publish packet received successfully." ) );
+
+        /* Process incoming Publish message. */
+        mqttProcessIncomingPublish( &publishInfo, responsePacketId );
+    }
+    else
+    {
+        /* If the received packet is not a Publish message, then it is an ACK for one
+         * of the messages we sent out, verify that the ACK packet is a valid MQTT
+         * packet. Since CONNACK is already processed, session present parameter is
+         * to NULL */
+        result = MQTT_DeserializeAck( &incomingPacket, &responsePacketId, &sessionPresent );
+        assert( result == MQTTSuccess );
+
+        /* Process the response. */
+        mqttProcessResponse( &incomingPacket, responsePacketId );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Entry point of demo.
+ */
+MQTTStatus_t RunMQTTTransportDemo( void )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTFixedBuffer_t fixedBuffer;
+    uint16_t loopCount = 0;
+    const uint16_t maxLoopCount = 5U;
+    uint16_t demoIterations = 0;
+    const uint16_t maxDemoIterations = 5U;
+    bool publishPacketSent = false;
+
+    /***
+     * The network context buffer must be provided by the application.
+     * Here we use static memory, but dynamic memory is OK too, so
+     * long as it is provided and allocated by the user
+     ***/
+    uint8_t buf[ STATIC_BUFFER_SIZE ];
+
+    pContext.buf = buf;
+    pContext.bufSize = STATIC_BUFFER_SIZE;
+
+    /***
+     * Set Fixed size buffer structure that is required by API to serialize
+     * and deserialize data. pBuffer is pointing to a fixed sized mqttSharedBuffer.
+     * The application may allocate dynamic memory as well.
+     ***/
+    uint8_t demoStaticBuffer[ STATIC_BUFFER_SIZE ];
+    fixedBuffer.pBuffer = demoStaticBuffer;
+    fixedBuffer.size = STATIC_BUFFER_SIZE;
+
+    status = demoInitChannel();
+
+    if( status != MQTTSuccess )
+    {
+        LogError( ( "There was a problem initializing the data channel" ) );
+        assert( false );
+    }
+
+    for( demoIterations = 0; demoIterations < maxDemoIterations; demoIterations++ )
+    {
+        if( status == MQTTSuccess )
+        {
+            /* Sends an MQTT Connect packet over the already connected TCP socket
+             * tcpSocket, and waits for connection acknowledgment (CONNACK) packet. */
+            LogInfo( ( "Establishing MQTT connection to server" ) );
+            status = createMQTTConnectionWithBroker( &fixedBuffer );
+
+            if( ( status != MQTTSuccess ) && ( channelActive == false ) )
+            {
+                break;
+            }
+
+            /**************************** Subscribe. ******************************/
+
+            /* The client is now connected to the broker. Subscribe to the topic
+             * as specified in MQTT_EXAMPLE_TOPIC at the top of this file by sending a
+             * subscribe packet then waiting for a subscribe acknowledgment (SUBACK).
+             * This client will then publish to the same topic it subscribed to, so it
+             * will expect all the messages it sends to the broker to be sent back to it
+             * from the broker. This demo uses QOS0 in subscribe, therefore, the Publish
+             * messages received from the broker will have QOS0. */
+            /* Subscribe and SUBACK */
+            LogInfo( ( "Attempt to subscribe to the MQTT topic %s\r\n", MQTT_EXAMPLE_TOPIC ) );
+            mqttSubscribeToTopic( &fixedBuffer );
+
+            /* Process incoming packet from the broker. After sending the subscribe, the
+             * client may receive a publish before it receives a subscribe ack. Therefore,
+             * call generic incoming packet processing function. Since this demo is
+             * subscribing to the topic to which no one is publishing, probability of
+             * receiving Publish message before subscribe ack is zero; but application
+             * must be ready to receive any packet.  This demo uses the generic packet
+             * processing function everywhere to highlight this fact. */
+            mqttProcessIncomingPacket( &fixedBuffer );
+
+            /********************* Publish and Keep Alive Loop. ********************/
+            /* Publish messages with QOS0, send and process Keep alive messages. */
+            for( loopCount = 0; loopCount < maxLoopCount; loopCount++ )
+            {
+                if( channelActive == false )
+                {
+                    break;
+                }
+
+                /* Get the current time stamp */
+                /* Publish to the topic every other time to trigger sending of PINGREQ  */
+                if( publishPacketSent == false )
+                {
+                    LogInfo( ( "Publish to the MQTT topic %s\r\n", MQTT_EXAMPLE_TOPIC ) );
+                    mqttPublishToTopic( &fixedBuffer );
+
+                    /* Set control packet sent flag to true so that the lastControlPacketSent
+                     * timestamp will be updated. */
+                    publishPacketSent = true;
+                }
+                else
+                {
+                    /* Check if the keep-alive period has elapsed, since the last control packet was sent.
+                     * If the period has elapsed, send out MQTT PINGREQ to the broker.  */
+
+                    /* Send PINGREQ to the broker */
+                    LogInfo( ( "Sending PINGREQ to the broker\n " ) );
+                    mqttKeepAlive( &fixedBuffer );
+
+                    /* Since PUBLISH packet is not sent for this iteration, set publishPacketSent to false
+                     * so the next iteration will send PUBLISH .*/
+                    publishPacketSent = false;
+                }
+
+                /* Since the application is subscribed publishing messages to the same topic,
+                 * the broker will send the same message back to the application.
+                 * Process incoming PUBLISH echo or PINGRESP. */
+                mqttProcessIncomingPacket( &fixedBuffer );
+
+                /* Sleep until keep alive time period, so that for the next iteration this
+                 * loop will send out a PINGREQ if PUBLISH was not sent for this iteration.
+                 * The broker will wait till 1.5 times keep-alive period before it disconnects
+                 * the client. */
+                ( void ) sleep( MQTT_KEEP_ALIVE_PERIOD_SECONDS );
+            }
+
+            if( channelActive == false )
+            {
+                break;
+            }
+
+            /* Unsubscribe from the previously subscribed topic */
+            LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", MQTT_EXAMPLE_TOPIC ) );
+            mqttUnsubscribeFromTopic( &fixedBuffer );
+            /* Process Incoming unsubscribe ack from the broker. */
+            mqttProcessIncomingPacket( &fixedBuffer );
+
+            /* Send an MQTT Disconnect packet over the already connected TCP socket.
+             * There is no corresponding response for the disconnect packet. After sending
+             * disconnect, client must close the network connection. */
+            LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", MQTT_EXAMPLE_TOPIC ) );
+            mqttDisconnect( &fixedBuffer );
+        }
+
+        if( demoIterations < ( maxDemoIterations - 1U ) )
+        {
+            /* Wait for some time between two iterations to ensure that we do not
+             * bombard the public test mosquitto broker. */
+            LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
+            ( void ) sleep( MQTT_DEMO_ITERATION_DELAY_SECONDS );
+
+            IotBleMqttTransportCleanup();
+            IotBleMqttTransportInit( &pContext );
+        }
+    }
+
+    if( channelActive == false )
+    {
+        IotBleMqttTransportCleanup();
+        LogError( ( "BLE disconnected unexpectedly" ) );
+        status = MQTTBadResponse;
+    }
+    else
+    {
+        LogInfo( ( "Demo completed successfully.\r\n" ) );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/

--- a/demos/mqtt_transport/mqtt_demo_transport.c
+++ b/demos/mqtt_transport/mqtt_demo_transport.c
@@ -69,8 +69,8 @@
 
 /**
  * @brief The size of the circular buffer used by the transport code to hold incoming packets.
- */ 
-#define INCOMING_PACKET_QUEUE_SIZE           256U        
+ */
+#define INCOMING_PACKET_QUEUE_SIZE           256U
 
 /**
  * @brief The number of subscription/unsubscription requests sent per packet in this demo
@@ -165,7 +165,7 @@ static NetworkContext_t xContext;
 static volatile bool channelActive = false;
 
 /**
- * @brief Buffer used by the transport interface to queue incoming packets for use. 
+ * @brief Buffer used by the transport interface to queue incoming packets for use.
  */
 static uint8_t contextBuf[ INCOMING_PACKET_QUEUE_SIZE ];
 
@@ -275,10 +275,10 @@ static MQTTStatus_t getNewData( const MQTTFixedBuffer_t * buf,
     uint32_t bytesReturned = 0;
     size_t bytesToRead = 0;
 
-    /* Waits until there is data available from the channel to receive it. 
-       A "No data was received from the transport." may appear from each unsuccessful attempt.
-       This program will stop after 20 attempts, with 250 seconds in between by default. 
-       If you have high latency, you can adjust MQTT_MAX_RECV_ATTEMPTS above. */
+    /* Waits until there is data available from the channel to receive it.
+     * A "No data was received from the transport." may appear from each unsuccessful attempt.
+     * This program will stop after 20 attempts, with 250 seconds in between by default.
+     * If you have high latency, you can adjust MQTT_MAX_RECV_ATTEMPTS above. */
     do
     {
         taskYIELD();
@@ -415,12 +415,12 @@ static void mqttSubscribeToTopics( const MQTTFixedBuffer_t * buf )
     ( void ) memset( ( void * ) &mqttSubscription, 0x00, sizeof( mqttSubscription ) );
 
     /* Populate the topic filter names with user defined strings. */
-    for ( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
+    for( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
     {
         mqttSubscription[ i ].pTopicFilter = subscriptionArray[ i ];
         mqttSubscription[ i ].topicFilterLength = ( uint16_t ) strlen( subscriptionArray[ i ] );
     }
-    
+
     result = MQTT_GetSubscribePacketSize( mqttSubscription,
                                           sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
                                           &remainingLength, &packetSize );
@@ -460,7 +460,7 @@ static void mqttUnsubscribeFromTopic( const MQTTFixedBuffer_t * buf )
     ( void ) memset( ( void * ) &mqttUnsubscription, 0x00, sizeof( mqttUnsubscription ) );
 
     /* Populate the topic filter names with user defined strings. */
-    for ( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
+    for( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
     {
         mqttUnsubscription[ i ].pTopicFilter = subscriptionArray[ i ];
         mqttUnsubscription[ i ].topicFilterLength = ( uint16_t ) strlen( subscriptionArray[ i ] );
@@ -556,13 +556,13 @@ static void mqttPublishToTopic( const MQTTFixedBuffer_t * buf )
     /* Some fields not used by this demo so start with everything as 0. */
     ( void ) memset( ( void * ) &mqttPublishInfo, 0x00, sizeof( mqttPublishInfo ) );
 
-    for(int i = 0; i < NUM_SUBS_AT_ONCE; ++i)
+    for( int subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
     {
         /* This demo uses QOS0 */
         mqttPublishInfo.qos = MQTTQoS0;
         mqttPublishInfo.retain = false;
-        mqttPublishInfo.pTopicName = subscriptionArray[ i ];
-        mqttPublishInfo.topicNameLength = ( uint16_t ) strlen( subscriptionArray[ i ] );
+        mqttPublishInfo.pTopicName = subscriptionArray[ subscriptionNumber ];
+        mqttPublishInfo.topicNameLength = ( uint16_t ) strlen( subscriptionArray[ subscriptionNumber ] );
         mqttPublishInfo.pPayload = MQTT_EXAMPLE_MESSAGE;
         mqttPublishInfo.payloadLength = strlen( MQTT_EXAMPLE_MESSAGE );
         mqttPublishInfo.dup = false;
@@ -574,8 +574,8 @@ static void mqttPublishToTopic( const MQTTFixedBuffer_t * buf )
         subPacketId = getNextPacketIdentifier();
 
         /* Serialize MQTT Publish packet header. The publish message payload will
-        * be sent directly in order to avoid copying it into the buffer.
-        * QOS0 does not make use of packet identifier, therefore value of 0 is used */
+         * be sent directly in order to avoid copying it into the buffer.
+         * QOS0 does not make use of packet identifier, therefore value of 0 is used */
         result = MQTT_SerializePublish( &mqttPublishInfo,
                                         subPacketId,
                                         remainingLength,
@@ -632,22 +632,22 @@ static void mqttProcessIncomingPublish( const MQTTPublishInfo_t * pPubInfo,
     ( void ) packetId;
 
     /* Verify the received publish is for the topic we have subscribed to. */
-    for ( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
+    for( size_t i = 0; i < NUM_SUBS_AT_ONCE; ++i )
     {
-        if ( 0 == strncmp( subscriptionArray[ i ], pPubInfo->pTopicName, pPubInfo->topicNameLength ) )
+        if( 0 == strncmp( subscriptionArray[ i ], pPubInfo->pTopicName, pPubInfo->topicNameLength ) )
         {
             LogInfo( ( "Incoming Publish Topic Name: %.*s matches subscribed topic.",
-                    pPubInfo->topicNameLength,
-                    pPubInfo->pTopicName ) );
+                       pPubInfo->topicNameLength,
+                       pPubInfo->pTopicName ) );
             LogInfo( ( "Incoming Publish Message : %.*s",
-                    pPubInfo->payloadLength,
-                    ( char * ) pPubInfo->pPayload ) );
+                       pPubInfo->payloadLength,
+                       ( char * ) pPubInfo->pPayload ) );
             matchedSubscription = true;
             break;
         }
     }
 
-    if ( !matchedSubscription )
+    if( !matchedSubscription )
     {
         LogError( ( "Incoming Publish Topic Name: %.*s does not match any subscribed topic.",
                     pPubInfo->topicNameLength,
@@ -742,7 +742,7 @@ MQTTStatus_t RunMQTTTransportDemo( void )
     {
         if( status == MQTTSuccess )
         {
-            /* Send a connect packet to the broker and waits for a connack packet 
+            /* Send a connect packet to the broker and waits for a connack packet
              * to establish an end to end connection */
             status = createMQTTConnectionWithBroker( &fixedBuffer );
 
@@ -762,12 +762,12 @@ MQTTStatus_t RunMQTTTransportDemo( void )
             mqttSubscribeToTopics( &fixedBuffer );
 
             /* Process incoming packets from the broker. There will be one SUBACK packet
-             * for each topic subscribed to.  There remains the possiblity that another 
+             * for each topic subscribed to.  There remains the possiblity that another
              * person will publish to the topic before the SUBACK is received, but since
              * we are the only ones using this topic filter name, here that chance is zero.
              * However, one should use a generic incoming packet function for higher use
              * topic filters in case a PUBLISH arrives before the SUBACK. */
-            for ( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
+            for( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
             {
                 mqttProcessIncomingPacket( &fixedBuffer );
             }
@@ -793,7 +793,7 @@ MQTTStatus_t RunMQTTTransportDemo( void )
                     publishPacketSent = true;
 
                     /* Loop through and accept each incoming publish from the ones we just sent. */
-                    for ( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
+                    for( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
                     {
                         mqttProcessIncomingPacket( &fixedBuffer );
                     }
@@ -828,7 +828,7 @@ MQTTStatus_t RunMQTTTransportDemo( void )
             mqttUnsubscribeFromTopic( &fixedBuffer );
 
             /* Process Incoming unsubscribe acks from the broker. */
-            for ( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
+            for( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
             {
                 mqttProcessIncomingPacket( &fixedBuffer );
             }
@@ -836,7 +836,7 @@ MQTTStatus_t RunMQTTTransportDemo( void )
             /* Send an MQTT Disconnect packet over the already connected BLE channel.
              * There is no corresponding response for the disconnect packet. After sending
              * disconnect, client must close the network connection. */
-            LogInfo( ( "Disconnecting the MQTT connection with the broker ") );
+            LogInfo( ( "Disconnecting the MQTT connection with the broker " ) );
             mqttDisconnect( &fixedBuffer );
         }
 
@@ -854,6 +854,7 @@ MQTTStatus_t RunMQTTTransportDemo( void )
     }
 
     IotBleMqttTransportCleanup();
+
     if( channelActive == false )
     {
         LogError( ( "BLE disconnected unexpectedly" ) );

--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -30,7 +30,6 @@ afr_module_sources(
         "${inc_dir}/iot_ble_data_transfer.h"
         "${inc_dir}/iot_ble_device_information.h"
         "${inc_dir}/iot_ble_mqtt_serialize.h"
-        "${inc_dir}/iot_ble_mqtt_transport.h"
         "${inc_dir}/iot_ble_wifi_provisioning.h"
         "${inc_dir}/iot_ble.h"
 )
@@ -116,6 +115,7 @@ afr_module_include_dirs(
     PUBLIC
         "${inc_dir}"
         "${AFR_MODULES_DIR}/c_sdk/standard/mqtt_v2/include/"
+        "${AFR_MODULES_DIR}/c_sdk/standard/logging_stack"
         "$<${AFR_IS_TESTING}:${src_dir}>"
     PRIVATE
         "${test_dir}"

--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -30,6 +30,7 @@ afr_module_sources(
         "${inc_dir}/iot_ble_data_transfer.h"
         "${inc_dir}/iot_ble_device_information.h"
         "${inc_dir}/iot_ble_mqtt_serialize.h"
+        "${inc_dir}/iot_ble_mqtt_transport.h"
         "${inc_dir}/iot_ble_wifi_provisioning.h"
         "${inc_dir}/iot_ble.h"
 )
@@ -98,4 +99,31 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         AFR::ble_wifi_provisioning
+)
+
+#MQTT over BLE
+afr_module(NAME mqtt_ble)
+
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    PRIVATE
+        "${src_dir}/iot_ble_mqtt_serialize.c"
+        "${src_dir}/iot_ble_mqtt_transport.c"
+)
+
+afr_module_include_dirs(
+    ${AFR_CURRENT_MODULE}
+    PUBLIC
+        "${inc_dir}"
+        "${AFR_MODULES_DIR}/c_sdk/standard/mqtt_v2/include/"
+        "$<${AFR_IS_TESTING}:${src_dir}>"
+    PRIVATE
+        "${test_dir}"
+)
+
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    PUBLIC
+        AFR::ble
+	    AFR::mqtt_v2
 )

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
@@ -150,8 +150,7 @@ MQTTStatus_t IotBleMqtt_DeserializeConnack( MQTTPacketInfo_t * pConnack );
 MQTTStatus_t IotBleMqtt_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo,
                                           uint8_t ** const pPublishPacket,
                                           size_t * const pPacketSize,
-                                          uint16_t * const pPacketIdentifier,
-                                          uint8_t ** pPacketIdentifierHigh );
+                                          uint16_t * const pPacketIdentifier);
 
 /**
  * @brief Set the DUP flag to indicate its a duplicate QoS1/QoS2 message.

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
@@ -150,7 +150,7 @@ MQTTStatus_t IotBleMqtt_DeserializeConnack( MQTTPacketInfo_t * pConnack );
 MQTTStatus_t IotBleMqtt_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo,
                                           uint8_t ** const pPublishPacket,
                                           size_t * const pPacketSize,
-                                          uint16_t * const pPacketIdentifier);
+                                          uint16_t * const pPacketIdentifier );
 
 /**
  * @brief Set the DUP flag to indicate its a duplicate QoS1/QoS2 message.

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
@@ -34,7 +34,16 @@
 #include "iot_ble_mqtt_serialize.h"
 #include "iot_ble_data_transfer.h"
 #include "platform/iot_network.h"
+#include "types/iot_platform_types.h"
 
+
+struct NetworkContext
+{
+    IotBleDataTransferChannel_t * pChannel;
+    IotSemaphore_t isReady;
+    void * buf;
+    size_t bufSize;
+};
 
 /**
  * @brief Initiailzes the Circular buffer to store the received data

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
@@ -1,0 +1,81 @@
+/*
+ * IoT Platform V1.1.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef IOT_BLE_MQTT_TRANSPORT_H
+#define IOT_BLE_MQTT_TRANSPORT_H
+
+/* Standard includes. */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "iot_ble_mqtt_transport_config.h"
+#include "mqtt_lightweight.h"
+#include "iot_ble_mqtt_serialize.h"
+#include "iot_ble_data_transfer.h"
+#include "platform/iot_network.h"
+
+
+/**
+ * @brief Initiailzes the Circular buffer to store the received data
+ */
+bool IotBleMqttTransportInit( const NetworkContext_t * pContext );
+
+/**
+ * @brief Cleans up the Circular buffer
+ */
+void IotBleMqttTransportCleanup( void );
+
+/**
+ * @brief Function to accept data from the channel
+ *
+ * @param[in] pContext An opaque used by transport interface.
+ */
+void IotBleMqttTransportAcceptData( const NetworkContext_t * pContext );
+
+/**
+ * @brief Transport interface write function.
+ *
+ * @param[in] context An opaque used by transport interface.
+ * @param[in] buf A pointer to a buffer containing data to be sent out.
+ * @param[in] bytesToWrite number of bytes to write from the buffer.
+ * @return the number of bytes sent.
+ */
+int32_t IotBleMqttTransportSend( NetworkContext_t * pContext,
+                                 void * buf,
+                                 size_t bytesToWrite );
+
+/**
+ * @brief Transport interface read function.
+ *
+ * @param[in] context An opaque used by transport interface.
+ * @param[in] buf A pointer to a buffer where incoming data will be stored.
+ * @param[in] bytesToRead number of bytes to read from the transport layer.
+ * @return the number of bytes successfully read.
+ */
+int32_t IotBleMqttTransportReceive( NetworkContext_t * pContext,
+                                    void * buf,
+                                    size_t bytesToRead );
+
+
+#endif /* ifndef IOT_BLE_MQTT_TRANSPORT_H */

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
@@ -47,4 +47,4 @@
  */
 #define RECV_TIMEOUT_MS             250U
 
-#endif
+#endif /* ifndef IOT_BLE_MQTT_TRANSPORT_CONFIG_H */

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
@@ -25,10 +25,26 @@
 #define IOT_BLE_MQTT_TRANSPORT_CONFIG_H
 
 
-/* The maximum number of subscriptions one subscribe packet can hold
- * RECV_PACKET_BUFFER_SIZE will be reconfigured in testing, and MAX_SUBS_PER_PACKET
- * will be a some factor of the buffer size.
+#include "logging_levels.h"
+
+/* Configure name and log level for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME     "MQTT_BLE"
+#endif
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#include "logging_stack.h"
+
+/**
+ * @brief The maximum number of subscriptions one subscribe packet can hold
  */
 #define MQTT_MAX_SUBS_PER_PACKET    10U
+
+/**
+ * @brief The amount of time transport layer blocks on receiving new data from the server.
+ */
+#define RECV_TIMEOUT_MS             250U
 
 #endif

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport_config.h
@@ -1,0 +1,34 @@
+/*
+ * IoT Platform V1.1.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef IOT_BLE_MQTT_TRANSPORT_CONFIG_H
+#define IOT_BLE_MQTT_TRANSPORT_CONFIG_H
+
+
+/* The maximum number of subscriptions one subscribe packet can hold
+ * RECV_PACKET_BUFFER_SIZE will be reconfigured in testing, and MAX_SUBS_PER_PACKET
+ * will be a some factor of the buffer size.
+ */
+#define MQTT_MAX_SUBS_PER_PACKET    10U
+
+#endif

--- a/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
@@ -1,0 +1,1048 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <string.h>
+#include <assert.h>
+
+#include "FreeRTOS.h"
+#include "stream_buffer.h"
+#include "iot_ble.h"
+#include "iot_ble_mqtt_transport.h"
+#include "iot_ble_mqtt_serialize.h"
+#include "mqtt_lightweight.h"
+
+/*-----------------------------------------------------------*/
+
+/* Size of CONNACK, PUBACK. */
+#define SIZE_OF_SIMPLE_ACK    4U
+
+/* Size of DISCONNECT, PINGRESP and PINGREQ. */
+#define SIZE_OF_PING          2U
+
+/* Size of SUBACK, UNSUBACK.
+ * As of now, the only one ACK is received for any request
+ * and the size is always 5.
+ */
+#define SIZE_OF_SUB_ACK       5U
+
+
+/* Define masks for each flag in Connect packets */
+#define CLEAN_SESSION_MASK    0x02U
+
+#define WILL_FLAG_MASK        0X04U
+
+#define WILL_QOS_MASK         0x18U
+
+#define WILL_RETAIN_MASK      0x20U
+
+#define PASSWORD_MASK         0x40U
+
+#define USERNAME_MASK         0x80U
+
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Returns the integer represented by two length bytes.
+ *
+ * @param[in] buf A pointer to the MSB of the integer.
+ */
+static uint16_t getIntFromTwoBytes( const uint8_t * buf );
+
+
+/**
+ * @brief Converts the given integer to MQTTQoS_t
+ *
+ * @param[in] incomingQos, the integer to convert
+ */
+static MQTTQoS_t convertIntToQos( const uint8_t incomingQos );
+
+/**
+ * @brief Sets flags in connectConfig according to the packet in buf.
+ *
+ * @param[in] connectConfig, expected to be empty.
+ * @param[in] buf, which points to the MQTT packet.
+ * @return MQTTSuccess or MQTTBadParameter
+ */
+static MQTTStatus_t parseConnect( MQTTConnectInfo_t * connectConfig,
+                                  const uint8_t * buf );
+
+/**
+ * @brief Calculates number of subscriptions requested in a subscribe packet.
+ *
+ * @param[in] buf, whic points to the MQTT packet.
+ * @param[in] remainingLength which is the size of the rest of the packet.
+ * @param[in] subscribe, true iff you are parsing a subscribe packet, false if unsubscribe.
+ * @return the number of subscriptions.
+ */
+static uint16_t calculateNumSubs( const uint8_t * buf,
+                                  uint8_t remainingLength,
+                                  bool subscribe );
+
+/**
+ * @brief Sets flags in global var subscriptions according to the packet in buf.
+ *
+ * @param[in] subscription count, a pointer to a size_t with num subscriptions.
+ * @param[in] buf, which points to the MQTT packet.
+ * @param[out] pIdentifier, which points to packet identifier.
+ * @param[in] subscribe, true iff you are parsing a subscribe packet, false if unsubscribe.
+ * @return MQTTSuccess or MQTTBadParameter
+ */
+static MQTTStatus_t parseSubscribe( size_t * subscriptionCount,
+                                    const uint8_t * buf,
+                                    uint16_t * pIdentifier,
+                                    bool subscribe );
+
+/**
+ * @brief Serializes an ACK packet in MQTT format.
+ *
+ * @param[in] pBuffer, which is the buffer to write the packet to.
+ * @param[in] packetType which corresponds to which ack should be written.
+ * @param[in] packetId, the packet Identifier (unused with CONNACK packets).
+ * @return returns MQTTSuccess, MQTTBadParameter, or MQTTNoMemory.
+ */
+static MQTTStatus_t transportSerializeSuback( MQTTFixedBuffer_t * pBuffer,
+                                              uint8_t packetType,
+                                              uint16_t packetId );
+
+
+/**
+ * @brief Serializes a SUBACK packet in MQTT format.
+ *
+ * @param[in] pBuffer, which is the buffer to write the packet to.
+ * @param[in] packetType which corresponds to which ack should be written.
+ * @param[in] packetId, the packet Identifier.
+ * @return returns MQTTSuccess, MQTTBadParameter, or MQTTNoMemory.
+ */
+static MQTTStatus_t transportSerializeAck( MQTTFixedBuffer_t * pBuffer,
+                                           uint8_t packetType,
+                                           uint16_t packetId );
+
+
+/**
+ * @brief Serializes a Pingresp packet in MQTT Format.
+ *
+ * @param[in] pBuffer, which is the buffer to write the packet to.
+ * @return returns MQTTSuccess, MQTTBadParameter, or MQTTNoMemory.
+ */
+static MQTTStatus_t transportSerializePingresp( MQTTFixedBuffer_t * pBuffer );
+
+
+/**
+ * @brief Deserializes a Publish packet in MQTT Format
+ * @param[in]
+ *
+ * statis MQTTStatus_t */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Holds the list of topic filters to put into the subscribe packet.
+ */
+static MQTTSubscribeInfo_t _subscriptions[ MQTT_MAX_SUBS_PER_PACKET ];
+
+/**
+ * @brief Data structure to hold received data before user makes a request for it.
+ */
+static StreamBufferHandle_t streamBuffer;
+StaticStreamBuffer_t xStreamBufferStruct;
+
+/*-----------------------------------------------------------*/
+
+
+bool IotBleMqttTransportInit( const NetworkContext_t * pContext )
+{
+    bool status = true;
+
+    streamBuffer = xStreamBufferCreateStatic( pContext->bufSize, 1, pContext->buf, &xStreamBufferStruct );
+
+    if( streamBuffer == NULL )
+    {
+        status = false;
+    }
+
+    return status;
+}
+
+
+void IotBleMqttTransportCleanup( void )
+{
+    vStreamBufferDelete( streamBuffer );
+}
+
+
+static uint16_t getIntFromTwoBytes( const uint8_t * buf )
+{
+    uint16_t result = 0;
+
+    result = buf[ 0 ];
+    result <<= 8;
+    result += buf[ 1 ];
+    return result;
+}
+
+
+static MQTTQoS_t convertIntToQos( const uint8_t incomingQos )
+{
+    MQTTQoS_t qosValue = MQTTQoS0;
+
+    switch( incomingQos )
+    {
+        case 0U:
+            qosValue = MQTTQoS0;
+            break;
+
+        case 1U:
+            qosValue = MQTTQoS1;
+            break;
+
+        default:
+            LogError( ( "QoS 2 is not supported by MQTT over BLE. Defaulting to Qos 1." ) );
+            qosValue = MQTTQoS1;
+            break;
+    }
+
+    return qosValue;
+}
+
+
+static MQTTStatus_t parseConnect( MQTTConnectInfo_t * connectConfig,
+                                  const uint8_t * buf )
+{
+    bool willFlag = false;
+    bool willRetain = false;
+    bool passwordFlag = false;
+    bool usernameFlag = false;
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTQoS_t willQos = 0;
+    uint8_t connectionFlags = 0;
+    size_t bufferIndex = 0;
+
+
+    if( ( buf[ 0 ] & 0xf0U ) != MQTT_PACKET_TYPE_CONNECT )
+    {
+        status = MQTTBadParameter;
+    }
+
+    if( status == MQTTSuccess )
+    {
+        /* Skips the remaining length, which is not needed in connect packet.  Finds first 'M' (77) in 'MQTT'. */
+        while( buf[ bufferIndex ] != 77U )
+        {
+            bufferIndex++;
+        }
+
+        /* Skips 'MQTT'. */
+        bufferIndex += 4U;
+
+        /* The service level of the packet. Must be 4. */
+        if( ( buf[ bufferIndex ] != 4U ) )
+        {
+            LogError( ( "The service level of a connect packet must be 4, see [MQTT-3.1.2-2]." ) );
+            status = MQTTBadParameter;
+        }
+
+        /* Increment bufferIndex to be the start of the payload. */
+        bufferIndex++;
+        /* Second byte after payload is connection flags. */
+        connectionFlags = buf[ bufferIndex ];
+
+        /* The LSB is reserved and must be 0. */
+        if( ( connectionFlags & 0x01U ) != 0U )
+        {
+            LogError( ( "LSB of Connect Flags byte must be 0, see [MQTT-3.1.2-3]." ) );
+            status = MQTTBadParameter;
+        }
+    }
+
+    if( status == MQTTSuccess )
+    {
+        /* Get flag data from the flag byte. */
+        connectConfig->cleanSession = ( ( ( connectionFlags & CLEAN_SESSION_MASK ) >> 1 ) == 1U );
+        willFlag = ( ( ( connectionFlags & WILL_FLAG_MASK ) >> 2 ) == 1U );
+        willQos = convertIntToQos( ( connectionFlags & WILL_QOS_MASK ) >> 3 );
+        willRetain = ( ( ( connectionFlags & WILL_RETAIN_MASK ) >> 5 ) == 1U );
+        passwordFlag = ( ( ( connectionFlags & PASSWORD_MASK ) >> 6 ) == 1U );
+        usernameFlag = ( ( ( connectionFlags & USERNAME_MASK ) >> 7 ) == 1U );
+
+        /* The will retain flag is currently unused */
+        ( void ) willRetain;
+    }
+
+    if( ( status == MQTTSuccess ) && ( willQos > MQTTQoS1 ) )
+    {
+        LogError( ( "Qos 2 or higher is not currently supported by this library." ) );
+        status = MQTTBadParameter;
+    }
+
+    if( status == MQTTSuccess )
+    {
+        /* Third and fourth bytes are keep alive time */
+        connectConfig->keepAliveSeconds = getIntFromTwoBytes( &buf[ bufferIndex + 1U ] );
+
+        /* Start of the payload */
+        bufferIndex += 3U;
+
+        /* Client identifier is required, 2 length bytes and then identifier */
+        connectConfig->clientIdentifierLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+        connectConfig->pClientIdentifier = ( const char * ) &buf[ bufferIndex + 2U ];
+    }
+
+    if( ( status == MQTTSuccess ) && ( connectConfig->clientIdentifierLength == 0U ) )
+    {
+        LogError( ( "A client identifier must be present in a connect packet [MQTT-3.1.3-3]." ) );
+        status = MQTTBadParameter;
+    }
+
+    /* Set to start of rest of payload. */
+    bufferIndex = bufferIndex + 2U + connectConfig->clientIdentifierLength;
+
+    if( ( status == MQTTSuccess ) && ( willFlag == true ) )
+    {
+        /* Populate Last Will header information. */
+        MQTTPublishInfo_t willInfo;
+        willInfo.qos = willQos;
+        willInfo.retain = willRetain;
+        willInfo.topicNameLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+        willInfo.pTopicName = ( const char * ) &buf[ bufferIndex + 2U ];
+
+        if( willInfo.topicNameLength == 0U )
+        {
+            LogError( ( "The will flag was set but no will topic was given." ) );
+            status = MQTTBadParameter;
+        }
+
+        if( status == MQTTSuccess )
+        {
+            bufferIndex = bufferIndex + 2U + willInfo.topicNameLength;
+
+            /* Populate Last Will payload information. */
+            willInfo.payloadLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+            willInfo.pPayload = ( const char * ) &buf[ bufferIndex + 2U ];
+
+            bufferIndex = bufferIndex + 2U + willInfo.payloadLength;
+        }
+
+        /* As of now, last will is not used */
+        ( void ) willInfo;
+    }
+
+    if( ( status == MQTTSuccess ) && ( usernameFlag == true ) )
+    {
+        /* Populate Username header information. */
+        connectConfig->userNameLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+        connectConfig->pUserName = ( const char * ) &buf[ bufferIndex + 2U ];
+
+        if( connectConfig->userNameLength == 0U )
+        {
+            LogError( ( "The username flag was set but no username was given." ) );
+            status = MQTTBadParameter;
+        }
+
+        bufferIndex = bufferIndex + 2U + connectConfig->userNameLength;
+    }
+
+    if( ( status == MQTTSuccess ) && ( passwordFlag == true ) )
+    {
+        /* Populate Password header information. */
+        connectConfig->passwordLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+        connectConfig->pPassword = ( const char * ) &buf[ bufferIndex + 2U ];
+
+        if( connectConfig->passwordLength == 0U )
+        {
+            LogError( ( "The password flag was set but no password was given." ) );
+            status = MQTTBadParameter;
+        }
+
+        bufferIndex = bufferIndex + 2U + connectConfig->passwordLength;
+    }
+
+    return status;
+}
+
+
+static uint16_t calculateNumSubs( const uint8_t * buf,
+                                  uint8_t remainingLength,
+                                  bool subscribe )
+{
+    uint16_t numSubs = 0, totalSize = 0;
+
+    /* Loop through the rest of the packet. */
+    while( remainingLength - totalSize > 0U )
+    {
+        totalSize += ( getIntFromTwoBytes( &buf[ totalSize ] ) + 2U );
+
+        if( subscribe )
+        {
+            /* Increment by 1 for Qos Byte. If it is unsubscribe packet, skip this. */
+            totalSize++;
+        }
+
+        numSubs++;
+    }
+
+    return numSubs;
+}
+
+static MQTTStatus_t parseSubscribe( size_t * subscriptionCount,
+                                    const uint8_t * buf,
+                                    uint16_t * pIdentifier,
+                                    bool subscribe )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint8_t remainingLength = 0;
+    uint16_t bufferIndex = 0;
+    size_t subscriptionIndex = 0;
+
+    *pIdentifier = getIntFromTwoBytes( &buf[ 2 ] );
+
+    /* Stores the remaining length after the identifier */
+    remainingLength = buf[ 1 ] - 2U;
+
+    *subscriptionCount = calculateNumSubs( &buf[ 4 ], remainingLength, subscribe );
+
+    bufferIndex = 4U;
+
+    for( subscriptionIndex = 0; subscriptionIndex < *subscriptionCount; ++subscriptionIndex )
+    {
+        /* Populate the name of the topic to (un)subscribe to. */
+        _subscriptions[ subscriptionIndex ].topicFilterLength = getIntFromTwoBytes( &buf[ bufferIndex ] );
+        _subscriptions[ subscriptionIndex ].pTopicFilter = ( const char * ) &buf[ bufferIndex + 2U ];
+        bufferIndex += _subscriptions[ subscriptionIndex ].topicFilterLength + 2U;
+
+        /* For subscribe packets only, increment past qos byte. */
+        if( subscribe )
+        {
+            _subscriptions[ subscriptionIndex ].qos = convertIntToQos( buf[ bufferIndex ] & 0x03U );
+            bufferIndex++;
+
+            if( _subscriptions[ subscriptionIndex ].qos > MQTTQoS1 )
+            {
+                LogError( ( "Only Qos 0 and 1 are supported over BLE." ) );
+                status = MQTTBadParameter;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+static MQTTStatus_t transportSerializePublish( MQTTFixedBuffer_t * pBuffer,
+                                               MQTTPublishInfo_t * pPublishConfig,
+                                               uint16_t packetId )
+{
+    const char * restOfTopicName = &pPublishConfig->pTopicName[ 1 ];
+    const uint16_t restOfTopicNameLength = pPublishConfig->topicNameLength - 1U;
+    const char * pPayload = pPublishConfig->pPayload;
+    const uint16_t payloadLength = ( uint16_t ) pPublishConfig->payloadLength;
+    size_t remainingLength = 0U;
+    size_t packetSize = 0U;
+    size_t headerSize = 0U;
+    uint8_t headerBuffer[ 10 ];
+    uint8_t serializedArray[ 2 ];
+    MQTTStatus_t status = MQTTSuccess;
+
+    /* Header will only be type (1) + remaining length ( <= 4) + topic length (2) + 1 char of topic */
+    pBuffer->pBuffer = headerBuffer;
+
+    /* Change size to prevent memory errors, the real allocation is in stream buffer. */
+    pBuffer->size = 0xFFU;
+
+    pPublishConfig->topicNameLength = 1U;
+    pPublishConfig->payloadLength = 0;
+
+    status = MQTT_GetPublishPacketSize( pPublishConfig, &remainingLength, &packetSize );
+
+    /* Topic name length + topic name + 1 for its first character + payload size */
+    remainingLength = 2U + restOfTopicNameLength + 1U + payloadLength;
+
+    /* Packet Identifier only exists in Qos 1 and Qos 2 */
+    if( pPublishConfig->qos >= MQTTQoS1 )
+    {
+        remainingLength += 2;
+    }
+
+    /* Generate the header with one character of topic to save stack allocation */
+    status = MQTT_SerializePublishHeader( pPublishConfig, packetId, remainingLength, pBuffer, &headerSize );
+
+    if( status == MQTTSuccess )
+    {
+        /* Change the length of the topic name in the packet to its real length */
+        pBuffer->pBuffer[ packetSize - 2U ] = ( ( restOfTopicNameLength + 1U ) );
+
+        /* Send the Fixed header + length + first character of topic into the buffer */
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pBuffer->pBuffer, packetSize, pdMS_TO_TICKS( 100 ) );
+
+        /* Send the rest of the topic into the buffer */
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) restOfTopicName, restOfTopicNameLength, pdMS_TO_TICKS( 100 ) );
+
+        if( pPublishConfig->qos >= MQTTQoS1 )
+        {
+            /* Send the packet identifier to the buffer; need to represent as two seperate bytes to resolve endianness. */
+            serializedArray[ 0 ] = ( uint8_t ) ( ( packetId & 0xFF00U ) >> 8 );
+            serializedArray[ 1 ] = ( uint8_t ) ( packetId & 0x00FFU );
+            ( void ) xStreamBufferSend( streamBuffer, ( void * ) serializedArray, 2U, pdMS_TO_TICKS( 100 ) );
+        }
+
+        /* Send the payload itself into the buffer */
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pPayload, payloadLength, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+static MQTTStatus_t transportSerializePingresp( MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    if( pBuffer == NULL )
+    {
+        LogError( ( "Provided buffer is NULL." ) );
+        status = MQTTBadParameter;
+    }
+    /* The buffer must be able to fit 2 bytes for the packet. */
+    else if( pBuffer->size < SIZE_OF_PING )
+    {
+        LogError( ( "Insufficient memory for packet." ) );
+        status = MQTTNoMemory;
+    }
+    else
+    {
+        pBuffer->pBuffer[ 0 ] = MQTT_PACKET_TYPE_PINGRESP;
+        pBuffer->pBuffer[ 1 ] = 0;
+    }
+
+    return status;
+}
+
+static MQTTStatus_t transportSerializeAck( MQTTFixedBuffer_t * pBuffer,
+                                           uint8_t packetType,
+                                           uint16_t packetId )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    if( pBuffer == NULL )
+    {
+        LogError( ( "Provided buffer is NULL." ) );
+        status = MQTTBadParameter;
+    }
+    /* The buffer must be able to fit 4 bytes for the packet. */
+    else if( pBuffer->size < SIZE_OF_SUB_ACK )
+    {
+        LogError( ( "Insufficient memory for packet." ) );
+        status = MQTTNoMemory;
+    }
+    else if( ( packetId == 0U ) && ( packetType == MQTT_PACKET_TYPE_PUBACK ) )
+    {
+        LogError( ( "Packet ID cannot be 0." ) );
+        status = MQTTBadParameter;
+    }
+    else
+    {
+        pBuffer->pBuffer[ 0 ] = packetType;
+        pBuffer->pBuffer[ 1 ] = 2;
+        pBuffer->pBuffer[ 2 ] = ( uint8_t ) ( packetId >> 8 );
+        pBuffer->pBuffer[ 3 ] = ( uint8_t ) ( packetId & 0x00ffU );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t transportSerializeSuback( MQTTFixedBuffer_t * pBuffer,
+                                              uint8_t packetType,
+                                              uint16_t packetId )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    if( pBuffer == NULL )
+    {
+        LogError( ( "Provided buffer is NULL." ) );
+        status = MQTTBadParameter;
+    }
+    /* The buffer must be able to fit 4 bytes for the packet. */
+    else if( pBuffer->size < SIZE_OF_SUB_ACK )
+    {
+        LogError( ( "Insufficient memory for packet." ) );
+        status = MQTTNoMemory;
+    }
+    else if( packetId == 0U )
+    {
+        LogError( ( "Packet ID cannot be 0." ) );
+        status = MQTTBadParameter;
+    }
+    else
+    {
+        pBuffer->pBuffer[ 0 ] = packetType;
+        pBuffer->pBuffer[ 1 ] = 3;
+        pBuffer->pBuffer[ 2 ] = ( uint8_t ) ( packetId >> 8 );
+        pBuffer->pBuffer[ 3 ] = ( uint8_t ) ( packetId & 0x00ffU );
+        pBuffer->pBuffer[ 4 ] = 1;
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t handleOutgoingConnect( const void * buf,
+                                           MQTTFixedBuffer_t * bufToSend,
+                                           size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTConnectInfo_t connectConfig;
+
+    memset( &connectConfig, 0x00, sizeof( MQTTConnectInfo_t ) );
+
+    status = parseConnect( &connectConfig, buf );
+
+    if( status == MQTTSuccess )
+    {
+        status = IotBleMqtt_SerializeConnect( &connectConfig, &bufToSend->pBuffer, pSize );
+    }
+
+    return status;
+}
+
+static MQTTStatus_t handleOutgoingPublish( void * buf,
+                                           MQTTFixedBuffer_t * bufToSend,
+                                           size_t * pSize,
+                                           size_t * bytesToSend )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+    MQTTPublishInfo_t publishConfig;
+    MQTTPacketInfo_t publishPacket;
+
+    memset( &publishConfig, 0x00, sizeof( MQTTPublishInfo_t ) );
+
+    publishPacket.pRemainingData = &( ( uint8_t * ) buf )[ 2 ];
+    publishPacket.type = MQTT_PACKET_TYPE_PUBLISH;
+    publishPacket.remainingLength = *bytesToSend - 2U;
+
+    status = MQTT_DeserializePublish( &publishPacket, &packetIdentifier, &publishConfig );
+
+    if( status == MQTTSuccess )
+    {
+        status = IotBleMqtt_SerializePublish( &publishConfig, &bufToSend->pBuffer, pSize, &packetIdentifier );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleOutgoingPuback( const void * buf,
+                                          MQTTFixedBuffer_t * bufToSend,
+                                          size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+    MQTTPacketInfo_t pubackPacket;
+
+    pubackPacket.pRemainingData = ( uint8_t * ) buf;
+    pubackPacket.type = MQTT_PACKET_TYPE_PUBACK;
+
+    status = MQTT_DeserializeAck( &pubackPacket, &packetIdentifier, NULL );
+
+    if( status == MQTTSuccess )
+    {
+        status = IotBleMqtt_SerializePuback( packetIdentifier, &bufToSend->pBuffer, pSize );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleOutgoingSubscribe( const void * buf,
+                                             MQTTFixedBuffer_t * bufToSend,
+                                             size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+    size_t subscriptionCount = 0;
+
+    status = parseSubscribe( &subscriptionCount, buf, &packetIdentifier, true );
+
+    if( status == MQTTSuccess )
+    {
+        status = IotBleMqtt_SerializeSubscribe( _subscriptions, subscriptionCount, &bufToSend->pBuffer, pSize, &packetIdentifier );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleOutgoingUnsubscribe( const void * buf,
+                                               MQTTFixedBuffer_t * bufToSend,
+                                               size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+    size_t subscriptionCount = 0;
+
+    status = parseSubscribe( &subscriptionCount, buf, &packetIdentifier, false );
+
+    if( status == MQTTSuccess )
+    {
+        status = IotBleMqtt_SerializeUnsubscribe( _subscriptions, subscriptionCount, &bufToSend->pBuffer, pSize, &packetIdentifier );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleOutgoingPingReq( MQTTFixedBuffer_t * bufToSend,
+                                           size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    *pSize = SIZE_OF_PING;
+    status = IotBleMqtt_SerializePingreq( &bufToSend->pBuffer, pSize );
+    return status;
+}
+
+static MQTTStatus_t handleOutgoingDisconnect( MQTTFixedBuffer_t * bufToSend,
+                                              size_t * pSize )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    *pSize = SIZE_OF_PING;
+    /* Disconnect packets are always 2 bytes */
+    status = IotBleMqtt_SerializeDisconnect( &bufToSend->pBuffer, pSize );
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t handleIncomingConnack( MQTTPacketInfo_t * packet,
+                                           MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    LogDebug( ( "Processing incoming CONNACK from channel." ) );
+
+    status = IotBleMqtt_DeserializeConnack( packet );
+
+    if( status == MQTTSuccess )
+    {
+        /* Packet ID is not used in connack. */
+        status = transportSerializeAck( pBuffer, packet->type, 0 );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+static MQTTStatus_t handleIncomingPuback( MQTTPacketInfo_t * packet,
+                                          MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+
+    LogDebug( ( "Processing incoming PUBACK from channel." ) );
+    status = IotBleMqtt_DeserializePuback( packet, &packetIdentifier );
+
+    if( status == MQTTSuccess )
+    {
+        status = transportSerializeAck( pBuffer, packet->type, packetIdentifier );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+static MQTTStatus_t handleIncomingPublish( MQTTPacketInfo_t * packet,
+                                           MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTPublishInfo_t publishInfo;
+    uint16_t packetIdentifier = 0;
+
+    LogDebug( ( "Processing incoming PUBLISH from channel." ) );
+
+    status = IotBleMqtt_DeserializePublish( packet, &publishInfo, &packetIdentifier );
+
+    if( status == MQTTSuccess )
+    {
+        status = transportSerializePublish( pBuffer, &publishInfo, packetIdentifier );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleIncomingSuback( MQTTPacketInfo_t * packet,
+                                          MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+
+    LogDebug( ( "Processing incoming SUBACK from channel." ) );
+    status = IotBleMqtt_DeserializeSuback( packet, &packetIdentifier );
+
+    if( status == MQTTSuccess )
+    {
+        status = transportSerializeSuback( pBuffer, packet->type, packetIdentifier );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SUB_ACK, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+static MQTTStatus_t handleIncomingUnsuback( MQTTPacketInfo_t * packet,
+                                            MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetIdentifier = 0;
+
+    LogDebug( ( "Processing incoming UNSUBACK from channel." ) );
+    status = IotBleMqtt_DeserializeUnsuback( packet, &packetIdentifier );
+
+    if( status == MQTTSuccess )
+    {
+        status = transportSerializeAck( pBuffer, packet->type, packetIdentifier );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SUB_ACK, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+
+static MQTTStatus_t handleIncomingPingresp( MQTTPacketInfo_t * packet,
+                                            MQTTFixedBuffer_t * pBuffer )
+{
+    MQTTStatus_t status = MQTTSuccess;
+
+    LogDebug( ( "Processing incoming PINGRESP from channel." ) );
+    status = IotBleMqtt_DeserializePingresp( packet );
+
+    if( status == MQTTSuccess )
+    {
+        status = transportSerializePingresp( pBuffer );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_PING, pdMS_TO_TICKS( 100 ) );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+
+/**
+ * @brief Transport interface write prototype.
+ *
+ * @param[in] context An opaque used by transport interface.
+ * @param[in] buf A pointer to a buffer containing data to be sent out.
+ * @param[in] bytesToWrite number of bytes to write from the buffer.
+ */
+int32_t IotBleMqttTransportSend( NetworkContext_t * pContext,
+                                 void * buf,
+                                 size_t bytesToWrite )
+{
+    size_t CBORbytesWritten = 0;
+    uint8_t packetType = *( ( uint8_t * ) buf );
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTFixedBuffer_t bufToSend;
+    size_t packetSize = 0;
+
+    /* The send function returns the CBOR bytes written, so need to return 0 or full amount of bytes sent. */
+    int32_t MQTTBytesWritten = ( int32_t ) bytesToWrite;
+
+    switch( packetType )
+    {
+        case MQTT_PACKET_TYPE_CONNECT:
+            status = handleOutgoingConnect( buf, &bufToSend, &packetSize );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBLISH:
+            status = handleOutgoingPublish( buf, &bufToSend, &packetSize, &bytesToWrite );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBACK:
+            status = handleOutgoingPuback( buf, &bufToSend, &packetSize );
+            break;
+
+        case MQTT_PACKET_TYPE_SUBSCRIBE:
+            status = handleOutgoingSubscribe( buf, &bufToSend, &packetSize );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBSCRIBE:
+            status = handleOutgoingUnsubscribe( buf, &bufToSend, &packetSize );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGREQ:
+            status = handleOutgoingPingReq( &bufToSend, &packetSize );
+            break;
+
+        case MQTT_PACKET_TYPE_DISCONNECT:
+            status = handleOutgoingDisconnect( &bufToSend, &packetSize );
+            break;
+
+        /* QoS 2 cases, currently not supported by BLE */
+        case MQTT_PACKET_TYPE_PUBREC:
+        case MQTT_PACKET_TYPE_PUBREL:
+        case MQTT_PACKET_TYPE_PUBCOMP:
+            status = MQTTSendFailed;
+            LogError( ( "Only Qos 0 and 1 are supported over BLE." ) );
+            break;
+
+        /* Client tries to send a server to client only packet */
+        default:
+            status = MQTTBadParameter;
+            LogError( ( "A server to client only packet was sent. Check packet type or ensure Qos < 2." ) );
+            LogError( ( "Your packet type was %i", packetType ) );
+            break;
+    }
+
+    if( status != MQTTSuccess )
+    {
+        /* The user would have already seen a log for the previous error */
+        LogError( ( "No data was sent because of a previous error." ) );
+        MQTTBytesWritten = 0;
+
+        if( bufToSend.pBuffer != NULL )
+        {
+            IotMqtt_FreeMessage( bufToSend.pBuffer );
+        }
+    }
+    else
+    {
+        CBORbytesWritten = IotBleDataTransfer_Send( pContext->pChannel, bufToSend.pBuffer, packetSize );
+    }
+
+    if( CBORbytesWritten == 0U )
+    {
+        LogError( ( "No data was sent because of the channel. Ensure that the channel is initialized and ready to send data." ) );
+        MQTTBytesWritten = 0;
+    }
+    else
+    {
+        IotMqtt_FreeMessage( bufToSend.pBuffer );
+        LogInfo( ( "Packet sent successfully over the BLE channel" ) );
+    }
+
+    return MQTTBytesWritten;
+}
+
+void IotBleMqttTransportAcceptData( const NetworkContext_t * pContext )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTPacketInfo_t packet;
+    MQTTFixedBuffer_t pBuffer;
+
+    /* Sub ack is the largest packet size expected except for publish, which has its own buffer allocation */
+    uint8_t sharedBuffer[ SIZE_OF_SUB_ACK ];
+
+    pBuffer.pBuffer = sharedBuffer;
+    pBuffer.size = SIZE_OF_SUB_ACK;
+
+    packet.type = IotBleMqtt_GetPacketType( pContext->pChannel );
+    IotBleDataTransfer_PeekReceiveBuffer( pContext->pChannel, ( const uint8_t ** ) &packet.pRemainingData, &packet.remainingLength );
+
+    LogDebug( ( "Receiving a packet from the server." ) );
+
+    switch( packet.type )
+    {
+        case MQTT_PACKET_TYPE_CONNACK:
+            status = handleIncomingConnack( &packet, &pBuffer );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBLISH:
+            status = handleIncomingPublish( &packet, &pBuffer );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBACK:
+            status = handleIncomingPuback( &packet, &pBuffer );
+            break;
+
+        case MQTT_PACKET_TYPE_SUBACK:
+            status = handleIncomingSuback( &packet, &pBuffer );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBACK:
+            status = handleIncomingUnsuback( &packet, &pBuffer );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGRESP:
+            status = handleIncomingPingresp( &packet, &pBuffer );
+            break;
+
+        /* QoS 2 cases, currently not supported by BLE */
+        case MQTT_PACKET_TYPE_PUBREC:
+        case MQTT_PACKET_TYPE_PUBREL:
+        case MQTT_PACKET_TYPE_PUBCOMP:
+            status = MQTTRecvFailed;
+
+            LogError( ( "Only Qos 0 and 1 are supported over BLE." ) );
+            break;
+
+        /* Server tries to send a client to server only packet */
+        default:
+            LogError( ( "Client received a client to server only packet." ) );
+            status = MQTTBadParameter;
+            break;
+    }
+
+    if( status != MQTTSuccess )
+    {
+        LogError( ( "An error occured when receiving data from the channel. No data was recorded." ) );
+    }
+    else
+    {
+        /* Flush the data from the channel */
+        ( void ) IotBleDataTransfer_Receive( pContext->pChannel, NULL, packet.remainingLength );
+    }
+}
+
+
+/**
+ * @brief Transport interface read prototype.
+ *
+ * @param[in] context An opaque used by transport interface.
+ * @param[out] buf A pointer to a buffer where incoming data will be stored.
+ * @param[in] bytesToRead number of bytes to read from the transport layer.
+ */
+int32_t IotBleMqttTransportReceive( NetworkContext_t * pContext,
+                                    void * buf,
+                                    size_t bytesToRead )
+{
+    ( void ) pContext;
+    return ( int32_t ) xStreamBufferReceive( streamBuffer, buf, bytesToRead, pdMS_TO_TICKS( 100 ) );
+}

--- a/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
@@ -823,7 +823,8 @@ static MQTTStatus_t handleIncomingUnsuback( MQTTPacketInfo_t * packet,
 {
     MQTTStatus_t status = MQTTSuccess;
     uint16_t packetIdentifier = 0;
-    printf("here here\r\n");
+
+    printf( "here here\r\n" );
     LogDebug( ( "Processing incoming UNSUBACK from channel." ) );
     status = IotBleMqtt_DeserializeUnsuback( packet, &packetIdentifier );
 

--- a/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_mqtt_transport.c
@@ -381,10 +381,10 @@ static uint16_t calculateNumSubs( const uint8_t * buf,
                                   uint8_t remainingLength,
                                   bool subscribe )
 {
-    uint16_t numSubs = 0, totalSize = 0;
+    uint16_t numSubs = 0U, totalSize = 0U;
 
     /* Loop through the rest of the packet. */
-    while( remainingLength - totalSize > 0U )
+    while( ( remainingLength - totalSize ) > 0U )
     {
         totalSize += ( getIntFromTwoBytes( &buf[ totalSize ] ) + 2U );
 
@@ -488,21 +488,21 @@ static MQTTStatus_t transportSerializePublish( MQTTFixedBuffer_t * pBuffer,
         pBuffer->pBuffer[ packetSize - 2U ] = ( ( restOfTopicNameLength + 1U ) );
 
         /* Send the Fixed header + length + first character of topic into the buffer */
-        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pBuffer->pBuffer, packetSize, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pBuffer->pBuffer, packetSize, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
 
         /* Send the rest of the topic into the buffer */
-        ( void ) xStreamBufferSend( streamBuffer, ( void * ) restOfTopicName, restOfTopicNameLength, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) restOfTopicName, restOfTopicNameLength, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
 
         if( pPublishConfig->qos >= MQTTQoS1 )
         {
             /* Send the packet identifier to the buffer; need to represent as two seperate bytes to resolve endianness. */
             serializedArray[ 0 ] = ( uint8_t ) ( ( packetId & 0xFF00U ) >> 8 );
             serializedArray[ 1 ] = ( uint8_t ) ( packetId & 0x00FFU );
-            ( void ) xStreamBufferSend( streamBuffer, ( void * ) serializedArray, 2U, pdMS_TO_TICKS( 100 ) );
+            ( void ) xStreamBufferSend( streamBuffer, ( void * ) serializedArray, 2U, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
         }
 
         /* Send the payload itself into the buffer */
-        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pPayload, payloadLength, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, ( void * ) pPayload, payloadLength, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -748,7 +748,7 @@ static MQTTStatus_t handleIncomingConnack( MQTTPacketInfo_t * packet,
 
     if( status == MQTTSuccess )
     {
-        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -770,7 +770,7 @@ static MQTTStatus_t handleIncomingPuback( MQTTPacketInfo_t * packet,
 
     if( status == MQTTSuccess )
     {
-        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -812,7 +812,7 @@ static MQTTStatus_t handleIncomingSuback( MQTTPacketInfo_t * packet,
 
     if( status == MQTTSuccess )
     {
-        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SUB_ACK, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SUB_ACK, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -823,7 +823,7 @@ static MQTTStatus_t handleIncomingUnsuback( MQTTPacketInfo_t * packet,
 {
     MQTTStatus_t status = MQTTSuccess;
     uint16_t packetIdentifier = 0;
-
+    printf("here here\r\n");
     LogDebug( ( "Processing incoming UNSUBACK from channel." ) );
     status = IotBleMqtt_DeserializeUnsuback( packet, &packetIdentifier );
 
@@ -834,7 +834,7 @@ static MQTTStatus_t handleIncomingUnsuback( MQTTPacketInfo_t * packet,
 
     if( status == MQTTSuccess )
     {
-        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SUB_ACK, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_SIMPLE_ACK, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -856,7 +856,7 @@ static MQTTStatus_t handleIncomingPingresp( MQTTPacketInfo_t * packet,
 
     if( status == MQTTSuccess )
     {
-        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_PING, pdMS_TO_TICKS( 100 ) );
+        ( void ) xStreamBufferSend( streamBuffer, pBuffer->pBuffer, SIZE_OF_PING, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
     }
 
     return status;
@@ -1044,5 +1044,5 @@ int32_t IotBleMqttTransportReceive( NetworkContext_t * pContext,
                                     size_t bytesToRead )
 {
     ( void ) pContext;
-    return ( int32_t ) xStreamBufferReceive( streamBuffer, buf, bytesToRead, pdMS_TO_TICKS( 100 ) );
+    return ( int32_t ) xStreamBufferReceive( streamBuffer, buf, bytesToRead, pdMS_TO_TICKS( RECV_TIMEOUT_MS ) );
 }

--- a/libraries/c_sdk/standard/mqtt/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt/CMakeLists.txt
@@ -14,7 +14,7 @@ set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
 
 # Compile BLE MQTT serializers on supported platforms.
 if(${BLE_SUPPORTED})
-    set(extra_mqtt_sources "${src_dir}/iot_ble_mqtt_serialize.c")
+    set(extra_mqtt_sources "${src_dir}/../../ble/src/iot_ble_mqtt_serialize.c")
     set(extra_mqtt_dependencies AFR::serializer AFR::ble)
 endif()
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -30,6 +30,7 @@
  * Only one demo can be configured at a time
  *
  *          CONFIG_MQTT_DEMO_ENABLED
+ *          CONFIG_MQTT_TRANSPORT_DEMO_ENABLED
  *          CONFIG_SHADOW_DEMO_ENABLED
  *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
@@ -53,6 +54,11 @@
 #if defined( CONFIG_MQTT_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
     #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
+#endif
+
+#if defined( CONFIG_MQTT_TRANSPORT_DEMO_ENABLED )
+    #undef democonfigNETWORK_TYPES
+    #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
 #endif
 
 #if defined( CONFIG_OTA_UPDATE_DEMO_ENABLED )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_config.h
@@ -47,8 +47,31 @@
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 
-/* Set network context to socket (int). */
-#include "iot_ble_data_transfer.h"
-typedef IotBleDataTransferChannel_t * NetworkContext_t;
+
+/**
+ * @brief The maximum number of MQTT PUBLISH messages that may be pending
+ * acknowledgement at any time.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
+ * they can be completed. While they are awaiting the acknowledgement, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains.
+ */
+#define MQTT_MAX_QUEUED_PUBLISH_MESSAGES    10
+
+/**
+ * @brief The maximum number of MQTT PUBLISH messages that may be pending
+ * acknowledgement at any time.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
+ * they can be completed. While they are awaiting the acknowledgement, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains.
+ */
+#define MQTT_STATE_ARRAY_MAX_COUNT          10U
+
+
 
 #endif /* ifndef MQTT_CONFIG_H_ */


### PR DESCRIPTION
Transport code implementation and demo

Description
-----------
New transport layer for MQTT over BLE
New demo to show how transport layer works
Fixed CMakeFile issues
Fixed issue in old MQTT wrapper function
Added transport config file
Changed existing serializer code to use argument's packet identifier
Made packet identifier the responsibility of the application
Uncrustify and Coverity checks
Addressing comments from previous PR

Note: This is a new iteration of an old PR, old PR is https://github.com/aws/amazon-freertos/pull/2318

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.