### PR TITLE
Update configurations.xml to fix build errors for MPLABX 5.40

### DIFF
--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -1,1346 +1,1412 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="65">
-	<logicalFolder name="root" displayName="root" projectFiles="true">
-		<logicalFolder name="freertos_kernel" displayName="freertos_kernel" projectFiles="true">
-			<itemPath>../../../../../freertos_kernel/event_groups.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/list.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/queue.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/stream_buffer.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/tasks.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/timers.c</itemPath>
-			<logicalFolder name="include" displayName="include" projectFiles="true">
-				<itemPath>../../../../../freertos_kernel/include/FreeRTOS.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/StackMacros.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/atomic.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/croutine.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/deprecated_definitions.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/event_groups.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/list.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/message_buffer.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/mpu_prototypes.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/mpu_wrappers.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/portable.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/projdefs.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/queue.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/semphr.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/stack_macros.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/stream_buffer.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/task.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/timers.h</itemPath>
-			</logicalFolder>
-			<logicalFolder name="portable" displayName="portable" projectFiles="true">
-				<logicalFolder name="MPLAB" displayName="MPLAB" projectFiles="true">
-					<logicalFolder name="PIC32MZ" displayName="PIC32MZ" projectFiles="true">
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port.c</itemPath>
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port_asm.S</itemPath>
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/portmacro.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="MemMang" displayName="MemMang" projectFiles="true">
-					<itemPath>../../../../../freertos_kernel/portable/MemMang/heap_4.c</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="demos" displayName="demos" projectFiles="true">
-			<logicalFolder name="demo_runner" displayName="demo_runner" projectFiles="true">
-				<itemPath>../../../../../demos/demo_runner/aws_demo_network_addr.c</itemPath>
-				<itemPath>../../../../../demos/demo_runner/aws_demo_version.c</itemPath>
-				<itemPath>../../../../../demos/demo_runner/aws_demo.c</itemPath>
-				<itemPath>../../../../../demos/demo_runner/iot_demo_freertos.c</itemPath>
-				<itemPath>../../../../../demos/demo_runner/iot_demo_runner.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="network_manager" displayName="network_manager" projectFiles="true">
-				<itemPath>../../../../../demos/network_manager/aws_iot_network_manager.c</itemPath>
-				<itemPath>../../../../../demos/network_manager/aws_iot_demo_network.c</itemPath>
-				<itemPath>../../../../../demos/network_manager/iot_network_manager_private.h</itemPath>
-			</logicalFolder>
-			<logicalFolder name="include" displayName="include" projectFiles="true">
-				<itemPath>../../../../../demos/include/aws_application_version.h</itemPath>
-				<itemPath>../../../../../demos/include/aws_clientcredential.h</itemPath>
-				<itemPath>../../../../../demos/include/aws_clientcredential_keys.h</itemPath>
-				<itemPath>../../../../../demos/include/aws_demo.h</itemPath>
-				<itemPath>../../../../../demos/include/aws_iot_demo_network.h</itemPath>
-				<itemPath>../../../../../demos/include/aws_ota_codesigner_certificate.h</itemPath>
-				<itemPath>../../../../../demos/include/iot_config_common.h</itemPath>
-				<itemPath>../../../../../demos/include/iot_demo_logging.h</itemPath>
-				<itemPath>../../../../../demos/include/iot_demo_runner.h</itemPath>
-			</logicalFolder>
-			<logicalFolder name="dev_mode_key_provisioning" displayName="dev_mode_key_provisioning" projectFiles="true">
-				<logicalFolder name="src" displayName="src" projectFiles="true">
-					<itemPath>../../../../../demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="include" displayName="include" projectFiles="true">
-					<itemPath>../../../../../demos/dev_mode_key_provisioning/include/aws_dev_mode_key_provisioning.h</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="defender" displayName="defender" projectFiles="true">
-				<itemPath>../../../../../demos/defender/aws_iot_demo_defender.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="greengrass_connectivity" displayName="greengrass_connectivity" projectFiles="true">
-				<itemPath>../../../../../demos/greengrass_connectivity/aws_greengrass_discovery_demo.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="https" displayName="https" projectFiles="true">
-				<itemPath>../../../../../demos/https/iot_demo_https_s3_download_sync.c</itemPath>
-				<itemPath>../../../../../demos/https/iot_demo_https_s3_download_async.c</itemPath>
-				<itemPath>../../../../../demos/https/iot_demo_https_s3_upload_sync.c</itemPath>
-				<itemPath>../../../../../demos/https/iot_demo_https_s3_upload_async.c</itemPath>
-				<itemPath>../../../../../demos/https/iot_demo_https_common.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
-				<itemPath>../../../../../demos/mqtt/iot_demo_mqtt.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="ota" displayName="ota" projectFiles="true">
-				<itemPath>../../../../../demos/ota/aws_iot_ota_update_demo.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="shadow" displayName="shadow" projectFiles="true">
-				<itemPath>../../../../../demos/shadow/aws_iot_demo_shadow.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="tcp" displayName="tcp" projectFiles="true">
-				<itemPath>../../../../../demos/tcp/aws_tcp_echo_client_single_task.c</itemPath>
-				<itemPath>../../../../../demos/tcp/aws_tcp_echo_client_single_tasks.h</itemPath>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="libraries" displayName="libraries" projectFiles="true">
-			<logicalFolder name="c_sdk" displayName="c_sdk" projectFiles="true">
-				<logicalFolder name="standard" displayName="standard" projectFiles="true">
-					<logicalFolder name="common" displayName="common" projectFiles="true">
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_init.c</itemPath>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_appversion32.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_init.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_linear_containers.h</itemPath>
-							<logicalFolder name="private" displayName="private" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_logging.h</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_taskpool_internal.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_task.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_setup.h</itemPath>
-							<logicalFolder name="types" displayName="types" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_network_types.h</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_taskpool_types.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_taskpool.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="logging" displayName="logging" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
-						</logicalFolder>
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
-						<logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_serialize.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="serializer" displayName="serializer" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<logicalFolder name="cbor" displayName="cbor" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_encoder.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="json" displayName="json" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_decoder.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_serializer_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_json_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_serializer.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_json_utils.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="https" displayName="https" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_client.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_utils.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="aws" displayName="aws" projectFiles="true">
-					<logicalFolder name="defender" displayName="defender" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c</itemPath>
-							<logicalFolder name="private" displayName="private" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/include/aws_iot_defender.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="shadow" displayName="shadow" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_subscription.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow_config_defaults.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_iot_shadow.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_shadow.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="abstractions" displayName="abstractions" projectFiles="true">
-				<logicalFolder name="platform" displayName="platform" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="platform" displayName="platform" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_clock.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_network.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_threads.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_metrics.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="types" displayName="types" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/platform/include/types/iot_platform_types.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="freertos" displayName="freertos" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_clock_freertos.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_threads_freertos.c</itemPath>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<logicalFolder name="platform" displayName="platform" projectFiles="true">
-								<itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_platform_types_freertos.h</itemPath>
-								<itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_metrics.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_network_freertos.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="secure_sockets" displayName="secure_sockets" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets.h</itemPath>
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_config_defaults.h</itemPath>
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_wrapper_metrics.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="freertos_plus_tcp" displayName="freertos_plus_tcp" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-					<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/threading_alt.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/wifi/include/iot_wifi.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="posix" displayName="posix" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="FreeRTOS_POSIX" displayName="FreeRTOS_POSIX" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/errno.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/fcntl.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/mqueue.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sched.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/semaphore.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/signal.h</itemPath>
-							<logicalFolder name="sys" displayName="sys" projectFiles="true">
-								<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sys/types.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/time.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/unistd.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/utils.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="freertos_plus" displayName="freertos_plus" projectFiles="true">
-				<logicalFolder name="standard" displayName="standard" projectFiles="true">
-					<logicalFolder name="freertos_plus_tcp" displayName="freertos_plus_tcp" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Stream_Buffer.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</itemPath>
-							<logicalFolder name="portable" displayName="portable" projectFiles="true">
-								<logicalFolder name="NetworkInterface" displayName="NetworkInterface" projectFiles="true">
-									<logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_errno_TCP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_WIN.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_UDP_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/IPTraceMacroDefaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="tls" displayName="tls" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/tls/src/iot_tls.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/tls/include/iot_tls.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="crypto" displayName="crypto" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/crypto/src/iot_crypto.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/crypto/include/iot_crypto.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="utils" displayName="utils" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_system_init.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_pki_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_system_init.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_pki_utils.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="freertos_plus_posix" displayName="freertos_plus_posix" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_clock.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_mqueue.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_barrier.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_cond.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_mutex.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_sched.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_semaphore.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_unistd.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_types.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_internal.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_portable_default.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="aws" displayName="aws" projectFiles="true">
-					<logicalFolder name="greengrass" displayName="greengrass" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_ggd_config_defaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="ota" displayName="ota" projectFiles="true">
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</itemPath>
-							<logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="http" displayName="http" projectFiles="true">
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="3rdparty" displayName="3rdparty" projectFiles="true">
-				<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-					<logicalFolder name="library" displayName="library" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/base64.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aes.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aesni.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/arc4.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aria.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1parse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1write.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/bignum.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/blowfish.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/camellia.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ccm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/certs.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/chacha20.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/chachapoly.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cmac.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ctr_drbg.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/debug.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/des.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/dhm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdh.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdsa.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecjpake.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp_curves.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy_poll.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/error.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/gcm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/havege.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/hkdf.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/hmac_drbg.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md2.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md4.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md5.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/memory_buffer_alloc.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/net_sockets.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/nist_kw.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/oid.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/padlock.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pem.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs11.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs12.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs5.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkparse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkwrite.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform_util.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/poly1305.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ripemd160.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa_internal.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha1.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha256.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha512.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cache.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ciphersuites.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cli.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cookie.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_srv.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ticket.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_tls.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/threading.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/timing.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/version.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/version_features.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_create.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crl.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crt.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_csr.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_crt.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_csr.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/xtea.c</itemPath>
-					</logicalFolder>
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aes.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aesni.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/arc4.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aria.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1write.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/base64.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bignum.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/blowfish.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bn_mul.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/camellia.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ccm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/certs.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chacha20.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chachapoly.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/check_config.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cmac.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/compat-1.3.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/config.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ctr_drbg.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/debug.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/des.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/dhm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdh.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdsa.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecjpake.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy_poll.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/error.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/gcm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/havege.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hkdf.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hmac_drbg.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md2.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md4.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md5.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/memory_buffer_alloc.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net_sockets.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/nist_kw.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/oid.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/padlock.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pem.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs11.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs12.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs5.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_time.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_util.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/poly1305.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ripemd160.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha1.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha256.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha512.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cache.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ciphersuites.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cookie.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ticket.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/threading.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/timing.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/version.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crl.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crt.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_csr.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/xtea.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="jsmn" displayName="jsmn" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11f.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11t.h</itemPath>
-				</logicalFolder>
-				<logicalFolder name="tinycbor" displayName="tinycbor" projectFiles="true">
-					<logicalFolder name="src" displayName="src" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty_stdio.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborerrorstrings.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser_dup_string.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
-					<logicalFolder name="lib" displayName="lib" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_decrypt.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_encrypt.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cbc_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ccm_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cmac_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_prng.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dh.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dsa.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_platform_specific.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac_prng.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/sha256.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/aes.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cbc_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ccm_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cmac_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/constants.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_prng.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dh.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dsa.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_platform_specific.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac_prng.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/sha256.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/utils.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="asn1" displayName="asn1" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1parse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="mbedtls_utils" displayName="mbedtls_utils" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_utils.c</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="http_parser" displayName="http_parser" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.c</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="vendors" displayName="vendors" projectFiles="true">
-			<logicalFolder name="microchip" displayName="microchip" projectFiles="true">
-				<logicalFolder name="boards" displayName="boards" projectFiles="true">
-					<logicalFolder name="curiosity_pic32mzef" displayName="curiosity_pic32mzef" projectFiles="true">
-						<logicalFolder name="ports" displayName="ports" projectFiles="true">
-							<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/aws_wifi_assert.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="ota" displayName="ota" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_ota_pal.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="posix" displayName="posix" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix/FreeRTOS_POSIX_portable.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="aws_demos" displayName="aws_demos" projectFiles="true">
-							<logicalFolder name="config_files" displayName="config_files" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_bufferpool_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ggd_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_mqtt_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_secure_sockets_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_shadow_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_wifi_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_mqtt_agent_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="application_code" displayName="application_code" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/main.c</itemPath>
-								<logicalFolder name="microchip_code" displayName="microchip_code" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/rtos_hooks.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_exceptions.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_init.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_interrupt.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_tasks.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/NetworkConfig.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_config.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_definitions.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_interrupt_a.S</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="harmony" displayName="harmony" projectFiles="true">
-					<logicalFolder name="v2.05" displayName="v2.05" projectFiles="true">
-						<logicalFolder name="framework" displayName="framework" projectFiles="true">
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<logicalFolder name="command" displayName="command" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/command/src/sys_command.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="clk" displayName="clk" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/clk/src/sys_clk_pic32mz.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="common" displayName="common" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_buffer.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_queue.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="console" displayName="console" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console_uart.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="debug" displayName="debug" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/debug/src/sys_debug.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="devcon" displayName="devcon" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_pic32mz.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_cache_pic32mz.S</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="dma" displayName="dma" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/dma/src/sys_dma.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="int" displayName="int" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/int/src/sys_int_pic32.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="ports" displayName="ports" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports_static.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="random" displayName="random" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/random/src/sys_random.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="reset" displayName="reset" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/reset/src/sys_reset.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/tmr/src/sys_tmr.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="driver" displayName="driver" projectFiles="true">
-								<logicalFolder name="ethmac" displayName="ethmac" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac_lib.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="ethphy" displayName="ethphy" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_ethphy.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_extphy_smsc8720.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="flash" displayName="flash" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/flash/src/drv_flash_static.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="miim" displayName="miim" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/miim/src/dynamic/drv_miim.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="spi" displayName="spi" projectFiles="true">
-									<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_api.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_dma_tasks.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_rm_tasks.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_tasks.c</itemPath>
-									</logicalFolder>
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi_api.c</itemPath>
-										</logicalFolder>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/drv_spi_sys_queue_fifo.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/tmr/src/dynamic/drv_tmr.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="usart" displayName="usart" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue_dma.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_byte_model.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_dma.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_read_write.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-									<logicalFolder name="wilc1000" displayName="wilc1000" projectFiles="true">
-										<logicalFolder name="dev" displayName="dev" projectFiles="true">
-											<logicalFolder name="console" displayName="console" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/console/wdrv_wilc1000_console.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="gpio" displayName="gpio" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_eint.c</itemPath>
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_gpio.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="spi" displayName="spi" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/spi/wdrv_wilc1000_spi.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="timer" displayName="timer" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/timer/wdrv_wilc1000_timer.c</itemPath>
-											</logicalFolder>
-										</logicalFolder>
-										<logicalFolder name="osal" displayName="osal" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/osal/wdrv_wilc1000_osal.c</itemPath>
-										</logicalFolder>
-										<logicalFolder name="wireless_driver" displayName="wireless_driver" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_cli.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_config.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_connmgr.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_events.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_iwpriv.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_main.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_scan_helper.c</itemPath>
-										</logicalFolder>
-										<logicalFolder name="wireless_driver_extension" displayName="wireless_driver_extension" projectFiles="true">
-											<logicalFolder name="common" displayName="common" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/source/nm_common.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<logicalFolder name="driver" displayName="driver" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_hif.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_periph.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_wifi.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmasic.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmbus.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmdrv.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmspi.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<logicalFolder name="spi_flash" displayName="spi_flash" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/spi_flash/source/spi_flash.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_fw_update.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_task.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="osal" displayName="osal" projectFiles="true">
-								<logicalFolder name="src" displayName="src" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal_freertos.c</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="peripheral" displayName="peripheral" projectFiles="true">
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/peripheral/tmr/src/plib_tmr_pic32.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="tcpip" displayName="tcpip" projectFiles="true">
-								<logicalFolder name="src" displayName="src" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_alloc.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_external.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_helpers.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="bsp" displayName="bsp" projectFiles="true">
-							<itemPath>../../../../../vendors/microchip/harmony/v2.05/bsp/bsp.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="LinkerScript" displayName="LinkerScript" projectFiles="true">
-			<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/app_mz.ld</itemPath>
-		</logicalFolder>
-	</logicalFolder>
-	<projectmakefile>Makefile</projectmakefile>
-	<confs>
-		<conf name="pic32mz_ef_curiosity" type="2">
-			<toolsSet>
-				<developmentServer>localhost</developmentServer>
-				<targetDevice>PIC32MZ2048EFM100</targetDevice>
-				<targetHeader/>
-				<targetPluginBoard/>
-				<platformTool>ICD4Tool</platformTool>
-				<languageToolchain>XC32</languageToolchain>
-				<languageToolchainVersion>2.10</languageToolchainVersion>
-				<platform>3</platform>
-			</toolsSet>
-			<packs>
-				<pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
-			</packs>
-			<compileType>
-				<linkerTool>
-					<linkerLibItems>
-						<linkerLibFileItem>../../../../../vendors/microchip/harmony/v2.05/bin/framework/peripheral/PIC32MZ2048EFM100_peripherals.a</linkerLibFileItem>
-					</linkerLibItems>
-				</linkerTool>
-				<archiverTool/>
-				<loading>
-					<makeArtifact PL="../bootloader" CT="1" CN="pic32mz_ef_curiosity" AC="true" BL="true" WD="../bootloader" BC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity" DBC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity TYPE_IMAGE=DEBUG_RUN" CC="rm -rf &quot;build/pic32mz_ef_curiosity&quot; &quot;dist/pic32mz_ef_curiosity&quot;" OP="dist/pic32mz_ef_curiosity/production/bootloader.production.hex" DOP="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf" FL="dist/pic32mz_ef_curiosity/production/bootloader.production.hex" PD="dist/pic32mz_ef_curiosity/production/bootloader.production.elf" DD="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf"/>
-					<useAlternateLoadableFile>false</useAlternateLoadableFile>
-					<parseOnProdLoad>false</parseOnProdLoad>
-					<alternateLoadableFile/>
-				</loading>
-				<subordinates/>
-			</compileType>
-			<makeCustomizationType>
-				<makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
-				<makeCustomizationPreStep/>
-				<makeCustomizationPostStepEnabled>true</makeCustomizationPostStepEnabled>
-				<makeCustomizationPostStep>python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/binary_image_generator.py -d ${MP_CC_DIR} -b xc32-objcopy -p &quot;-I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin&quot; &amp;&amp; python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
-				<makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
-				<makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
-				<makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
-			</makeCustomizationType>
-			<C32>
-				<property key="additional-warnings" value="false"/>
-				<property key="addresss-attribute-use" value="false"/>
-				<property key="enable-app-io" value="false"/>
-				<property key="enable-omit-frame-pointer" value="false"/>
-				<property key="enable-symbols" value="true"/>
-				<property key="enable-unroll-loops" value="false"/>
-				<property key="exclude-floating-point" value="false"/>
-				<property key="extra-include-directories" value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../demos/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/http_parser"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="isolate-each-function" value="true"/>
-				<property key="make-warnings-into-errors" value="false"/>
-				<property key="optimization-level" value="-O1"/>
-				<property key="place-data-into-section" value="false"/>
-				<property key="post-instruction-scheduling" value="default"/>
-				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
-				<property key="strict-ansi" value="false"/>
-				<property key="support-ansi" value="false"/>
-				<property key="toplevel-reordering" value=""/>
-				<property key="unaligned-access" value=""/>
-				<property key="use-cci" value="false"/>
-				<property key="use-iar" value="false"/>
-				<property key="use-indirect-calls" value="false"/>
-				<appendMe value="-mnewlib-libc -std=gnu99 -fgnu89-inline"/>
-			</C32>
-			<C32-AR>
-				<property key="additional-options-chop-files" value="false"/>
-			</C32-AR>
-			<C32-AS>
-				<property key="assembler-symbols" value=""/>
-				<property key="enable-symbols" value="true"/>
-				<property key="exclude-floating-point-library" value="false"/>
-				<property key="expand-macros" value="false"/>
-				<property key="extra-include-directories-for-assembler" value=""/>
-				<property key="extra-include-directories-for-preprocessor" value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../demos/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/http_parser"/>
-				<property key="false-conditionals" value="false"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="keep-locals" value="false"/>
-				<property key="list-assembly" value="false"/>
-				<property key="list-source" value="false"/>
-				<property key="list-symbols" value="false"/>
-				<property key="oXC32asm-list-to-file" value="false"/>
-				<property key="omit-debug-dirs" value="false"/>
-				<property key="omit-forms" value="false"/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="warning-level" value=""/>
-			</C32-AS>
-			<C32-LD>
-				<property key="additional-options-use-response-files" value="false"/>
-				<property key="allocate-dinit" value="false"/>
-				<property key="code-dinit" value="false"/>
-				<property key="ebase-addr" value=""/>
-				<property key="enable-check-sections" value="false"/>
-				<property key="exclude-floating-point-library" value="false"/>
-				<property key="exclude-standard-libraries" value="false"/>
-				<property key="extra-lib-directories" value=""/>
-				<property key="fill-flash-options-addr" value=""/>
-				<property key="fill-flash-options-const" value=""/>
-				<property key="fill-flash-options-how" value="0"/>
-				<property key="fill-flash-options-inc-const" value="1"/>
-				<property key="fill-flash-options-increment" value=""/>
-				<property key="fill-flash-options-seq" value=""/>
-				<property key="fill-flash-options-what" value="0"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-cross-reference-file" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="heap-size" value="10000"/>
-				<property key="input-libraries" value=""/>
-				<property key="kseg-length" value=""/>
-				<property key="kseg-origin" value=""/>
-				<property key="linker-symbols" value=""/>
-				<property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
-				<property key="no-device-startup-code" value="false"/>
-				<property key="no-startup-files" value="false"/>
-				<property key="oXC32ld-extra-opts" value="-mnewlib-libc"/>
-				<property key="optimization-level" value=""/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="remove-unused-sections" value="true"/>
-				<property key="report-memory-usage" value="false"/>
-				<property key="serial-length" value=""/>
-				<property key="serial-origin" value=""/>
-				<property key="stack-size" value="10000"/>
-				<property key="symbol-stripping" value=""/>
-				<property key="trace-symbols" value=""/>
-				<property key="warn-section-align" value="false"/>
-				<appendMe value="--allow-multiple-definition"/>
-			</C32-LD>
-			<C32CPP>
-				<property key="additional-warnings" value="false"/>
-				<property key="addresss-attribute-use" value="false"/>
-				<property key="check-new" value="false"/>
-				<property key="eh-specs" value="true"/>
-				<property key="enable-app-io" value="false"/>
-				<property key="enable-omit-frame-pointer" value="false"/>
-				<property key="enable-symbols" value="true"/>
-				<property key="enable-unroll-loops" value="false"/>
-				<property key="exceptions" value="true"/>
-				<property key="exclude-floating-point" value="false"/>
-				<property key="extra-include-directories" value=""/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="isolate-each-function" value="false"/>
-				<property key="make-warnings-into-errors" value="false"/>
-				<property key="optimization-level" value=""/>
-				<property key="place-data-into-section" value="false"/>
-				<property key="post-instruction-scheduling" value="default"/>
-				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="rtti" value="true"/>
-				<property key="strict-ansi" value="false"/>
-				<property key="toplevel-reordering" value=""/>
-				<property key="unaligned-access" value=""/>
-				<property key="use-cci" value="false"/>
-				<property key="use-iar" value="false"/>
-				<property key="use-indirect-calls" value="false"/>
-			</C32CPP>
-			<C32Global>
-				<property key="common-include-directories" value=""/>
-				<property key="gp-relative-option" value=""/>
-				<property key="legacy-libc" value="false"/>
-				<property key="mdtcm" value=""/>
-				<property key="mitcm" value=""/>
-				<property key="mstacktcm" value="false"/>
-				<property key="relaxed-math" value="false"/>
-				<property key="save-temps" value="false"/>
-				<property key="wpo-lto" value="false"/>
-			</C32Global>
-			<ICD4Tool>
-				<property key="ADC" value="true"/>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="CAN1" value="true"/>
-				<property key="CAN2" value="true"/>
-				<property key="CHANGE NOTICE A" value="true"/>
-				<property key="CHANGE NOTICE B" value="true"/>
-				<property key="CHANGE NOTICE C" value="true"/>
-				<property key="CHANGE NOTICE D" value="true"/>
-				<property key="CHANGE NOTICE E" value="true"/>
-				<property key="CHANGE NOTICE F" value="true"/>
-				<property key="CHANGE NOTICE G" value="true"/>
-				<property key="COMPARATOR" value="true"/>
-				<property key="DMA" value="true"/>
-				<property key="ETHERNET CONTROLLER" value="true"/>
-				<property key="Freeze All Other Peripherals" value="true"/>
-				<property key="I2C 1" value="true"/>
-				<property key="I2C 2" value="true"/>
-				<property key="I2C 3" value="true"/>
-				<property key="I2C 4" value="true"/>
-				<property key="I2C 5" value="true"/>
-				<property key="INPUT CAPTURE 1" value="true"/>
-				<property key="INPUT CAPTURE 2" value="true"/>
-				<property key="INPUT CAPTURE 3" value="true"/>
-				<property key="INPUT CAPTURE 4" value="true"/>
-				<property key="INPUT CAPTURE 5" value="true"/>
-				<property key="INPUT CAPTURE 6" value="true"/>
-				<property key="INPUT CAPTURE 7" value="true"/>
-				<property key="INPUT CAPTURE 8" value="true"/>
-				<property key="INPUT CAPTURE 9" value="true"/>
-				<property key="INTERRUPT CONTROL" value="true"/>
-				<property key="OUTPUT COMPARE 1" value="true"/>
-				<property key="OUTPUT COMPARE 2" value="true"/>
-				<property key="OUTPUT COMPARE 3" value="true"/>
-				<property key="OUTPUT COMPARE 4" value="true"/>
-				<property key="OUTPUT COMPARE 5" value="true"/>
-				<property key="OUTPUT COMPARE 6" value="true"/>
-				<property key="OUTPUT COMPARE 7" value="true"/>
-				<property key="OUTPUT COMPARE 8" value="true"/>
-				<property key="OUTPUT COMPARE 9" value="true"/>
-				<property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
-				<property key="REAL TIME CLOCK" value="true"/>
-				<property key="REFERENCE CLOCK1" value="true"/>
-				<property key="REFERENCE CLOCK2" value="true"/>
-				<property key="REFERENCE CLOCK3" value="true"/>
-				<property key="REFERENCE CLOCK4" value="true"/>
-				<property key="SPI/I2S 1" value="true"/>
-				<property key="SPI/I2S 2" value="true"/>
-				<property key="SPI/I2S 3" value="true"/>
-				<property key="SPI/I2S 4" value="true"/>
-				<property key="SPI/I2S 5" value="true"/>
-				<property key="SPI/I2S 6" value="true"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="TIMER1" value="true"/>
-				<property key="TIMER2" value="true"/>
-				<property key="TIMER3" value="true"/>
-				<property key="TIMER4" value="true"/>
-				<property key="TIMER5" value="true"/>
-				<property key="TIMER6" value="true"/>
-				<property key="TIMER7" value="true"/>
-				<property key="TIMER8" value="true"/>
-				<property key="TIMER9" value="true"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="UART1" value="true"/>
-				<property key="UART2" value="true"/>
-				<property key="UART3" value="true"/>
-				<property key="UART4" value="true"/>
-				<property key="UART5" value="true"/>
-				<property key="UART6" value="true"/>
-				<property key="debugoptions.useswbreakpoints" value="false"/>
-				<property key="hwtoolclock.frcindebug" value="false"/>
-				<property key="memories.aux" value="false"/>
-				<property key="memories.bootflash" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.configurationmemory2" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.flashdata" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.instruction.ram.ranges" value="${memories.instruction.ram.ranges}"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="poweroptions.powerenable" value="false"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.ledbrightness" value="5"/>
-				<property key="programoptions.pgcconfig" value="pull down"/>
-				<property key="programoptions.pgcresistor.value" value="4.7"/>
-				<property key="programoptions.pgdconfig" value="pull down"/>
-				<property key="programoptions.pgdresistor.value" value="4.7"/>
-				<property key="programoptions.pgmentry.voltage" value="low"/>
-				<property key="programoptions.pgmspeed" value="Med"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.preserveuserid" value="false"/>
-				<property key="programoptions.programcalmem" value="false"/>
-				<property key="programoptions.programuserotp" value="false"/>
-				<property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
-				<property key="voltagevalue" value="3.25"/>
-			</ICD4Tool>
-			<PKOBSKDEPlatformTool>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="memories.userotp" value="true"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preservedataflash.ranges" value=""/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.usehighvoltageonmclr" value="false"/>
-				<property key="programoptions.uselvpprogramming" value="true"/>
-			</PKOBSKDEPlatformTool>
-			<RealICEPlatformTool>
-				<property key="ADC" value="true"/>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="CAN1" value="true"/>
-				<property key="CAN2" value="true"/>
-				<property key="CHANGE NOTICE A" value="true"/>
-				<property key="CHANGE NOTICE B" value="true"/>
-				<property key="CHANGE NOTICE C" value="true"/>
-				<property key="CHANGE NOTICE D" value="true"/>
-				<property key="CHANGE NOTICE E" value="true"/>
-				<property key="CHANGE NOTICE F" value="true"/>
-				<property key="CHANGE NOTICE G" value="true"/>
-				<property key="COMPARATOR" value="true"/>
-				<property key="DMA" value="true"/>
-				<property key="ETHERNET CONTROLLER" value="true"/>
-				<property key="Freeze All Other Peripherals" value="true"/>
-				<property key="I2C 1" value="true"/>
-				<property key="I2C 2" value="true"/>
-				<property key="I2C 3" value="true"/>
-				<property key="I2C 4" value="true"/>
-				<property key="I2C 5" value="true"/>
-				<property key="INPUT CAPTURE 1" value="true"/>
-				<property key="INPUT CAPTURE 2" value="true"/>
-				<property key="INPUT CAPTURE 3" value="true"/>
-				<property key="INPUT CAPTURE 4" value="true"/>
-				<property key="INPUT CAPTURE 5" value="true"/>
-				<property key="INPUT CAPTURE 6" value="true"/>
-				<property key="INPUT CAPTURE 7" value="true"/>
-				<property key="INPUT CAPTURE 8" value="true"/>
-				<property key="INPUT CAPTURE 9" value="true"/>
-				<property key="INTERRUPT CONTROL" value="true"/>
-				<property key="OUTPUT COMPARE 1" value="true"/>
-				<property key="OUTPUT COMPARE 2" value="true"/>
-				<property key="OUTPUT COMPARE 3" value="true"/>
-				<property key="OUTPUT COMPARE 4" value="true"/>
-				<property key="OUTPUT COMPARE 5" value="true"/>
-				<property key="OUTPUT COMPARE 6" value="true"/>
-				<property key="OUTPUT COMPARE 7" value="true"/>
-				<property key="OUTPUT COMPARE 8" value="true"/>
-				<property key="OUTPUT COMPARE 9" value="true"/>
-				<property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
-				<property key="REAL TIME CLOCK" value="true"/>
-				<property key="REFERENCE CLOCK1" value="true"/>
-				<property key="REFERENCE CLOCK2" value="true"/>
-				<property key="REFERENCE CLOCK3" value="true"/>
-				<property key="REFERENCE CLOCK4" value="true"/>
-				<property key="RIExTrigs.Five" value="OFF"/>
-				<property key="RIExTrigs.Four" value="OFF"/>
-				<property key="RIExTrigs.One" value="OFF"/>
-				<property key="RIExTrigs.Seven" value="OFF"/>
-				<property key="RIExTrigs.Six" value="OFF"/>
-				<property key="RIExTrigs.Three" value="OFF"/>
-				<property key="RIExTrigs.Two" value="OFF"/>
-				<property key="RIExTrigs.Zero" value="OFF"/>
-				<property key="SPI/I2S 1" value="true"/>
-				<property key="SPI/I2S 2" value="true"/>
-				<property key="SPI/I2S 3" value="true"/>
-				<property key="SPI/I2S 4" value="true"/>
-				<property key="SPI/I2S 5" value="true"/>
-				<property key="SPI/I2S 6" value="true"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="TIMER1" value="true"/>
-				<property key="TIMER2" value="true"/>
-				<property key="TIMER3" value="true"/>
-				<property key="TIMER4" value="true"/>
-				<property key="TIMER5" value="true"/>
-				<property key="TIMER6" value="true"/>
-				<property key="TIMER7" value="true"/>
-				<property key="TIMER8" value="true"/>
-				<property key="TIMER9" value="true"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="UART1" value="true"/>
-				<property key="UART2" value="true"/>
-				<property key="UART3" value="true"/>
-				<property key="UART4" value="true"/>
-				<property key="UART5" value="true"/>
-				<property key="UART6" value="true"/>
-				<property key="debugoptions.useswbreakpoints" value="false"/>
-				<property key="hwtoolclock.frcindebug" value="false"/>
-				<property key="hwtoolclock.instructionspeed" value="4"/>
-				<property key="hwtoolclock.units" value="mips"/>
-				<property key="memories.aux" value="false"/>
-				<property key="memories.bootflash" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.configurationmemory2" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.flashdata" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.instruction.ram" value="true"/>
-				<property key="memories.instruction.ram.ranges" value="${memories.instruction.ram.ranges}"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="poweroptions.powerenable" value="false"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preservedataflash.ranges" value=""/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.preserveuserid" value="false"/>
-				<property key="programoptions.programcalmem" value="false"/>
-				<property key="programoptions.programuserotp" value="false"/>
-				<property key="programoptions.usehighvoltageonmclr" value="false"/>
-				<property key="programoptions.uselvpprogramming" value="false"/>
-				<property key="tracecontrol.include.timestamp" value="summarydataenabled"/>
-				<property key="tracecontrol.select" value="0"/>
-				<property key="tracecontrol.stallontracebufferfull" value="false"/>
-				<property key="tracecontrol.tracebufmax" value="546000"/>
-				<property key="tracecontrol.tracefile" value="defmplabxtrace.log"/>
-				<property key="tracecontrol.tracefilemax" value="10000000"/>
-				<property key="voltagevalue" value="3.25"/>
-			</RealICEPlatformTool>
-		</conf>
-	</confs>
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="demos" displayName="demos" projectFiles="true">
+      <logicalFolder name="defender" displayName="defender" projectFiles="true">
+        <itemPath>../../../../../demos/defender/aws_iot_demo_defender.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="demo_runner" displayName="demo_runner" projectFiles="true">
+        <itemPath>../../../../../demos/demo_runner/aws_demo_network_addr.c</itemPath>
+        <itemPath>../../../../../demos/demo_runner/aws_demo_version.c</itemPath>
+        <itemPath>../../../../../demos/demo_runner/aws_demo.c</itemPath>
+        <itemPath>../../../../../demos/demo_runner/iot_demo_freertos.c</itemPath>
+        <itemPath>../../../../../demos/demo_runner/iot_demo_runner.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="dev_mode_key_provisioning"
+                     displayName="dev_mode_key_provisioning"
+                     projectFiles="true">
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <itemPath>../../../../../demos/dev_mode_key_provisioning/include/aws_dev_mode_key_provisioning.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="src" displayName="src" projectFiles="true">
+          <itemPath>../../../../../demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c</itemPath>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="greengrass_connectivity"
+                     displayName="greengrass_connectivity"
+                     projectFiles="true">
+        <itemPath>../../../../../demos/greengrass_connectivity/aws_greengrass_discovery_demo.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="https" displayName="https" projectFiles="true">
+        <itemPath>../../../../../demos/https/iot_demo_https_s3_download_sync.c</itemPath>
+        <itemPath>../../../../../demos/https/iot_demo_https_s3_download_async.c</itemPath>
+        <itemPath>../../../../../demos/https/iot_demo_https_s3_upload_sync.c</itemPath>
+        <itemPath>../../../../../demos/https/iot_demo_https_s3_upload_async.c</itemPath>
+        <itemPath>../../../../../demos/https/iot_demo_https_common.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="include" displayName="include" projectFiles="true">
+        <itemPath>../../../../../demos/include/aws_application_version.h</itemPath>
+        <itemPath>../../../../../demos/include/aws_clientcredential.h</itemPath>
+        <itemPath>../../../../../demos/include/aws_clientcredential_keys.h</itemPath>
+        <itemPath>../../../../../demos/include/aws_demo.h</itemPath>
+        <itemPath>../../../../../demos/include/aws_iot_demo_network.h</itemPath>
+        <itemPath>../../../../../demos/include/aws_ota_codesigner_certificate.h</itemPath>
+        <itemPath>../../../../../demos/include/iot_config_common.h</itemPath>
+        <itemPath>../../../../../demos/include/iot_demo_logging.h</itemPath>
+        <itemPath>../../../../../demos/include/iot_demo_runner.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
+        <itemPath>../../../../../demos/mqtt/iot_demo_mqtt.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="network_manager"
+                     displayName="network_manager"
+                     projectFiles="true">
+        <itemPath>../../../../../demos/network_manager/aws_iot_network_manager.c</itemPath>
+        <itemPath>../../../../../demos/network_manager/aws_iot_demo_network.c</itemPath>
+        <itemPath>../../../../../demos/network_manager/iot_network_manager_private.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="ota" displayName="ota" projectFiles="true">
+        <itemPath>../../../../../demos/ota/aws_iot_ota_update_demo.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="shadow" displayName="shadow" projectFiles="true">
+        <itemPath>../../../../../demos/shadow/aws_iot_demo_shadow.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="tcp" displayName="tcp" projectFiles="true">
+        <itemPath>../../../../../demos/tcp/aws_tcp_echo_client_single_task.c</itemPath>
+        <itemPath>../../../../../demos/tcp/aws_tcp_echo_client_single_tasks.h</itemPath>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="freertos_kernel"
+                   displayName="freertos_kernel"
+                   projectFiles="true">
+      <logicalFolder name="include" displayName="include" projectFiles="true">
+        <itemPath>../../../../../freertos_kernel/include/FreeRTOS.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/StackMacros.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/atomic.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/croutine.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/deprecated_definitions.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/event_groups.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/list.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/message_buffer.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/mpu_prototypes.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/mpu_wrappers.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/portable.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/projdefs.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/queue.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/semphr.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/stack_macros.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/stream_buffer.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/task.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/timers.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="portable" displayName="portable" projectFiles="true">
+        <logicalFolder name="MemMang" displayName="MemMang" projectFiles="true">
+          <itemPath>../../../../../freertos_kernel/portable/MemMang/heap_4.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="MPLAB" displayName="MPLAB" projectFiles="true">
+          <logicalFolder name="PIC32MZ" displayName="PIC32MZ" projectFiles="true">
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port.c</itemPath>
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port_asm.S</itemPath>
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/portmacro.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <itemPath>../../../../../freertos_kernel/event_groups.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/list.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/queue.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/stream_buffer.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/tasks.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/timers.c</itemPath>
+    </logicalFolder>
+    <logicalFolder name="libraries" displayName="libraries" projectFiles="true">
+      <logicalFolder name="3rdparty" displayName="3rdparty" projectFiles="true">
+        <logicalFolder name="http_parser" displayName="http_parser" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="jsmn" displayName="jsmn" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aes.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aesni.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/arc4.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aria.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1write.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/base64.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bignum.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/blowfish.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bn_mul.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/camellia.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ccm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/certs.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chacha20.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chachapoly.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/check_config.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cmac.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/compat-1.3.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/config.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ctr_drbg.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/debug.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/des.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/dhm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdh.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdsa.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecjpake.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy_poll.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/error.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/gcm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/havege.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hkdf.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hmac_drbg.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md2.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md4.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md5.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/memory_buffer_alloc.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net_sockets.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/nist_kw.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/oid.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/padlock.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pem.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs11.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs12.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs5.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_time.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_util.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/poly1305.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ripemd160.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha1.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha256.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha512.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cache.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ciphersuites.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cookie.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ticket.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/threading.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/timing.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/version.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crl.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crt.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_csr.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/xtea.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="library" displayName="library" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/base64.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aes.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aesni.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/arc4.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aria.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1parse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1write.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/bignum.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/blowfish.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/camellia.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ccm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/certs.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/chacha20.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/chachapoly.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cmac.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ctr_drbg.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/debug.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/des.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/dhm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdh.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdsa.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecjpake.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp_curves.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy_poll.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/error.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/gcm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/havege.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/hkdf.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/hmac_drbg.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md2.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md4.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md5.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/memory_buffer_alloc.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/net_sockets.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/nist_kw.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/oid.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/padlock.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pem.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs11.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs12.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs5.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkparse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkwrite.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform_util.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/poly1305.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ripemd160.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa_internal.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha1.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha256.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha512.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cache.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ciphersuites.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cli.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cookie.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_srv.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ticket.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_tls.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/threading.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/timing.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/version.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/version_features.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_create.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crl.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crt.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_csr.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_crt.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_csr.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/xtea.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="mbedtls_utils"
+                       displayName="mbedtls_utils"
+                       projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_utils.c</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11f.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11t.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="tinycbor" displayName="tinycbor" projectFiles="true">
+          <logicalFolder name="src" displayName="src" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty_stdio.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborerrorstrings.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser_dup_string.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
+          <logicalFolder name="asn1" displayName="asn1" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1parse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="lib" displayName="lib" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/aes.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cbc_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ccm_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cmac_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/constants.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_prng.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dh.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dsa.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_platform_specific.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac_prng.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/sha256.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/utils.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_decrypt.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_encrypt.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cbc_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ccm_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cmac_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_prng.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dh.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dsa.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_platform_specific.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac_prng.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/sha256.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="abstractions"
+                     displayName="abstractions"
+                     projectFiles="true">
+        <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/threading_alt.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="platform" displayName="platform" projectFiles="true">
+          <logicalFolder name="freertos" displayName="freertos" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="platform" displayName="platform" projectFiles="true">
+                <itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_platform_types_freertos.h</itemPath>
+                <itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_clock_freertos.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_threads_freertos.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_metrics.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_network_freertos.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="platform" displayName="platform" projectFiles="true">
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_clock.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_network.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_threads.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_metrics.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="types" displayName="types" projectFiles="true">
+              <itemPath>../../../../../libraries/abstractions/platform/include/types/iot_platform_types.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="posix" displayName="posix" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="FreeRTOS_POSIX"
+                           displayName="FreeRTOS_POSIX"
+                           projectFiles="true">
+              <logicalFolder name="sys" displayName="sys" projectFiles="true">
+                <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sys/types.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/errno.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/fcntl.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/mqueue.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sched.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/semaphore.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/signal.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/time.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/unistd.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/utils.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="secure_sockets"
+                       displayName="secure_sockets"
+                       projectFiles="true">
+          <logicalFolder name="freertos_plus_tcp"
+                         displayName="freertos_plus_tcp"
+                         projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets.h</itemPath>
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_config_defaults.h</itemPath>
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_wrapper_metrics.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/wifi/include/iot_wifi.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="c_sdk" displayName="c_sdk" projectFiles="true">
+        <logicalFolder name="aws" displayName="aws" projectFiles="true">
+          <logicalFolder name="defender" displayName="defender" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/include/aws_iot_defender.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="private" displayName="private" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="shadow" displayName="shadow" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_iot_shadow.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_shadow.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_subscription.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow_config_defaults.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="standard" displayName="standard" projectFiles="true">
+          <logicalFolder name="common" displayName="common" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="private" displayName="private" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_logging.h</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_taskpool_internal.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="types" displayName="types" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_network_types.h</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_taskpool_types.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_appversion32.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_init.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_linear_containers.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_task.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_setup.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_taskpool.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="logging" displayName="logging" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
+            </logicalFolder>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_init.c</itemPath>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="https" displayName="https" projectFiles="true">
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_client.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_serialize.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="serializer" displayName="serializer" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_serializer.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_json_utils.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="cbor" displayName="cbor" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_encoder.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="json" displayName="json" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_decoder.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_serializer_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_json_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="freertos_plus"
+                     displayName="freertos_plus"
+                     projectFiles="true">
+        <logicalFolder name="aws" displayName="aws" projectFiles="true">
+          <logicalFolder name="greengrass" displayName="greengrass" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_ggd_config_defaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="ota" displayName="ota" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="http" displayName="http" projectFiles="true">
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="standard" displayName="standard" projectFiles="true">
+          <logicalFolder name="crypto" displayName="crypto" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/crypto/include/iot_crypto.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/crypto/src/iot_crypto.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="freertos_plus_posix"
+                         displayName="freertos_plus_posix"
+                         projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_types.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_internal.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_portable_default.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_clock.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_mqueue.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_barrier.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_cond.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_mutex.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_sched.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_semaphore.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_unistd.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="freertos_plus_tcp"
+                         displayName="freertos_plus_tcp"
+                         projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_errno_TCP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_WIN.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_UDP_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/IPTraceMacroDefaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <logicalFolder name="portable" displayName="portable" projectFiles="true">
+                <logicalFolder name="NetworkInterface"
+                               displayName="NetworkInterface"
+                               projectFiles="true">
+                  <logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Stream_Buffer.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="tls" displayName="tls" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/tls/include/iot_tls.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/tls/src/iot_tls.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="utils" displayName="utils" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_system_init.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_pki_utils.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_system_init.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_pki_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="LinkerScript"
+                   projectFiles="true">
+      <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/app_mz.ld</itemPath>
+    </logicalFolder>
+    <logicalFolder name="vendors" displayName="vendors" projectFiles="true">
+      <logicalFolder name="microchip" displayName="microchip" projectFiles="true">
+        <logicalFolder name="boards" displayName="boards" projectFiles="true">
+          <logicalFolder name="curiosity_pic32mzef"
+                         displayName="curiosity_pic32mzef"
+                         projectFiles="true">
+            <logicalFolder name="aws_demos" displayName="aws_demos" projectFiles="true">
+              <logicalFolder name="application_code"
+                             displayName="application_code"
+                             projectFiles="true">
+                <logicalFolder name="microchip_code"
+                               displayName="microchip_code"
+                               projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/rtos_hooks.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_exceptions.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_init.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_interrupt.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_tasks.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/NetworkConfig.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_config.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_definitions.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code/system_interrupt_a.S</itemPath>
+                </logicalFolder>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/main.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="config_files"
+                             displayName="config_files"
+                             projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSConfig.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/FreeRTOSIPConfig.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_bufferpool_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_demo_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ggd_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_iot_network_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_mqtt_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_secure_sockets_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_shadow_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_wifi_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_mqtt_agent_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/iot_pkcs11_config.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <logicalFolder name="ports" displayName="ports" projectFiles="true">
+              <logicalFolder name="ota" displayName="ota" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_ota_pal.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="posix" displayName="posix" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix/FreeRTOS_POSIX_portable.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/aws_wifi_assert.c</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="harmony" displayName="harmony" projectFiles="true">
+          <logicalFolder name="v2.05" displayName="v2.05" projectFiles="true">
+            <logicalFolder name="bsp" displayName="bsp" projectFiles="true">
+              <itemPath>../../../../../vendors/microchip/harmony/v2.05/bsp/bsp.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="framework" displayName="framework" projectFiles="true">
+              <logicalFolder name="driver" displayName="driver" projectFiles="true">
+                <logicalFolder name="ethmac" displayName="ethmac" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac_lib.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="ethphy" displayName="ethphy" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_ethphy.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_extphy_smsc8720.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="flash" displayName="flash" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/flash/src/drv_flash_static.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="miim" displayName="miim" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/miim/src/dynamic/drv_miim.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="spi" displayName="spi" projectFiles="true">
+                  <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_api.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_dma_tasks.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_rm_tasks.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_tasks.c</itemPath>
+                  </logicalFolder>
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi_api.c</itemPath>
+                    </logicalFolder>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/drv_spi_sys_queue_fifo.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/tmr/src/dynamic/drv_tmr.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="usart" displayName="usart" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue_dma.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_byte_model.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_dma.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_read_write.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+                  <logicalFolder name="wilc1000" displayName="wilc1000" projectFiles="true">
+                    <logicalFolder name="dev" displayName="dev" projectFiles="true">
+                      <logicalFolder name="console" displayName="console" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/console/wdrv_wilc1000_console.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="gpio" displayName="gpio" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_eint.c</itemPath>
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_gpio.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="spi" displayName="spi" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/spi/wdrv_wilc1000_spi.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="timer" displayName="timer" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/timer/wdrv_wilc1000_timer.c</itemPath>
+                      </logicalFolder>
+                    </logicalFolder>
+                    <logicalFolder name="osal" displayName="osal" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/osal/wdrv_wilc1000_osal.c</itemPath>
+                    </logicalFolder>
+                    <logicalFolder name="wireless_driver"
+                                   displayName="wireless_driver"
+                                   projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_cli.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_config.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_connmgr.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_events.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_iwpriv.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_main.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_scan_helper.c</itemPath>
+                    </logicalFolder>
+                    <logicalFolder name="wireless_driver_extension"
+                                   displayName="wireless_driver_extension"
+                                   projectFiles="true">
+                      <logicalFolder name="common" displayName="common" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/source/nm_common.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <logicalFolder name="driver" displayName="driver" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_hif.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_periph.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_wifi.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmasic.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmbus.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmdrv.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmspi.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <logicalFolder name="spi_flash" displayName="spi_flash" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/spi_flash/source/spi_flash.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_fw_update.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_task.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="osal" displayName="osal" projectFiles="true">
+                <logicalFolder name="src" displayName="src" projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal_freertos.c</itemPath>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="peripheral" displayName="peripheral" projectFiles="true">
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/peripheral/tmr/src/plib_tmr_pic32.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <logicalFolder name="clk" displayName="clk" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/clk/src/sys_clk_pic32mz.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="command" displayName="command" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/command/src/sys_command.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="common" displayName="common" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_buffer.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_queue.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="console" displayName="console" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console_uart.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="debug" displayName="debug" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/debug/src/sys_debug.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="devcon" displayName="devcon" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_pic32mz.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_cache_pic32mz.S</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="dma" displayName="dma" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/dma/src/sys_dma.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="int" displayName="int" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/int/src/sys_int_pic32.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="ports" displayName="ports" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports_static.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="random" displayName="random" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/random/src/sys_random.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="reset" displayName="reset" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/reset/src/sys_reset.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/tmr/src/sys_tmr.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="tcpip" displayName="tcpip" projectFiles="true">
+                <logicalFolder name="src" displayName="src" projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_alloc.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_external.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_helpers.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c</itemPath>
+                </logicalFolder>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+    </logicalFolder>
+  </logicalFolder>
+  <projectmakefile>Makefile</projectmakefile>
+  <confs>
+    <conf name="pic32mz_ef_curiosity" type="2">
+      <toolsSet>
+        <developmentServer>localhost</developmentServer>
+        <targetDevice>PIC32MZ2048EFM100</targetDevice>
+        <targetHeader></targetHeader>
+        <targetPluginBoard></targetPluginBoard>
+        <platformTool>ICD4Tool</platformTool>
+        <languageToolchain>XC32</languageToolchain>
+        <languageToolchainVersion>2.10</languageToolchainVersion>
+        <platform>3</platform>
+      </toolsSet>
+      <packs>
+        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
+      </packs>
+      <ScriptingSettings>
+      </ScriptingSettings>
+      <compileType>
+        <linkerTool>
+          <linkerLibItems>
+            <linkerLibFileItem>../../../../../vendors/microchip/harmony/v2.05/bin/framework/peripheral/PIC32MZ2048EFM100_peripherals.a</linkerLibFileItem>
+          </linkerLibItems>
+        </linkerTool>
+        <archiverTool>
+        </archiverTool>
+        <loading>
+          <makeArtifact PL="../bootloader"
+                        CT="1"
+                        CN="pic32mz_ef_curiosity"
+                        AC="true"
+                        BL="true"
+                        WD="../bootloader"
+                        BC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity"
+                        DBC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity TYPE_IMAGE=DEBUG_RUN"
+                        CC="rm -rf &quot;build/pic32mz_ef_curiosity&quot; &quot;dist/pic32mz_ef_curiosity&quot;"
+                        OP="dist/pic32mz_ef_curiosity/production/bootloader.production.hex"
+                        DOP="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf"
+                        FL="dist/pic32mz_ef_curiosity/production/bootloader.production.hex"
+                        PD="dist/pic32mz_ef_curiosity/production/bootloader.production.elf"
+                        DD="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf">
+          </makeArtifact>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
+          <alternateLoadableFile></alternateLoadableFile>
+        </loading>
+        <subordinates>
+        </subordinates>
+      </compileType>
+      <makeCustomizationType>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStep></makeCustomizationPreStep>
+        <makeCustomizationPostStepEnabled>true</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStep>python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/binary_image_generator.py -d ${MP_CC_DIR} -b xc32-objcopy -p "-I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin" &amp;&amp; python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
+      </makeCustomizationType>
+      <C32>
+        <property key="additional-warnings" value="false"/>
+        <property key="addresss-attribute-use" value="false"/>
+        <property key="enable-app-io" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
+        <property key="exclude-floating-point" value="false"/>
+        <property key="extra-include-directories"
+                  value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../demos/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/http_parser"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="isolate-each-function" value="true"/>
+        <property key="make-warnings-into-errors" value="false"/>
+        <property key="optimization-level" value="-O1"/>
+        <property key="place-data-into-section" value="false"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros"
+                  value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
+        <property key="strict-ansi" value="false"/>
+        <property key="support-ansi" value="false"/>
+        <property key="toplevel-reordering" value=""/>
+        <property key="unaligned-access" value=""/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
+        <property key="use-indirect-calls" value="false"/>
+        <appendMe value="-mnewlib-libc -std=gnu99 -fgnu89-inline"/>
+      </C32>
+      <C32-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C32-AR>
+      <C32-AS>
+        <property key="assembler-symbols" value=""/>
+        <property key="enable-symbols" value="true"/>
+        <property key="exclude-floating-point-library" value="false"/>
+        <property key="expand-macros" value="false"/>
+        <property key="extra-include-directories-for-assembler" value=""/>
+        <property key="extra-include-directories-for-preprocessor"
+                  value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../demos/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/http_parser"/>
+        <property key="false-conditionals" value="false"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC32asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="warning-level" value=""/>
+      </C32-AS>
+      <C32-LD>
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="allocate-dinit" value="false"/>
+        <property key="code-dinit" value="false"/>
+        <property key="ebase-addr" value=""/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="exclude-floating-point-library" value="false"/>
+        <property key="exclude-standard-libraries" value="false"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="heap-size" value="10000"/>
+        <property key="input-libraries" value=""/>
+        <property key="kseg-length" value=""/>
+        <property key="kseg-origin" value=""/>
+        <property key="linker-symbols" value=""/>
+        <property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
+        <property key="no-device-startup-code" value="false"/>
+        <property key="no-startup-files" value="false"/>
+        <property key="oXC32ld-extra-opts" value="-mnewlib-libc"/>
+        <property key="optimization-level" value=""/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="true"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="serial-length" value=""/>
+        <property key="serial-origin" value=""/>
+        <property key="stack-size" value="10000"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
+        <appendMe value="--allow-multiple-definition"/>
+      </C32-LD>
+      <C32CPP>
+        <property key="additional-warnings" value="false"/>
+        <property key="addresss-attribute-use" value="false"/>
+        <property key="check-new" value="false"/>
+        <property key="eh-specs" value="true"/>
+        <property key="enable-app-io" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
+        <property key="exceptions" value="true"/>
+        <property key="exclude-floating-point" value="false"/>
+        <property key="extra-include-directories" value=""/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="make-warnings-into-errors" value="false"/>
+        <property key="optimization-level" value=""/>
+        <property key="place-data-into-section" value="false"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="rtti" value="true"/>
+        <property key="strict-ansi" value="false"/>
+        <property key="toplevel-reordering" value=""/>
+        <property key="unaligned-access" value=""/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
+        <property key="use-indirect-calls" value="false"/>
+      </C32CPP>
+      <C32Global>
+        <property key="common-include-directories" value=""/>
+        <property key="gp-relative-option" value=""/>
+        <property key="legacy-libc" value="false"/>
+        <property key="mdtcm" value=""/>
+        <property key="mitcm" value=""/>
+        <property key="mstacktcm" value="false"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
+        <property key="wpo-lto" value="false"/>
+      </C32Global>
+      <ICD4Tool>
+        <property key="ADC" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="CAN1" value="true"/>
+        <property key="CAN2" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CHANGE NOTICE E" value="true"/>
+        <property key="CHANGE NOTICE F" value="true"/>
+        <property key="CHANGE NOTICE G" value="true"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="ETHERNET CONTROLLER" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C 1" value="true"/>
+        <property key="I2C 2" value="true"/>
+        <property key="I2C 3" value="true"/>
+        <property key="I2C 4" value="true"/>
+        <property key="I2C 5" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="INTERRUPT CONTROL" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="REAL TIME CLOCK" value="true"/>
+        <property key="REFERENCE CLOCK1" value="true"/>
+        <property key="REFERENCE CLOCK2" value="true"/>
+        <property key="REFERENCE CLOCK3" value="true"/>
+        <property key="REFERENCE CLOCK4" value="true"/>
+        <property key="SPI/I2S 1" value="true"/>
+        <property key="SPI/I2S 2" value="true"/>
+        <property key="SPI/I2S 3" value="true"/>
+        <property key="SPI/I2S 4" value="true"/>
+        <property key="SPI/I2S 5" value="true"/>
+        <property key="SPI/I2S 6" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="UART4" value="true"/>
+        <property key="UART5" value="true"/>
+        <property key="UART6" value="true"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.ledbrightness" value="5"/>
+        <property key="programoptions.pgcconfig" value="pull down"/>
+        <property key="programoptions.pgcresistor.value" value="4.7"/>
+        <property key="programoptions.pgdconfig" value="pull down"/>
+        <property key="programoptions.pgdresistor.value" value="4.7"/>
+        <property key="programoptions.pgmentry.voltage" value="low"/>
+        <property key="programoptions.pgmspeed" value="Med"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="voltagevalue" value="3.25"/>
+      </ICD4Tool>
+      <PKOBSKDEPlatformTool>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="memories.userotp" value="true"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges" value=""/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="true"/>
+      </PKOBSKDEPlatformTool>
+      <RealICEPlatformTool>
+        <property key="ADC" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="CAN1" value="true"/>
+        <property key="CAN2" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CHANGE NOTICE E" value="true"/>
+        <property key="CHANGE NOTICE F" value="true"/>
+        <property key="CHANGE NOTICE G" value="true"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="ETHERNET CONTROLLER" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C 1" value="true"/>
+        <property key="I2C 2" value="true"/>
+        <property key="I2C 3" value="true"/>
+        <property key="I2C 4" value="true"/>
+        <property key="I2C 5" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="INTERRUPT CONTROL" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="REAL TIME CLOCK" value="true"/>
+        <property key="REFERENCE CLOCK1" value="true"/>
+        <property key="REFERENCE CLOCK2" value="true"/>
+        <property key="REFERENCE CLOCK3" value="true"/>
+        <property key="REFERENCE CLOCK4" value="true"/>
+        <property key="RIExTrigs.Five" value="OFF"/>
+        <property key="RIExTrigs.Four" value="OFF"/>
+        <property key="RIExTrigs.One" value="OFF"/>
+        <property key="RIExTrigs.Seven" value="OFF"/>
+        <property key="RIExTrigs.Six" value="OFF"/>
+        <property key="RIExTrigs.Three" value="OFF"/>
+        <property key="RIExTrigs.Two" value="OFF"/>
+        <property key="RIExTrigs.Zero" value="OFF"/>
+        <property key="SPI/I2S 1" value="true"/>
+        <property key="SPI/I2S 2" value="true"/>
+        <property key="SPI/I2S 3" value="true"/>
+        <property key="SPI/I2S 4" value="true"/>
+        <property key="SPI/I2S 5" value="true"/>
+        <property key="SPI/I2S 6" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="UART4" value="true"/>
+        <property key="UART5" value="true"/>
+        <property key="UART6" value="true"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="hwtoolclock.instructionspeed" value="4"/>
+        <property key="hwtoolclock.units" value="mips"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges" value=""/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="tracecontrol.include.timestamp" value="summarydataenabled"/>
+        <property key="tracecontrol.select" value="0"/>
+        <property key="tracecontrol.stallontracebufferfull" value="false"/>
+        <property key="tracecontrol.tracebufmax" value="546000"/>
+        <property key="tracecontrol.tracefile" value="defmplabxtrace.log"/>
+        <property key="tracecontrol.tracefilemax" value="10000000"/>
+        <property key="voltagevalue" value="3.25"/>
+      </RealICEPlatformTool>
+    </conf>
+  </confs>
 </configurationDescriptor>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -985,7 +985,7 @@
 				<property key="place-data-into-section" value="false"/>
 				<property key="post-instruction-scheduling" value="default"/>
 				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\\\&quot;aws_mbedtls_config.h\\\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
+				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
 				<property key="strict-ansi" value="false"/>
 				<property key="support-ansi" value="false"/>
 				<property key="toplevel-reordering" value=""/>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -982,7 +982,7 @@
         <platform>3</platform>
       </toolsSet>
       <packs>
-        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
+        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.2.51"/>
       </packs>
       <ScriptingSettings>
       </ScriptingSettings>
@@ -1079,6 +1079,9 @@
         <property key="preprocessor-macros" value=""/>
         <property key="warning-level" value=""/>
       </C32-AS>
+      <C32-CO>
+        <property key="coverage-enable" value=""/>
+      </C32-CO>
       <C32-LD>
         <property key="additional-options-use-response-files" value="false"/>
         <property key="allocate-dinit" value="false"/>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -1068,7 +1068,7 @@
         <platform>3</platform>
       </toolsSet>
       <packs>
-        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
+        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.2.51"/>
       </packs>
       <ScriptingSettings>
       </ScriptingSettings>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -1075,7 +1075,7 @@
 				<property key="place-data-into-section" value="false"/>
 				<property key="post-instruction-scheduling" value="default"/>
 				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\\\&quot;aws_mbedtls_config.h\\\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;AMAZON_FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
+				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;AMAZON_FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
 				<property key="strict-ansi" value="false"/>
 				<property key="support-ansi" value="false"/>
 				<property key="toplevel-reordering" value=""/>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -1,1444 +1,1506 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="65">
-	<logicalFolder name="root" displayName="root" projectFiles="true">
-		<logicalFolder name="freertos_kernel" displayName="freertos_kernel" projectFiles="true">
-			<itemPath>../../../../../freertos_kernel/event_groups.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/list.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/queue.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/stream_buffer.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/tasks.c</itemPath>
-			<itemPath>../../../../../freertos_kernel/timers.c</itemPath>
-			<logicalFolder name="include" displayName="include" projectFiles="true">
-				<itemPath>../../../../../freertos_kernel/include/FreeRTOS.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/StackMacros.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/atomic.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/croutine.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/deprecated_definitions.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/event_groups.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/list.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/message_buffer.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/mpu_prototypes.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/mpu_wrappers.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/portable.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/projdefs.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/queue.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/semphr.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/stack_macros.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/stream_buffer.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/task.h</itemPath>
-				<itemPath>../../../../../freertos_kernel/include/timers.h</itemPath>
-			</logicalFolder>
-			<logicalFolder name="portable" displayName="portable" projectFiles="true">
-				<logicalFolder name="MPLAB" displayName="MPLAB" projectFiles="true">
-					<logicalFolder name="PIC32MZ" displayName="PIC32MZ" projectFiles="true">
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port.c</itemPath>
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port_asm.S</itemPath>
-						<itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/portmacro.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="MemMang" displayName="MemMang" projectFiles="true">
-					<itemPath>../../../../../freertos_kernel/portable/MemMang/heap_4.c</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="tests" displayName="tests" projectFiles="true">
-			<logicalFolder name="common" displayName="common" projectFiles="true">
-				<itemPath>../../../../../tests/common/aws_test_framework.c</itemPath>
-				<itemPath>../../../../../tests/common/aws_test_runner.c</itemPath>
-				<itemPath>../../../../../tests/common/aws_test.c</itemPath>
-				<itemPath>../../../../../tests/common/iot_test_freertos.c</itemPath>
-				<itemPath>../../../../../tests/common/iot_tests_network.c</itemPath>
-			</logicalFolder>
-			<logicalFolder name="include" displayName="include" projectFiles="true">
-				<itemPath>../../../../../tests/include/aws_application_version.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_clientcredential.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_clientcredential_keys.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_test_runner.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_test_framework.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_test_tcp.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_test_utils.h</itemPath>
-				<itemPath>../../../../../tests/include/aws_unity_config.h</itemPath>
-				<itemPath>../../../../../tests/include/iot_config_common.h</itemPath>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="libraries" displayName="libraries" projectFiles="true">
-			<logicalFolder name="c_sdk" displayName="c_sdk" projectFiles="true">
-				<logicalFolder name="standard" displayName="standard" projectFiles="true">
-					<logicalFolder name="common" displayName="common" projectFiles="true">
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_init.c</itemPath>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_appversion32.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_init.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_linear_containers.h</itemPath>
-							<logicalFolder name="private" displayName="private" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_logging.h</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_taskpool_internal.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_task.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_setup.h</itemPath>
-							<logicalFolder name="types" displayName="types" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_network_types.h</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_taskpool_types.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_taskpool.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="logging" displayName="logging" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
-						</logicalFolder>
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
-						<itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
-						<logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/common/test/iot_memory_leak.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/common/test/iot_tests_taskpool.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_serialize.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<logicalFolder name="mock" displayName="mock" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/mock/iot_tests_mqtt_mock.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="unit" displayName="unit" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_receive.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_validate.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="serializer" displayName="serializer" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<logicalFolder name="cbor" displayName="cbor" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_encoder.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="json" displayName="json" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_decoder.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_serializer_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_json_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_serializer.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_json_utils.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_serializer_json.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_deserializer_json.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="https" displayName="https" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_client.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<logicalFolder name="unit" displayName="unit" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_client.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_utils.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_sync.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_async.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="aws" displayName="aws" projectFiles="true">
-					<logicalFolder name="defender" displayName="defender" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c</itemPath>
-							<logicalFolder name="private" displayName="private" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/defender/include/aws_iot_defender.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<logicalFolder name="unit" displayName="unit" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/defender/test/unit/aws_iot_tests_defender_unit.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="shadow" displayName="shadow" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_static_memory.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_subscription.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow.c</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow_config_defaults.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_iot_shadow.h</itemPath>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_shadow.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<logicalFolder name="unit" displayName="unit" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_api.c</itemPath>
-								<itemPath>../../../../../libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_parser.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<itemPath>../../../../../libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/c_sdk/aws/shadow/test/aws_test_shadow.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="abstractions" displayName="abstractions" projectFiles="true">
-				<logicalFolder name="platform" displayName="platform" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="platform" displayName="platform" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_clock.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_network.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_threads.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_metrics.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="types" displayName="types" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/platform/include/types/iot_platform_types.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="freertos" displayName="freertos" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_clock_freertos.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_threads_freertos.c</itemPath>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<logicalFolder name="platform" displayName="platform" projectFiles="true">
-								<itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_platform_types_freertos.h</itemPath>
-								<itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_metrics.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/platform/freertos/iot_network_freertos.c</itemPath>
-					</logicalFolder>
-					<logicalFolder name="test" displayName="test" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/platform/test/iot_test_platform_clock.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/platform/test/iot_test_platform_threads.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="secure_sockets" displayName="secure_sockets" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets.h</itemPath>
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_config_defaults.h</itemPath>
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_wrapper_metrics.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="freertos_plus_tcp" displayName="freertos_plus_tcp" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</itemPath>
-					</logicalFolder>
-					<logicalFolder name="test" displayName="test" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/secure_sockets/test/iot_test_tcp.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-					<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c</itemPath>
-						<itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/threading_alt.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="test" displayName="test" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/pkcs11/test/iot_test_pkcs11.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/wifi/include/iot_wifi.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="test" displayName="test" projectFiles="true">
-						<itemPath>../../../../../libraries/abstractions/wifi/test/iot_test_wifi.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="posix" displayName="posix" projectFiles="true">
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="FreeRTOS_POSIX" displayName="FreeRTOS_POSIX" projectFiles="true">
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/errno.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/fcntl.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/mqueue.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sched.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/semaphore.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/signal.h</itemPath>
-							<logicalFolder name="sys" displayName="sys" projectFiles="true">
-								<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sys/types.h</itemPath>
-							</logicalFolder>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/time.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/unistd.h</itemPath>
-							<itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/utils.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="freertos_plus" displayName="freertos_plus" projectFiles="true">
-				<logicalFolder name="standard" displayName="standard" projectFiles="true">
-					<logicalFolder name="freertos_plus_tcp" displayName="freertos_plus_tcp" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Stream_Buffer.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</itemPath>
-							<logicalFolder name="portable" displayName="portable" projectFiles="true">
-								<logicalFolder name="NetworkInterface" displayName="NetworkInterface" projectFiles="true">
-									<logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
-										<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_errno_TCP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_WIN.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_UDP_IP.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/IPTraceMacroDefaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test/iot_test_freertos_tcp.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="tls" displayName="tls" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/tls/src/iot_tls.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/tls/include/iot_tls.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/tls/test/iot_test_tls.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="crypto" displayName="crypto" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/crypto/src/iot_crypto.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/crypto/include/iot_crypto.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/crypto/test/iot_test_crypto.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="utils" displayName="utils" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_system_init.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_pki_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_system_init.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_pki_utils.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="freertos_plus_posix" displayName="freertos_plus_posix" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_clock.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_mqueue.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_barrier.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_cond.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_mutex.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_sched.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_semaphore.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_unistd.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_types.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_internal.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_portable_default.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_clock.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_mqueue.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_pthread.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_semaphore.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_stress.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_timer.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_unistd.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_utils.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="aws" displayName="aws" projectFiles="true">
-					<logicalFolder name="greengrass" displayName="greengrass" projectFiles="true">
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_ggd_config_defaults.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_unit.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_helper_secure_connect.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="ota" displayName="ota" projectFiles="true">
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</itemPath>
-						</logicalFolder>
-						<logicalFolder name="src" displayName="src" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</itemPath>
-							<logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="http" displayName="http" projectFiles="true">
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</itemPath>
-								<itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="test" displayName="test" projectFiles="true">
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c</itemPath>
-							<itemPath>../../../../../libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-			<logicalFolder name="3rdparty" displayName="3rdparty" projectFiles="true">
-				<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-					<logicalFolder name="library" displayName="library" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/base64.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aes.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aesni.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/arc4.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/aria.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1parse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1write.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/bignum.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/blowfish.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/camellia.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ccm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/certs.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/chacha20.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/chachapoly.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/cmac.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ctr_drbg.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/debug.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/des.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/dhm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdh.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdsa.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecjpake.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp_curves.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy_poll.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/error.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/gcm.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/havege.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/hkdf.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/hmac_drbg.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md2.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md4.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md5.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/md_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/memory_buffer_alloc.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/net_sockets.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/nist_kw.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/oid.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/padlock.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pem.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk_wrap.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs11.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs12.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs5.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkparse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkwrite.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform_util.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/poly1305.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ripemd160.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa_internal.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha1.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha256.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha512.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cache.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ciphersuites.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cli.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cookie.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_srv.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ticket.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_tls.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/threading.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/timing.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/version.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/version_features.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_create.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crl.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crt.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_csr.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_crt.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_csr.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/mbedtls/library/xtea.c</itemPath>
-					</logicalFolder>
-					<logicalFolder name="include" displayName="include" projectFiles="true">
-						<logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aes.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aesni.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/arc4.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aria.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1write.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/base64.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bignum.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/blowfish.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bn_mul.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/camellia.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ccm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/certs.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chacha20.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chachapoly.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/check_config.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cmac.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/compat-1.3.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/config.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ctr_drbg.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/debug.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/des.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/dhm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdh.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdsa.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecjpake.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy_poll.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/error.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/gcm.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/havege.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hkdf.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hmac_drbg.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md2.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md4.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md5.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/memory_buffer_alloc.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net_sockets.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/nist_kw.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/oid.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/padlock.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pem.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs11.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs12.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs5.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_time.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_util.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/poly1305.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ripemd160.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha1.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha256.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha512.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cache.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ciphersuites.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cookie.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_internal.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ticket.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/threading.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/timing.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/version.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crl.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crt.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_csr.h</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/xtea.h</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="jsmn" displayName="jsmn" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11f.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11t.h</itemPath>
-				</logicalFolder>
-				<logicalFolder name="tinycbor" displayName="tinycbor" projectFiles="true">
-					<logicalFolder name="src" displayName="src" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty_stdio.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborerrorstrings.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser_dup_string.c</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
-					<logicalFolder name="lib" displayName="lib" projectFiles="true">
-						<logicalFolder name="source" displayName="source" projectFiles="true">
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_decrypt.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_encrypt.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cbc_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ccm_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cmac_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_mode.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_prng.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dh.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dsa.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_platform_specific.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac_prng.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/sha256.c</itemPath>
-							<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/utils.c</itemPath>
-						</logicalFolder>
-						<logicalFolder name="include" displayName="include" projectFiles="true">
-							<logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/aes.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cbc_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ccm_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cmac_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/constants.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_mode.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_prng.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dh.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dsa.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_platform_specific.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac_prng.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/sha256.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/utils.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-					<logicalFolder name="asn1" displayName="asn1" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1parse.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1.h</itemPath>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="mbedtls_utils" displayName="mbedtls_utils" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_utils.c</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="unity" displayName="unity" projectFiles="true">
-					<logicalFolder name="src" displayName="src" projectFiles="true">
-						<itemPath>../../../../../libraries/3rdparty/unity/src/unity.c</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/unity/src/unity.h</itemPath>
-						<itemPath>../../../../../libraries/3rdparty/unity/src/unity_internals.h</itemPath>
-					</logicalFolder>
-					<logicalFolder name="extras" displayName="extras" projectFiles="true">
-						<logicalFolder name="fixture" displayName="fixture" projectFiles="true">
-							<logicalFolder name="src" displayName="src" projectFiles="true">
-								<itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture.c</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture_internals.h</itemPath>
-								<itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture_malloc_overrides.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="http_parser" displayName="http_parser" projectFiles="true">
-					<itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.h</itemPath>
-					<itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.c</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="vendors" displayName="vendors" projectFiles="true">
-			<logicalFolder name="microchip" displayName="microchip" projectFiles="true">
-				<logicalFolder name="boards" displayName="boards" projectFiles="true">
-					<logicalFolder name="curiosity_pic32mzef" displayName="curiosity_pic32mzef" projectFiles="true">
-						<logicalFolder name="ports" displayName="ports" projectFiles="true">
-							<logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/aws_wifi_assert.c</itemPath>
-							</logicalFolder>
-							<logicalFolder name="ota" displayName="ota" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_ota_pal.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.c</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="posix" displayName="posix" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix/FreeRTOS_POSIX_portable.h</itemPath>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="aws_tests" displayName="aws_tests" projectFiles="true">
-							<logicalFolder name="config_files" displayName="config_files" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_bufferpool_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_demo_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ggd_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_mqtt_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_secure_sockets_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_shadow_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_ota_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_wifi_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_wifi_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_mqtt_agent_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_test_pkcs11_config.h</itemPath>
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/unity_config.h</itemPath>
-							</logicalFolder>
-							<logicalFolder name="application_code" displayName="application_code" projectFiles="true">
-								<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/main.c</itemPath>
-								<logicalFolder name="microchip_code" displayName="microchip_code" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/rtos_hooks.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_exceptions.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_init.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_interrupt.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_tasks.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/NetworkConfig.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_config.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_definitions.h</itemPath>
-									<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_interrupt_a.S</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-				<logicalFolder name="harmony" displayName="harmony" projectFiles="true">
-					<logicalFolder name="v2.05" displayName="v2.05" projectFiles="true">
-						<logicalFolder name="framework" displayName="framework" projectFiles="true">
-							<logicalFolder name="system" displayName="system" projectFiles="true">
-								<logicalFolder name="command" displayName="command" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/command/src/sys_command.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="clk" displayName="clk" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/clk/src/sys_clk_pic32mz.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="common" displayName="common" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_buffer.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_queue.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="console" displayName="console" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console_uart.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="debug" displayName="debug" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/debug/src/sys_debug.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="devcon" displayName="devcon" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_pic32mz.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_cache_pic32mz.S</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="dma" displayName="dma" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/dma/src/sys_dma.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="int" displayName="int" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/int/src/sys_int_pic32.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="ports" displayName="ports" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports_static.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="random" displayName="random" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/random/src/sys_random.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="reset" displayName="reset" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/reset/src/sys_reset.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/tmr/src/sys_tmr.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="driver" displayName="driver" projectFiles="true">
-								<logicalFolder name="ethmac" displayName="ethmac" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac_lib.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="ethphy" displayName="ethphy" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_ethphy.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_extphy_smsc8720.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="flash" displayName="flash" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/flash/src/drv_flash_static.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="miim" displayName="miim" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/miim/src/dynamic/drv_miim.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="spi" displayName="spi" projectFiles="true">
-									<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_api.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_dma_tasks.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_rm_tasks.c</itemPath>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_tasks.c</itemPath>
-									</logicalFolder>
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi_api.c</itemPath>
-										</logicalFolder>
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/drv_spi_sys_queue_fifo.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/tmr/src/dynamic/drv_tmr.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="usart" displayName="usart" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue_dma.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_byte_model.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_dma.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_read_write.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-								<logicalFolder name="wifi" displayName="wifi" projectFiles="true">
-									<logicalFolder name="wilc1000" displayName="wilc1000" projectFiles="true">
-										<logicalFolder name="dev" displayName="dev" projectFiles="true">
-											<logicalFolder name="console" displayName="console" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/console/wdrv_wilc1000_console.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="gpio" displayName="gpio" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_eint.c</itemPath>
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_gpio.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="spi" displayName="spi" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/spi/wdrv_wilc1000_spi.c</itemPath>
-											</logicalFolder>
-											<logicalFolder name="timer" displayName="timer" projectFiles="true">
-												<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/timer/wdrv_wilc1000_timer.c</itemPath>
-											</logicalFolder>
-										</logicalFolder>
-										<logicalFolder name="osal" displayName="osal" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/osal/wdrv_wilc1000_osal.c</itemPath>
-										</logicalFolder>
-										<logicalFolder name="wireless_driver" displayName="wireless_driver" projectFiles="true">
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_cli.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_config.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_connmgr.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_events.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_iwpriv.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_main.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_scan_helper.c</itemPath>
-										</logicalFolder>
-										<logicalFolder name="wireless_driver_extension" displayName="wireless_driver_extension" projectFiles="true">
-											<logicalFolder name="common" displayName="common" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/source/nm_common.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<logicalFolder name="driver" displayName="driver" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_hif.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_periph.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_wifi.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmasic.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmbus.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmdrv.c</itemPath>
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmspi.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<logicalFolder name="spi_flash" displayName="spi_flash" projectFiles="true">
-												<logicalFolder name="source" displayName="source" projectFiles="true">
-													<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/spi_flash/source/spi_flash.c</itemPath>
-												</logicalFolder>
-											</logicalFolder>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_fw_update.c</itemPath>
-											<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_task.c</itemPath>
-										</logicalFolder>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="osal" displayName="osal" projectFiles="true">
-								<logicalFolder name="src" displayName="src" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal_freertos.c</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="peripheral" displayName="peripheral" projectFiles="true">
-								<logicalFolder name="tmr" displayName="tmr" projectFiles="true">
-									<logicalFolder name="src" displayName="src" projectFiles="true">
-										<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/peripheral/tmr/src/plib_tmr_pic32.c</itemPath>
-									</logicalFolder>
-								</logicalFolder>
-							</logicalFolder>
-							<logicalFolder name="tcpip" displayName="tcpip" projectFiles="true">
-								<logicalFolder name="src" displayName="src" projectFiles="true">
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_alloc.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_external.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_helpers.c</itemPath>
-									<itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c</itemPath>
-								</logicalFolder>
-							</logicalFolder>
-						</logicalFolder>
-						<logicalFolder name="bsp" displayName="bsp" projectFiles="true">
-							<itemPath>../../../../../vendors/microchip/harmony/v2.05/bsp/bsp.c</itemPath>
-						</logicalFolder>
-					</logicalFolder>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="demos" displayName="demos" projectFiles="true">
-			<logicalFolder name="dev_mode_key_provisioning" displayName="dev_mode_key_provisioning" projectFiles="true">
-				<logicalFolder name="src" displayName="src" projectFiles="true">
-					<itemPath>../../../../../demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c</itemPath>
-				</logicalFolder>
-				<logicalFolder name="include" displayName="include" projectFiles="true">
-					<itemPath>../../../../../demos/dev_mode_key_provisioning/include/aws_dev_mode_key_provisioning.h</itemPath>
-				</logicalFolder>
-			</logicalFolder>
-		</logicalFolder>
-		<logicalFolder name="LinkerScript" displayName="LinkerScript" projectFiles="true">
-			<itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/app_mz.ld</itemPath>
-		</logicalFolder>
-	</logicalFolder>
-	<projectmakefile>Makefile</projectmakefile>
-	<confs>
-		<conf name="pic32mz_ef_curiosity" type="2">
-			<toolsSet>
-				<developmentServer>localhost</developmentServer>
-				<targetDevice>PIC32MZ2048EFM100</targetDevice>
-				<targetHeader/>
-				<targetPluginBoard/>
-				<platformTool>ICD4Tool</platformTool>
-				<languageToolchain>XC32</languageToolchain>
-				<languageToolchainVersion>2.05</languageToolchainVersion>
-				<platform>3</platform>
-			</toolsSet>
-			<packs>
-				<pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
-			</packs>
-			<compileType>
-				<linkerTool>
-					<linkerLibItems>
-						<linkerLibFileItem>../../../../../vendors/microchip/harmony/v2.05/bin/framework/peripheral/PIC32MZ2048EFM100_peripherals.a</linkerLibFileItem>
-					</linkerLibItems>
-				</linkerTool>
-				<archiverTool/>
-				<loading>
-					<makeArtifact PL="../bootloader" CT="1" CN="pic32mz_ef_curiosity" AC="true" BL="true" WD="../bootloader" BC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity" DBC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity TYPE_IMAGE=DEBUG_RUN" CC="rm -rf &quot;build/pic32mz_ef_curiosity&quot; &quot;dist/pic32mz_ef_curiosity&quot;" OP="dist/pic32mz_ef_curiosity/production/bootloader.production.hex" DOP="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf" FL="dist/pic32mz_ef_curiosity/production/bootloader.production.hex" PD="dist/pic32mz_ef_curiosity/production/bootloader.production.elf" DD="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf"/>
-					<useAlternateLoadableFile>false</useAlternateLoadableFile>
-					<parseOnProdLoad>false</parseOnProdLoad>
-					<alternateLoadableFile/>
-				</loading>
-				<subordinates/>
-			</compileType>
-			<makeCustomizationType>
-				<makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
-				<makeCustomizationPreStep/>
-				<makeCustomizationPostStepEnabled>true</makeCustomizationPostStepEnabled>
-				<makeCustomizationPostStep>python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/binary_image_generator.py -d ${MP_CC_DIR} -b xc32-objcopy -p &quot;-I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin&quot; &amp;&amp; python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
-				<makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
-				<makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
-				<makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
-			</makeCustomizationType>
-			<C32>
-				<property key="additional-warnings" value="true"/>
-				<property key="addresss-attribute-use" value="false"/>
-				<property key="enable-app-io" value="false"/>
-				<property key="enable-omit-frame-pointer" value="false"/>
-				<property key="enable-symbols" value="true"/>
-				<property key="enable-unroll-loops" value="false"/>
-				<property key="exclude-floating-point" value="false"/>
-				<property key="extra-include-directories" value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../tests/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/aws/ota/test;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/aws/defender/src;../../../../../libraries/c_sdk/standard/mqtt/test/access;../../../../../libraries/c_sdk/standard/mqtt/test/mock;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/mqtt/src;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/aws/shadow/src;../../../../../libraries/c_sdk/standard/https/test/access;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/c_sdk/standard/https/src;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/http_parser"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="isolate-each-function" value="true"/>
-				<property key="make-warnings-into-errors" value="false"/>
-				<property key="optimization-level" value="-O1"/>
-				<property key="place-data-into-section" value="false"/>
-				<property key="post-instruction-scheduling" value="default"/>
-				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;AMAZON_FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
-				<property key="strict-ansi" value="false"/>
-				<property key="support-ansi" value="false"/>
-				<property key="toplevel-reordering" value=""/>
-				<property key="unaligned-access" value=""/>
-				<property key="use-cci" value="false"/>
-				<property key="use-iar" value="false"/>
-				<property key="use-indirect-calls" value="false"/>
-				<appendMe value="-mnewlib-libc -std=gnu99 -fgnu89-inline"/>
-			</C32>
-			<C32-AR>
-				<property key="additional-options-chop-files" value="false"/>
-			</C32-AR>
-			<C32-AS>
-				<property key="assembler-symbols" value=""/>
-				<property key="enable-symbols" value="true"/>
-				<property key="exclude-floating-point-library" value="false"/>
-				<property key="expand-macros" value="false"/>
-				<property key="extra-include-directories-for-assembler" value=""/>
-				<property key="extra-include-directories-for-preprocessor" value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../tests/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/aws/ota/test;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/aws/defender/src;../../../../../libraries/c_sdk/standard/mqtt/test/access;../../../../../libraries/c_sdk/standard/mqtt/test/mock;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/mqtt/src;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/aws/shadow/src;../../../../../libraries/c_sdk/standard/https/test/access;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/c_sdk/standard/https/src;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/http_parser"/>
-				<property key="false-conditionals" value="false"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="keep-locals" value="false"/>
-				<property key="list-assembly" value="false"/>
-				<property key="list-source" value="false"/>
-				<property key="list-symbols" value="false"/>
-				<property key="oXC32asm-list-to-file" value="false"/>
-				<property key="omit-debug-dirs" value="false"/>
-				<property key="omit-forms" value="false"/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="warning-level" value=""/>
-			</C32-AS>
-			<C32-CO>
-				<property key="coverage-enable" value=""/>
-			</C32-CO>
-			<C32-LD>
-				<property key="additional-options-use-response-files" value="false"/>
-				<property key="additional-options-write-sla" value="false"/>
-				<property key="allocate-dinit" value="false"/>
-				<property key="code-dinit" value="false"/>
-				<property key="ebase-addr" value=""/>
-				<property key="enable-check-sections" value="false"/>
-				<property key="exclude-floating-point-library" value="false"/>
-				<property key="exclude-standard-libraries" value="false"/>
-				<property key="extra-lib-directories" value=""/>
-				<property key="fill-flash-options-addr" value=""/>
-				<property key="fill-flash-options-const" value=""/>
-				<property key="fill-flash-options-how" value="0"/>
-				<property key="fill-flash-options-inc-const" value="1"/>
-				<property key="fill-flash-options-increment" value=""/>
-				<property key="fill-flash-options-seq" value=""/>
-				<property key="fill-flash-options-what" value="0"/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-cross-reference-file" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="heap-size" value="10000"/>
-				<property key="input-libraries" value=""/>
-				<property key="kseg-length" value=""/>
-				<property key="kseg-origin" value=""/>
-				<property key="linker-symbols" value=""/>
-				<property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
-				<property key="no-device-startup-code" value="false"/>
-				<property key="no-startup-files" value="false"/>
-				<property key="oXC32ld-extra-opts" value="-mnewlib-libc"/>
-				<property key="optimization-level" value=""/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="remove-unused-sections" value="true"/>
-				<property key="report-memory-usage" value="false"/>
-				<property key="serial-length" value=""/>
-				<property key="serial-origin" value=""/>
-				<property key="stack-size" value="10000"/>
-				<property key="symbol-stripping" value=""/>
-				<property key="trace-symbols" value=""/>
-				<property key="warn-section-align" value="false"/>
-				<appendMe value="--allow-multiple-definition"/>
-			</C32-LD>
-			<C32CPP>
-				<property key="additional-warnings" value="false"/>
-				<property key="addresss-attribute-use" value="false"/>
-				<property key="check-new" value="false"/>
-				<property key="eh-specs" value="true"/>
-				<property key="enable-app-io" value="false"/>
-				<property key="enable-omit-frame-pointer" value="false"/>
-				<property key="enable-symbols" value="true"/>
-				<property key="enable-unroll-loops" value="false"/>
-				<property key="exceptions" value="true"/>
-				<property key="exclude-floating-point" value="false"/>
-				<property key="extra-include-directories" value=""/>
-				<property key="generate-16-bit-code" value="false"/>
-				<property key="generate-micro-compressed-code" value="false"/>
-				<property key="isolate-each-function" value="false"/>
-				<property key="make-warnings-into-errors" value="false"/>
-				<property key="optimization-level" value=""/>
-				<property key="place-data-into-section" value="false"/>
-				<property key="post-instruction-scheduling" value="default"/>
-				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value=""/>
-				<property key="rtti" value="true"/>
-				<property key="strict-ansi" value="false"/>
-				<property key="toplevel-reordering" value=""/>
-				<property key="unaligned-access" value=""/>
-				<property key="use-cci" value="false"/>
-				<property key="use-iar" value="false"/>
-				<property key="use-indirect-calls" value="false"/>
-			</C32CPP>
-			<C32Global>
-				<property key="common-include-directories" value=""/>
-				<property key="gp-relative-option" value=""/>
-				<property key="legacy-libc" value="false"/>
-				<property key="mdtcm" value=""/>
-				<property key="mitcm" value=""/>
-				<property key="mstacktcm" value="false"/>
-				<property key="relaxed-math" value="false"/>
-				<property key="save-temps" value="false"/>
-				<property key="wpo-lto" value="false"/>
-			</C32Global>
-			<ICD3PlatformTool>
-				<property key="firmware.download.all" value="false"/>
-			</ICD3PlatformTool>
-			<ICD4Tool>
-				<property key="ADC" value="true"/>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="CAN1" value="true"/>
-				<property key="CAN2" value="true"/>
-				<property key="CHANGE NOTICE A" value="true"/>
-				<property key="CHANGE NOTICE B" value="true"/>
-				<property key="CHANGE NOTICE C" value="true"/>
-				<property key="CHANGE NOTICE D" value="true"/>
-				<property key="CHANGE NOTICE E" value="true"/>
-				<property key="CHANGE NOTICE F" value="true"/>
-				<property key="CHANGE NOTICE G" value="true"/>
-				<property key="COMPARATOR" value="true"/>
-				<property key="DMA" value="true"/>
-				<property key="ETHERNET CONTROLLER" value="true"/>
-				<property key="Freeze All Other Peripherals" value="true"/>
-				<property key="I2C 1" value="true"/>
-				<property key="I2C 2" value="true"/>
-				<property key="I2C 3" value="true"/>
-				<property key="I2C 4" value="true"/>
-				<property key="I2C 5" value="true"/>
-				<property key="INPUT CAPTURE 1" value="true"/>
-				<property key="INPUT CAPTURE 2" value="true"/>
-				<property key="INPUT CAPTURE 3" value="true"/>
-				<property key="INPUT CAPTURE 4" value="true"/>
-				<property key="INPUT CAPTURE 5" value="true"/>
-				<property key="INPUT CAPTURE 6" value="true"/>
-				<property key="INPUT CAPTURE 7" value="true"/>
-				<property key="INPUT CAPTURE 8" value="true"/>
-				<property key="INPUT CAPTURE 9" value="true"/>
-				<property key="INTERRUPT CONTROL" value="true"/>
-				<property key="OUTPUT COMPARE 1" value="true"/>
-				<property key="OUTPUT COMPARE 2" value="true"/>
-				<property key="OUTPUT COMPARE 3" value="true"/>
-				<property key="OUTPUT COMPARE 4" value="true"/>
-				<property key="OUTPUT COMPARE 5" value="true"/>
-				<property key="OUTPUT COMPARE 6" value="true"/>
-				<property key="OUTPUT COMPARE 7" value="true"/>
-				<property key="OUTPUT COMPARE 8" value="true"/>
-				<property key="OUTPUT COMPARE 9" value="true"/>
-				<property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
-				<property key="REAL TIME CLOCK" value="true"/>
-				<property key="REFERENCE CLOCK1" value="true"/>
-				<property key="REFERENCE CLOCK2" value="true"/>
-				<property key="REFERENCE CLOCK3" value="true"/>
-				<property key="REFERENCE CLOCK4" value="true"/>
-				<property key="SPI/I2S 1" value="true"/>
-				<property key="SPI/I2S 2" value="true"/>
-				<property key="SPI/I2S 3" value="true"/>
-				<property key="SPI/I2S 4" value="true"/>
-				<property key="SPI/I2S 5" value="true"/>
-				<property key="SPI/I2S 6" value="true"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="TIMER1" value="true"/>
-				<property key="TIMER2" value="true"/>
-				<property key="TIMER3" value="true"/>
-				<property key="TIMER4" value="true"/>
-				<property key="TIMER5" value="true"/>
-				<property key="TIMER6" value="true"/>
-				<property key="TIMER7" value="true"/>
-				<property key="TIMER8" value="true"/>
-				<property key="TIMER9" value="true"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="UART1" value="true"/>
-				<property key="UART2" value="true"/>
-				<property key="UART3" value="true"/>
-				<property key="UART4" value="true"/>
-				<property key="UART5" value="true"/>
-				<property key="UART6" value="true"/>
-				<property key="debugoptions.useswbreakpoints" value="false"/>
-				<property key="hwtoolclock.frcindebug" value="false"/>
-				<property key="memories.aux" value="false"/>
-				<property key="memories.bootflash" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.configurationmemory2" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.exclude.configurationmemory" value="true"/>
-				<property key="memories.flashdata" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.instruction.ram.ranges" value="${memories.instruction.ram.ranges}"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="poweroptions.powerenable" value="false"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.ledbrightness" value="5"/>
-				<property key="programoptions.pgcconfig" value="pull down"/>
-				<property key="programoptions.pgcresistor.value" value="4.7"/>
-				<property key="programoptions.pgdconfig" value="pull down"/>
-				<property key="programoptions.pgdresistor.value" value="4.7"/>
-				<property key="programoptions.pgmentry.voltage" value="low"/>
-				<property key="programoptions.pgmspeed" value="Med"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.preserveuserid" value="false"/>
-				<property key="programoptions.programcalmem" value="false"/>
-				<property key="programoptions.programuserotp" value="false"/>
-				<property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
-				<property key="voltagevalue" value="3.25"/>
-			</ICD4Tool>
-			<PKOBSKDEPlatformTool>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="memories.userotp" value="true"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preservedataflash.ranges" value=""/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.usehighvoltageonmclr" value="false"/>
-				<property key="programoptions.uselvpprogramming" value="true"/>
-			</PKOBSKDEPlatformTool>
-			<RealICEPlatformTool>
-				<property key="ADC" value="true"/>
-				<property key="AutoSelectMemRanges" value="auto"/>
-				<property key="CAN1" value="true"/>
-				<property key="CAN2" value="true"/>
-				<property key="CHANGE NOTICE A" value="true"/>
-				<property key="CHANGE NOTICE B" value="true"/>
-				<property key="CHANGE NOTICE C" value="true"/>
-				<property key="CHANGE NOTICE D" value="true"/>
-				<property key="CHANGE NOTICE E" value="true"/>
-				<property key="CHANGE NOTICE F" value="true"/>
-				<property key="CHANGE NOTICE G" value="true"/>
-				<property key="COMPARATOR" value="true"/>
-				<property key="DMA" value="true"/>
-				<property key="ETHERNET CONTROLLER" value="true"/>
-				<property key="Freeze All Other Peripherals" value="true"/>
-				<property key="I2C 1" value="true"/>
-				<property key="I2C 2" value="true"/>
-				<property key="I2C 3" value="true"/>
-				<property key="I2C 4" value="true"/>
-				<property key="I2C 5" value="true"/>
-				<property key="INPUT CAPTURE 1" value="true"/>
-				<property key="INPUT CAPTURE 2" value="true"/>
-				<property key="INPUT CAPTURE 3" value="true"/>
-				<property key="INPUT CAPTURE 4" value="true"/>
-				<property key="INPUT CAPTURE 5" value="true"/>
-				<property key="INPUT CAPTURE 6" value="true"/>
-				<property key="INPUT CAPTURE 7" value="true"/>
-				<property key="INPUT CAPTURE 8" value="true"/>
-				<property key="INPUT CAPTURE 9" value="true"/>
-				<property key="INTERRUPT CONTROL" value="true"/>
-				<property key="OUTPUT COMPARE 1" value="true"/>
-				<property key="OUTPUT COMPARE 2" value="true"/>
-				<property key="OUTPUT COMPARE 3" value="true"/>
-				<property key="OUTPUT COMPARE 4" value="true"/>
-				<property key="OUTPUT COMPARE 5" value="true"/>
-				<property key="OUTPUT COMPARE 6" value="true"/>
-				<property key="OUTPUT COMPARE 7" value="true"/>
-				<property key="OUTPUT COMPARE 8" value="true"/>
-				<property key="OUTPUT COMPARE 9" value="true"/>
-				<property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
-				<property key="REAL TIME CLOCK" value="true"/>
-				<property key="REFERENCE CLOCK1" value="true"/>
-				<property key="REFERENCE CLOCK2" value="true"/>
-				<property key="REFERENCE CLOCK3" value="true"/>
-				<property key="REFERENCE CLOCK4" value="true"/>
-				<property key="RIExTrigs.Five" value="OFF"/>
-				<property key="RIExTrigs.Four" value="OFF"/>
-				<property key="RIExTrigs.One" value="OFF"/>
-				<property key="RIExTrigs.Seven" value="OFF"/>
-				<property key="RIExTrigs.Six" value="OFF"/>
-				<property key="RIExTrigs.Three" value="OFF"/>
-				<property key="RIExTrigs.Two" value="OFF"/>
-				<property key="RIExTrigs.Zero" value="OFF"/>
-				<property key="SPI/I2S 1" value="true"/>
-				<property key="SPI/I2S 2" value="true"/>
-				<property key="SPI/I2S 3" value="true"/>
-				<property key="SPI/I2S 4" value="true"/>
-				<property key="SPI/I2S 5" value="true"/>
-				<property key="SPI/I2S 6" value="true"/>
-				<property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
-				<property key="TIMER1" value="true"/>
-				<property key="TIMER2" value="true"/>
-				<property key="TIMER3" value="true"/>
-				<property key="TIMER4" value="true"/>
-				<property key="TIMER5" value="true"/>
-				<property key="TIMER6" value="true"/>
-				<property key="TIMER7" value="true"/>
-				<property key="TIMER8" value="true"/>
-				<property key="TIMER9" value="true"/>
-				<property key="ToolFirmwareFilePath" value="Press to browse for a specific firmware version"/>
-				<property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
-				<property key="UART1" value="true"/>
-				<property key="UART2" value="true"/>
-				<property key="UART3" value="true"/>
-				<property key="UART4" value="true"/>
-				<property key="UART5" value="true"/>
-				<property key="UART6" value="true"/>
-				<property key="debugoptions.useswbreakpoints" value="false"/>
-				<property key="hwtoolclock.frcindebug" value="false"/>
-				<property key="hwtoolclock.instructionspeed" value="4"/>
-				<property key="hwtoolclock.units" value="mips"/>
-				<property key="memories.aux" value="false"/>
-				<property key="memories.bootflash" value="true"/>
-				<property key="memories.configurationmemory" value="true"/>
-				<property key="memories.configurationmemory2" value="true"/>
-				<property key="memories.dataflash" value="true"/>
-				<property key="memories.eeprom" value="true"/>
-				<property key="memories.flashdata" value="true"/>
-				<property key="memories.id" value="true"/>
-				<property key="memories.instruction.ram" value="true"/>
-				<property key="memories.instruction.ram.ranges" value="${memories.instruction.ram.ranges}"/>
-				<property key="memories.programmemory" value="true"/>
-				<property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
-				<property key="poweroptions.powerenable" value="false"/>
-				<property key="programoptions.donoteraseauxmem" value="false"/>
-				<property key="programoptions.eraseb4program" value="true"/>
-				<property key="programoptions.preservedataflash" value="false"/>
-				<property key="programoptions.preservedataflash.ranges" value=""/>
-				<property key="programoptions.preserveeeprom" value="false"/>
-				<property key="programoptions.preserveeeprom.ranges" value=""/>
-				<property key="programoptions.preserveprogram.ranges" value=""/>
-				<property key="programoptions.preserveprogramrange" value="false"/>
-				<property key="programoptions.preserveuserid" value="false"/>
-				<property key="programoptions.programcalmem" value="false"/>
-				<property key="programoptions.programuserotp" value="false"/>
-				<property key="programoptions.usehighvoltageonmclr" value="false"/>
-				<property key="programoptions.uselvpprogramming" value="false"/>
-				<property key="tracecontrol.include.timestamp" value="summarydataenabled"/>
-				<property key="tracecontrol.select" value="0"/>
-				<property key="tracecontrol.stallontracebufferfull" value="false"/>
-				<property key="tracecontrol.tracebufmax" value="546000"/>
-				<property key="tracecontrol.tracefile" value="defmplabxtrace.log"/>
-				<property key="tracecontrol.tracefilemax" value="10000000"/>
-				<property key="voltagevalue" value="3.25"/>
-			</RealICEPlatformTool>
-		</conf>
-	</confs>
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="demos" displayName="demos" projectFiles="true">
+      <logicalFolder name="dev_mode_key_provisioning"
+                     displayName="dev_mode_key_provisioning"
+                     projectFiles="true">
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <itemPath>../../../../../demos/dev_mode_key_provisioning/include/aws_dev_mode_key_provisioning.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="src" displayName="src" projectFiles="true">
+          <itemPath>../../../../../demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c</itemPath>
+        </logicalFolder>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="freertos_kernel"
+                   displayName="freertos_kernel"
+                   projectFiles="true">
+      <logicalFolder name="include" displayName="include" projectFiles="true">
+        <itemPath>../../../../../freertos_kernel/include/FreeRTOS.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/StackMacros.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/atomic.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/croutine.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/deprecated_definitions.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/event_groups.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/list.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/message_buffer.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/mpu_prototypes.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/mpu_wrappers.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/portable.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/projdefs.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/queue.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/semphr.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/stack_macros.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/stream_buffer.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/task.h</itemPath>
+        <itemPath>../../../../../freertos_kernel/include/timers.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="portable" displayName="portable" projectFiles="true">
+        <logicalFolder name="MemMang" displayName="MemMang" projectFiles="true">
+          <itemPath>../../../../../freertos_kernel/portable/MemMang/heap_4.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="MPLAB" displayName="MPLAB" projectFiles="true">
+          <logicalFolder name="PIC32MZ" displayName="PIC32MZ" projectFiles="true">
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port.c</itemPath>
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/port_asm.S</itemPath>
+            <itemPath>../../../../../freertos_kernel/portable/MPLAB/PIC32MZ/portmacro.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <itemPath>../../../../../freertos_kernel/event_groups.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/list.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/queue.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/stream_buffer.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/tasks.c</itemPath>
+      <itemPath>../../../../../freertos_kernel/timers.c</itemPath>
+    </logicalFolder>
+    <logicalFolder name="libraries" displayName="libraries" projectFiles="true">
+      <logicalFolder name="3rdparty" displayName="3rdparty" projectFiles="true">
+        <logicalFolder name="http_parser" displayName="http_parser" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/http_parser/http_parser.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="jsmn" displayName="jsmn" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/jsmn/jsmn.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aes.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aesni.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/arc4.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/aria.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/asn1write.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/base64.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bignum.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/blowfish.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/bn_mul.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/camellia.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ccm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/certs.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chacha20.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/chachapoly.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/check_config.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cipher_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/cmac.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/compat-1.3.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/config.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ctr_drbg.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/debug.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/des.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/dhm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdh.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecdsa.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecjpake.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ecp_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/entropy_poll.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/error.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/gcm.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/havege.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hkdf.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/hmac_drbg.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md2.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md4.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md5.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/md_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/memory_buffer_alloc.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/net_sockets.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/nist_kw.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/oid.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/padlock.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pem.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pk_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs11.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs12.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/pkcs5.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_time.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/platform_util.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/poly1305.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ripemd160.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/rsa_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha1.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha256.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/sha512.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cache.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ciphersuites.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_cookie.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_internal.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/ssl_ticket.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/threading.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/timing.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/version.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crl.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_crt.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/x509_csr.h</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/mbedtls/include/mbedtls/xtea.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="library" displayName="library" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/base64.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aes.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aesni.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/arc4.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/aria.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1parse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/asn1write.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/bignum.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/blowfish.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/camellia.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ccm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/certs.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/chacha20.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/chachapoly.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cipher_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/cmac.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ctr_drbg.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/debug.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/des.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/dhm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdh.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecdsa.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecjpake.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ecp_curves.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/entropy_poll.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/error.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/gcm.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/havege.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/hkdf.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/hmac_drbg.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md2.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md4.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md5.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/md_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/memory_buffer_alloc.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/net_sockets.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/nist_kw.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/oid.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/padlock.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pem.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pk_wrap.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs11.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs12.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkcs5.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkparse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/pkwrite.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/platform_util.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/poly1305.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ripemd160.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/rsa_internal.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha1.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha256.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/sha512.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cache.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ciphersuites.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cli.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_cookie.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_srv.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_ticket.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/ssl_tls.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/threading.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/timing.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/version.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/version_features.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_create.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crl.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_crt.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509_csr.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_crt.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/x509write_csr.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/mbedtls/library/xtea.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="mbedtls_utils"
+                       displayName="mbedtls_utils"
+                       projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_utils.c</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/mbedtls_utils/mbedtls_error.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11f.h</itemPath>
+          <itemPath>../../../../../libraries/3rdparty/pkcs11/pkcs11t.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="tinycbor" displayName="tinycbor" projectFiles="true">
+          <logicalFolder name="src" displayName="src" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborpretty_stdio.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborencoder_close_container_checked.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborerrorstrings.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycbor/src/cborparser_dup_string.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
+          <logicalFolder name="asn1" displayName="asn1" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1parse.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/tinycrypt/asn1/asn1.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="lib" displayName="lib" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="tinycrypt" displayName="tinycrypt" projectFiles="true">
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/aes.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cbc_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ccm_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/cmac_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/constants.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_mode.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ctr_prng.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dh.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_dsa.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/ecc_platform_specific.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/hmac_prng.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/sha256.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/include/tinycrypt/utils.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_decrypt.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/aes_encrypt.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cbc_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ccm_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/cmac_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_mode.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ctr_prng.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dh.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_dsa.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/ecc_platform_specific.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/hmac_prng.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/sha256.c</itemPath>
+              <itemPath>../../../../../libraries/3rdparty/tinycrypt/lib/source/utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="unity" displayName="unity" projectFiles="true">
+          <logicalFolder name="extras" displayName="extras" projectFiles="true">
+            <logicalFolder name="fixture" displayName="fixture" projectFiles="true">
+              <logicalFolder name="src" displayName="src" projectFiles="true">
+                <itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture.c</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture_internals.h</itemPath>
+                <itemPath>../../../../../libraries/3rdparty/unity/extras/fixture/src/unity_fixture_malloc_overrides.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="src" displayName="src" projectFiles="true">
+            <itemPath>../../../../../libraries/3rdparty/unity/src/unity.c</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/unity/src/unity.h</itemPath>
+            <itemPath>../../../../../libraries/3rdparty/unity/src/unity_internals.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="abstractions"
+                     displayName="abstractions"
+                     projectFiles="true">
+        <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/pkcs11/include/iot_pkcs11_pal.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="mbedtls" displayName="mbedtls" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/pkcs11/mbedtls/threading_alt.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="test" displayName="test" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/pkcs11/test/iot_test_pkcs11.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="platform" displayName="platform" projectFiles="true">
+          <logicalFolder name="freertos" displayName="freertos" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="platform" displayName="platform" projectFiles="true">
+                <itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_platform_types_freertos.h</itemPath>
+                <itemPath>../../../../../libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_clock_freertos.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_threads_freertos.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_metrics.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/freertos/iot_network_freertos.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="platform" displayName="platform" projectFiles="true">
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_clock.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_network.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_threads.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/platform/include/platform/iot_metrics.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="types" displayName="types" projectFiles="true">
+              <itemPath>../../../../../libraries/abstractions/platform/include/types/iot_platform_types.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="test" displayName="test" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/platform/test/iot_test_platform_clock.c</itemPath>
+            <itemPath>../../../../../libraries/abstractions/platform/test/iot_test_platform_threads.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="posix" displayName="posix" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <logicalFolder name="FreeRTOS_POSIX"
+                           displayName="FreeRTOS_POSIX"
+                           projectFiles="true">
+              <logicalFolder name="sys" displayName="sys" projectFiles="true">
+                <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sys/types.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/errno.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/fcntl.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/mqueue.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/sched.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/semaphore.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/signal.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/time.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/unistd.h</itemPath>
+              <itemPath>../../../../../libraries/abstractions/posix/include/FreeRTOS_POSIX/utils.h</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="secure_sockets"
+                       displayName="secure_sockets"
+                       projectFiles="true">
+          <logicalFolder name="freertos_plus_tcp"
+                         displayName="freertos_plus_tcp"
+                         projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets.h</itemPath>
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_config_defaults.h</itemPath>
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/include/iot_secure_sockets_wrapper_metrics.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="test" displayName="test" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/secure_sockets/test/iot_test_tcp.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+          <logicalFolder name="include" displayName="include" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/wifi/include/iot_wifi.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="test" displayName="test" projectFiles="true">
+            <itemPath>../../../../../libraries/abstractions/wifi/test/iot_test_wifi.c</itemPath>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="c_sdk" displayName="c_sdk" projectFiles="true">
+        <logicalFolder name="aws" displayName="aws" projectFiles="true">
+          <logicalFolder name="defender" displayName="defender" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/include/aws_iot_defender.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="private" displayName="private" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/defender/src/private/aws_iot_defender_internal.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_mqtt.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/defender/src/aws_iot_defender_v1.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/defender/test/system/aws_iot_tests_defender_system.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="unit" displayName="unit" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/defender/test/unit/aws_iot_tests_defender_unit.c</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="shadow" displayName="shadow" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_iot_shadow.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/include/aws_shadow.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_operation.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_parser.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_iot_shadow_subscription.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/src/aws_shadow_config_defaults.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/shadow/test/system/aws_iot_tests_shadow_system.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="unit" displayName="unit" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_api.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_parser.c</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/aws/shadow/test/aws_test_shadow.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="standard" displayName="standard" projectFiles="true">
+          <logicalFolder name="common" displayName="common" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <logicalFolder name="private" displayName="private" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_logging.h</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/private/iot_taskpool_internal.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="types" displayName="types" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_network_types.h</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/common/include/types/iot_taskpool_types.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_appversion32.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_init.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_linear_containers.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_task.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_logging_setup.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/include/iot_taskpool.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="logging" displayName="logging" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging_task_dynamic_buffers.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/logging/iot_logging.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="taskpool" displayName="taskpool" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/taskpool/iot_taskpool_static_memory.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/common/test/iot_memory_leak.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/common/test/iot_tests_taskpool.c</itemPath>
+            </logicalFolder>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_init.c</itemPath>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_static_memory_common.c</itemPath>
+            <itemPath>../../../../../libraries/c_sdk/standard/common/iot_device_metrics.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="https" displayName="https" projectFiles="true">
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_client.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/https/src/iot_https_utils.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/system/iot_tests_https_system.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="unit" displayName="unit" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_client.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_utils.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_sync.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/https/test/unit/iot_tests_https_async.c</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_network.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_serialize.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_validate.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/src/iot_mqtt_agent.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <logicalFolder name="mock" displayName="mock" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/mock/iot_tests_mqtt_mock.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/system/iot_tests_mqtt_system.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="unit" displayName="unit" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_receive.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_validate.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_metrics.c</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="serializer" displayName="serializer" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_serializer.h</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/include/iot_json_utils.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="cbor" displayName="cbor" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_encoder.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="json" displayName="json" projectFiles="true">
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_decoder.c</itemPath>
+                <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_serializer_static_memory.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/src/iot_json_utils.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_serializer_json.c</itemPath>
+              <itemPath>../../../../../libraries/c_sdk/standard/serializer/test/iot_tests_deserializer_json.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="freertos_plus"
+                     displayName="freertos_plus"
+                     projectFiles="true">
+        <logicalFolder name="aws" displayName="aws" projectFiles="true">
+          <logicalFolder name="greengrass" displayName="greengrass" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_ggd_config_defaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_greengrass_discovery.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/src/aws_helper_secure_connect.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_system.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_ggd_unit.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/greengrass/test/aws_test_helper_secure_connect.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="ota" displayName="ota" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <logicalFolder name="http" displayName="http" projectFiles="true">
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="mqtt" displayName="mqtt" projectFiles="true">
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c</itemPath>
+                <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</itemPath>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/test/aws_test_ota_agent.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/aws/ota/test/aws_test_ota_pal.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="standard" displayName="standard" projectFiles="true">
+          <logicalFolder name="crypto" displayName="crypto" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/crypto/include/iot_crypto.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/crypto/src/iot_crypto.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/crypto/test/iot_test_crypto.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="freertos_plus_posix"
+                         displayName="freertos_plus_posix"
+                         projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_types.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_internal.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include/FreeRTOS_POSIX_portable_default.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_clock.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_mqueue.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_barrier.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_cond.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_pthread_mutex.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_sched.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_semaphore.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_timer.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_unistd.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/source/FreeRTOS_POSIX_utils.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_clock.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_mqueue.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_pthread.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_semaphore.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_stress.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_timer.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_unistd.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="freertos_plus_tcp"
+                         displayName="freertos_plus_tcp"
+                         projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_errno_TCP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_WIN.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_UDP_IP.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/IPTraceMacroDefaults.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="source" displayName="source" projectFiles="true">
+              <logicalFolder name="portable" displayName="portable" projectFiles="true">
+                <logicalFolder name="NetworkInterface"
+                               displayName="NetworkInterface"
+                               projectFiles="true">
+                  <logicalFolder name="pic32mzef" displayName="pic32mzef" projectFiles="true">
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c</itemPath>
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c</itemPath>
+                    <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Stream_Buffer.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test/iot_test_freertos_tcp.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/pkcs11/src/iot_pkcs11.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="tls" displayName="tls" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/tls/include/iot_tls.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/tls/src/iot_tls.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="test" displayName="test" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/tls/test/iot_test_tls.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+          <logicalFolder name="utils" displayName="utils" projectFiles="true">
+            <logicalFolder name="include" displayName="include" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_system_init.h</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/include/iot_pki_utils.h</itemPath>
+            </logicalFolder>
+            <logicalFolder name="src" displayName="src" projectFiles="true">
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_system_init.c</itemPath>
+              <itemPath>../../../../../libraries/freertos_plus/standard/utils/src/iot_pki_utils.c</itemPath>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="LinkerScript"
+                   projectFiles="true">
+      <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/app_mz.ld</itemPath>
+    </logicalFolder>
+    <logicalFolder name="tests" displayName="tests" projectFiles="true">
+      <logicalFolder name="common" displayName="common" projectFiles="true">
+        <itemPath>../../../../../tests/common/aws_test_framework.c</itemPath>
+        <itemPath>../../../../../tests/common/aws_test_runner.c</itemPath>
+        <itemPath>../../../../../tests/common/aws_test.c</itemPath>
+        <itemPath>../../../../../tests/common/iot_test_freertos.c</itemPath>
+        <itemPath>../../../../../tests/common/iot_tests_network.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="include" displayName="include" projectFiles="true">
+        <itemPath>../../../../../tests/include/aws_application_version.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_clientcredential.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_clientcredential_keys.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_test_runner.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_test_framework.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_test_tcp.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_test_utils.h</itemPath>
+        <itemPath>../../../../../tests/include/aws_unity_config.h</itemPath>
+        <itemPath>../../../../../tests/include/iot_config_common.h</itemPath>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="vendors" displayName="vendors" projectFiles="true">
+      <logicalFolder name="microchip" displayName="microchip" projectFiles="true">
+        <logicalFolder name="boards" displayName="boards" projectFiles="true">
+          <logicalFolder name="curiosity_pic32mzef"
+                         displayName="curiosity_pic32mzef"
+                         projectFiles="true">
+            <logicalFolder name="aws_tests" displayName="aws_tests" projectFiles="true">
+              <logicalFolder name="application_code"
+                             displayName="application_code"
+                             projectFiles="true">
+                <logicalFolder name="microchip_code"
+                               displayName="microchip_code"
+                               projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/rtos_hooks.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_exceptions.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_init.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_interrupt.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_tasks.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/NetworkConfig.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_config.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_definitions.h</itemPath>
+                  <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code/system_interrupt_a.S</itemPath>
+                </logicalFolder>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/main.c</itemPath>
+              </logicalFolder>
+              <logicalFolder name="config_files"
+                             displayName="config_files"
+                             projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSConfig.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/FreeRTOSIPConfig.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_bufferpool_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_demo_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ggd_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_iot_network_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_mqtt_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_secure_sockets_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_shadow_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_ota_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_wifi_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_wifi_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_mqtt_agent_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_pkcs11_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/iot_test_pkcs11_config.h</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/unity_config.h</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+            <logicalFolder name="ports" displayName="ports" projectFiles="true">
+              <logicalFolder name="ota" displayName="ota" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_ota_pal.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/ota/aws_nvm.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="pkcs11" displayName="pkcs11" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/iot_pkcs11_pal.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/pkcs11_nvm.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="posix" displayName="posix" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix/FreeRTOS_POSIX_portable.h</itemPath>
+              </logicalFolder>
+              <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c</itemPath>
+                <itemPath>../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/aws_wifi_assert.c</itemPath>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+        <logicalFolder name="harmony" displayName="harmony" projectFiles="true">
+          <logicalFolder name="v2.05" displayName="v2.05" projectFiles="true">
+            <logicalFolder name="bsp" displayName="bsp" projectFiles="true">
+              <itemPath>../../../../../vendors/microchip/harmony/v2.05/bsp/bsp.c</itemPath>
+            </logicalFolder>
+            <logicalFolder name="framework" displayName="framework" projectFiles="true">
+              <logicalFolder name="driver" displayName="driver" projectFiles="true">
+                <logicalFolder name="ethmac" displayName="ethmac" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethmac/src/dynamic/drv_ethmac_lib.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="ethphy" displayName="ethphy" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_ethphy.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/ethphy/src/dynamic/drv_extphy_smsc8720.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="flash" displayName="flash" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/flash/src/drv_flash_static.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="miim" displayName="miim" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/miim/src/dynamic/drv_miim.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="spi" displayName="spi" projectFiles="true">
+                  <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_api.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_dma_tasks.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_master_rm_tasks.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/dynamic/drv_spi_tasks.c</itemPath>
+                  </logicalFolder>
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/dynamic/drv_spi_api.c</itemPath>
+                    </logicalFolder>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/spi/src/drv_spi_sys_queue_fifo.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/tmr/src/dynamic/drv_tmr.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="usart" displayName="usart" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <logicalFolder name="dynamic" displayName="dynamic" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_buffer_queue_dma.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_byte_model.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_dma.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/usart/src/dynamic/drv_usart_read_write.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="wifi" displayName="wifi" projectFiles="true">
+                  <logicalFolder name="wilc1000" displayName="wilc1000" projectFiles="true">
+                    <logicalFolder name="dev" displayName="dev" projectFiles="true">
+                      <logicalFolder name="console" displayName="console" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/console/wdrv_wilc1000_console.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="gpio" displayName="gpio" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_eint.c</itemPath>
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/gpio/wdrv_wilc1000_gpio.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="spi" displayName="spi" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/spi/wdrv_wilc1000_spi.c</itemPath>
+                      </logicalFolder>
+                      <logicalFolder name="timer" displayName="timer" projectFiles="true">
+                        <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/dev/timer/wdrv_wilc1000_timer.c</itemPath>
+                      </logicalFolder>
+                    </logicalFolder>
+                    <logicalFolder name="osal" displayName="osal" projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/osal/wdrv_wilc1000_osal.c</itemPath>
+                    </logicalFolder>
+                    <logicalFolder name="wireless_driver"
+                                   displayName="wireless_driver"
+                                   projectFiles="true">
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_cli.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_config.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_connmgr.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_events.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_iwpriv.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_main.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/wdrv_wilc1000_scan_helper.c</itemPath>
+                    </logicalFolder>
+                    <logicalFolder name="wireless_driver_extension"
+                                   displayName="wireless_driver_extension"
+                                   projectFiles="true">
+                      <logicalFolder name="common" displayName="common" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/source/nm_common.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <logicalFolder name="driver" displayName="driver" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_hif.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_periph.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/m2m_wifi.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmasic.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmbus.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmdrv.c</itemPath>
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source/nmspi.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <logicalFolder name="spi_flash" displayName="spi_flash" projectFiles="true">
+                        <logicalFolder name="source" displayName="source" projectFiles="true">
+                          <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/spi_flash/source/spi_flash.c</itemPath>
+                        </logicalFolder>
+                      </logicalFolder>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wdrvext_wilc1000.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_fw_update.c</itemPath>
+                      <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/wilc1000_task.c</itemPath>
+                    </logicalFolder>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="osal" displayName="osal" projectFiles="true">
+                <logicalFolder name="src" displayName="src" projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/osal/src/osal_freertos.c</itemPath>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="peripheral" displayName="peripheral" projectFiles="true">
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/peripheral/tmr/src/plib_tmr_pic32.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="system" displayName="system" projectFiles="true">
+                <logicalFolder name="clk" displayName="clk" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/clk/src/sys_clk_pic32mz.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="command" displayName="command" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/command/src/sys_command.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="common" displayName="common" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_buffer.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/common/src/sys_queue.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="console" displayName="console" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/console/src/sys_console_uart.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="debug" displayName="debug" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/debug/src/sys_debug.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="devcon" displayName="devcon" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_pic32mz.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/devcon/src/sys_devcon_cache_pic32mz.S</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="dma" displayName="dma" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/dma/src/sys_dma.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="int" displayName="int" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/int/src/sys_int_pic32.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="ports" displayName="ports" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports.c</itemPath>
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/ports/src/sys_ports_static.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="random" displayName="random" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/random/src/sys_random.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="reset" displayName="reset" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/reset/src/sys_reset.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+                <logicalFolder name="tmr" displayName="tmr" projectFiles="true">
+                  <logicalFolder name="src" displayName="src" projectFiles="true">
+                    <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/system/tmr/src/sys_tmr.c</itemPath>
+                  </logicalFolder>
+                </logicalFolder>
+              </logicalFolder>
+              <logicalFolder name="tcpip" displayName="tcpip" projectFiles="true">
+                <logicalFolder name="src" displayName="src" projectFiles="true">
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_alloc.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_heap_external.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_helpers.c</itemPath>
+                  <itemPath>../../../../../vendors/microchip/harmony/v2.05/framework/tcpip/src/tcpip_packet.c</itemPath>
+                </logicalFolder>
+              </logicalFolder>
+            </logicalFolder>
+          </logicalFolder>
+        </logicalFolder>
+      </logicalFolder>
+    </logicalFolder>
+  </logicalFolder>
+  <projectmakefile>Makefile</projectmakefile>
+  <confs>
+    <conf name="pic32mz_ef_curiosity" type="2">
+      <toolsSet>
+        <developmentServer>localhost</developmentServer>
+        <targetDevice>PIC32MZ2048EFM100</targetDevice>
+        <targetHeader></targetHeader>
+        <targetPluginBoard></targetPluginBoard>
+        <platformTool>ICD4Tool</platformTool>
+        <languageToolchain>XC32</languageToolchain>
+        <languageToolchainVersion>2.05</languageToolchainVersion>
+        <platform>3</platform>
+      </toolsSet>
+      <packs>
+        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
+      </packs>
+      <ScriptingSettings>
+      </ScriptingSettings>
+      <compileType>
+        <linkerTool>
+          <linkerLibItems>
+            <linkerLibFileItem>../../../../../vendors/microchip/harmony/v2.05/bin/framework/peripheral/PIC32MZ2048EFM100_peripherals.a</linkerLibFileItem>
+          </linkerLibItems>
+        </linkerTool>
+        <archiverTool>
+        </archiverTool>
+        <loading>
+          <makeArtifact PL="../bootloader"
+                        CT="1"
+                        CN="pic32mz_ef_curiosity"
+                        AC="true"
+                        BL="true"
+                        WD="../bootloader"
+                        BC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity"
+                        DBC="${MAKE}  -f Makefile CONF=pic32mz_ef_curiosity TYPE_IMAGE=DEBUG_RUN"
+                        CC="rm -rf &quot;build/pic32mz_ef_curiosity&quot; &quot;dist/pic32mz_ef_curiosity&quot;"
+                        OP="dist/pic32mz_ef_curiosity/production/bootloader.production.hex"
+                        DOP="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf"
+                        FL="dist/pic32mz_ef_curiosity/production/bootloader.production.hex"
+                        PD="dist/pic32mz_ef_curiosity/production/bootloader.production.elf"
+                        DD="dist/pic32mz_ef_curiosity/debug/bootloader.debug.elf">
+          </makeArtifact>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
+          <alternateLoadableFile></alternateLoadableFile>
+        </loading>
+        <subordinates>
+        </subordinates>
+      </compileType>
+      <makeCustomizationType>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStep></makeCustomizationPreStep>
+        <makeCustomizationPostStepEnabled>true</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStep>python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/binary_image_generator.py -d ${MP_CC_DIR} -b xc32-objcopy -p "-I ihex ${ImagePath} -O binary ${ImageDir}/mplab.${IMAGE_TYPE}.bin" &amp;&amp; python ../../../../../vendors/microchip/boards/curiosity_pic32mzef/bootloader/bootloader/utility/ota_image_generator.py -b ${ImageDir}/mplab.${IMAGE_TYPE}.bin -p MCHP-Curiosity-PIC32MZEF</makeCustomizationPostStep>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
+      </makeCustomizationType>
+      <C32>
+        <property key="additional-warnings" value="true"/>
+        <property key="addresss-attribute-use" value="false"/>
+        <property key="enable-app-io" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
+        <property key="exclude-floating-point" value="false"/>
+        <property key="extra-include-directories"
+                  value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../tests/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/aws/ota/test;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/aws/defender/src;../../../../../libraries/c_sdk/standard/mqtt/test/access;../../../../../libraries/c_sdk/standard/mqtt/test/mock;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/mqtt/src;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/aws/shadow/src;../../../../../libraries/c_sdk/standard/https/test/access;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/c_sdk/standard/https/src;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/http_parser"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="isolate-each-function" value="true"/>
+        <property key="make-warnings-into-errors" value="false"/>
+        <property key="optimization-level" value="-O1"/>
+        <property key="place-data-into-section" value="false"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros"
+                  value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;AMAZON_FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
+        <property key="strict-ansi" value="false"/>
+        <property key="support-ansi" value="false"/>
+        <property key="toplevel-reordering" value=""/>
+        <property key="unaligned-access" value=""/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
+        <property key="use-indirect-calls" value="false"/>
+        <appendMe value="-mnewlib-libc -std=gnu99 -fgnu89-inline"/>
+      </C32>
+      <C32-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C32-AR>
+      <C32-AS>
+        <property key="assembler-symbols" value=""/>
+        <property key="enable-symbols" value="true"/>
+        <property key="exclude-floating-point-library" value="false"/>
+        <property key="expand-macros" value="false"/>
+        <property key="extra-include-directories-for-assembler" value=""/>
+        <property key="extra-include-directories-for-preprocessor"
+                  value="../../../../../freertos_kernel/include;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/abstractions/pkcs11/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/application_code/microchip_code;../../../../../freertos_kernel/portable/MPLAB/PIC32MZ;../../../../../vendors/microchip/harmony/v2.05/framework;../../../../../vendors/microchip/harmony/v2.05/bsp;../../../../../tests/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/test;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/include;../../../../../libraries/freertos_plus/standard/pkcs11/include;../../../../../libraries/freertos_plus/aws/ota/test;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../vendors/microchip/harmony/v2.05/framework/system/common;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/common/include;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver_extension/driver/source;../../../../../vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/wireless_driver/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/aws/defender/src;../../../../../libraries/c_sdk/standard/mqtt/test/access;../../../../../libraries/c_sdk/standard/mqtt/test/mock;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/mqtt/src;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/aws/shadow/src;../../../../../libraries/c_sdk/standard/https/test/access;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/c_sdk/standard/https/src;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/freertos_plus/aws/ota/src;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/posix/include;../../../../../vendors/microchip/boards/curiosity_pic32mzef/ports/posix;../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/tinycrypt/asn1;../../../../../libraries/3rdparty/tinycrypt/lib/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/http_parser"/>
+        <property key="false-conditionals" value="false"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC32asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="warning-level" value=""/>
+      </C32-AS>
+      <C32-CO>
+        <property key="coverage-enable" value=""/>
+      </C32-CO>
+      <C32-LD>
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="additional-options-write-sla" value="false"/>
+        <property key="allocate-dinit" value="false"/>
+        <property key="code-dinit" value="false"/>
+        <property key="ebase-addr" value=""/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="exclude-floating-point-library" value="false"/>
+        <property key="exclude-standard-libraries" value="false"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="heap-size" value="10000"/>
+        <property key="input-libraries" value=""/>
+        <property key="kseg-length" value=""/>
+        <property key="kseg-origin" value=""/>
+        <property key="linker-symbols" value=""/>
+        <property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
+        <property key="no-device-startup-code" value="false"/>
+        <property key="no-startup-files" value="false"/>
+        <property key="oXC32ld-extra-opts" value="-mnewlib-libc"/>
+        <property key="optimization-level" value=""/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="true"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="serial-length" value=""/>
+        <property key="serial-origin" value=""/>
+        <property key="stack-size" value="10000"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
+        <appendMe value="--allow-multiple-definition"/>
+      </C32-LD>
+      <C32CPP>
+        <property key="additional-warnings" value="false"/>
+        <property key="addresss-attribute-use" value="false"/>
+        <property key="check-new" value="false"/>
+        <property key="eh-specs" value="true"/>
+        <property key="enable-app-io" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
+        <property key="exceptions" value="true"/>
+        <property key="exclude-floating-point" value="false"/>
+        <property key="extra-include-directories" value=""/>
+        <property key="generate-16-bit-code" value="false"/>
+        <property key="generate-micro-compressed-code" value="false"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="make-warnings-into-errors" value="false"/>
+        <property key="optimization-level" value=""/>
+        <property key="place-data-into-section" value="false"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="rtti" value="true"/>
+        <property key="strict-ansi" value="false"/>
+        <property key="toplevel-reordering" value=""/>
+        <property key="unaligned-access" value=""/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
+        <property key="use-indirect-calls" value="false"/>
+      </C32CPP>
+      <C32Global>
+        <property key="common-include-directories" value=""/>
+        <property key="gp-relative-option" value=""/>
+        <property key="legacy-libc" value="false"/>
+        <property key="mdtcm" value=""/>
+        <property key="mitcm" value=""/>
+        <property key="mstacktcm" value="false"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
+        <property key="wpo-lto" value="false"/>
+      </C32Global>
+      <ICD3PlatformTool>
+        <property key="firmware.download.all" value="false"/>
+      </ICD3PlatformTool>
+      <ICD4Tool>
+        <property key="ADC" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="CAN1" value="true"/>
+        <property key="CAN2" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CHANGE NOTICE E" value="true"/>
+        <property key="CHANGE NOTICE F" value="true"/>
+        <property key="CHANGE NOTICE G" value="true"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="ETHERNET CONTROLLER" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C 1" value="true"/>
+        <property key="I2C 2" value="true"/>
+        <property key="I2C 3" value="true"/>
+        <property key="I2C 4" value="true"/>
+        <property key="I2C 5" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="INTERRUPT CONTROL" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="REAL TIME CLOCK" value="true"/>
+        <property key="REFERENCE CLOCK1" value="true"/>
+        <property key="REFERENCE CLOCK2" value="true"/>
+        <property key="REFERENCE CLOCK3" value="true"/>
+        <property key="REFERENCE CLOCK4" value="true"/>
+        <property key="SPI/I2S 1" value="true"/>
+        <property key="SPI/I2S 2" value="true"/>
+        <property key="SPI/I2S 3" value="true"/>
+        <property key="SPI/I2S 4" value="true"/>
+        <property key="SPI/I2S 5" value="true"/>
+        <property key="SPI/I2S 6" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="UART4" value="true"/>
+        <property key="UART5" value="true"/>
+        <property key="UART6" value="true"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.exclude.configurationmemory" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.ledbrightness" value="5"/>
+        <property key="programoptions.pgcconfig" value="pull down"/>
+        <property key="programoptions.pgcresistor.value" value="4.7"/>
+        <property key="programoptions.pgdconfig" value="pull down"/>
+        <property key="programoptions.pgdresistor.value" value="4.7"/>
+        <property key="programoptions.pgmentry.voltage" value="low"/>
+        <property key="programoptions.pgmspeed" value="Med"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="voltagevalue" value="3.25"/>
+      </ICD4Tool>
+      <PKOBSKDEPlatformTool>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="memories.userotp" value="true"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges" value=""/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="true"/>
+      </PKOBSKDEPlatformTool>
+      <RealICEPlatformTool>
+        <property key="ADC" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="CAN1" value="true"/>
+        <property key="CAN2" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CHANGE NOTICE E" value="true"/>
+        <property key="CHANGE NOTICE F" value="true"/>
+        <property key="CHANGE NOTICE G" value="true"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="ETHERNET CONTROLLER" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C 1" value="true"/>
+        <property key="I2C 2" value="true"/>
+        <property key="I2C 3" value="true"/>
+        <property key="I2C 4" value="true"/>
+        <property key="I2C 5" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="INTERRUPT CONTROL" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="REAL TIME CLOCK" value="true"/>
+        <property key="REFERENCE CLOCK1" value="true"/>
+        <property key="REFERENCE CLOCK2" value="true"/>
+        <property key="REFERENCE CLOCK3" value="true"/>
+        <property key="REFERENCE CLOCK4" value="true"/>
+        <property key="RIExTrigs.Five" value="OFF"/>
+        <property key="RIExTrigs.Four" value="OFF"/>
+        <property key="RIExTrigs.One" value="OFF"/>
+        <property key="RIExTrigs.Seven" value="OFF"/>
+        <property key="RIExTrigs.Six" value="OFF"/>
+        <property key="RIExTrigs.Three" value="OFF"/>
+        <property key="RIExTrigs.Two" value="OFF"/>
+        <property key="RIExTrigs.Zero" value="OFF"/>
+        <property key="SPI/I2S 1" value="true"/>
+        <property key="SPI/I2S 2" value="true"/>
+        <property key="SPI/I2S 3" value="true"/>
+        <property key="SPI/I2S 4" value="true"/>
+        <property key="SPI/I2S 5" value="true"/>
+        <property key="SPI/I2S 6" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="UART4" value="true"/>
+        <property key="UART5" value="true"/>
+        <property key="UART6" value="true"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="hwtoolclock.instructionspeed" value="4"/>
+        <property key="hwtoolclock.units" value="mips"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="1d000000-1d1fffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges" value=""/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="tracecontrol.include.timestamp" value="summarydataenabled"/>
+        <property key="tracecontrol.select" value="0"/>
+        <property key="tracecontrol.stallontracebufferfull" value="false"/>
+        <property key="tracecontrol.tracebufmax" value="546000"/>
+        <property key="tracecontrol.tracefile" value="defmplabxtrace.log"/>
+        <property key="tracecontrol.tracefilemax" value="10000000"/>
+        <property key="voltagevalue" value="3.25"/>
+      </RealICEPlatformTool>
+    </conf>
+  </confs>
 </configurationDescriptor>

--- a/projects/microchip/curiosity_pic32mzef/mplab/bootloader/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/bootloader/nbproject/configurations.xml
@@ -190,6 +190,8 @@
       <packs>
         <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
       </packs>
+      <ScriptingSettings>
+      </ScriptingSettings>
       <compileType>
         <linkerTool>
           <linkerLibItems>

--- a/projects/microchip/curiosity_pic32mzef/mplab/bootloader/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/bootloader/nbproject/configurations.xml
@@ -188,7 +188,7 @@
         <platform>3</platform>
       </toolsSet>
       <packs>
-        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.0.20"/>
+        <pack name="PIC32MZ-EF_DFP" vendor="Microchip" version="1.2.51"/>
       </packs>
       <ScriptingSettings>
       </ScriptingSettings>
@@ -267,6 +267,9 @@
         <property key="preprocessor-macros" value=""/>
         <property key="warning-level" value=""/>
       </C32-AS>
+      <C32-CO>
+        <property key="coverage-enable" value=""/>
+      </C32-CO>
       <C32-LD>
         <property key="additional-options-use-response-files" value="false"/>
         <property key="additional-options-write-sla" value="false"/>


### PR DESCRIPTION
<!--- Title -->
Update configurations.xml to fix build errors for MPLABX 5.40

Description
-----------
<!--- Describe your changes in detail -->
In the latest release of amazon-freertos (2020007.0):
MPLABX 5.40 DOES NOT work with XC compiler version 2.41, 2.40, and 2.30 on both my Windows and Mac environment.
However, MPLABX 5.35 works with XC compiler version 2.41, 2.40, and 2.30 on both my Windows and Mac environment.
I believe CI is using MPLABX 5.35, and both XC compiler versions 2.40 and 2.30.

The error in MPLABX 5.40 of amazon-freertos 2020007.0 stems from passing a string literal as a preprocessor macro in `configurations.xml`:
```xml
<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\\\&quot;aws_mbedtls_config.h\\\&quot;;
```
This ends up giving the following error in MPLABX 5.40:
```
In file included from ../../../../../libraries/c_sdk/standard/serializer/src/json/iot_serializer_json_encoder.c:40:0:
../../../../../libraries/3rdparty/mbedtls/include/mbedtls/base64.h:30:10: error: #include expects "FILENAME" or <FILENAME>
#include MBEDTLS_CONFIG_FILE
```

The fix is to update `configurations.xml` to use a single backslash instead:
```xml
<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;
```

Keep in mind that I do not experience the error above in version 202002.00 of amazon-freertos as there is no preprocessor macro for `MBEDTLS_CONFIG_FILE`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.