### PR TITLE
NimBLE AFR: Accommodate 128bit UUID type for comparison with standard CCCD(0x2902)

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -43,6 +43,8 @@
 #define APP_ID          0
 #define MAX_SERVICES    20
 
+#define BLE_GATT_DSC_CLT_CFG_UUID128 0xFB, 0x34, 0x9B, 0x5F, 0x80, 0x00, 0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0x02, 0x29, 0x00, 0x00
+
 static struct ble_gatt_svc_def espServices[ MAX_SERVICES + 1 ];
 static BTService_t * afrServices[ MAX_SERVICES ];
 static uint16_t serviceCnt = 0;
@@ -952,8 +954,10 @@ BTStatus_t prvAddServiceBlob( uint8_t ucServerIf,
                     }
 
                     /* Characteristic descriptors are automatically added, so no need to add them here, otherwise they will be declared twice. */
-                    if( ble_uuid_cmp( uuid, BLE_UUID16_DECLARE( BLE_GATT_DSC_CLT_CFG_UUID16 ) ) == 0 )
-                    {
+                    if (((uuid->type == BLE_UUID_TYPE_16) &&
+                         (ble_uuid_cmp( uuid, BLE_UUID16_DECLARE( BLE_GATT_DSC_CLT_CFG_UUID16 ) ) == 0 )) ||
+                        ((uuid->type == BLE_UUID_TYPE_128) &&
+                         (ble_uuid_cmp( uuid, BLE_UUID128_DECLARE( BLE_GATT_DSC_CLT_CFG_UUID128) ) == 0))) {
                         continue;
                     }
 


### PR DESCRIPTION
Characteristic descriptors are internally added by NimBLE stack, so to avoid duplication we avoid adding descriptors (16 bit UUID = 0x2902) to GATT database. The problem may come when the caller to `prvAddServiceBlob` provides CCCD with 128bit UUID type and standard base UUID. Ideally this should be avoided, but to avoid duplication this PR intends to accommodate 128 bit UUID comparison as well.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Add `BLE_GATT_DSC_CLT_CFG_UUID128` macro to convert 16 bit CCCD UUID (`0x2902`) to 128 bit UUID.
- Compare characteristic descriptor UUID with `BLE_GATT_DSC_CLT_CFG_UUID128`.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.