### PR TITLE
Adding Advertise Tx Power defines

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager_adapter_ble.h
@@ -46,6 +46,13 @@
 #include "bt_hal_manager_types.h"
 #include "bt_hal_manager.h"
 
+/* Ble Advertisement Power Levels Index. This index would translate into platform specific values power (bBm) values */
+#define BT_HAL_BLE_ADV_TX_PWR_ULTRA_LOW     0              /* Ultra Low Adv Tx Power   */
+#define BT_HAL_BLE_ADV_TX_PWR_LOW           1              /* Low Adv Tx Power           */
+#define BT_HAL_BLE_ADV_TX_PWR_MEDIUM        2              /* Medium Adv Tx Power     */
+#define BT_HAL_BLE_ADV_TX_PWR_HIGH          3              /* High Adv Tx Power          */
+#define BT_HAL_BLE_ADV_TX_PWR_ULTRA_HIGH    4              /* Ultra High Adv Tx Power  */
+
 /**
  * @brief Scan Filter Parameters
  */


### PR DESCRIPTION
Adding Advertise Tx Power defines

Description
-----------
  * Tx Power defines which would be an index to Advertising Power values (in dBm) to be set by platforms.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
      (Only defines)
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.