### PR TITLE
Change ioctl test case for ADC to use greater than equal.

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -551,8 +551,8 @@ TEST( TEST_IOT_ADC, AFQP_IotAdcIoctlSetConfigFuzzy )
 
         lRetVal = iot_adc_ioctl( xAdcHandle, eGetAdcConfig, &xAdcConfig );
         TEST_ASSERT_EQUAL( IOT_ADC_SUCCESS, lRetVal );
-        TEST_ASSERT_EQUAL( 3, xAdcConfig.ulAdcSampleTime );
-        TEST_ASSERT_EQUAL( 12, xAdcConfig.ucAdcResolution );
+        TEST_ASSERT_TRUE( xAdcConfig.ulAdcSampleTime >= 3 );
+        TEST_ASSERT_TRUE( xAdcConfig.ucAdcResolution >= 12 );
     }
 
     lRetVal = iot_adc_close( xAdcHandle );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.