### PR TITLE
Fix logging issue that is causing mangled start markers in Microchip boards

### DIFF
--- a/vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include/wdrv_wilc1000_stub.h
+++ b/vendors/microchip/harmony/v2.05/framework/driver/wifi/wilc1000/include/wdrv_wilc1000_stub.h
@@ -40,7 +40,7 @@ SUBSTITUTE GOODS, TECHNOLOGY, SERVICES, OR ANY CLAIMS BY THIRD PARTIES
 #ifndef _WDRV_WILC1000_STUB_H
 #define _WDRV_WILC1000_STUB_H
 
-#define WDRV_STUB_Print(x) SYS_CONSOLE_PRINT x
+#define WDRV_STUB_Print(x) configPRINTF(x)
 
 //*******************************************************************************
 /*


### PR DESCRIPTION
<!--- Title -->
This PR addresses the issue by defining `WDRV_STUB_Print` to be `configPRINTF` rather than `SYS_CONSOLE_PRINT`. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.