### PR TITLE
Update IotThreads_Free and IotThreads_Malloc default values

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_threads_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_threads_freertos.c
@@ -57,22 +57,22 @@
  * the usage of dynamic memory allocation.
  */
 #ifndef IotThreads_Malloc
-    #include <stdlib.h>
+    #include "FreeRTOS.h"
 
 /**
  * @brief Memory allocation. This function should have the same signature
  * as [malloc](http://pubs.opengroup.org/onlinepubs/9699919799/functions/malloc.html).
  */
-    #define IotThreads_Malloc    malloc
+    #define IotThreads_Malloc    pvPortMalloc
 #endif
 #ifndef IotThreads_Free
-    #include <stdlib.h>
+    #include "FreeRTOS.h"
 
 /**
  * @brief Free memory. This function should have the same signature as
  * [free](http://pubs.opengroup.org/onlinepubs/9699919799/functions/free.html).
  */
-    #define IotThreads_Free    free
+    #define IotThreads_Free    pvPortFree
 #endif
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Update IotThreads_Free and IotThreads_Malloc default values

Description
-----------
The current default values for IotThreads_Free and IotThreads_Malloc in iot_threads_freertos.c are set to the standard library free and malloc functions. These functions are not thread-safe and can likely lead to issues. There are no current issues because they can be overridden, but they make for poor defaults.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.