### PR TITLE
Fix public key deletion and PKCS #11 tests on Optiga X.

### DIFF
--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1834,9 +1834,9 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     /* mbedTLS structures for verification. */
     uint8_t ucSecp256r1Oid[] = pkcs11DER_ENCODED_OID_P256; /*"\x06\x08" MBEDTLS_OID_EC_GRP_SECP256R1; */
 
-    /* TODO: We should be destroying credentials first, just in case. Currently a port cannot do this, but once that is complete this will need to be updated. 
+    /* TODO: We should be destroying credentials first, just in case. Currently a port cannot do this, but once that is complete this will need to be updated.
      * xResult = prvDestroyTestCredentials();
-     * TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" ); 
+     * TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" );
      * */
     xCurrentCredentials = eNone;
 

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1834,11 +1834,6 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     /* mbedTLS structures for verification. */
     uint8_t ucSecp256r1Oid[] = pkcs11DER_ENCODED_OID_P256; /*"\x06\x08" MBEDTLS_OID_EC_GRP_SECP256R1; */
 
-     xResult = prvDestroyTestCredentials();
-     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" );
-
-    xCurrentCredentials = eNone;
-
     xResult = xProvisionGenerateKeyPairEC( xGlobalSession,
                                            ( uint8_t * ) pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
                                            ( uint8_t * ) pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1834,8 +1834,10 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     /* mbedTLS structures for verification. */
     uint8_t ucSecp256r1Oid[] = pkcs11DER_ENCODED_OID_P256; /*"\x06\x08" MBEDTLS_OID_EC_GRP_SECP256R1; */
 
-    xResult = prvDestroyTestCredentials();
-    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" );
+    /* TODO: We should be destroying credentials first, just in case. Currently a port cannot do this, but once that is complete this will need to be updated. 
+     * xResult = prvDestroyTestCredentials();
+     * TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" ); 
+     * */
     xCurrentCredentials = eNone;
 
     xResult = xProvisionGenerateKeyPairEC( xGlobalSession,
@@ -2287,7 +2289,7 @@ TEST( Full_PKCS11_EC, AFQP_FindObjectMultiThread )
         xGlobalTaskParams[ xTaskNumber ].pvTaskData = &xSessionHandle[ xTaskNumber ];
     }
 
-    prvProvisionEcTestCredentials( &xPrivateKey, &xCertificate, &xPublicKey );
+    prvFindObjectTest( &xPrivateKey, &xCertificate, &xPublicKey );
 
     prvMultiThreadHelper( ( void * ) prvFindObjectMultiThreadTask );
 
@@ -2414,7 +2416,7 @@ TEST( Full_PKCS11_EC, AFQP_GetAttributeValueMultiThread )
         xGlobalTaskParams[ xTaskNumber ].pvTaskData = &xSessionHandle[ xTaskNumber ];
     }
 
-    prvProvisionEcTestCredentials( &xPrivateKey, &xCertificate, &xPublicKey );
+    prvFindObjectTest( &xPrivateKey, &xCertificate, &xPublicKey );
 
     prvMultiThreadHelper( ( void * ) prvECGetAttributeValueMultiThreadTask );
 
@@ -2507,7 +2509,7 @@ TEST( Full_PKCS11_EC, AFQP_SignVerifyMultiThread )
     CK_OBJECT_HANDLE xCertificate;
     CK_OBJECT_HANDLE xPublicKey;
 
-    prvProvisionEcTestCredentials( &xPrivateKey, &xCertificate, &xPublicKey );
+    prvFindObjectTest( &xPrivateKey, &xCertificate, &xPublicKey );
 
     for( xTaskNumber = 0; xTaskNumber < pkcs11testMULTI_THREAD_TASK_COUNT; xTaskNumber++ )
     {

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1834,10 +1834,9 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     /* mbedTLS structures for verification. */
     uint8_t ucSecp256r1Oid[] = pkcs11DER_ENCODED_OID_P256; /*"\x06\x08" MBEDTLS_OID_EC_GRP_SECP256R1; */
 
-    /* TODO: We should be destroying credentials first, just in case. Currently a port cannot do this, but once that is complete this will need to be updated.
-     * xResult = prvDestroyTestCredentials();
-     * TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" );
-     * */
+     xResult = prvDestroyTestCredentials();
+     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, xResult, "Failed to destroy credentials before Generating Key Pair" );
+
     xCurrentCredentials = eNone;
 
     xResult = xProvisionGenerateKeyPairEC( xGlobalSession,

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -96,7 +96,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     "0xF1D2"
+#define pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS     "0xF1D4"
 
 /**
  * @brief The PKCS #11 label for the device certificate.

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -2240,8 +2240,8 @@ CK_DEFINE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
         }
         else if( ( xPalHandle == eAwsDevicePrivateKey ) || ( xPalHandle == eAwsTestPrivateKey ) )
         {
+            xResult = prvAddObjectToList( xPalHandle, pxObject, pxSession->pxFindObjectLabel, strlen( ( const char * ) pxSession->pxFindObjectLabel ) );
             *pulObjectCount = 1;
-            xResult = CKR_OK;
         }
         else
         {


### PR DESCRIPTION
Fix public key deletion and PKCS #11 tests on Optiga X.

Description
-----------
The newly refactored tests were overwriting and deleting the public key stored on the device. Need to do further tests to ensure this is the correct solution, but this will fix the "real" public key being deleted, as well as making the PKCS #11 tests pass.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.