### PR TITLE
Remove wifi dependency from lwip Secure Sockets implementation

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -845,7 +845,6 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 
     if( strlen( pcHostName ) <= ( size_t ) securesocketsMAX_DNS_NAME_LENGTH )
     {
-/*        WIFI_GetHostIP( ( char * ) pcHostName, ( uint8_t * ) &addr ); */
         xLwipError = dns_gethostbyname_addrtype( pcHostName, &xLwipIpv4Address,
                                                  lwip_dns_found_callback, ( void * ) &addr,
                                                  LWIP_DNS_ADDRTYPE_IPV4 );

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -58,8 +58,8 @@
  * to complete.
  */
 
-#define lwip_dns_resolver_DELAY_MS            ( 250 )
-#define lwip_dns_resolver_LOOP_DELAY          ( ( TickType_t ) lwip_dns_resolver_DELAY_MS / portTICK_PERIOD_MS )
+#define lwip_dns_resolver_LOOP_DELAY_MS       ( 250 )
+#define lwip_dns_resolver_LOOP_DELAY_TICKS    ( ( TickType_t ) lwip_dns_resolver_LOOP_DELAY_MS / portTICK_PERIOD_MS )
 
 /*
  * The maximum time to wait for DNS resolution
@@ -73,7 +73,7 @@
  */
 #define lwip_dns_resolver_MAX_WAIT_CYCLES                 \
     ( ( ( lwip_dns_resolver_MAX_WAIT_SECONDS ) * 1000 ) / \
-      ( lwip_dns_resolver_DELAY_MS ) )
+      ( lwip_dns_resolver_LOOP_DELAY_MS ) )
 
 /*-----------------------------------------------------------*/
 
@@ -823,7 +823,7 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
  * declared in lwip/dns.h.
  *
  * NOTE: this resolves only ipv4 addresses; calls to dns_gethostbyname_addrtype()
- * must specify dns_addrtype == LWIP_DNS_ADDRTYPE_IPV4
+ * must specify dns_addrtype == LWIP_DNS_ADDRTYPE_IPV4.
  */
 static void lwip_dns_found_callback( const char * name,
                                      const ip_addr_t * ipaddr,
@@ -864,7 +864,7 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
                  */
                 do
                 {
-                    vTaskDelay( lwip_dns_resolver_LOOP_DELAY );
+                    vTaskDelay( lwip_dns_resolver_LOOP_DELAY_TICKS );
                 }   while( ( ulDnsResolutionWaitCycles++ < lwip_dns_resolver_MAX_WAIT_CYCLES ) && addr == 0 );
 
                 if( addr == 0 )

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -853,7 +853,7 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
         switch( xLwipError )
         {
             case ERR_OK:
-                addr = *( ( uint32_t * ) xLwipIpv4Address ); /* NOTE: IPv4 addresses only */
+                addr = *( ( uint32_t * ) &xLwipIpv4Address ); /* NOTE: IPv4 addresses only */
                 break;
 
             case ERR_INPROGRESS:

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -25,21 +25,21 @@
 
 /**
  * @file iot_secure_sockets.c
- * @brief WiFi and Secure Socket interface implementation.
+ * @brief Secure Socket interface implementation.
  */
 
 /* Define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE to prevent secure sockets functions
  * from redefining in iot_secure_sockets_wrapper_metrics.h */
 #define _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
 
-/* Socket and WiFi interface includes. */
+/* Secure Socket interface includes. */
 #include "iot_secure_sockets.h"
 
 
 #include "lwip/sockets.h"
 #include "lwip/netdb.h"
-
-#include "iot_wifi.h"
+#include "lwip/dns.h"
+#include "lwip/err.h"
 
 #include "iot_tls.h"
 
@@ -52,6 +52,27 @@
 #include <stdbool.h>
 
 #undef _SECURE_SOCKETS_WRAPPER_NOT_REDEFINE
+
+/*
+ * The loop delay used while waiting for DNS resolution
+ * to complete.
+ */
+
+#define lwip_dns_resolver_DELAY_MS    ( 250 )
+#define lwip_dns_resolver_LOOP_DELAY  ( ( TickType_t ) lwip_dns_resolver_DELAY_MS / portTICK_PERIOD_MS )
+
+/*
+ * The maximum time to wait for DNS resolution
+ * to complete.
+ */
+#define lwip_dns_resolver_MAX_WAIT_SECONDS   ( 20 )
+
+/*
+ * The maximum number of loop iterations to wait for DNS
+ * resolution to complete.
+ */
+#define lwip_dns_resolver_MAX_WAIT_CYCLES     ( ( ( lwip_dns_resolver_MAX_WAIT_SECONDS ) * 1000 ) / \
+                ( lwip_dns_resolver_DELAY_MS ) )
 
 /*-----------------------------------------------------------*/
 
@@ -795,14 +816,63 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
 }
 
 /*-----------------------------------------------------------*/
+/*
+ * Lwip DNS Found callback, compatible with type "dns_found_callback"
+ * declared in lwip/dns.h.
+ *
+ * NOTE: this resolves only ipv4 addresses; calls to dns_gethostbyname_addrtype()
+ * must specify dns_addrtype == LWIP_DNS_ADDRTYPE_IPV4
+ */
+static void lwip_dns_found_callback(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
+{
+   uint32_t *addr = (uint32_t *)callback_arg;
+
+   *addr = *((uint32_t *)ipaddr);  /* NOTE: IPv4 addresses only */
+}
+
+/*-----------------------------------------------------------*/
 
 uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 {
-    uint32_t addr = 0;
+    uint32_t addr = 0;     /* 0 indicates failure to caller */
+    err_t xLwipError = ERR_OK;
+    ip_addr_t xLwipIpv4Address;
+    uint32_t ulDnsResolutionWaitCycles = 0;
 
     if( strlen( pcHostName ) <= ( size_t ) securesocketsMAX_DNS_NAME_LENGTH )
     {
-        WIFI_GetHostIP( ( char * ) pcHostName, ( uint8_t * ) &addr );
+//        WIFI_GetHostIP( ( char * ) pcHostName, ( uint8_t * ) &addr );
+        xLwipError = dns_gethostbyname_addrtype( pcHostName, &xLwipIpv4Address,
+                                   lwip_dns_found_callback, (void *)&addr,
+                                   LWIP_DNS_ADDRTYPE_IPV4 );
+
+		switch( xLwipError )
+		{
+            case ERR_OK:
+                addr = *((uint32_t *)xLwipIpv4Address);  /* NOTE: IPv4 addresses only */
+                break;
+            case ERR_INPROGRESS:
+                /*
+                 * The DNS resolver is working the request.  Wait for it to complete
+                 * or time out; print a timeout error message if configured for debug
+                 * printing.
+                 */
+                do
+                {
+                    vTaskDelay( lwip_dns_resolver_LOOP_DELAY );
+                }   while(( ulDnsResolutionWaitCycles++ < lwip_dns_resolver_MAX_WAIT_CYCLES ) && addr == 0 );
+                if( addr == 0 )
+                {
+                    configPRINTF( ( "Unable to resolve (%s) within (%ul) seconds",
+                        pcHostName, lwip_dns_resolver_MAX_WAIT_SECONDS ) );
+                }
+                break;
+            default:
+                configPRINTF( ( "Unexpected error (%lu) from dns_gethostbyname_addrtype() while resolving (%s)!",
+                    (uint32_t)xLwipError, pcHostName ) );
+                break;
+		}
+
     }
     else
     {
@@ -818,6 +888,8 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 BaseType_t SOCKETS_Init( void )
 {
     BaseType_t xResult = pdPASS;
+
+    dns_init();
 
     return xResult;
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] My code is Linted.

[Issue #2307](https://github.com/aws/amazon-freertos/issues/2307) points out that there is a wifi dependency in the lwip implementation of the Secure Sockets API.  This Pull Request eliminates that dependency.  Has been tested on espressif & mediatek boards with Full_TCP, HTTPS_Client_System, and MQTT_System tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.