### PR TITLE
Secure Socket changes to enable TCP keep-alive

### DIFF
--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -211,16 +211,6 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
     return FreeRTOS_gethostbyname( pcHostName );
 }
 
-
-/*-----------------------------------------------------------*/
-
-int32_t SOCKETS_Bind( Socket_t xSocket,
-                      SocketsSockaddr_t *pxAddress,
-                      Socklen_t xAddressLength )
-{
-   return SOCKETS_SOCKET_ERROR;
-}
-
 /*-----------------------------------------------------------*/
 
 int32_t SOCKETS_Recv( Socket_t xSocket,

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -210,7 +210,6 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 {
     return FreeRTOS_gethostbyname( pcHostName );
 }
-
 /*-----------------------------------------------------------*/
 
 int32_t SOCKETS_Recv( Socket_t xSocket,

--- a/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c
@@ -210,6 +210,17 @@ uint32_t SOCKETS_GetHostByName( const char * pcHostName )
 {
     return FreeRTOS_gethostbyname( pcHostName );
 }
+
+
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Bind( Socket_t xSocket,
+                      SocketsSockaddr_t *pxAddress,
+                      Socklen_t xAddressLength )
+{
+   return SOCKETS_SOCKET_ERROR;
+}
+
 /*-----------------------------------------------------------*/
 
 int32_t SOCKETS_Recv( Socket_t xSocket,

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -168,6 +168,10 @@ typedef struct xSOCKET * Socket_t; /**< @brief Socket handle data type. */
 #define SOCKETS_SO_NONBLOCK                      ( 9 )  /**< Socket is nonblocking. */
 #define SOCKETS_SO_ALPN_PROTOCOLS                ( 10 ) /**< Application protocol list to be included in TLS ClientHello. */
 #define SOCKETS_SO_WAKEUP_CALLBACK               ( 17 ) /**< Set the callback to be called whenever there is data available on the socket for reading. */
+#define SOCKETS_SO_TCPKEEPALIVE                  ( 18 ) /**< Enable/Disable TCP keep-alive. */
+#define SOCKETS_SO_TCPKEEPALIVE_INTERVAL         ( 19 ) /**< Set the interval in seconds between TCP keep-alive probes. */
+#define SOCKETS_SO_TCPKEEPALIVE_COUNT            ( 20 ) /**< Set the maximum number of TCP keep-alive probes to be sent */
+#define SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME        ( 21 ) /**< Set the duration in seconds for which the connection needs to be idle before TCP sends out keep-alive probes. */
 
 /**@} */
 
@@ -253,6 +257,33 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
                          int32_t lProtocol );
 /* @[declare_secure_sockets_socket] */
 
+/**
+ * @brief Bind a TCP socket.
+ *
+ * See the [FreeRTOS+TCP networking tutorial]
+ * (https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Networking_Tutorial.html)
+ * for more information on TCP sockets.
+ *
+ * See the [Berkeley Sockets API]
+ * (https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions)
+ * in wikipedia
+ *
+ * @sa SOCKETS_Bind()
+ *
+ * @param[in] xSocket The handle of the socket to which specified address to be bound.
+ * @param[in] pxAddress A pointer to a SocketsSockaddr_t structure that contains
+ * the address and port to be bound to the socket.
+ * @param[in] xAddressLength Should be set to sizeof( @ref SocketsSockaddr_t ).
+ *
+ * @return
+ * * If the bind was successful then SOCKETS_ERROR_NONE is returned.
+ * * If an error occurred, a negative value is returned. @ref SocketsErrors
+ */
+/* @[declare_secure_sockets_bind] */
+int32_t SOCKETS_Bind( Socket_t xSocket,
+                      SocketsSockaddr_t *pxAddress,
+                      Socklen_t xAddressLength );
+/* @[declare_secure_sockets_bind] */
 
 /**
  * @brief Connects the socket to the specified IP address and port.
@@ -472,6 +503,21 @@ int32_t SOCKETS_Close( Socket_t xSocket );
  *      - The ALPN list is expressed as an array of NULL-terminated ANSI
  *        strings.
  *      - xOptionLength is the number of items in the array.
+ *    - @ref SOCKETS_SO_TCPKEEPALIVE
+ *      - Enable or disable the Keepalive functionality for specific
+ *        socket.
+ *      - pvOptionValue is the value to enable/disable Keepalive.
+ *    - @ref SOCKETS_SO_TCPKEEPALIVE_INTERVAL
+ *      - Set the time between each probe request to check socket
+ *        connection status.
+ *      - pvOptionValue is the time in seconds.
+ *    - @ref SOCKETS_SO_TCPKEEPALIVE_COUNT
+ *      - Set number of probe requests to be sent between each idle time.
+ *      - pvOptionValue is the number of probe requests.
+ *    - @ref SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME
+ *      - Set the time for connection to remain idle before initiating keep alive
+ *        packets.
+ *      - pvOptionValue is the time in seconds.
  *
  * @return
  * * On success, 0 is returned.

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -168,10 +168,10 @@ typedef struct xSOCKET * Socket_t; /**< @brief Socket handle data type. */
 #define SOCKETS_SO_NONBLOCK                      ( 9 )  /**< Socket is nonblocking. */
 #define SOCKETS_SO_ALPN_PROTOCOLS                ( 10 ) /**< Application protocol list to be included in TLS ClientHello. */
 #define SOCKETS_SO_WAKEUP_CALLBACK               ( 17 ) /**< Set the callback to be called whenever there is data available on the socket for reading. */
-#define SOCKETS_SO_TCPKEEPALIVE                  ( 18 ) /**< Enable/Disable TCP keep-alive. */
-#define SOCKETS_SO_TCPKEEPALIVE_INTERVAL         ( 19 ) /**< Set the interval in seconds between TCP keep-alive probes. */
-#define SOCKETS_SO_TCPKEEPALIVE_COUNT            ( 20 ) /**< Set the maximum number of TCP keep-alive probes to be sent */
-#define SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME        ( 21 ) /**< Set the duration in seconds for which the connection needs to be idle before TCP sends out keep-alive probes. */
+#define SOCKETS_SO_TCPKEEPALIVE                  ( 18 ) /**< Enable or Disable TCP keep-alive functionality. */
+#define SOCKETS_SO_TCPKEEPALIVE_INTERVAL         ( 19 ) /**< Set the time in seconds between individual TCP keep-alive probes. */
+#define SOCKETS_SO_TCPKEEPALIVE_COUNT            ( 20 ) /**< Set the maximum number of keep-alive probes TCP should send before dropping the connection. */
+#define SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME        ( 21 ) /**< Set the time in seconds for which the connection needs to remain idle before TCP starts sending keep-alive probes. */
 
 /**@} */
 
@@ -477,19 +477,18 @@ int32_t SOCKETS_Close( Socket_t xSocket );
  *        strings.
  *      - xOptionLength is the number of items in the array.
  *    - @ref SOCKETS_SO_TCPKEEPALIVE
- *      - Enable or disable the Keepalive functionality for specific
- *        socket.
- *      - pvOptionValue is the value to enable/disable Keepalive.
+ *      - Enable or disable the TCP keep-alive functionality.
+ *      - pvOptionValue is the value to enable or disable Keepalive.
  *    - @ref SOCKETS_SO_TCPKEEPALIVE_INTERVAL
- *      - Set the time between each probe request to check socket
- *        connection status.
+ *      - Set the time in seconds between individual TCP keep-alive probes.
  *      - pvOptionValue is the time in seconds.
  *    - @ref SOCKETS_SO_TCPKEEPALIVE_COUNT
- *      - Set number of probe requests to be sent between each idle time.
- *      - pvOptionValue is the number of probe requests.
+ *      - Set the maximum number of keep-alive probes TCP should send before
+ *        dropping the connection.
+ *      - pvOptionValue is the maximum number of keep-alive probes.
  *    - @ref SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME
- *      - Set the time for connection to remain idle before initiating keep alive
- *        packets.
+ *      - Set the time in seconds for which the connection needs to remain idle
+ *        before TCP starts sending keep-alive probes.
  *      - pvOptionValue is the time in seconds.
  *
  * @return

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -257,6 +257,7 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
                          int32_t lProtocol );
 /* @[declare_secure_sockets_socket] */
 
+
 /**
  * @brief Connects the socket to the specified IP address and port.
  *

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -258,34 +258,6 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
 /* @[declare_secure_sockets_socket] */
 
 /**
- * @brief Bind a TCP socket.
- *
- * See the [FreeRTOS+TCP networking tutorial]
- * (https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Networking_Tutorial.html)
- * for more information on TCP sockets.
- *
- * See the [Berkeley Sockets API]
- * (https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions)
- * in wikipedia
- *
- * @sa SOCKETS_Bind()
- *
- * @param[in] xSocket The handle of the socket to which specified address to be bound.
- * @param[in] pxAddress A pointer to a SocketsSockaddr_t structure that contains
- * the address and port to be bound to the socket.
- * @param[in] xAddressLength Should be set to sizeof( @ref SocketsSockaddr_t ).
- *
- * @return
- * * If the bind was successful then SOCKETS_ERROR_NONE is returned.
- * * If an error occurred, a negative value is returned. @ref SocketsErrors
- */
-/* @[declare_secure_sockets_bind] */
-int32_t SOCKETS_Bind( Socket_t xSocket,
-                      SocketsSockaddr_t *pxAddress,
-                      Socklen_t xAddressLength );
-/* @[declare_secure_sockets_bind] */
-
-/**
  * @brief Connects the socket to the specified IP address and port.
  *
  * The socket must first have been successfully created by a call to SOCKETS_Socket().

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -811,45 +811,45 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
 
         case SOCKETS_SO_TCPKEEPALIVE:
 
-        	ret = lwip_setsockopt( ctx->ip_socket,
+            ret = lwip_setsockopt( ctx->ip_socket,
                                    SOL_SOCKET,
                                    SO_KEEPALIVE,
                                    pvOptionValue,
                                    sizeof( int ) );
 
-        	break;
+            break;
 
-#if LWIP_TCP_KEEPALIVE
-       case SOCKETS_SO_TCPKEEPALIVE_INTERVAL:
+            #if LWIP_TCP_KEEPALIVE
+                case SOCKETS_SO_TCPKEEPALIVE_INTERVAL:
 
-    	   ret = lwip_setsockopt( ctx->ip_socket,
-                                  IPPROTO_TCP,
-                                  TCP_KEEPINTVL,
-                                  pvOptionValue,
-                                  sizeof( int ) );
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPINTVL,
+                                           pvOptionValue,
+                                           sizeof( int ) );
 
-           break;
+                    break;
 
-        case SOCKETS_SO_TCPKEEPALIVE_COUNT:
+                case SOCKETS_SO_TCPKEEPALIVE_COUNT:
 
-           ret = lwip_setsockopt( ctx->ip_socket,
-                                  IPPROTO_TCP,
-                                  TCP_KEEPCNT,
-                                  pvOptionValue,
-                                  sizeof( int ) );
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPCNT,
+                                           pvOptionValue,
+                                           sizeof( int ) );
 
-           break;
+                    break;
 
-        case SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME:
+                case SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME:
 
-           ret = lwip_setsockopt( ctx->ip_socket,
-                                  IPPROTO_TCP,
-                                  TCP_KEEPIDLE,
-                                  pvOptionValue,
-                                  sizeof( int ) );
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPIDLE,
+                                           pvOptionValue,
+                                           sizeof( int ) );
 
-           break;
-#endif /* if LWIP_TCP_KEEPALIVE */
+                    break;
+            #endif /* if LWIP_TCP_KEEPALIVE */
 
 
         default:
@@ -858,7 +858,7 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
 
     if( 0 > ret )
     {
-       return SOCKETS_SOCKET_ERROR;
+        return SOCKETS_SOCKET_ERROR;
     }
 
     return ret;

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -101,7 +101,7 @@ typedef struct _ss_ctx_t
     int recv_flag;
 
     TaskHandle_t rx_handle;
-    void ( *rx_callback )( Socket_t pxSocket );
+    void ( * rx_callback )( Socket_t pxSocket );
 
     bool enforce_tls;
     void * tls_ctx;

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -809,7 +809,7 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
 
             break;
 			
-			case SOCKETS_SO_TCPKEEPALIVE:
+            case SOCKETS_SO_TCPKEEPALIVE:
             {
                 int keep_alive = *((int *)pvOptionValue);
 

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -386,6 +386,62 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
 
     return ( Socket_t ) SOCKETS_INVALID_SOCKET;
 }
+/*-----------------------------------------------------------*/
+
+int32_t SOCKETS_Bind( Socket_t xSocket,
+                      SocketsSockaddr_t *pxAddress,
+                      Socklen_t xAddressLength )
+{
+    ss_ctx_t * ctx;
+    int32_t ret;
+    struct sockaddr_in sa_addr = { 0 };
+
+    if( SOCKETS_INVALID_SOCKET == xSocket )
+    {
+        configPRINTF( ( "TCP socket Invalid\n" ) );
+        return SOCKETS_EINVAL;
+    }
+
+    if( pxAddress == NULL )
+    {
+        return SOCKETS_EINVAL;
+    }
+
+    ctx = ( ss_ctx_t * ) xSocket;
+
+    if( 0 > ctx->ip_socket )
+    {
+        configPRINTF( ( "TCP socket Invalid index\n" ) );
+        return SOCKETS_EINVAL;
+    }
+
+    /*
+     * Setting SO_REUSEADDR socket option in order to be able to bind to the same ip:port again
+     * without netconn_bind failing.
+     */
+#if SO_REUSE
+    ret = lwip_setsockopt( ctx->ip_socket, SOL_SOCKET, SO_REUSEADDR, &(uint32_t){1}, sizeof(uint32_t));
+
+    if( 0 > ret )
+    {
+        return SOCKETS_SOCKET_ERROR;
+    }
+#endif /* SO_REUSE */
+
+    sa_addr.sin_family = pxAddress->ucSocketDomain ? pxAddress->ucSocketDomain : AF_INET;
+    sa_addr.sin_addr.s_addr = pxAddress->ulAddress;
+    sa_addr.sin_port = pxAddress->usPort;
+
+    ret = lwip_bind(ctx->ip_socket, ( struct sockaddr * ) &sa_addr, sizeof( sa_addr ));
+    if( 0 > ret )
+    {
+        configPRINTF(( "lwip_bind fail :%d\n",ret ) );
+        return SOCKETS_SOCKET_ERROR;
+    }
+
+    return SOCKETS_ERROR_NONE;
+
+}
 
 /*-----------------------------------------------------------*/
 
@@ -808,6 +864,70 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
             }
 
             break;
+			
+			case SOCKETS_SO_TCPKEEPALIVE:
+            {
+                int keep_alive = *((int *)pvOptionValue);
+
+                if( keep_alive == 0 || keep_alive == 1 )
+                {
+                   ret = lwip_setsockopt( ctx->ip_socket,
+                                          SOL_SOCKET,
+                                          SO_KEEPALIVE,
+                                          &keep_alive,
+                                          sizeof( keep_alive ) );
+                   if( 0 > ret )
+                   {
+                       return SOCKETS_SOCKET_ERROR;
+                   }
+               }
+               else
+               {
+                  return SOCKETS_EINVAL;
+               }
+               break;
+            }
+
+#if LWIP_TCP_KEEPALIVE
+            case SOCKETS_SO_TCPKEEPALIVE_INTERVAL:
+
+                ret = lwip_setsockopt( ctx->ip_socket,
+                                       IPPROTO_TCP,
+                                       TCP_KEEPINTVL,
+                                       pvOptionValue,
+                                       sizeof( int ) );
+                if( 0 > ret )
+                {
+                	return SOCKETS_SOCKET_ERROR;
+                }
+                break;
+
+            case SOCKETS_SO_TCPKEEPALIVE_COUNT:
+
+                ret = lwip_setsockopt( ctx->ip_socket,
+                                       IPPROTO_TCP,
+                                       TCP_KEEPCNT,
+                                       pvOptionValue,
+                                       sizeof( int ) );
+                if( 0 > ret )
+                {
+                   return SOCKETS_SOCKET_ERROR;
+                }
+                break;
+
+            case SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME:
+
+                ret = lwip_setsockopt( ctx->ip_socket,
+                                       IPPROTO_TCP,
+                                       TCP_KEEPIDLE,
+                                       pvOptionValue,
+                                      sizeof( int ) );
+                if( 0 > ret )
+                {
+                    return SOCKETS_SOCKET_ERROR;
+                }
+                break;
+#endif
 
         default:
             return SOCKETS_ENOPROTOOPT;

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -101,7 +101,7 @@ typedef struct _ss_ctx_t
     int recv_flag;
 
     TaskHandle_t rx_handle;
-    void ( * rx_callback )( Socket_t pxSocket );
+    void ( *rx_callback )( Socket_t pxSocket );
 
     bool enforce_tls;
     void * tls_ctx;
@@ -808,18 +808,19 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
             }
 
             break;
-			
-            case SOCKETS_SO_TCPKEEPALIVE:
-            {
-                int keep_alive = *((int *)pvOptionValue);
 
-                if( keep_alive == 0 || keep_alive == 1 )
-                {
+        case SOCKETS_SO_TCPKEEPALIVE:
+           {
+               int keep_alive = *( ( int * ) pvOptionValue );
+
+               if( ( keep_alive == 0 ) || ( keep_alive == 1 ) )
+               {
                    ret = lwip_setsockopt( ctx->ip_socket,
                                           SOL_SOCKET,
                                           SO_KEEPALIVE,
                                           &keep_alive,
                                           sizeof( keep_alive ) );
+
                    if( 0 > ret )
                    {
                        return SOCKETS_SOCKET_ERROR;
@@ -827,51 +828,57 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
                }
                else
                {
-                  return SOCKETS_EINVAL;
+                   return SOCKETS_EINVAL;
                }
+
                break;
-            }
+           }
 
-#if LWIP_TCP_KEEPALIVE
-            case SOCKETS_SO_TCPKEEPALIVE_INTERVAL:
+            #if LWIP_TCP_KEEPALIVE
+                case SOCKETS_SO_TCPKEEPALIVE_INTERVAL:
 
-                ret = lwip_setsockopt( ctx->ip_socket,
-                                       IPPROTO_TCP,
-                                       TCP_KEEPINTVL,
-                                       pvOptionValue,
-                                       sizeof( int ) );
-                if( 0 > ret )
-                {
-                	return SOCKETS_SOCKET_ERROR;
-                }
-                break;
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPINTVL,
+                                           pvOptionValue,
+                                           sizeof( int ) );
 
-            case SOCKETS_SO_TCPKEEPALIVE_COUNT:
+                    if( 0 > ret )
+                    {
+                        return SOCKETS_SOCKET_ERROR;
+                    }
 
-                ret = lwip_setsockopt( ctx->ip_socket,
-                                       IPPROTO_TCP,
-                                       TCP_KEEPCNT,
-                                       pvOptionValue,
-                                       sizeof( int ) );
-                if( 0 > ret )
-                {
-                   return SOCKETS_SOCKET_ERROR;
-                }
-                break;
+                    break;
 
-            case SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME:
+                case SOCKETS_SO_TCPKEEPALIVE_COUNT:
 
-                ret = lwip_setsockopt( ctx->ip_socket,
-                                       IPPROTO_TCP,
-                                       TCP_KEEPIDLE,
-                                       pvOptionValue,
-                                      sizeof( int ) );
-                if( 0 > ret )
-                {
-                    return SOCKETS_SOCKET_ERROR;
-                }
-                break;
-#endif
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPCNT,
+                                           pvOptionValue,
+                                           sizeof( int ) );
+
+                    if( 0 > ret )
+                    {
+                        return SOCKETS_SOCKET_ERROR;
+                    }
+
+                    break;
+
+                case SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME:
+
+                    ret = lwip_setsockopt( ctx->ip_socket,
+                                           IPPROTO_TCP,
+                                           TCP_KEEPIDLE,
+                                           pvOptionValue,
+                                           sizeof( int ) );
+
+                    if( 0 > ret )
+                    {
+                        return SOCKETS_SOCKET_ERROR;
+                    }
+                    break;
+            #endif /* if LWIP_TCP_KEEPALIVE */
 
         default:
             return SOCKETS_ENOPROTOOPT;

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -386,62 +386,6 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
 
     return ( Socket_t ) SOCKETS_INVALID_SOCKET;
 }
-/*-----------------------------------------------------------*/
-
-int32_t SOCKETS_Bind( Socket_t xSocket,
-                      SocketsSockaddr_t *pxAddress,
-                      Socklen_t xAddressLength )
-{
-    ss_ctx_t * ctx;
-    int32_t ret;
-    struct sockaddr_in sa_addr = { 0 };
-
-    if( SOCKETS_INVALID_SOCKET == xSocket )
-    {
-        configPRINTF( ( "TCP socket Invalid\n" ) );
-        return SOCKETS_EINVAL;
-    }
-
-    if( pxAddress == NULL )
-    {
-        return SOCKETS_EINVAL;
-    }
-
-    ctx = ( ss_ctx_t * ) xSocket;
-
-    if( 0 > ctx->ip_socket )
-    {
-        configPRINTF( ( "TCP socket Invalid index\n" ) );
-        return SOCKETS_EINVAL;
-    }
-
-    /*
-     * Setting SO_REUSEADDR socket option in order to be able to bind to the same ip:port again
-     * without netconn_bind failing.
-     */
-#if SO_REUSE
-    ret = lwip_setsockopt( ctx->ip_socket, SOL_SOCKET, SO_REUSEADDR, &(uint32_t){1}, sizeof(uint32_t));
-
-    if( 0 > ret )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
-#endif /* SO_REUSE */
-
-    sa_addr.sin_family = pxAddress->ucSocketDomain ? pxAddress->ucSocketDomain : AF_INET;
-    sa_addr.sin_addr.s_addr = pxAddress->ulAddress;
-    sa_addr.sin_port = pxAddress->usPort;
-
-    ret = lwip_bind(ctx->ip_socket, ( struct sockaddr * ) &sa_addr, sizeof( sa_addr ));
-    if( 0 > ret )
-    {
-        configPRINTF(( "lwip_bind fail :%d\n",ret ) );
-        return SOCKETS_SOCKET_ERROR;
-    }
-
-    return SOCKETS_ERROR_NONE;
-
-}
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Secure Socket changes  to enable TCP keep-alive

Description
-----------
 Added TCP Keep-alive option to enable and configure values via SOCKETS_SetSockOpt for LWIP and these options are not supported for FreeRTOS Plus TCP.

Checklist:
----------
- [ x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.