### PR TITLE
Improve demo comment related to IotSdk_Init

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -204,7 +204,8 @@ static int _initialize( demoContext_t * pContext )
     bool commonLibrariesInitialized = false;
     bool semaphoreCreated = false;
 
-    /* Initialize common libraries required by network manager and demo. */
+    /* Initialize the C-SDK common libraries. This function must be called
+     * once (and only once) before calling any other C-SDK function. */
     if( IotSdk_Init() == true )
     {
         commonLibrariesInitialized = true;


### PR DESCRIPTION
Improve demo comment related to IotSdk_Init

Description
-----------
Improve comment in iot_demo_freertos.c to clearly state the requirement of
calling the IotSdk_Init function before any other C-SDK related functions.

This is PR is to address to issue #2369 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.