### PR TITLE
Test: Do not Wifi Scan before each testcase

### DIFF
--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -596,42 +596,11 @@ static void prvFinishWiFiTesting( void )
     }
 }
 
-static void prvSetupWiFiTests( void )
-{
-    int32_t lI = 0;
-    int8_t cScanSize = 10;
-    WIFIReturnCode_t xWiFiStatus;
-    WIFIScanResult_t xScanResults[ 10 ] = { 0 };
-
-    /* Disconnect first before running any Wi-Fi test. */
-    xWiFiStatus = WIFI_Disconnect();
-    TEST_ASSERT_EQUAL_INT( eWiFiSuccess, xWiFiStatus );
-
-    xWiFiStatus = WIFI_Scan( xScanResults, cScanSize );
-
-    TEST_ASSERT_EQUAL_INT( eWiFiSuccess, xWiFiStatus );
-
-    configPRINTF(
-        ( "WiFi Networks and strength: \r\n" ) );
-
-    for( lI = 0; lI < cScanSize; lI++ )
-    {
-        configPRINTF( ( "    %s: %d\r\n",
-                        xScanResults[ lI ].cSSID, xScanResults[ lI ].cRSSI ) );
-    }
-
-    configPRINTF(
-        ( "End of WiFi Networks\r\n" ) );
-
-    vTaskDelay( testwifiCONNECTION_DELAY );
-}
-
 /* Unity TEST initializations. */
 TEST_GROUP( Full_WiFi );
 
 TEST_SETUP( Full_WiFi )
 {
-    /* prvSetupWiFiTests(); */
 }
 
 TEST_TEAR_DOWN( Full_WiFi )
@@ -686,7 +655,6 @@ TEST_GROUP( Quarantine_WiFi );
 
 TEST_SETUP( Quarantine_WiFi )
 {
-    prvSetupWiFiTests();
 }
 
 TEST_TEAR_DOWN( Quarantine_WiFi )

--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -631,7 +631,7 @@ TEST_GROUP( Full_WiFi );
 
 TEST_SETUP( Full_WiFi )
 {
-    prvSetupWiFiTests();
+    /* prvSetupWiFiTests(); */
 }
 
 TEST_TEAR_DOWN( Full_WiFi )
@@ -640,6 +640,7 @@ TEST_TEAR_DOWN( Full_WiFi )
 
 TEST_GROUP_RUNNER( Full_WiFi )
 {
+    RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_Scan );
     /* Null parameter tests. */
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_GetMode_NullParameters );
     RUN_TEST_CASE( Full_WiFi, AFQP_WIFI_GetIP_NullParameters );
@@ -818,6 +819,39 @@ TEST( Quarantine_WiFi, AFQP_WiFiMode )
     {
         TEST_FAIL();
     }
+}
+
+/**
+ * @brief Call WIFI_GetMode() with Null parameterrs and verify failure.
+ */
+TEST( Full_WiFi, AFQP_WIFI_Scan )
+{
+    int32_t lI = 0;
+    int8_t cScanSize = 10;
+    WIFIReturnCode_t xWiFiStatus;
+    WIFIScanResult_t xScanResults[ 10 ] = { 0 };
+
+    /* Disconnect first before running any Wi-Fi test. */
+    xWiFiStatus = WIFI_Disconnect();
+    TEST_ASSERT_EQUAL_INT( eWiFiSuccess, xWiFiStatus );
+
+    xWiFiStatus = WIFI_Scan( xScanResults, cScanSize );
+
+    TEST_ASSERT_EQUAL_INT( eWiFiSuccess, xWiFiStatus );
+
+    configPRINTF(
+        ( "WiFi Networks and strength: \r\n" ) );
+
+    for( lI = 0; lI < cScanSize; lI++ )
+    {
+        configPRINTF( ( "    %s: %d\r\n",
+                        xScanResults[ lI ].cSSID, xScanResults[ lI ].cRSSI ) );
+    }
+
+    configPRINTF(
+        ( "End of WiFi Networks\r\n" ) );
+
+    vTaskDelay( testwifiCONNECTION_DELAY );
 }
 
 /**


### PR DESCRIPTION
Test: Do not Wifi Scan before each testcase

Description
-----------
Remove the testSetup, which was calling Wifi_Scan and disconnect before each testcasse 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.