### PR TITLE
Sync with the OPTIGA Trust X PR 42

### DIFF
--- a/vendors/infineon/secure_elements/optiga_trust_x/optiga/cmd/CommandLib.c
+++ b/vendors/infineon/secure_elements/optiga_trust_x/optiga/cmd/CommandLib.c
@@ -1755,9 +1755,17 @@ int32_t CmdLib_CalcHash(sCalcHash_d* PpsCalcHash)
             }
 
             PpsCalcHash->sOutHash.wRespLength = Utility_GetUint16(sApduData.prgbRespBuffer + LEN_APDUHEADER + BYTES_SEQ);
+            
+            //Length check for wRespLength
+            if((PpsCalcHash->sOutHash.wRespLength) != SHA256_HASH_LEN)
+            {
+                i4Status = (int32_t)CMD_LIB_INSUFFICIENT_MEMORY;
+                break;
+            }
+            
             OCP_MEMCPY(PpsCalcHash->sOutHash.prgbBuffer, (sApduData.prgbRespBuffer + CALC_HASH_FIXED_OVERHEAD_SIZE), PpsCalcHash->sOutHash.wRespLength);
         }
-
+	    
         //Validate the Context buffer size if the 0x06 context data tag is there in response and 
         //copy the context data to pbContextData buffer
         if((TAG_CONTEXT_OUTPUT == (*(sApduData.prgbRespBuffer + LEN_APDUHEADER))) && (sApduData.wResponseLength != 0))
@@ -1770,6 +1778,14 @@ int32_t CmdLib_CalcHash(sCalcHash_d* PpsCalcHash)
             }
 
             PpsCalcHash->sContextInfo.dwContextLen = Utility_GetUint16(sApduData.prgbRespBuffer + LEN_APDUHEADER + BYTES_SEQ);
+            
+            //Length check for Context Length
+            if((PpsCalcHash->sContextInfo.dwContextLen) != CALC_HASH_SHA256_CONTEXT_SIZE)
+            {
+                i4Status = (int32_t)CMD_LIB_INSUFFICIENT_MEMORY;
+                break;
+            }
+            
             OCP_MEMCPY(PpsCalcHash->sContextInfo.pbContextData, (sApduData.prgbRespBuffer + CALC_HASH_FIXED_OVERHEAD_SIZE), PpsCalcHash->sContextInfo.dwContextLen);
         }
         


### PR DESCRIPTION
https://github.com/Infineon/optiga-trust-x/pull/42

Sync with the OPTIGA Trust X repo.

These important security relevant changes are recommended for all new designes
-----------
With this PR Incoming hash and hash context are now protected from beining manipulated on the i2c line without being recognised.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [+ ] I have tested my changes. No regression in existing tests.
- [ +] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.