### PR TITLE
Add a delay before logging demo finished messages

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -361,6 +361,11 @@ void runDemoTask( void * pArgument )
             IotLogInfo( "memory_metrics::demo_task_stack::after::bytes::%u", xAfterDemoTaskWaterMark );
         #endif /* democonfigMEMORY_ANALYSIS */
 
+        /* Give a chance to drain the logging queue to increase the probability
+         * of the following messages used by the test framework not getting
+         * dropped. */
+        vTaskDelay( pdMS_TO_TICKS( 1000 ) );
+
         /* Log the demo status. */
         if( status == EXIT_SUCCESS )
         {


### PR DESCRIPTION
Description
-----------

This delay give the logging task a chance to drain the logging queue. This increases the probability of demo status and demo finished messages used by the test framework not getting dropped.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.