### PR TITLE
Utility macros to improve readability/static analysis.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
@@ -45,6 +45,20 @@ extern "C" {
 
 #include "event_groups.h"
 
+/*-----------------------------------------------------------*/
+/* Utility macros for marking casts as recognized during     */
+/* static analysis.                                          */
+/*-----------------------------------------------------------*/
+#define ipCAST_PTR_TO_TYPE_PTR( TYPE, pointer ) ( vCastPointerTo_##TYPE( ( void * )( pointer ) ) )
+#define ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( TYPE, pointer ) ( vCastConstPointerTo_##TYPE( ( const void * )( pointer ) ) )
+
+/*-----------------------------------------------------------*/
+/* Utility macros for declaring cast utility functions in    */
+/* order to centralize typecasting for static analysis.      */
+/*-----------------------------------------------------------*/
+#define ipDECL_CAST_PTR_FUNC_FOR_TYPE( TYPE ) TYPE * vCastPointerTo_##TYPE( void * pvArgument )
+#define ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TYPE ) const TYPE * vCastConstPointerTo_##TYPE( const void * pvArgument )
+
 typedef struct xNetworkAddressingParameters
 {
 	uint32_t ulDefaultIPAddress;
@@ -188,6 +202,17 @@ struct xUDP_PACKET
 }
 #include "pack_struct_end.h"
 typedef struct xUDP_PACKET UDPPacket_t;
+
+static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    return ( UDPPacket_t *)pvArgument;
+}
+static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    return ( const UDPPacket_t *) pvArgument;
+}
 
 #include "pack_struct_start.h"
 struct xTCP_PACKET

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h
@@ -205,6 +205,12 @@ struct xSOCKET;
 typedef struct xSOCKET *Socket_t;
 typedef struct xSOCKET const * ConstSocket_t;
 
+static portINLINE int prvSocketValid( Socket_t xSocket )
+{
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    return ( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) );
+}
+
 #if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 	/* The SocketSet_t type is the equivalent to the fd_set type used by the
 	Berkeley API. */

--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -250,6 +250,17 @@ struct xDNSMessage
 #include "pack_struct_end.h"
 typedef struct xDNSMessage DNSMessage_t;
 
+	static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( DNSMessage_t )
+	{
+		/* coverity[misra_c_2012_rule_11_3_violation] */
+		return ( DNSMessage_t *)pvArgument;
+	}
+	static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( DNSMessage_t )
+	{
+		/* coverity[misra_c_2012_rule_11_3_violation] */
+		return ( const DNSMessage_t *) pvArgument;
+	}
+
 /* A DNS query consists of a header, as described in 'struct xDNSMessage'
 It is followed by 1 or more queries, each one consisting of a name and a tail,
 with two fields: type and class
@@ -263,6 +274,12 @@ struct xDNSTail
 #include "pack_struct_end.h"
 typedef struct xDNSTail DNSTail_t;
 
+	static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( DNSTail_t )
+	{
+		/* coverity[misra_c_2012_rule_11_3_violation] */
+		return ( DNSTail_t * ) pvArgument;
+	}
+
 /* DNS answer record header. */
 #include "pack_struct_start.h"
 struct xDNSAnswerRecord
@@ -274,6 +291,12 @@ struct xDNSAnswerRecord
 }
 #include "pack_struct_end.h"
 typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
+
+	static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( DNSAnswerRecord_t )
+	{
+		/* coverity[misra_c_2012_rule_11_3_violation] */
+		return ( DNSAnswerRecord_t * ) pvArgument;
+	}
 
 #if( ipconfigUSE_LLMNR == 1 )
 
@@ -377,7 +400,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	void vDNSCheckCallBack( void *pvSearchID )
 	{
 	const ListItem_t * pxIterator;
-	const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
+	const ListItem_t * xEnd = listGET_END_MARKER( &xCallbackList );
 
 		vTaskSuspendAll();
 		{
@@ -467,7 +490,7 @@ typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 	{
 	BaseType_t xResult = pdFALSE;
 	const ListItem_t * pxIterator;
-	const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
+	const ListItem_t * xEnd = listGET_END_MARKER( &xCallbackList );
 
 		vTaskSuspendAll();
 		{
@@ -549,8 +572,8 @@ TickType_t uxIdentifier = 0U;
 			else
 			{
 				FreeRTOS_printf( ( "prvPrepareLookup: name is too long ( %lu > %lu )\n",
-								   ( unsigned long ) xLength,
-								   ( unsigned long ) ipconfigDNS_CACHE_NAME_LENGTH ) );
+								   ( uint32_t ) xLength,
+								   ( uint32_t ) ipconfigDNS_CACHE_NAME_LENGTH ) );
 			}
 		}
 	}
@@ -709,7 +732,7 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 				if( bHasDot == pdFALSE )
 				{
 					/* Use LLMNR addressing. */
-					( ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer ) )->usFlags = 0;
+					( ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pucUDPPayloadBuffer ) )->usFlags = 0;
 					xAddress.sin_addr = ipLLMNR_IP_ADDR; /* Is in network byte order. */
 					xAddress.sin_port = ipLLMNR_PORT;
 					xAddress.sin_port = FreeRTOS_ntohs( xAddress.sin_port );
@@ -732,7 +755,7 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 					if( lBytes > 0 )
 					{
 					BaseType_t xExpected;
-					const DNSMessage_t *pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucReceiveBuffer );
+					const DNSMessage_t *pxDNSMessageHeader = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( DNSMessage_t, pucReceiveBuffer );
 
 						/* See if the identifiers match. */
 						if( uxIdentifier == ( TickType_t ) pxDNSMessageHeader->usIdentifier )
@@ -815,7 +838,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 	/* Write in a unique identifier. Cast the Payload Buffer to DNSMessage_t
 	 * to easily access fields of the DNS Message. */
-	pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+	pxDNSMessageHeader = ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pucUDPPayloadBuffer );
 	pxDNSMessageHeader->usIdentifier = ( uint16_t ) uxIdentifier;
 
 	/* Create the resource record at the end of the header.  First
@@ -856,7 +879,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 	/* Finish off the record. Cast the record onto DNSTail_t stucture to easily
 	 * access the fields of the DNS Message. */
-	pxTail = ipPOINTER_CAST(DNSTail_t *, &( pucByte[ 1 ] ) );
+	pxTail = ipCAST_PTR_TO_TYPE_PTR( DNSTail_t, &( pucByte[ 1 ] ) );
 
 	#if defined( _lint ) || defined( __COVERITY__ )
 	( void ) pxTail;
@@ -1051,7 +1074,7 @@ size_t uxPayloadSize;
 		if( uxPayloadSize >= sizeof( DNSMessage_t ) )
 		{
 			pxDNSMessageHeader =
-				ipPOINTER_CAST( DNSMessage_t *, &( pxNetworkBuffer->pucEthernetBuffer [ sizeof( UDPPacket_t ) ] ) );
+				ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pxNetworkBuffer->pucEthernetBuffer );
 
 			/* The parameter pdFALSE indicates that the reply was not expected. */
 			( void ) prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
@@ -1069,7 +1092,7 @@ size_t uxPayloadSize;
 
 	uint32_t ulNBNSHandlePacket( NetworkBufferDescriptor_t * pxNetworkBuffer )
 	{
-	UDPPacket_t *pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+	UDPPacket_t *pxUDPPacket = ipCAST_PTR_TO_TYPE_PTR( UDPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
 	uint8_t *pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( *pxUDPPacket ) ] );
 
 		prvTreatNBNS( pucUDPPayloadBuffer,
@@ -1119,7 +1142,7 @@ BaseType_t xReturn = pdTRUE;
 
 		/* Parse the DNS message header. Map the byte stream onto a structure 
 		 * for easier access. */
-		pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+		pxDNSMessageHeader = ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pucUDPPayloadBuffer );
 
 		/* Introduce a do {} while (0) to allow the use of breaks. */
 		do
@@ -1266,7 +1289,7 @@ BaseType_t xReturn = pdTRUE;
 						/* This is the required record type and is of sufficient size. */
 						/* Mapping pucByte to a DNSAnswerRecord allows easy access of the
 						 * fields of the structure. */
-						pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
+						pxDNSAnswerRecord = ipCAST_PTR_TO_TYPE_PTR( DNSAnswerRecord_t, pucByte );
 
 						/* Sanity check the data length of an IPv4 answer. */
 						if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == ( uint16_t ) sizeof( uint32_t ) )
@@ -1319,7 +1342,7 @@ BaseType_t xReturn = pdTRUE;
 						/* It's not an A record, so skip it. Get the header location
 						and then jump over the header. */
 						/* Cast the response to DNSAnswerRecord for easy access to fields of the DNS response. */
-						pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
+						pxDNSAnswerRecord = ipCAST_PTR_TO_TYPE_PTR( DNSAnswerRecord_t, pucByte );
 
 						pucByte = &( pucByte[ sizeof( DNSAnswerRecord_t ) ] );
 						uxSourceBytesRemaining -= sizeof( DNSAnswerRecord_t );
@@ -1380,7 +1403,7 @@ BaseType_t xReturn = pdTRUE;
 
 							pucByte = &( pucNewBuffer[ xOffset1 ] );
 							pcRequestedName = ( char * ) &( pucNewBuffer[ xOffset2 ] );
-							pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucNewBuffer );
+							pxDNSMessageHeader = ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pucNewBuffer );
 						}
 						else
 						{
@@ -1568,7 +1591,7 @@ BaseType_t xReturn = pdTRUE;
 				/* Should not occur: pucUDPPayloadBuffer is part of a xNetworkBufferDescriptor */
 				if( pxNetworkBuffer != NULL )
 				{
-					pxMessage = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+					pxMessage = ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pucUDPPayloadBuffer );
 
 					/* As the fields in the structures are not word-aligned, we have to
 					copy the values byte-by-byte using macro's vSetField16() and vSetField32() */
@@ -1615,7 +1638,7 @@ BaseType_t xReturn;
 	/* This must be the first time this function has been called.  Create
 	the socket. */
 	xSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
-	if( ( xSocket == FREERTOS_INVALID_SOCKET ) || ( xSocket == NULL ) )
+	if( prvSocketValid( xSocket ) != pdTRUE )
 	{
 		/* There was an error, return NULL. */
 		xSocket = NULL;
@@ -1652,7 +1675,7 @@ BaseType_t xReturn;
 	UDPHeader_t *pxUDPHeader;
 	size_t uxDataLength;
 
-		pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+		pxUDPPacket = ipCAST_PTR_TO_TYPE_PTR( UDPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
 		pxIPHeader = &pxUDPPacket->xIPHeader;
 		pxUDPHeader = &pxUDPPacket->xUDPHeader;
 		/* HT: started using defines like 'ipSIZE_OF_xxx' */
@@ -1700,7 +1723,7 @@ BaseType_t xReturn;
 	{
 	BaseType_t x;
 	BaseType_t xFound = pdFALSE;
-	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000U;
+	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000UL;
 	uint32_t ulIPAddressIndex = 0;
 	static BaseType_t xFreeEntry = 0;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Casts from general types (e.g. `uint8_t *`, `void *`) to specific types are common in network stack code, however such casts violate MISRA Rule 11.3.  This PR introduces utility macros to isolate these casts to one particular place in the code, and make it very clear when such casting is being applied.  These changes also include a few other improvements designed to improve readability of both code and static analysis results.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.