### PR TITLE
Remove CMake instructions for building CBMC proofs

### DIFF
--- a/tools/cbmc/README.md
+++ b/tools/cbmc/README.md
@@ -16,49 +16,6 @@ how to run the proofs on your local clone of a:FR.
 Bulding and running proofs
 --------------------------
 
-For historical reasons, some of the proofs are built and run using CMake
-and CTest. Others use a custom python-based build system. New proofs
-should use CMake. This README describes how to build and run both kinds
-of proof.
-
-
-CMake-based build
------------------
-
-Follow the CBMC installation instructions below.
-
-Suppose that the amazon-freertos source tree is located at
-`~/src/amazon-freertos` and you wish to build the proofs into
-`~/build/amazon-freertos`. The following three commands build and run
-the proofs:
-
-```sh
-cmake -S~/src/amazon-freertos -B~/build/amazon-freertos -DCOMPILER=cbmc
--DBOARD=windows -DVENDOR=pc
-cmake --build ~/build/amazon-freertos --target all-proofs
-cd ~/build/amazon-freertos && ctest -L cbmc
-```
-
-Alternatively, this single command does the same thing, assuming you
-have the Ninja build tool installed:
-
-```sh
-ctest --build-and-test                \
-    ~/src/amazon-freertos             \
-    ~/build/amazon-freertos           \
-    --build-target cbmc               \
-    --build-generator Ninja           \
-    --build-options                   \
-      -DCOMPILER=cbmc                 \
-      -DBOARD=windows                 \
-      -DVENDOR=pc                     \
-    --test-command ctest -j4 -L cbmc --output-on-failure
-```
-
-
-
-Python-based build
-------------------
 
 ### Prerequisites
 


### PR DESCRIPTION
These instructions are outdated and only ever worked for a single proof.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.