### PR TITLE
Fix WIFI_StartAP in esp32 port

### DIFF
--- a/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
@@ -1228,6 +1228,9 @@ WIFIReturnCode_t WIFI_StartAP( void )
         // Wait for wifi started event
         xEventGroupWaitBits(wifi_event_group, AP_STARTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
         wifi_ret = eWiFiSuccess;
+
+        /* Return the semaphore. */
+        xSemaphoreGive( xWiFiSem );
     }
     return wifi_ret;
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Semaphore is not released in esp32 WIFI_StartAP. Address issue #2415.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.