### PR TITLE
Update IotNetworkAfr_Send to call Sockets_Send while there are bytes remaining

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -476,7 +476,7 @@ size_t IotNetworkAfr_Send( void * pConnection,
                            const uint8_t * pMessage,
                            size_t messageLength )
 {
-    size_t bytesSent = 0;
+    size_t bytesSent = 0U, bytesRemaining = messageLength;
     int32_t socketStatus = SOCKETS_ERROR_NONE;
 
     /* Cast network connection to the correct type. */
@@ -487,18 +487,25 @@ size_t IotNetworkAfr_Send( void * pConnection,
     if( xSemaphoreTake( ( QueueHandle_t ) &( pNetworkConnection->socketMutex ),
                         portMAX_DELAY ) == pdTRUE )
     {
-        socketStatus = SOCKETS_Send( pNetworkConnection->socket,
-                                     pMessage,
-                                     messageLength,
-                                     0 );
+        while( bytesRemaining > 0U )
+        {
+            socketStatus = SOCKETS_Send( pNetworkConnection->socket,
+                                         pMessage,
+                                         messageLength,
+                                         0 );
 
-        if( socketStatus > 0 )
-        {
-            bytesSent = ( size_t ) socketStatus;
-        }
-        else
-        {
-            IotLogError( "Error %ld while sending data.", ( long int ) socketStatus );
+            if( socketStatus > 0 )
+            {
+                bytesSent += ( size_t ) socketStatus;
+                pMessage += ( size_t ) socketStatus;
+                bytesRemaining -= ( size_t ) socketStatus;
+                configASSERT( bytesSent + bytesRemaining == messageLength );
+            }
+            else
+            {
+                IotLogError( "Error %ld while sending data.", ( long int ) socketStatus );
+                break;
+            }
         }
 
         xSemaphoreGive( ( QueueHandle_t ) &( pNetworkConnection->socketMutex ) );


### PR DESCRIPTION
<!--- Title -->
Update IotNetworkAfr_Send to call Sockets_Send while there are remaining bytes

Description
-----------
<!--- Describe your changes in detail -->
This fixes issue #2336. Depending on the size of the write buffer, `Sockets_Send` may return a number of bytes that is less than the message length. In which case, we must continually call `Sockets_Send` until all bytes remaining are sent.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.