### PR TITLE
Remove portYIELD_FROM_ISR Calls in common-io Tests

### DIFF
--- a/libraries/abstractions/common_io/include/iot_adc.h
+++ b/libraries/abstractions/common_io/include/iot_adc.h
@@ -122,7 +122,6 @@ int32_t iot_adc_close( IotAdcHandle_t const pxAdc );
  * {
  *     BaseType_t xHigherPriorityTaskWoken;
  *     xSemaphoreGiveFromISR( xIotAdcSemaphore, &xHigherPriorityTaskWoken );
- *     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
  * }
  * @endcode
  */

--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -122,7 +122,7 @@ static void prvAdcChCallback( uint16_t * pusConvertedData,
     }
 
     xSemaphoreGiveFromISR( xtestIotAdcTestSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_adc.c
+++ b/libraries/abstractions/common_io/test/test_iot_adc.c
@@ -122,7 +122,6 @@ static void prvAdcChCallback( uint16_t * pusConvertedData,
     }
 
     xSemaphoreGiveFromISR( xtestIotAdcTestSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -102,7 +102,7 @@ static void prvIotFlashEraseCallback( IotFlashOperationStatus_t pxStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotFlashSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/
@@ -124,7 +124,7 @@ static void prvIotTimerCallback( void * pvUserContext )
     }
 
     xSemaphoreGiveFromISR( xtestIotFlashTimerSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_flash.c
+++ b/libraries/abstractions/common_io/test/test_iot_flash.c
@@ -102,7 +102,6 @@ static void prvIotFlashEraseCallback( IotFlashOperationStatus_t pxStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotFlashSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /*-----------------------------------------------------------*/
@@ -124,7 +123,6 @@ static void prvIotTimerCallback( void * pvUserContext )
     }
 
     xSemaphoreGiveFromISR( xtestIotFlashTimerSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -581,7 +581,6 @@ static void prvGpioInterruptCallback( uint8_t ucPinState,
     }
 
     xSemaphoreGiveFromISR( xtestIotGpioSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 
@@ -725,7 +724,6 @@ static void prvGpioCallback( uint8_t ucPinState,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotGpioSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_gpio.c
+++ b/libraries/abstractions/common_io/test/test_iot_gpio.c
@@ -581,7 +581,7 @@ static void prvGpioInterruptCallback( uint8_t ucPinState,
     }
 
     xSemaphoreGiveFromISR( xtestIotGpioSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 
@@ -725,7 +725,7 @@ static void prvGpioCallback( uint8_t ucPinState,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotGpioSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_i2s.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2s.c
@@ -98,7 +98,6 @@ void prvI2SWriteCallback( IotI2SOperationStatus_t xOpStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotI2SWriteSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /**
@@ -110,7 +109,6 @@ void prvI2SReadCallback( IotI2SOperationStatus_t xOpStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotI2SReadSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 

--- a/libraries/abstractions/common_io/test/test_iot_i2s.c
+++ b/libraries/abstractions/common_io/test/test_iot_i2s.c
@@ -98,7 +98,7 @@ void prvI2SWriteCallback( IotI2SOperationStatus_t xOpStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotI2SWriteSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /**
@@ -110,7 +110,7 @@ void prvI2SReadCallback( IotI2SOperationStatus_t xOpStatus,
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotI2SReadSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 

--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -86,7 +86,6 @@ static void prvTimerCallback( void * pvUserContext )
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotTimerSemaphore, &xHigherPriorityTaskWoken );
-    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -86,7 +86,7 @@ static void prvTimerCallback( void * pvUserContext )
     BaseType_t xHigherPriorityTaskWoken;
 
     xSemaphoreGiveFromISR( xtestIotTimerSemaphore, &xHigherPriorityTaskWoken );
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_watchdog.c
+++ b/libraries/abstractions/common_io/test/test_iot_watchdog.c
@@ -143,8 +143,6 @@ static void prvWdogCallback( void * pvUserContext )
 
         xSemaphoreGiveFromISR( xtestIotWatchdogBiteSemaphore, &xHigherPriorityTaskWoken );
     }
-
-    
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/common_io/test/test_iot_watchdog.c
+++ b/libraries/abstractions/common_io/test/test_iot_watchdog.c
@@ -144,7 +144,7 @@ static void prvWdogCallback( void * pvUserContext )
         xSemaphoreGiveFromISR( xtestIotWatchdogBiteSemaphore, &xHigherPriorityTaskWoken );
     }
 
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Remove portYIELD_FROM_ISR calls in common-io tests.

Description
-----------
This change removes calls to portYIELD_FROM_ISR as the function prototype is not consistent between kernel ports. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.