### PR TITLE
Fix Remove all bonds test in BLE HAL

### DIFF
--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -1011,7 +1011,7 @@ void IotTestBleHal_SetGetProperty( BTProperty_t * pxProperty,
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xSetGetPropertyCb.xStatus );
     TEST_ASSERT_EQUAL( 1, xSetGetPropertyCb.ulNumProperties );
     TEST_ASSERT_EQUAL( xSetGetPropertyCb.xProperties.xType, pxProperty->xType );
-    TEST_ASSERT_LESS_THAN( bletestsMAX_PROPERTY_SIZE, pxProperty->xLen );
+    TEST_ASSERT_LESS_THAN( bletestsMAX_PROPERTY_SIZE, xSetGetPropertyCb.xProperties.xLen );
 
     if( bIsSet == true )
     {

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -1011,6 +1011,7 @@ void IotTestBleHal_SetGetProperty( BTProperty_t * pxProperty,
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xSetGetPropertyCb.xStatus );
     TEST_ASSERT_EQUAL( 1, xSetGetPropertyCb.ulNumProperties );
     TEST_ASSERT_EQUAL( xSetGetPropertyCb.xProperties.xType, pxProperty->xType );
+    TEST_ASSERT_LESS_THAN( bletestsMAX_PROPERTY_SIZE, pxProperty->xLen );
 
     if( bIsSet == true )
     {
@@ -1512,11 +1513,11 @@ void prvAdapterPropertiesCb( BTStatus_t xStatus,
 
                 if( pxProperties->pvVal != NULL )
                 {
-                    memcpy( pxSetGetPropertyCb->xProperties.pvVal, pxProperties->pvVal, sizeof( BTBdaddr_t ) );
+                    memcpy( pxSetGetPropertyCb->xProperties.pvVal, pxProperties->pvVal, pxProperties->xLen );
                 }
                 else
                 {
-                    memset( pxSetGetPropertyCb->xProperties.pvVal, 0, sizeof( BTBdaddr_t ) );
+                    memset( pxSetGetPropertyCb->xProperties.pvVal, 0, pxProperties->xLen );
                 }
 
                 break;


### PR DESCRIPTION
Fix Remove all bonds test in BLE HAL qualification test

Description
-----------
Remove all bonds test was only copying  one bond (the first element of array), which causes it to fail if there are more than one bonds.

Fixed to copy the full array of bonds.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.