### PR TITLE
Use semaphore in common-io UART loopback test

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_uart.c
+++ b/libraries/abstractions/common_io/test/test_iot_uart.c
@@ -387,6 +387,7 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
     uint8_t cpBuffer[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
     uint8_t cpBufferRead[ testIotUART_BUFFER_LENGTH + 1 ] = { 0 };
     uint8_t uStringCompare = 1;
+    BaseType_t xCallbackReturn;
 
     memcpy( cpBuffer, testIotUART_BUFFER_STRING, testIotUART_BUFFER_LENGTH );
 
@@ -395,18 +396,23 @@ TEST( TEST_IOT_UART, AFQP_IotUARTWriteAsyncReadAsyncLoopbackTest )
 
     if( TEST_PROTECT() )
     {
+        iot_uart_set_callback( xUartHandle, prvReadWriteCallback, NULL );
+
         lRead = iot_uart_read_async( xUartHandle, cpBufferRead, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lRead );
 
         lWrite = iot_uart_write_async( xUartHandle, cpBuffer, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lWrite );
 
+        xCallbackReturn = xSemaphoreTake( xWriteCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
+
+        xCallbackReturn = xSemaphoreTake( xReadCompleteSemaphore, testIotUART_DEFAULT_SEMPAHORE_DELAY );
+        TEST_ASSERT_EQUAL( pdTRUE, xCallbackReturn );
+
         lIoctl = iot_uart_ioctl( xUartHandle, eGetTxNoOfbytes, &lTransferAmount );
         TEST_ASSERT_EQUAL( IOT_UART_SUCCESS, lIoctl );
         TEST_ASSERT_GREATER_THAN( 0, lTransferAmount );
-
-        /* Delay for 1 sec. */
-        vTaskDelay( testIotUART_DELAY );
 
         uStringCompare = memcmp( cpBuffer, cpBufferRead, testIotUART_BUFFER_LENGTH );
         TEST_ASSERT_EQUAL( 0, uStringCompare );


### PR DESCRIPTION
Use semaphore in loopback test.

Description
-----------
The call to vTaskDelay is after the call to the ioctl. Instead it should be before, to allow the UART to transmit it's message. Instead we will use semaphores to release the test task once the write and read interrupts have fired.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.