### PR TITLE
Tests: SecureSockets: Enable SNI when connecting to IoT Core 

### DIFF
--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -409,7 +409,7 @@ static MultithreadTaskParams_t xGlobalTaskParams[ pkcs11testMULTI_THREAD_TASK_CO
 /*-----------------------------------------------------------*/
 /* Stack size of each task. This can be configured in iot_test_pkcs11_config.h. */
 #ifndef pkcs11testMULTI_TASK_STACK_SIZE
-    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 6 )
+    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
 #endif
 
 /* Priority of each task. This can be configured in iot_test_pkcs11_config.h. */

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -409,7 +409,7 @@ static MultithreadTaskParams_t xGlobalTaskParams[ pkcs11testMULTI_THREAD_TASK_CO
 /*-----------------------------------------------------------*/
 /* Stack size of each task. This can be configured in iot_test_pkcs11_config.h. */
 #ifndef pkcs11testMULTI_TASK_STACK_SIZE
-    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+    #define pkcs11testMULTI_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 6 )
 #endif
 
 /* Priority of each task. This can be configured in iot_test_pkcs11_config.h. */

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -646,10 +646,10 @@ static BaseType_t prvAwsIotBrokerConnectHelper( Socket_t xSocket,
             /* Try to set SNI option. It does not matter if this passes or fails,
              * in relation to the tests. The purpose of this is to allow devices
              * that rely on SNI to authenticate, eg. AWS IoT Core's multi account
-             * registration to be pass mutual auth test cases.
+             * registration.
              */
             ( void ) SOCKETS_SetSockOpt( xSocket,
-                                         0,  /* Level - Unused. */
+                                         0, /* Level - Unused. */
                                          SOCKETS_SO_SERVER_NAME_INDICATION,
                                          clientcredentialMQTT_BROKER_ENDPOINT,
                                          sizeof( clientcredentialMQTT_BROKER_ENDPOINT ) );
@@ -2502,16 +2502,16 @@ static void prvServerDomainName( void )
     xResult = prvSetSockOptHelper( xSocket, xReceiveTimeOut, xSendTimeOut );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Set sockopt Failed" );
 
+    /* Get the address struct for AWS Broker and SetSockOpt REQUIRE_TLS. */
+    xResult = prvAwsIotBrokerConnectHelper( xSocket, &xAwsBrokerAddress );
+    TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Failed setup AWS Broker address struct." );
+
     /* Give the client an INVALID subject name to check against. */
     xResult = SOCKETS_SetSockOpt( xSocket,
                                   0,
                                   SOCKETS_SO_SERVER_NAME_INDICATION,
                                   cFakeAddress,
                                   sizeof( cFakeAddress ) );
-
-    /* Get the address struct for AWS Broker and SetSockOpt REQUIRE_TLS. */
-    xResult = prvAwsIotBrokerConnectHelper( xSocket, &xAwsBrokerAddress );
-    TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Failed setup AWS Broker address struct." );
 
     xResult = SOCKETS_Connect( xSocket, &xAwsBrokerAddress, sizeof( SocketsSockaddr_t ) );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, xResult, "Connect worked when subject name check should have failed it." );

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -641,6 +641,19 @@ static BaseType_t prvAwsIotBrokerConnectHelper( Socket_t xSocket,
         {
             tcptestFAILUREPRINTF( ( "%s: Failed to setSockOpt SOCKETS_SO_REQUIRE_TLS \r\n", __FUNCTION__ ) );
         }
+        else
+        {
+            /* Try to set SNI option. It does not matter if this passes or fails,
+             * in relation to the tests. The purpose of this is to allow devices
+             * that rely on SNI to authenticate, eg. AWS IoT Core's multi account
+             * registration to be pass mutual auth test cases.
+             */
+            ( void ) SOCKETS_SetSockOpt( xSocket,
+                                         0,  /* Level - Unused. */
+                                         SOCKETS_SO_SERVER_NAME_INDICATION,
+                                         clientcredentialMQTT_BROKER_ENDPOINT,
+                                         sizeof( clientcredentialMQTT_BROKER_ENDPOINT ) );
+        }
     }
 
     return xResult;


### PR DESCRIPTION
Tests: SecureSockets: Enable SNI when connecting to IoT Core 

Description
-----------
When connecting to IoT Core, always try to use SNI to enable device's relying on Multi Account Registration.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.