### PR TITLE
Change metrics malloc to metrics specific macro

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_metrics.c
+++ b/libraries/abstractions/platform/freertos/iot_metrics.c
@@ -111,7 +111,7 @@
 /*-----------------------------------------------------------*/
 
     void IotMetrics_GetTcpConnections( void * pContext,
-                                       void ( *metricsCallback )( void *, const IotListDouble_t * ) )
+                                       void ( * metricsCallback )( void *, const IotListDouble_t * ) )
     {
         /* Provide the connection list. Ensure that it is not modified elsewhere by
          * locking the connection list mutex. */

--- a/libraries/abstractions/platform/freertos/iot_metrics.c
+++ b/libraries/abstractions/platform/freertos/iot_metrics.c
@@ -111,7 +111,7 @@
 /*-----------------------------------------------------------*/
 
     void IotMetrics_GetTcpConnections( void * pContext,
-                                       void ( * metricsCallback )( void *, const IotListDouble_t * ) )
+                                       void ( *metricsCallback )( void *, const IotListDouble_t * ) )
     {
         /* Provide the connection list. Ensure that it is not modified elsewhere by
          * locking the connection list mutex. */
@@ -137,7 +137,7 @@
                                           pSocketContext ) == NULL )
         {
             /* Allocate memory for a new metrics connection. */
-            pTcpConnection = pvPortMalloc( sizeof( IotMetricsTcpConnection_t ) );
+            pTcpConnection = IotMetrics_MallocTcpConnection( sizeof( IotMetricsTcpConnection_t ) );
 
             if( pTcpConnection != NULL )
             {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
`iot_metrics.c` uses `IotMetrics_FreeTcpConnection` to free malloc'ed TCP connections, but `pvPortMalloc` to allocate them. This changes `pvPortMalloc` to `IotMetrics_MallocTcpConnection` so both malloc and free use the metrics specific macros

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.