### PR TITLE
Rename underscored function for MSVC

### DIFF
--- a/libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c
+++ b/libraries/c_sdk/aws/defender/src/aws_iot_defender_collector.c
@@ -83,7 +83,7 @@ static void _assertSuccessOrBufferToSmall( IotSerializerError_t error );
 
 static void _copyMetricsFlag( void );
 
-static void _serialize( void );
+static void serializeReport( void );
 
 static void _serializeTcpConnections( void * param1,
                                       const IotListDouble_t * pTcpConnectionsMetricsList );
@@ -145,7 +145,7 @@ bool AwsIotDefenderInternal_CreateReport( void )
     _AwsIotDefenderReportId = IotClock_GetTimeMs();
 
     /* Dry-run serialization to calculate the required size. */
-    _serialize();
+    serializeReport();
 
     /* Get the calculated required size. */
     dataSize = _pAwsIotDefenderEncoder->getExtraBufferSizeNeeded( pEncoderObject );
@@ -162,7 +162,7 @@ bool AwsIotDefenderInternal_CreateReport( void )
         _report.size = dataSize;
 
         /* Actual serialization. */
-        _serialize();
+        serializeReport();
 
         /* Ouput the report to stdout if debugging mode is enabled. */
         #if DEBUG_CBOR_PRINT == 1
@@ -205,7 +205,7 @@ void AwsIotDefenderInternal_DeleteReport( void )
  *  }
  * }
  */
-static void _serialize( void )
+static void serializeReport( void )
 {
     IotSerializerError_t serializerError = IOT_SERIALIZER_SUCCESS;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
`aws_iot_defender_collector` defines a helper function named `_serialize`. Functions prefixed with underscores are reserved for the compiler, and compiling with MSVC on Visual Studio 2019, version 16.7.2, gives me the error `'_serialize': intrinsic function, cannot be defined`. This renames the function so the code can compile for the Windows simulator.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.