### PR TITLE
Add public key support in the PKCS11 PAL for ST

### DIFF
--- a/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
+++ b/libraries/abstractions/pkcs11/mbedtls/iot_pkcs11_mbedtls.c
@@ -2307,11 +2307,11 @@ static void prvGetLabel( CK_ATTRIBUTE ** ppxLabel,
 
         if( 0 == strncmp( pxLabel->pValue, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, pxLabel->ulValueLen ) )
         {
-            *pxPalHandle = PKCS11_PAL_FindObject( pxPubKeyLabel, pxLabel->ulValueLen );
+            *pxPalHandle = PKCS11_PAL_FindObject( pxPrivKeyLabel, pxLabel->ulValueLen );
         }
         else if( 0 == strncmp( pxLabel->pValue, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, pxLabel->ulValueLen ) )
         {
-            *pxPalHandle = PKCS11_PAL_FindObject( pxPrivKeyLabel, pxLabel->ulValueLen );
+            *pxPalHandle = PKCS11_PAL_FindObject( pxPubKeyLabel, pxLabel->ulValueLen );
             /* See explanation in prvCheckValidSessionAndModule for this exception. */
             /* coverity[misra_c_2012_rule_10_5_violation] */
             xIsPrivate = ( CK_BBOOL ) CK_FALSE;

--- a/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
+++ b/libraries/abstractions/pkcs11/test/iot_test_pkcs11.c
@@ -1821,8 +1821,6 @@ TEST( Full_PKCS11_EC, AFQP_GenerateKeyPair )
     CK_OBJECT_HANDLE xPrivateKeyHandle = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE xPublicKeyHandle = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE xCertificateHandle = CK_INVALID_HANDLE;
-    CK_OBJECT_HANDLE xFoundPrivateKeyHandle = CK_INVALID_HANDLE;
-    CK_OBJECT_HANDLE xFoundPublicKeyHandle = CK_INVALID_HANDLE;
 
     CK_BYTE xEcPoint[ 256 ] = { 0 };
     CK_BYTE xPrivateKeyBuffer[ 32 ] = { 0 };

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
@@ -81,7 +81,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configUSE_TIMERS                             1
 #define configTIMER_TASK_PRIORITY                    ( configMAX_PRIORITIES - 2 )
 #define configTIMER_QUEUE_LENGTH                     10
-#define configTIMER_TASK_STACK_DEPTH                 ( configMINIMAL_STACK_SIZE * 2 )
+#define configTIMER_TASK_STACK_DEPTH                 ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function. */

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -71,6 +71,11 @@
  */
 #define pkcs11testEC_KEY_SUPPORT                      ( 0 )
 
+/**
+ * @brief Size of the stack for each task in multi task test.
+ */
+#define pkcs11testMULTI_TASK_STACK_SIZE               ( 4096 )
+
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.
  */


### PR DESCRIPTION
Description
-----------

This is needed for PKCS11 EC tests to pass when TLS is done on the host itself as opposed to offloading to the WiFi module. In addition to these changes, the following config changes are also needed to run EC tests:
- Set `pkcs11testEC_KEY_SUPPORT` to 1 in iot_test_pkcs11_config.h.
- Set `pkcs11testGENERATE_KEYPAIR_SUPPORT` to 1 in iot_test_pkcs11_config.h.
- Set `pkcs11configSUPPRESS_ECDSA_MECHANISM` to 0 in iot_pkcs11_config.h.

This commit also fixes a bug in the iot_pkcs11_mbedtls.c where incorrect label (public key/private key) was used to find the corresponding object.

Testing
-----------

All the PKCS11 tests pass locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.