### PR TITLE
Update IotNetworkAfr_Send to fix chunk size while sending remaining bytes.

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -491,7 +491,7 @@ size_t IotNetworkAfr_Send( void * pConnection,
         {
             socketStatus = SOCKETS_Send( pNetworkConnection->socket,
                                          pMessage,
-                                         messageLength,
+                                         bytesRemaining,
                                          0 );
 
             if( socketStatus > 0 )


### PR DESCRIPTION
This fix according to commit 63856c1626f71fc1de2519839757d4ded25c7737. Chunk size of bytesRemaining must be sent in current iteration instead of full messageLength.