### PR TITLE
CY8CKIT_064S0S2_4343W: Correct PKCS#11 build

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
@@ -261,7 +261,7 @@ INCLUDES+=\
 
 ifneq ($(CY_TFM_PSA_SUPPORTED),)
 SOURCES+=\
-	$(wildcard $(CY_AFR_ROOT)/libraries/abstractions/pkcs11/mbedtls/*c)
+	$(wildcard $(CY_AFR_ROOT)/libraries/abstractions/pkcs11/mbedtls/*.c)
 
 endif
 

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -128,7 +128,7 @@ SOURCES+=\
 	$(CY_AFR_BOARD_PATH)/ports/pkcs11/hw_poll.c
 
 INCLUDES+=\
-	$(CY_AFR_ROOT)/libraries/abstractions/pkcs11/psa/*.c\
+	$(CY_AFR_ROOT)/libraries/abstractions/pkcs11/psa\
 	$(CY_EXTAPP_PATH)/psoc6/psoc64tfm/COMPONENT_TFM_NS_INTERFACE/include
 endif
 
@@ -262,7 +262,7 @@ INCLUDES+=\
 
 ifneq ($(CY_TFM_PSA_SUPPORTED),)
 SOURCES+=\
-	$(wildcard $(CY_AFR_ROOT)/libraries/abstractions/pkcs11/mbedtls/*c)
+	$(wildcard $(CY_AFR_ROOT)/libraries/abstractions/pkcs11/mbedtls/*.c)
 
 endif
 


### PR DESCRIPTION
CY8CKIT_064S0S2_4343W: Correct PKCS#11 build

Description
-----------
Errors in afr.mk that is causing MTB Windows builds to fail.

Signed-off-by: Raymond Ngun <raymond.ngun@cypress.com>
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.