### PR TITLE
Nimble: Disable RPA feature before BLE disable

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -626,7 +626,16 @@ BTStatus_t prvBTDisable()
     BTStatus_t xStatus = eBTStatusFail;
     int rc;
 
-    rc = nimble_port_stop();
+    rc = ble_hs_pvcy_rpa_config( 0 );
+    if( rc != 0 )
+    {
+        ESP_LOGE( TAG, "Failed to disable RPA config, reason = %d\n", rc );
+    }
+
+    if( rc == 0 )
+    {
+        rc = nimble_port_stop();
+    }
 
     if( rc == 0 )
     {


### PR DESCRIPTION
Nimble: Disable RPA feature before BLE disable

Description
-----------
Disable RPA feature as a stale timer from RPA causes NIMBLE port to crash 15 mins (RPA timeout) after BLE shutdown.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.