### PR TITLE
Decrease memory used in the HTTPS Client unit tests

### DIFF
--- a/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
+++ b/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
@@ -62,7 +62,7 @@
 /**
  * @brief Test address to share among the tests.
  */
-#define HTTPS_TEST_ADDRESS          "www.amazon.com "
+#define HTTPS_TEST_ADDRESS          "www.amazon.com"
 
 /**
  * @brief Test path to share among the tests.
@@ -109,7 +109,7 @@
 /**
  * @brief The size of the request user buffer to use among the tests.
  */
-#define HTTPS_TEST_REQ_USER_BUFFER_SIZE         ( sizeof( _httpsRequest_t ) + 128 )
+#define HTTPS_TEST_REQ_USER_BUFFER_SIZE         ( sizeof( _httpsRequest_t ) + 256 )
 
 /**
  * @brief The size of the response user buffer to use among the tests.

--- a/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
+++ b/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
@@ -129,7 +129,7 @@
  * The buffer of this length is used to test a few scenarios where the headers or body are found in either the header
  * buffer or body buffer and need to be copied over appropriately.
  */
-#define HTTPS_TEST_RESPONSE_MESSAGE_LENGTH      ( 256 )
+#define HTTPS_TEST_RESPONSE_MESSAGE_LENGTH      ( 512 )
 
 /**
  * @brief The length of the response header buffer shared among the tests.

--- a/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
+++ b/libraries/c_sdk/standard/https/test/unit/iot_tests_https_common.h
@@ -109,7 +109,7 @@
 /**
  * @brief The size of the request user buffer to use among the tests.
  */
-#define HTTPS_TEST_REQ_USER_BUFFER_SIZE         ( 512 )
+#define HTTPS_TEST_REQ_USER_BUFFER_SIZE         ( sizeof( _httpsRequest_t ) + 128 )
 
 /**
  * @brief The size of the response user buffer to use among the tests.
@@ -121,7 +121,7 @@
 /**
  * @brief The size of the response body buffer to use among the tests.
  */
-#define HTTPS_TEST_RESP_BODY_BUFFER_SIZE        ( 256 )
+#define HTTPS_TEST_RESP_BODY_BUFFER_SIZE        ( 128 )
 
 /**
  * @brief The maximum length of the HTTP response message buffer shared among the test.
@@ -129,7 +129,7 @@
  * The buffer of this length is used to test a few scenarios where the headers or body are found in either the header
  * buffer or body buffer and need to be copied over appropriately.
  */
-#define HTTPS_TEST_RESPONSE_MESSAGE_LENGTH      ( 1024 )
+#define HTTPS_TEST_RESPONSE_MESSAGE_LENGTH      ( 256 )
 
 /**
  * @brief The length of the response header buffer shared among the tests.

--- a/projects/st/stm32l475_discovery/ac6/aws_tests/.project
+++ b/projects/st/stm32l475_discovery/ac6/aws_tests/.project
@@ -1143,9 +1143,9 @@
 			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/GCC/ARM_CM4F/portmacro.h</locationURI>
 		</link>
 		<link>
-			<name>freertos_kernel/portable/MemMang/heap_4.c</name>
+			<name>freertos_kernel/portable/MemMang/heap_5.c</name>
 			<type>1</type>
-			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/MemMang/heap_4.c</locationURI>
+			<locationURI>AWS_IOT_MCU_ROOT/freertos_kernel/portable/MemMang/heap_5.c</locationURI>
 		</link>
 		<link>
 			<name>tests/common/aws_test_framework.c</name>

--- a/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
+++ b/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
@@ -79,7 +79,7 @@ target_sources(
         ${driver_src}
         "${AFR_KERNEL_DIR}/portable/GCC/ARM_CM4F/port.c"
         "${AFR_KERNEL_DIR}/portable/GCC/ARM_CM4F/portmacro.h"
-        "${AFR_KERNEL_DIR}/portable/MemMang/$<IF:${AFR_IS_TESTING},heap_4.c,heap_5.c>"
+        "${AFR_KERNEL_DIR}/portable/MemMang/heap_5.c"
 )
 set(
     kernel_inc_dirs

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/STM32L475VGTx_FLASH.ld
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/STM32L475VGTx_FLASH.ld
@@ -150,7 +150,7 @@ SECTIONS
     _sdata = .;        /* create a global symbol at data start */
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
-
+    *(.freertos_heap2)
     . = ALIGN(8);
     _edata = .;        /* define a global symbol at data end */
   } >RAM2 AT> FLASH

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
@@ -89,6 +89,15 @@ static void prvWifiConnect( void );
 static void prvMiscInitialization( void );
 
 /**
+ * @brief Initializes the FreeRTOS heap.
+ *
+ * Heap_5 is being used because the RAM is not contiguous, therefore the heap
+ * needs to be initialized.  See http://www.freertos.org/a00111.html
+ */
+static void prvInitializeHeap( void );
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Application runtime entry point.
  */
 int main( void )
@@ -274,6 +283,10 @@ static void prvMiscInitialization( void )
 
     /* Configure the system clock. */
     SystemClock_Config();
+
+    /* Heap_5 is being used because the RAM is not contiguous in memory, so the
+     * heap must be initialized. */
+    prvInitializeHeap();
 
     BSP_LED_Init( LED_GREEN );
     BSP_PB_Init( BUTTON_USER, BUTTON_MODE_EXTI );
@@ -597,6 +610,22 @@ int iMainRand32( void )
     uxlNextRand = ( ulMultiplier * uxlNextRand ) + ulIncrement;
 
     return( ( int ) ( uxlNextRand >> 16UL ) & 0x7fffUL );
+}
+/*-----------------------------------------------------------*/
+
+static void prvInitializeHeap( void )
+{
+    static uint8_t ucHeap1[ configTOTAL_HEAP_SIZE ];
+    static uint8_t ucHeap2[ 10 * 1024 ] __attribute__( ( section( ".freertos_heap2" ) ) );
+
+    HeapRegion_t xHeapRegions[] =
+    {
+        { ( unsigned char * ) ucHeap2, sizeof( ucHeap2 ) },
+        { ( unsigned char * ) ucHeap1, sizeof( ucHeap1 ) },
+        { NULL,                        0                 }
+    };
+
+    vPortDefineHeapRegions( xHeapRegions );
 }
 /*-----------------------------------------------------------*/
 

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
@@ -56,7 +56,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
-#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 78 * 1024 ) )    /* 78 Kbytes. */
+#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 70 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                      ( 16 )
 #define configUSE_TRACE_FACILITY                     1
 #define configUSE_16_BIT_TICKS                       0


### PR DESCRIPTION
The tests require that the amount of headers in the response fit at a minimum the following string (69 characters):
```
HTTP/1.1 200 OK\r\nContent-Length: <bodyLengthStr>\r\nheader0: value0\r\n\r\n
```

The tests require that HTTPS_TEST_RESP_BODY_BUFFER_SIZE + HTTPS_TEST_RESP_HEADER_BUFFER_LENGTH < HTTPS_TEST_RESPONSE_MESSAGE_LENGTH.

We have also updated the ST tests to use heap5 to save more memory. 

All HTTPS Client tests passing on windows and ST:
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/583/
All HTTP tests passing on all boards (except transient not passing in infineon and microchip with reruns below):
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/584/
HTTP tests passing on Infineon:
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/586/
HTTP tests passing on Microchip:
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/587/
All tests passing on ST except for the ones that have already been failing on master:
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/585/


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.