### PR TITLE
Fix warnings in BLE demo build

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -431,8 +431,8 @@ typedef union
 
 /**
  * @cond DOXYGEN_IGNORE
- * @brief that implementation of this function need to be given when IOT_BLE_ADD_CUSTOM_SERVICES is true
- * and when the user needs to add his own services
+ * @brief The implementation of this function needs to be given when IOT_BLE_ADD_CUSTOM_SERVICES is set to
+ * 1 and when the user needs to add their own services.
  */
     void IotBle_AddCustomServicesCb( void );
 /** @endcond */
@@ -442,8 +442,8 @@ typedef union
 
 /**
  * @cond DOXYGEN_IGNORE
- * @brief the implementation of this function need to be given when IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG is true
- * and when the user needs to set his own advertisement/scan response message
+ * @brief The implementation of this function needs to be given when IOT_BLE_SET_CUSTOM_ADVERTISEMENT_MSG is
+ * set to 1 and when the user needs to set their own advertisement/scan response message.
  *
  * @param[out] pAdvParams: Advertisment structure. Needs to be filled by the user.
  *  @param[out] pScanParams: Scan response structure. Needs to be filled by the user.


### PR DESCRIPTION
Move all related code related to IOT_BLE_ADD_CUSTOM_SERVICES to within if defined blocks.

This fixes warnings in the build as seen when building esp32.

All this PR does is move these functions:
- vCounterUpdateTaskFunction()
- vGattDemoSvcHook()
- _connectionCallback()

To within this if preprocessor block for IOT_BLE_ADD_CUSTOM_SERVICES :
```
#if ( IOT_BLE_ADD_CUSTOM_SERVICES == 1 )
    ...
#endif
```

Oh and I fixed some comments in iot_ble.h for vGattDemoSvcHook() and another close by.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.