### PR TITLE
Add submodule to coreMQTT repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,6 @@
 [submodule "libraries/abstractions/pkcs11/psa"]
 	path = libraries/abstractions/pkcs11/psa
 	url = https://github.com/Linaro/freertos-pkcs11-psa.git
-[submodule "libraries/standard/c_sdk_v4/coreMQTT"]
-	path = libraries/standard/c_sdk_v4/coreMQTT
+[submodule "libraries/c_sdk_v4/standard/coreMQTT"]
+	path = libraries/c_sdk_v4/standard/coreMQTT
 	url = git@github.com:FreeRTOS/coreMQTT.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -32,4 +32,4 @@
 	url = https://github.com/Linaro/freertos-pkcs11-psa.git
 [submodule "libraries/c_sdk_v4/standard/coreMQTT"]
 	path = libraries/c_sdk_v4/standard/coreMQTT
-	url = git@github.com:FreeRTOS/coreMQTT.git
+	url = https://github.com/FreeRTOS/coreMQTT.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "libraries/abstractions/pkcs11/psa"]
 	path = libraries/abstractions/pkcs11/psa
 	url = https://github.com/Linaro/freertos-pkcs11-psa.git
+[submodule "libraries/standard/c_sdk_v4/coreMQTT"]
+	path = libraries/standard/c_sdk_v4/coreMQTT
+	url = git@github.com:FreeRTOS/coreMQTT.git


### PR DESCRIPTION
Add submodule reference to `v1.0.0` tag of [coreMQTT](https://github.com/FreeRTOS/coreMQTT) repository

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
