### PR TITLE
Test: Add new trace definitions to unit tests configs

### DIFF
--- a/tests/unit_test/linux/config_files/FreeRTOSConfig.h
+++ b/tests/unit_test/linux/config_files/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ extern uint32_t ulRand();
 #define configRAND32()    ulRand()
 
 /* The platform that FreeRTOS is running on. */
-#define configPLATFORM_NAME    "WinSim"
+#define configPLATFORM_NAME    "Linux_ut"
 
 /* Header required for the tracealyzer recorder library. */
 #include "trcRecorder.h"

--- a/tests/unit_test/linux/config_files/trcConfig.h
+++ b/tests/unit_test/linux/config_files/trcConfig.h
@@ -54,6 +54,11 @@
 
     #include "trcPortDefines.h"
 
+    #define TRC_CFG_NSTREAMBUFFER             50
+    #define TRC_CFG_NMESSAGEBUFFER            50
+    #define TRC_CFG_NAME_LEN_STREAMBUFFER     50
+    #define TRC_CFG_NAME_LEN_MESSAGEBUFFER    50
+
 /******************************************************************************
  * Include of processor header file
  *

--- a/tests/unit_test/linux/utils/wait_for_event.c
+++ b/tests/unit_test/linux/utils/wait_for_event.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
+
 #include "wait_for_event.h"
 
 struct event
@@ -62,6 +63,7 @@ bool event_wait( struct event * ev )
         pthread_cond_wait( &ev->cond, &ev->mutex );
     }
 
+    ev->event_triggered = false;
     pthread_mutex_unlock( &ev->mutex );
     return true;
 }

--- a/tests/unit_test/linux/utils/wait_for_event.c
+++ b/tests/unit_test/linux/utils/wait_for_event.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <errno.h>
 
-
 #include "wait_for_event.h"
 
 struct event


### PR DESCRIPTION
Add new trace definitions to unit tests configs

Description
-----------
Unit tests are failing to build after upgrading the new version of tracalayzer which uses new defines, adding those defines to the config files.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.