### PR TITLE
NimBLE AFR: Check if the handle is valid for prvBTStartService

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -601,14 +601,17 @@ BTStatus_t prvBTStartService( uint8_t ucServerIf,
                               BTTransport_t xTransport )
 {
     BTStatus_t xStatus = eBTStatusFail;
+    uint16_t index;
 
-    if ( serviceCnt != 0 )
+    /* GATT Service is supposed to start in prvAddServiceBlob, we just
+     * check if handle is matching with the one populated in
+     * prvAddServiceBlob for each service */
+    for( index = 0; index < serviceCnt; index++ )
     {
-        /* GATT Service is supposed to start in prvAddServiceBlob, we just
-         * check if handle is matching with the one populated in prvAddServiceBlob */
-        if ( usServiceHandle == afrServices[ serviceCnt - 1 ]->pusHandlesBuffer[ 0 ] )
+        if ( usServiceHandle == afrServices[ index ]->pusHandlesBuffer[ 0 ] )
         {
             xStatus = eBTStatusSuccess;
+            break;
         }
     }
 

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -600,7 +600,24 @@ BTStatus_t prvBTStartService( uint8_t ucServerIf,
                               uint16_t usServiceHandle,
                               BTTransport_t xTransport )
 {
-    return eBTStatusUnsupported;
+    BTStatus_t xStatus = eBTStatusFail;
+
+    if ( serviceCnt != 0 )
+    {
+        /* GATT Service is supposed to start in prvAddServiceBlob, we just
+         * check if handle is matching with the one populated in prvAddServiceBlob */
+        if ( usServiceHandle == afrServices[ serviceCnt - 1 ]->pusHandlesBuffer[ 0 ] )
+        {
+            xStatus = eBTStatusSuccess;
+        }
+    }
+
+    if( xGattServerCb.pxServiceStartedCb != NULL )
+    {
+        xGattServerCb.pxServiceStartedCb( xStatus, ucServerIf, usServiceHandle );
+    }
+
+    return xStatus;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Fix `prvBTStartService` in NimBLE port. This change also assumes that `prvAddServiceBlob` was called before calling `prvBTStartService`.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Previous to this PR, `eBTStatusUnsupported` was returned.
- Check if the input handle matches with the one populated in `prvAddServiceBlob`.
- Call `pxServiceStartedCb` callback if not NULL.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.