### PR TITLE
Docs: Fix html doc for wrong path for demos/include directory

### DIFF
--- a/tools/certificate_configuration/CertificateConfigurator.html
+++ b/tools/certificate_configuration/CertificateConfigurator.html
@@ -54,7 +54,7 @@
                                 </div>
                                 <p class="text-primary" style="font-size:14px">
                                     <span class="glyphicon glyphicon-warning-sign" style="font-size:16px"></span> 
-                                    Save the generated header file to the <i>demos/common/include</i> folder of the demo project.
+                                    Save the generated header file to the <i>demos/include</i> folder of the demo project.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Fix html doc for wrong path for demos/include directory

Description
-----------
The path in CertificateConfigurator.html for the include directory is wrong (./demos/common/include)
fixing to (./demos/include)

issue #2478 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.