### PR TITLE
Fix MSP stack check in ST linker scripts

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/aws_demos/STM32L475VGTx_FLASH.ld
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/STM32L475VGTx_FLASH.ld
@@ -175,7 +175,7 @@ SECTIONS
     . = . + _Min_Heap_Size;
     . = . + _Min_Stack_Size;
     . = ALIGN(8);
-  } >RAM2
+  } >RAM
 
   
 

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/STM32L475VGTx_FLASH.ld
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/STM32L475VGTx_FLASH.ld
@@ -181,7 +181,7 @@ SECTIONS
     . = . + _Min_Heap_Size;
     . = . + _Min_Stack_Size;
     . = ALIGN(8);
-  } >RAM2
+  } >RAM
 
   
 


### PR DESCRIPTION
Description
-----------
Linker script verifies that there is enough space for the MSP stack in the RAM. The MSP was placed in the RAM1 while the check was being done on RAM2 leaving the check useless and leaving a possibility that RAM1 does not have enough space for MSP. This commit moves the check to RAM1.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.