### PR TITLE
Implemented runtime timer command

### DIFF
--- a/vendors/pc/boards/windows/aws_demos/application_code/commandTask.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/commandTask.c
@@ -1,0 +1,33 @@
+#include "commandTask.h"
+
+#include <stdio.h>
+
+#include "FreeRTOS.h"
+#include "FreeRTOSIPConfig.h"
+#include "runtimeTimer.h"
+#include "task.h"
+
+#define MAX_COMMAND_LENGTH 3 // only supported command is "rt"
+static uint8_t ucParameterToPass = 0; // Required as part of task creation.
+TaskHandle_t commandTaskHandle = NULL;
+
+void prvCommandTaskCode(void* pvParameters) {
+    char input[MAX_COMMAND_LENGTH];
+
+    for (;;) {
+        scanf("%s", input);
+        if (strcmp(input, "rt") == 0) printRuntime();
+    }
+}
+
+void initializeCommandTask(void)
+{   
+    xTaskCreate(
+        prvCommandTaskCode,
+        "USER_COMMANDS",
+        configMINIMAL_STACK_SIZE,
+        &ucParameterToPass, //ucParameterToPass must exist for the lifetime of the task, even if unused
+        tskIDLE_PRIORITY,
+        &commandTaskHandle);
+    configASSERT(commandTaskHandle);
+}

--- a/vendors/pc/boards/windows/aws_demos/application_code/commandTask.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/commandTask.h
@@ -1,0 +1,2 @@
+/* Function for task for running commands based on user input */
+void initializeCommandTask(void);

--- a/vendors/pc/boards/windows/aws_demos/application_code/main.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/main.c
@@ -58,6 +58,9 @@
 #include "iot_network_manager_private.h"
 #include "aws_iot_network_config.h"
 
+#include "commandTask.h"
+#include "runtimeTimer.h"
+
 /* Define a name that will be used for LLMNR and NBNS searches. Once running,
  * you can "ping RTOSDemo" instead of pinging the IP address, which is useful when
  * using DHCP. */
@@ -119,6 +122,9 @@ int main( void )
      * but a DHCP server cannot be contacted. */
 	FreeRTOS_printf(("FreeRTOS_IPInit\n"));
 	vApplicationIPInit();
+
+    initializeRuntimeTimer();
+    initializeCommandTask();
 
     /* Start the RTOS scheduler. */
     FreeRTOS_printf( ( "vTaskStartScheduler\n" ) );
@@ -302,12 +308,3 @@ static void prvSaveTraceFile( void )
         printf( "\r\nFailed to create trace dump file\r\n" );
     }
 }
-/*-----------------------------------------------------------*/
-
-void getUserCmd( char * pucUserCmd )
-{
-    char cTmp;
-
-    scanf( "%c%c", pucUserCmd, &cTmp );
-}
-/*-----------------------------------------------------------*/

--- a/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.c
@@ -1,0 +1,70 @@
+#include "runtimeTimer.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOSIPConfig.h"
+#include "task.h"
+#include "timers.h"
+
+#define MS_PER_MINUTE (SECONDS_PER_MINUTE * MS_PER_SECOND)
+#define SECONDS_PER_MINUTE (60)
+#define MS_PER_SECOND (1000)
+
+#define RUNTIME_TASK_INTERRUPT_NUMBER (3)
+
+volatile unsigned long long runtime_ms = 0;
+static StaticTimer_t xRuntimeTimerBuffer[configMINIMAL_STACK_SIZE];
+static unsigned long runtimeTimerId = 1004; // Arbitrary value
+// portTICK_PERIOD_MS is 1. Windows Simulator Tick is 1kHZ.
+const TickType_t xDelay = 1 / portTICK_PERIOD_MS; 
+
+uint32_t runtimeInterrupt(void)
+{
+    runtime_ms += xDelay;
+    return 0;
+}
+
+void prvRuntimeTimerCallback(TimerHandle_t xTimer)
+{
+    vPortGenerateSimulatedInterrupt(RUNTIME_TASK_INTERRUPT_NUMBER);
+}
+
+void initializeRuntimeTimer(void) {
+    BaseType_t xResult;
+    runtime_ms = 0;
+
+    TimerHandle_t runtimeTimer = xTimerCreateStatic(
+        "Runtime", /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+        xDelay,
+        pdTRUE,
+        (void *) &runtimeTimerId,
+        prvRuntimeTimerCallback,
+        xRuntimeTimerBuffer);
+    vPortSetInterruptHandler(RUNTIME_TASK_INTERRUPT_NUMBER, runtimeInterrupt);
+
+    // Initialize runtime timer before starting scheduler, to avoid using a block time
+    xResult = xTimerStart(runtimeTimer, 0); 
+    FreeRTOS_printf( (xResult == pdPASS ?
+        "Runtime Timer Initialized" :
+        "Runtime Timer Init Failed") );
+}
+
+void printRuntime(void) {
+    // Copy the global variable to avoid race condition during processing.
+    unsigned long long local_copy = runtime_ms;
+
+    unsigned long rt_1 = portGET_RUN_TIME_COUNTER_VALUE();
+
+    unsigned long minutes = (unsigned long) local_copy / MS_PER_MINUTE;
+    unsigned int seconds = (unsigned int) (local_copy % MS_PER_MINUTE) / MS_PER_SECOND;
+    unsigned int milliseconds = (unsigned int) local_copy % MS_PER_SECOND;
+    FreeRTOS_printf( ("Timer-Based Runtime: %ld:%02ld:%03d\r\n", minutes, seconds, milliseconds) );
+
+    unsigned long rt_2= portGET_RUN_TIME_COUNTER_VALUE();
+    FreeRTOS_printf(("Latency: %ld.%02ldms\r\n", (rt_2 - rt_1) / 100, (rt_2 - rt_1) % 100));
+
+    unsigned long  windows_ticks_ms = rt_1 / 100;
+    minutes = (unsigned long)windows_ticks_ms / MS_PER_MINUTE;
+    seconds = (unsigned int)(windows_ticks_ms % MS_PER_MINUTE) / MS_PER_SECOND;
+    milliseconds = (unsigned int)windows_ticks_ms % MS_PER_SECOND;
+    FreeRTOS_printf(("Windows-Tick Runtime: %ld:%02ld:%03d\r\n", minutes, seconds, milliseconds));
+}

--- a/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.h
@@ -1,0 +1,8 @@
+#pragma once
+/* Function for intializing runtime timer based on timer task.
+   This function must be called before vTaskStartScheduler is called*/
+void initializeRuntimeTimer(void);
+
+/* Prints the current runtime of the simulator, based on timer task
+   in MINUTES:SECONDS:MILLSECONDS format, with leading 0's*/
+void printRuntime(void);


### PR DESCRIPTION
* Implemented a runtime timer using the timer task and simulated
interrupts.

* Calculated runtime timer latency using the aws_run-time-stats-utils

* Added more accurate runtime based on Windows' System Ticks.

* Added "rt" command to print out the runtime.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.