### PR TITLE
Fix PKCS #11 Capabilities Test Failures on Renesas.

### DIFF
--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_test_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/iot_test_pkcs11_config.h
@@ -62,7 +62,7 @@
 /*
  * @brief Set to 1 if RSA private keys are supported by the platform.  0 if not.
  */
-#define pkcs11testRSA_KEY_SUPPORT              ( 0 )
+#define pkcs11testRSA_KEY_SUPPORT              ( 1 )
 
 /*
  * @brief Set to 1 if elliptic curve private keys are supported by the platform.  0 if not.


### PR DESCRIPTION
Fix PKCS #11 Capabilities Test Failures on Renesas.

Description
-----------
The PKCS #11 config was mis-configured and causing failures to to inconsistencies with the run time capabilities of the stack.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.