### PR TITLE
Make common_io as a library target

### DIFF
--- a/libraries/abstractions/common_io/CMakeLists.txt
+++ b/libraries/abstractions/common_io/CMakeLists.txt
@@ -43,7 +43,7 @@ afr_module_dependencies(
 afr_test_module()
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    PUBLIC
+    INTERFACE
         "${test_dir}/iot_test_common_io_internal.h"
         "${test_dir}/iot_test_common_io.c"
         "${test_dir}/test_iot_adc.c"

--- a/libraries/abstractions/common_io/CMakeLists.txt
+++ b/libraries/abstractions/common_io/CMakeLists.txt
@@ -31,12 +31,14 @@ afr_module_sources(
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    PUBLIC "${inc_dir}"
+    PUBLIC 
+        "${inc_dir}"
 )
 
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    PUBLIC AFR::common_io::mcu_port
+    PRIVATE 
+        AFR::common_io::mcu_port
 )
 
 # Common I/O tests

--- a/libraries/abstractions/common_io/CMakeLists.txt
+++ b/libraries/abstractions/common_io/CMakeLists.txt
@@ -1,11 +1,11 @@
-afr_module(INTERFACE)
+afr_module()
 
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    INTERFACE
+    PUBLIC
         "${inc_dir}/iot_adc.h"
         "${inc_dir}/iot_battery.h"
         "${inc_dir}/iot_efuse.h"
@@ -31,19 +31,19 @@ afr_module_sources(
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    INTERFACE "${inc_dir}"
+    PUBLIC "${inc_dir}"
 )
 
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::common_io::mcu_port
+    PUBLIC AFR::common_io::mcu_port
 )
 
 # Common I/O tests
 afr_test_module()
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
-    INTERFACE
+    PUBLIC
         "${test_dir}/iot_test_common_io_internal.h"
         "${test_dir}/iot_test_common_io.c"
         "${test_dir}/test_iot_adc.c"

--- a/libraries/abstractions/common_io/CMakeLists.txt
+++ b/libraries/abstractions/common_io/CMakeLists.txt
@@ -37,7 +37,7 @@ afr_module_include_dirs(
 
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    PRIVATE 
+    PUBLIC 
         AFR::common_io::mcu_port
 )
 

--- a/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
+++ b/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
@@ -158,7 +158,7 @@ target_sources(
 target_include_directories(
     AFR::common_io::mcu_port
     INTERFACE
-        "${AFR_MODULES_ABSTRACTIONS_DIR}/platform/freertos/include"
+        "${AFR_MODULES_ABSTRACTIONS_DIR}/platform/freertos/include/platform"
         # test code
         $<${AFR_IS_TESTING}:${AFR_MODULES_ABSTRACTIONS_DIR}/common_io/test>
 )

--- a/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
+++ b/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
@@ -158,7 +158,7 @@ target_sources(
 target_include_directories(
     AFR::common_io::mcu_port
     INTERFACE
-        "${AFR_MODULES_ABSTRACTIONS_DIR}/platform/freertos/include/platform"
+        "${AFR_MODULES_ABSTRACTIONS_DIR}/platform/freertos/include"
         # test code
         $<${AFR_IS_TESTING}:${AFR_MODULES_ABSTRACTIONS_DIR}/common_io/test>
 )

--- a/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
+++ b/vendors/st/boards/stm32l475_discovery/CMakeLists.txt
@@ -155,6 +155,15 @@ target_sources(
         $<${AFR_IS_TESTING}:${afr_ports_dir}/common_io/iot_test_common_io_internal.c>
 )
 
+target_include_directories(
+    AFR::common_io::mcu_port
+    INTERFACE
+        "${AFR_MODULES_ABSTRACTIONS_DIR}/platform/freertos/include/platform"
+        # test code
+        $<${AFR_IS_TESTING}:${AFR_MODULES_ABSTRACTIONS_DIR}/common_io/test>
+)
+
+
 # -------------------------------------------------------------------------------------------------
 # FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Update `AFR::common_io` module to be built as a library so that application can link against it.

Currently, the module is configured as an `INTERFACE` which makes it as a non-independent library target. By removing the `INTERFACE` configuration, CMake will expose `afr_common_io` as a library target which can be linked against with `target_link_libraries`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
