### PR TITLE
Add socket bind API to LWIP

### DIFF
--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -275,7 +275,7 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
  * Limitations:
  *
  *   i.  The caller of SOCKETS_Bind() API should make sure the socket address has the correct local IP address for the interface.
- *   ii. The LWIP stack has ephemeral port range from 49152 to 65535, it is better to avoid the source port in this range.
+ *   ii. some source ports may be unavailable depending on the TCP/IP stack implementation.
  *
  *       NOTE: If the SOCKETS_Bind() API binds to a source port in ephemeral port range, and the caller calls SOCKETS_Bind() API
  *             before SOCKETS_Connect() API, then a conflict of source port arises as another TCP connection

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -275,11 +275,11 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
  * Limitations:
  *
  *   i.  The caller of SOCKETS_Bind() API should make sure the socket address has the correct local IP address for the interface.
- *   ii. The LWIP stack has ephemeral port range from 49152 to 65535, it is better avoid the source port in this range.
+ *   ii. The LWIP stack has ephemeral port range from 49152 to 65535, it is better to avoid the source port in this range.
  *
- *       NOTE: If the SOCKETS_Bind() API binds to a source port in ephemeral port range and calls SOCKETS_Bind() API
- *             but before SOCKETS_Connect() API is called then a conflict of source port arises that another TCP connection
- *             may pick the the same chosen port via API tcp_new_port() ( by scanning its internal TCP connection list )
+ *       NOTE: If the SOCKETS_Bind() API binds to a source port in ephemeral port range, and the caller calls SOCKETS_Bind() API
+ *             before SOCKETS_Connect() API, then a conflict of source port arises as another TCP connection
+ *             may pick the the same chosen port via tcp_new_port() API ( by scanning its internal TCP connection list )
  *
  *
  * @param[in] xSocket The handle of the socket to which specified address to be bound.

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -257,6 +257,45 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
                          int32_t lProtocol );
 /* @[declare_secure_sockets_socket] */
 
+/**
+ * @brief Bind a TCP socket.
+ *
+ * See the [FreeRTOS+TCP networking tutorial]
+ * (https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Networking_Tutorial.html)
+ * for more information on TCP sockets.
+ *
+ * See the [Berkeley Sockets API]
+ * (https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions)
+ * in wikipedia
+ *
+ * @sa SOCKETS_Bind()
+ * A pre-configured source port allows customers to bind to the specified local port instead of ephemeral port
+ * for security and packet filter reasons.
+ *
+ * Limitations:
+ *
+ *   i.  The caller of SOCKETS_Bind() API should make sure the socket address has the correct local IP address for the interface.
+ *   ii. The LWIP stack has ephemeral port range from 49152 to 65535, it is better avoid the source port in this range.
+ *
+ *       NOTE: If the SOCKETS_Bind() API binds to a source port in ephemeral port range and calls SOCKETS_Bind() API
+ *             but before SOCKETS_Connect() API is called then a conflict of source port arises that another TCP connection
+ *             may pick the the same chosen port via API tcp_new_port() ( by scanning its internal TCP connection list )
+ *
+ *
+ * @param[in] xSocket The handle of the socket to which specified address to be bound.
+ * @param[in] pxAddress A pointer to a SocketsSockaddr_t structure that contains
+ * the address and port to be bound to the socket.
+ * @param[in] xAddressLength Should be set to sizeof( @ref SocketsSockaddr_t ).
+ *
+ * @return
+ * * If the bind was successful then SOCKETS_ERROR_NONE is returned.
+ * * If an error occurred, a negative value is returned. @ref SocketsErrors
+ */
+/* @[declare_secure_sockets_bind] */
+int32_t SOCKETS_Bind( Socket_t xSocket,
+                      SocketsSockaddr_t * pxAddress,
+                      Socklen_t xAddressLength );
+/* @[declare_secure_sockets_bind] */
 
 /**
  * @brief Connects the socket to the specified IP address and port.

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -275,7 +275,7 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
  * Limitations:
  *
  *   i.  The caller of SOCKETS_Bind() API should make sure the socket address has the correct local IP address for the interface.
- *   ii. some source ports may be unavailable depending on the TCP/IP stack implementation.
+ *   ii. Some source ports may be unavailable depending on the TCP/IP stack implementation.
  *
  *       NOTE: If the SOCKETS_Bind() API binds to a source port in ephemeral port range, and the caller calls SOCKETS_Bind() API
  *             before SOCKETS_Connect() API, then a conflict of source port arises as another TCP connection

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -405,6 +405,7 @@ int32_t SOCKETS_Bind( Socket_t xSocket,
 
     if( pxAddress == NULL )
     {
+        configPRINTF( ( "TCP socket Invalid Address\n" ) );
         return SOCKETS_EINVAL;
     }
 

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -411,6 +411,12 @@ int32_t SOCKETS_Bind( Socket_t xSocket,
 
     ctx = ( ss_ctx_t * ) xSocket;
 
+    if( NULL == ctx )
+    {
+        configPRINTF( ( "Invalid secure socket passed: Socket=%p\n", ctx ) );
+        return SOCKETS_EINVAL;
+    }
+
     if( 0 > ctx->ip_socket )
     {
         configPRINTF( ( "TCP socket Invalid index\n" ) );

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -389,6 +389,63 @@ Socket_t SOCKETS_Socket( int32_t lDomain,
 
 /*-----------------------------------------------------------*/
 
+int32_t SOCKETS_Bind( Socket_t xSocket,
+                      SocketsSockaddr_t * pxAddress,
+                      Socklen_t xAddressLength )
+{
+    ss_ctx_t * ctx;
+    int32_t ret;
+    struct sockaddr_in sa_addr = { 0 };
+
+    if( SOCKETS_INVALID_SOCKET == xSocket )
+    {
+        configPRINTF( ( "TCP socket Invalid\n" ) );
+        return SOCKETS_EINVAL;
+    }
+
+    if( pxAddress == NULL )
+    {
+        return SOCKETS_EINVAL;
+    }
+
+    ctx = ( ss_ctx_t * ) xSocket;
+
+    if( 0 > ctx->ip_socket )
+    {
+        configPRINTF( ( "TCP socket Invalid index\n" ) );
+        return SOCKETS_EINVAL;
+    }
+
+    /*
+     * Setting SO_REUSEADDR socket option in order to be able to bind to the same ip:port again
+     * without netconn_bind failing.
+     */
+    #if SO_REUSE
+        ret = lwip_setsockopt( ctx->ip_socket, SOL_SOCKET, SO_REUSEADDR, &( uint32_t ) { 1 }, sizeof( uint32_t ) );
+
+        if( 0 > ret )
+        {
+            return SOCKETS_SOCKET_ERROR;
+        }
+    #endif /* SO_REUSE */
+
+    sa_addr.sin_family = pxAddress->ucSocketDomain ? pxAddress->ucSocketDomain : AF_INET;
+    sa_addr.sin_addr.s_addr = pxAddress->ulAddress;
+    sa_addr.sin_port = pxAddress->usPort;
+
+    ret = lwip_bind( ctx->ip_socket, ( struct sockaddr * ) &sa_addr, sizeof( sa_addr ) );
+
+    if( 0 > ret )
+    {
+        configPRINTF( ( "lwip_bind fail :%d\n", ret ) );
+        return SOCKETS_SOCKET_ERROR;
+    }
+
+    return SOCKETS_ERROR_NONE;
+}
+
+/*-----------------------------------------------------------*/
+
 int32_t SOCKETS_Connect( Socket_t xSocket,
                          SocketsSockaddr_t * pxAddress,
                          Socklen_t xAddressLength )

--- a/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
+++ b/libraries/abstractions/secure_sockets/utest/secure_sockets_utest.c
@@ -183,6 +183,17 @@ static void setServerCert( Socket_t s )
     TEST_ASSERT_EQUAL_INT( SOCKETS_ERROR_NONE, ret );
 }
 
+static void bindSocket( Socket_t s )
+{
+	int32_t ret;
+	SocketsSockaddr_t pxAddress;
+
+	lwip_bind_ExpectAnyArgsAndReturn( 0 );
+	ret = SOCKETS_Bind( s, &pxAddress, sizeof( SocketsSockaddr_t ));
+
+	TEST_ASSERT_EQUAL_INT ( SOCKETS_ERROR_NONE, ret );
+}
+
 static void connectSocket( Socket_t s )
 {
     int32_t ret;
@@ -211,6 +222,16 @@ static Socket_t create_normal_connection()
     connectSocket( s );
     return s;
 }
+
+static Socket_t create_connection_after_bind()
+{
+	Socket_t s = initSocket();
+
+	bindSocket(s);
+	connectSocket(s);
+	return s;
+}
+
 /* ======================  TESTING SOCKETS_Send  ============================ */
 
 /*!
@@ -233,6 +254,29 @@ void test_SecureSockets_send_successful( void )
     TEST_ASSERT_EQUAL_INT( BUFFER_LEN, ret );
     deinitSocket( so );
 }
+
+/*!
+ * @brief A happy send case after bind with normal sockets
+ *
+ * @details The purpose is to make sure we get returned the same number of bytes
+ *          That lwip_send returned
+ */
+void test_SecureSockets_send_successful_after_bind ( void )
+{
+	int32_t ret;
+	Socket_t so = create_connection_after_bind ();
+
+	const char buffer[ BUFFER_LEN ];
+
+	lwip_send_ExpectAnyArgsAndReturn( BUFFER_LEN );
+	ret = SOCKETS_Send( so,
+	                        buffer,
+	                        BUFFER_LEN,
+	                        0 );
+	TEST_ASSERT_EQUAL_INT( BUFFER_LEN, ret );
+	deinitSocket( so );
+}
+
 
 /*!
  * @brief A happy send case with tls sockets
@@ -561,6 +605,35 @@ void test_SecureSockets_Recv_NotConnected( void )
     TEST_ASSERT_EQUAL_INT( SOCKETS_ENOTCONN, ret );
     deinitSocket( so );
 }
+/*!
+ * @brief bind invalid socket
+ *
+ * The purpose of this test is to show that SOCKETS_Bind will be able to handle
+ * wrong or bad parameters and return the appropriate errors
+ */
+
+void test_SecureSockets_Bind_Invalid_Input (void )
+{
+	int32_t ret;
+	SocketsSockaddr_t pxAddress;
+
+	Socket_t so = SOCKETS_INVALID_SOCKET;
+
+	ret = SOCKETS_Bind( so,  &pxAddress, sizeof( pxAddress));
+	TEST_ASSERT_EQUAL( SOCKETS_EINVAL, ret );
+
+	so = initSocket();
+
+	pxAddress.ucLength = 32;
+	pxAddress.ucSocketDomain = SOCKETS_AF_INET;
+	pxAddress.usPort = 1000;
+	pxAddress.ulAddress = 1234567;
+
+	ret = SOCKETS_Bind( so, NULL, sizeof( pxAddress ) );
+	TEST_ASSERT_EQUAL_INT( SOCKETS_EINVAL, ret );
+	deinitSocket( so );
+}
+
 
 /*!
  * @brief Receive invalid socket


### PR DESCRIPTION
<!--- Title -->
Secure Socket changes to support socket bind API

Description
-----------
Add Secure Socket bind API to LWIP stack.

As per discussion with Amazon team on 10/2/2020, Amazon team has agreed for socket bind API support.
The original PR  https://github.com/aws/amazon-freertos/pull/2392 is closed, opening a new PR with the latest code from master branch
All the review comments are captured in PR https://github.com/aws/amazon-freertos/pull/2392

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.