### PR TITLE
Fix transport_secure_sockets implementation

### DIFF
--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -100,9 +100,10 @@ int32_t SecureSocketsTransport_Send( const NetworkContext_t * pNetworkContext,
                     pMessage, bytesToSend, pNetworkContext ) );
         bytesSent = SOCKETS_EINVAL;
     }
-    else if( ( pNetworkContext != NULL ) && ( pNetworkContext->pContext == NULL ) )
+    else if( ( pNetworkContext != NULL ) && ( pNetworkContext->pContext == SOCKETS_INVALID_SOCKET ) )
     {
-        LogError( ( "Invalid parameter: pNetworkContext->pContext cannot be NULL." ) );
+        LogError( ( "Invalid parameter: pNetworkContext->pContext is invalid. Socket=%d",
+                    pNetworkContext->pContext ) );
         bytesSent = SOCKETS_EINVAL;
     }
     else
@@ -150,9 +151,10 @@ int32_t SecureSocketsTransport_Recv( const NetworkContext_t * pNetworkContext,
                     pBuffer, bytesToRecv, pNetworkContext ) );
         bytesReceived = SOCKETS_EINVAL;
     }
-    else if( ( pNetworkContext != NULL ) && ( pNetworkContext->pContext == NULL ) )
+    else if( ( pNetworkContext != NULL ) && ( pNetworkContext->pContext == SOCKETS_INVALID_SOCKET ) )
     {
-        LogError( ( "Invalid parameter: pNetworkContext->pContext cannot be NULL." ) );
+        LogError( ( "Invalid parameter: pNetworkContext->pContext is invalid. Socket=%d",
+                    pNetworkContext->pContext ) );
         bytesReceived = SOCKETS_EINVAL;
     }
     else

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -757,36 +757,6 @@ static int32_t failedRecv( const NetworkContext_t * pNetworkContext,
     return -1;
 }
 
-static void startPersistentSession()
-{
-    /* Terminate TLS session and TCP network connection to discard the current MQTT session
-     * that was created as a "clean session". */
-    ( void ) SecureSocketsTransport_Disconnect( &networkContext );
-
-    /* Establish a new MQTT connection over TLS with the broker with the "clean session" flag set to 0
-     * to start a persistent session with the broker. */
-
-    /* Create the TLS+TCP connection with the broker. */
-    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
-
-    /* Establish a new MQTT connection for a persistent session with the broker. */
-    establishMqttSession( &context, &networkContext, false, &persistentSession );
-    TEST_ASSERT_FALSE( persistentSession );
-}
-
-static void resumePersistentSession()
-{
-    /* Create a new TLS+TCP network connection with the server. */
-    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
-
-    /* Re-establish the persistent session with the broker by connecting with "clean session" flag set to 0. */
-    TEST_ASSERT_FALSE( persistentSession );
-    establishMqttSession( &context, &networkContext, false, &persistentSession );
-
-    /* Verify that the session was resumed. */
-    TEST_ASSERT_TRUE( persistentSession );
-}
-
 static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext )
 {
     bool isSuccessful = false;
@@ -841,6 +811,36 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     } while( ( transportStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( retryUtilsStatus == RetryUtilsSuccess ) );
 
     return isSuccessful;
+}
+
+static void startPersistentSession()
+{
+    /* Terminate TLS session and TCP network connection to discard the current MQTT session
+     * that was created as a "clean session". */
+    ( void ) SecureSocketsTransport_Disconnect( &networkContext );
+
+    /* Establish a new MQTT connection over TLS with the broker with the "clean session" flag set to 0
+     * to start a persistent session with the broker. */
+
+    /* Create the TLS+TCP connection with the broker. */
+    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
+
+    /* Establish a new MQTT connection for a persistent session with the broker. */
+    establishMqttSession( &context, &networkContext, false, &persistentSession );
+    TEST_ASSERT_FALSE( persistentSession );
+}
+
+static void resumePersistentSession()
+{
+    /* Create a new TLS+TCP network connection with the server. */
+    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
+
+    /* Re-establish the persistent session with the broker by connecting with "clean session" flag set to 0. */
+    TEST_ASSERT_FALSE( persistentSession );
+    establishMqttSession( &context, &networkContext, false, &persistentSession );
+
+    /* Verify that the session was resumed. */
+    TEST_ASSERT_TRUE( persistentSession );
 }
 
 /* ============================   UNITY FIXTURES ============================ */

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -767,10 +767,7 @@ static void startPersistentSession()
      * to start a persistent session with the broker. */
 
     /* Create the TLS+TCP connection with the broker. */
-    TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_SUCCESS, SecureSocketsTransport_Connect( &networkContext,
-                                                                                        &serverInfo,
-                                                                                        &socketsConfig ) );
-    TEST_ASSERT_NOT_NULL( networkContext.pContext );
+    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
 
     /* Establish a new MQTT connection for a persistent session with the broker. */
     establishMqttSession( &context, &networkContext, false, &persistentSession );
@@ -780,10 +777,7 @@ static void startPersistentSession()
 static void resumePersistentSession()
 {
     /* Create a new TLS+TCP network connection with the server. */
-    TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_SUCCESS, SecureSocketsTransport_Connect( &networkContext,
-                                                                                        &serverInfo,
-                                                                                        &socketsConfig ) );
-    TEST_ASSERT_NOT_NULL( networkContext.pContext );
+    TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
 
     /* Re-establish the persistent session with the broker by connecting with "clean session" flag set to 0. */
     TEST_ASSERT_FALSE( persistentSession );
@@ -826,7 +820,7 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     {
         /* Establish a TCP connection with the server endpoint, then
          * establish TLS session on top of TCP connection. */
-        transportStatus = SecureSocketsTransport_Connect( &networkContext,
+        transportStatus = SecureSocketsTransport_Connect( pNetworkContext,
                                                           &serverInfo,
                                                           &socketsConfig );
 
@@ -869,7 +863,6 @@ void testSetUp()
 
     /* Establish TLS over TCP connection with retry attempts on failures. */
     TEST_ASSERT_TRUE( connectToServerWithBackoffRetries( &networkContext ) );
-    TEST_ASSERT_NOT_NULL( networkContext.pContext );
 
     /* Establish MQTT session on top of the TCP+TLS connection. */
     establishMqttSession( &context, &networkContext, true, &persistentSession );


### PR DESCRIPTION
Remove instances of NULL check with SOCKETS_INVALID_SOCKET in `transport_secure_sockets.c` and `core_mqtt_system.c` implementation