### PR TITLE
Fix GGD tests build failure for ST

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
@@ -616,7 +616,7 @@ int iMainRand32( void )
 static void prvInitializeHeap( void )
 {
     static uint8_t ucHeap1[ configTOTAL_HEAP_SIZE ];
-    static uint8_t ucHeap2[ 10 * 1024 ] __attribute__( ( section( ".freertos_heap2" ) ) );
+    static uint8_t ucHeap2[ 12 * 1024 ] __attribute__( ( section( ".freertos_heap2" ) ) );
 
     HeapRegion_t xHeapRegions[] =
     {

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/FreeRTOSConfig.h
@@ -56,7 +56,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
-#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 70 * 1024 ) )
+#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 68 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                      ( 16 )
 #define configUSE_TRACE_FACILITY                     1
 #define configUSE_16_BIT_TICKS                       0


### PR DESCRIPTION
Description
-----------
Move 2KB heap from RAM1 to RAM2. This fixes GGD tests that are failing to build because of RAM overflow.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.