### PR TITLE
Report the success of the defender metrics to the demo for CI.

### DIFF
--- a/demos/defender/aws_iot_demo_defender.c
+++ b/demos/defender/aws_iot_demo_defender.c
@@ -343,7 +343,8 @@ int RunDefenderDemo( bool awsIotMqttMode,
         IotMqtt_Cleanup();
     }
 
-    /* The demo is successful only if the metrics were accepted by AWS IoT. */
+    /* The demo is successful only if the metrics were accepted by 
+     * the AWS IoT Device Defender Service. */
     if( metricsAccepted == false )
     {
         status = EXIT_FAILURE;

--- a/demos/defender/aws_iot_demo_defender.c
+++ b/demos/defender/aws_iot_demo_defender.c
@@ -299,14 +299,25 @@ int RunDefenderDemo( bool awsIotMqttMode,
 
         if( defenderResult == AWS_IOT_DEFENDER_SUCCESS )
         {
-            /* Let the Device Defender library run for 3 seconds before stopping.
+            /* Let the Device Defender Library run for 3 seconds before stopping.
              * This is to allow enough time for the AWS IoT Device Defender
-             * service to accept the metrics. When the metrics are accepted, the
-             * application is notified in _defenderCallback() with an event type
-             * of AWS_IOT_DEFENDER_METRICS_ACCEPTED. Also, upon metrics acceptance,
-             * the Defender library will print "Metrics report was accepted by
-             * defender service." and the variable metricsAccepted, set in the
-             * callback context, will be set to true. */
+             * Service to accept the metrics report.
+             * 
+             * The following happens when the metrics report is accepted by the AWS IoT
+             * Device Defender Service:
+             *
+             * 1. The application is notified in _defenderCallback() with an event
+             *    type of AWS_IOT_DEFENDER_METRICS_ACCEPTED. In this demo, the
+             *    callback sets the variable metricsAccepted to true which is passed
+             *    as the callback context.
+             * 2. The Defender library prints "Metrics report was accepted by
+             *     defender service."
+             *
+             * It is okay to pass the local variable metricsAccepted in the callback
+             * context because the Device Defender Library is stopped in this function
+             * itself. Therefore, the callback can never execute after this function
+             * has exited.
+             */
             IotClock_SleepMs( 3000 );
             /* Stop the defender agent. */
             AwsIotDefender_Stop();

--- a/demos/defender/aws_iot_demo_defender.c
+++ b/demos/defender/aws_iot_demo_defender.c
@@ -302,7 +302,7 @@ int RunDefenderDemo( bool awsIotMqttMode,
             /* Let the Device Defender Library run for 3 seconds before stopping.
              * This is to allow enough time for the AWS IoT Device Defender
              * Service to accept the metrics report.
-             * 
+             *
              * The following happens when the metrics report is accepted by the AWS IoT
              * Device Defender Service:
              *
@@ -343,7 +343,7 @@ int RunDefenderDemo( bool awsIotMqttMode,
         IotMqtt_Cleanup();
     }
 
-    /* The demo is successful only if the metrics were accepted by 
+    /* The demo is successful only if the metrics were accepted by
      * the AWS IoT Device Defender Service. */
     if( metricsAccepted == false )
     {


### PR DESCRIPTION
The CI currently checks for the string "Metrics report was accepted by defender service." to note if the Defender demo passes.
This string is printed in the current Device Defender library and then passes the AWS_IOT_DEFENDER_METRICS_ACCEPTED event to the demo's registered callback.
The demo currently always returns EXIT_SUCCESS for the Defender library starting successfully, even if AWS IoT did not accept the metrics.


This change registers a boolean context to the callback to catch the AWS_IOT_DEFENDER_METRICS_ACCEPTED event.
With this change, the demo will return EXIT_FAILURE if the AWS_IOT_DEFENDER_METRICS_ACCEPTED event is not reached. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.