### PR TITLE
Add CLI config to mediatek and nxp boards

### DIFF
--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/FreeRTOSConfig.h
@@ -317,6 +317,16 @@ void vLoggingPrintf( const char *pcFormat, ... );
 
 #define configUSE_POSIX_ERRNO               ( 1 )
 
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
+
 /* chip include (also indirectly includes core_cm4.h) */
 #include "mt7687.h"
 

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/FreeRTOSConfig.h
@@ -296,6 +296,15 @@ extern uint32_t                             SystemCoreClock;
 
 #define configUSE_POSIX_ERRNO               ( 1 )
 
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
 /* chip include (also indirectly includes core_cm4.h) */
 #include "mt7687.h"
 

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
@@ -204,4 +204,13 @@
 /* The platform FreeRTOS is running on. */
 #define configPLATFORM_NAME    "NXPLPC54018"
 
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
 #endif /* FREERTOS_CONFIG_H */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/FreeRTOSConfig.h
@@ -208,4 +208,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* The platform FreeRTOS is running on. */
 #define configPLATFORM_NAME    "NXPLPC54018"
 
+/* The size of the global output buffer that is available for use when there
+ * are multiple command interpreters running at once (for example, one on a UART
+ * and one on TCP/IP).  This is done to prevent an output buffer being defined by
+ * each implementation - which would waste RAM.  In this case, there is only one
+ * command interpreter running, and it has its own local output buffer, so the
+ * global buffer is just set to be one byte long as it is not used and should not
+ * take up unnecessary RAM. */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
+
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
Add CLI config to mediatek and nxp boards

Description
-----------
Boards were missing the config for CLI library.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.