### PR TITLE
OTA: Abort the image if job status update fails

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
+++ b/libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c
@@ -1131,7 +1131,23 @@ static OTA_Err_t prvProcessDataHandler( OTA_EventData_t * pxEventData )
 
             if( xErr != kOTA_Err_None )
             {
-                OTA_LOG_L2( "[%s] Failed to update job status %d\r\n", OTA_METHOD_NAME, xErr );
+                OTA_LOG_L1( "[%s] Failed to update job status %d\r\n", OTA_METHOD_NAME, xErr );
+
+                /* Job status update failed, call the platform specific code to abort the image. */
+                xErr = xOTA_Agent.xPALCallbacks.xSetPlatformImageState( xOTA_Agent.ulServerFileID, eOTA_ImageState_Aborted );
+
+                if( xErr != kOTA_Err_None )
+                {
+                    OTA_LOG_L1( "[%s] Error trying to set platform image state (0x%08x)\r\n", OTA_METHOD_NAME, ( int32_t ) xErr );
+                }
+
+                /* Let application know of the fail event. */
+                xOTA_Agent.xPALCallbacks.xCompleteCallback( eOTA_JobEvent_Fail );
+            }
+            else
+            {
+                /* Let application know of the activate state. */
+                xOTA_Agent.xPALCallbacks.xCompleteCallback( eOTA_JobEvent_Activate );
             }
         }
         else
@@ -1143,7 +1159,7 @@ static OTA_Err_t prvProcessDataHandler( OTA_EventData_t * pxEventData )
 
             if( xErr != kOTA_Err_None )
             {
-                OTA_LOG_L2( "[%s] Error trying to set platform image state (0x%08x)\r\n", OTA_METHOD_NAME, ( int32_t ) xErr );
+                OTA_LOG_L1( "[%s] Error trying to set platform image state (0x%08x)\r\n", OTA_METHOD_NAME, ( int32_t ) xErr );
             }
 
             /* Update the job status with the with failure code. */
@@ -1151,8 +1167,11 @@ static OTA_Err_t prvProcessDataHandler( OTA_EventData_t * pxEventData )
 
             if( xErr != kOTA_Err_None )
             {
-                OTA_LOG_L2( "[%s] Failed to update job status %d\r\n", OTA_METHOD_NAME, xErr );
+                OTA_LOG_L1( "[%s] Failed to update job status %d\r\n", OTA_METHOD_NAME, xErr );
             }
+
+            /* Let application know of the fail event. */
+            xOTA_Agent.xPALCallbacks.xCompleteCallback( eOTA_JobEvent_Fail );
         }
 
         /* Send event to close file. */
@@ -1160,11 +1179,8 @@ static OTA_Err_t prvProcessDataHandler( OTA_EventData_t * pxEventData )
 
         if( !OTA_SignalEvent( &xEventMsg ) )
         {
-            OTA_LOG_L2( "[%s] Failed to singal OTA agent to close file.", OTA_METHOD_NAME );
+            OTA_LOG_L1( "[%s] Failed to singal OTA agent to close file.", OTA_METHOD_NAME );
         }
-
-        /* Let main application know of our result. */
-        xOTA_Agent.xPALCallbacks.xCompleteCallback( ( xResult == eIngest_Result_FileComplete ) ? eOTA_JobEvent_Activate : eOTA_JobEvent_Fail );
 
         /* Free any remaining string memory holding the job name since this job is done. */
         if( xOTA_Agent.pcOTA_Singleton_ActiveJobName != NULL )


### PR DESCRIPTION
<!--- Title -->
Abort the update image if self-test jobs status fails.

Description
-----------
<!--- Describe your changes in detail -->
The change adds a check before activating the image to abort if the publish for job status update failed. The image will be activated only when the publish is successful. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.