### PR TITLE
Improve logging on Windows

### DIFF
--- a/libraries/c_sdk/standard/common/include/logging_stack.h
+++ b/libraries/c_sdk/standard/common/include/logging_stack.h
@@ -41,7 +41,11 @@
 
 /* Macro to extract only the file name from file path to use for metadata in
  * log messages. */
-#define FILENAME               ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
+#ifdef _MSC_VER
+    #define FILENAME           ( strrchr( __FILE__, '\\' ) ? strrchr( __FILE__, '\\' ) + 1 : __FILE__ )
+#else
+    #define FILENAME           ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
+#endif
 
 #define LOG_METADATA_FORMAT    "[%s:%d] "
 #define LOG_METADATA_ARGS      FILENAME, __LINE__


### PR DESCRIPTION
Update `logging_stack.h` file to support filename extraction from `__FILE__` macro for Windows platform.