### PR TITLE
Kernel update

### DIFF
--- a/vendors/cypress/MTB/psoc6/common/FreeRTOS-openocd.c
+++ b/vendors/cypress/MTB/psoc6/common/FreeRTOS-openocd.c
@@ -17,4 +17,5 @@
 #define USED
 #endif
 
-const int USED uxTopUsedPriority = configMAX_PRIORITIES - 1;
+/* This symbol is no longer needed when using FreeRTOS Kernel v10.4.2 or newer. */
+/* const int USED uxTopUsedPriority = configMAX_PRIORITIES - 1; */

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -156,7 +156,7 @@ target_include_directories(
     AFR::kernel::mcu_port
     INTERFACE
         ${kernel_inc_dirs}
-        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32/include/"
+        "${AFR_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32_IDF3/include/"
         "${aws_credentials_include}"
         "${board_dir}/config_files"
         "$<$<NOT:${AFR_METADATA_MODE}>:${CMAKE_BINARY_DIR}/config>"

--- a/vendors/espressif/boards/esp32/components/freertos/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/components/freertos/CMakeLists.txt
@@ -6,7 +6,7 @@ set(
     include_dirs
     include
     ${AMAZON_FREERTOS_KERNEL_DIR}/include
-    ${AMAZON_FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32/include
+    ${AMAZON_FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32_IDF3/include
 )
 
 if(AFR_ENABLE_TESTS)
@@ -26,7 +26,7 @@ set(COMPONENT_ADD_INCLUDEDIRS "${include_dirs}")
 set(COMPONENT_REQUIRES )
 set(COMPONENT_PRIV_REQUIRES )
 
-set(COMPONENT_SRCDIRS . ${AMAZON_FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32 ${AMAZON_FREERTOS_KERNEL_DIR})
+set(COMPONENT_SRCDIRS . ${AMAZON_FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Xtensa_ESP32_IDF3 ${AMAZON_FREERTOS_KERNEL_DIR})
 
 set(COMPONENT_ADD_LDFRAGMENTS linker.lf)
 


### PR DESCRIPTION
Kernel update

Description
-----------    
Fix Espressif ESP32 build when targeting IDF v3.3. The new FreeRTOS kernel supports both Espressif's IDF v3.3 and v4.2. Due to this the cmake build must be updated to target v3.3, until Amazon FreeRTOS has updated to IDF v4.2.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.