### PR TITLE
Use unique MQTT topics in integration tests

### DIFF
--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -153,12 +153,12 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                       "/iot/integration/test"
+#define TEST_MQTT_TOPIC                       clientcredentialIOT_THING_NAME "/iot/integration/test"
 
 /**
  * @brief Sample topic filter 2 to use in tests.
  */
-#define TEST_MQTT_TOPIC_2                     "/iot/integration/test2"
+#define TEST_MQTT_TOPIC_2                     clientcredentialIOT_THING_NAME "/iot/integration/test2"
 
 /**
  * @brief Length of sample topic filter.
@@ -168,7 +168,7 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                   "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                   clientcredentialIOT_THING_NAME "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -153,12 +153,12 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                       clientcredentialIOT_THING_NAME "/iot/integration/test"
+#define TEST_MQTT_TOPIC                       TEST_CLIENT_IDENTIFIER "/iot/integration/test"
 
 /**
  * @brief Sample topic filter 2 to use in tests.
  */
-#define TEST_MQTT_TOPIC_2                     clientcredentialIOT_THING_NAME "/iot/integration/test2"
+#define TEST_MQTT_TOPIC_2                     TEST_CLIENT_IDENTIFIER "/iot/integration/test2"
 
 /**
  * @brief Length of sample topic filter.
@@ -168,7 +168,7 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                   clientcredentialIOT_THING_NAME "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                   TEST_CLIENT_IDENTIFIER "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.


### PR DESCRIPTION
### Problem
Parallel MQTT integration jobs against the same broker interfere with each other because of using the same set of MQTT topics per job.

### Fix
Add uniqueness in MQTT topics by prefixing the configurable client ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.