### PR TITLE
Disable metadata configuration of old MQTT demos

### DIFF
--- a/demos/mqtt/CMakeLists.txt
+++ b/demos/mqtt/CMakeLists.txt
@@ -1,10 +1,6 @@
 # C SDK MQTT demo
 afr_demo_module(mqtt)
 
-afr_set_demo_metadata(ID "MQTT_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates MQTT")
-afr_set_demo_metadata(DISPLAY_NAME "MQTT Hello World")
-
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE


### PR DESCRIPTION
Remove metadata configuration of old MQTT demos in `demos/mqtt` to favor new MQTT demos in `demos/coreMQTT`