### PR TITLE
BLE AFQP test update

### DIFF
--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/startTests_afqp.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/startTests_afqp.py
@@ -32,6 +32,7 @@ import time
 from testClass import runTest
 from bleAdapter import bleAdapter
 
+ENABLE_TC_AFQP_READ_WRITE_LONG = 1
 
 def main():
     scan_filter = dict()
@@ -79,10 +80,11 @@ def main():
     runTest.submitTestResult(isTestSuccessFull, runTest.checkProperties)
 
     # CHeck long write
-    isTestSuccessFull = runTest.writereadLongCharacteristic()
-    runTest.submitTestResult(
-        isTestSuccessFull,
-        runTest.writereadLongCharacteristic)
+    if ENABLE_TC_AFQP_READ_WRITE_LONG == 1:
+        isTestSuccessFull = runTest.writereadLongCharacteristic()
+        runTest.submitTestResult(
+            isTestSuccessFull,
+            runTest.writereadLongCharacteristic)
 
     # Check read/write, simple connection
     isTestSuccessFull = runTest.readWriteSimpleConnection()

--- a/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
+++ b/libraries/abstractions/ble_hal/test/ble_test_scipts/testClass.py
@@ -367,7 +367,7 @@ class runTest:
         if charRead != long_value:
             isTestSuccessfull = False
             print(
-                "readWriteSimpleConnection test: Expected value:" +
+                "writereadLongCharacteristic test: Expected value:" +
                 long_value +
                 " got:" +
                 charRead)

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -266,12 +266,18 @@ TEST( Full_BLE, BLE_Connection_Mode1Level2 )
     IotTestBleHal_WaitConnection( true );
 
     xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), BLE_TESTS_WAIT );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-    TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
 
-    xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    if( xStatus == eBTStatusSuccess )
+    {
+        /*
+         * Pairing request user level callback is optional for Mode 1 level 2, as they dont need authentication and BLE stack can accept or reject mode 1 level 2 pairing requests without
+         * user intervention.
+         */
+        TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+        TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
+        xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
+    }
 
     xStatus = IotTestBleHal_WaitEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), bletestWAIT_MODE1_LEVEL2_QUERY, IotTestBleHal_CheckBondState );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );                        /* Pairing should never come since it is secure connection only */

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -1119,15 +1119,13 @@ void IotTestBleHal_CreateSecureConnection_Model1Level4( bool IsBondSucc )
     /* Wait secure connection. Secure connection is triggered by writting to bletestsCHARB. */
     xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), BLE_TESTS_WAIT );
 
-    if( IsBondSucc == true )
-    {
-        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-        TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-        TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
-    }
-
     if( xStatus == eBTStatusSuccess )
     {
+        /*
+         * Initial Pairing request user level callback with consent is optional for Mode 1 level 4, as the user interaction is required in next step.
+         */
+        TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+        TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
         IotTestBleHal_ClearEventQueue();
 
         xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_common_gap.c
@@ -321,11 +321,6 @@ void prvGAPeventHandler( ble_evt_t const * p_ble_evt,
                 xErrCode = nrf_ble_gatt_att_mtu_periph_set( xGattHandler, xProperties.ulMtu );
             }
 
-            if( ( xErrCode == NRF_SUCCESS ) && bGattInitialized )
-            {
-                xErrCode = xBTGattUpdateMtu( xGattHandler, usGattConnHandle );
-            }
-
             if( xGattServerCb.pxConnectionCb )
             {
                 xGattServerCb.pxConnectionCb( p_ble_evt->evt.gap_evt.conn_handle,
@@ -527,21 +522,10 @@ void prvGAPeventHandler( ble_evt_t const * p_ble_evt,
             break;
 
         case BLE_GATTC_EVT_EXCHANGE_MTU_RSP:
-
-            if( xGattServerCb.pxMtuChangedCb != NULL )
-            {
-                xGattServerCb.pxMtuChangedCb( p_ble_evt->evt.gap_evt.conn_handle, p_ble_evt->evt.gattc_evt.params.exchange_mtu_rsp.server_rx_mtu );
-            }
-
             break;
 
         case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST:
-
-            if( xGattServerCb.pxMtuChangedCb != NULL )
-            {
-                xGattServerCb.pxMtuChangedCb( p_ble_evt->evt.gap_evt.conn_handle, p_ble_evt->evt.gatts_evt.params.exchange_mtu_request.client_rx_mtu );
-            }
-
+            IotLogDebug( "MTU exchange request from GATT client, mtu = %d.", p_ble_evt->evt.gatts_evt.params.exchange_mtu_request.client_rx_mtu );
             break;
 
         case BLE_GAP_EVT_CONN_PARAM_UPDATE:
@@ -1051,16 +1035,11 @@ BTStatus_t prvBTSetDeviceProperty( const BTProperty_t * pxProperty )
             break;
 
         case eBTpropertyLocalMTUSize: /* TODO: Check if we should save gatt handler from connection even and update its MTU */
-            xProperties.ulMtu = *( ( uint32_t * ) pxProperty->pvVal );
+            xProperties.ulMtu = *( ( uint16_t * ) pxProperty->pvVal );
 
             if( bGattInitialized )
             {
                 xNRFstatus = nrf_ble_gatt_att_mtu_periph_set( xGattHandler, xProperties.ulMtu );
-
-                if( ( xNRFstatus == NRF_SUCCESS ) && bIsConnected )
-                {
-                    xNRFstatus = xBTGattUpdateMtu( xGattHandler, usGattConnHandle );
-                }
             }
 
             xStatus = BTNRFError( xNRFstatus );

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gatt_server.c
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_gatt_server.c
@@ -105,6 +105,23 @@ nrf_ble_gatt_t * prvGetGattHandle()
     return &xGattHandler;
 }
 
+
+static void prvBLEGattEventCallback (nrf_ble_gatt_t * p_gatt, nrf_ble_gatt_evt_t const * p_evt)
+{
+    switch( p_evt->evt_id )
+    {
+        case NRF_BLE_GATT_EVT_ATT_MTU_UPDATED:
+            if( xGattServerCb.pxMtuChangedCb != NULL )
+            {
+                xGattServerCb.pxMtuChangedCb( p_evt->conn_handle, p_evt->params.att_mtu_effective );
+            }
+            break;
+        case NRF_BLE_GATT_EVT_DATA_LENGTH_UPDATED:
+            NRF_LOG_INFO( "Data length updated for connection %d, length = %d.\r\n", p_evt->conn_handle, p_evt->params.data_length );
+            break;
+    }
+}
+
 /**
  * @brief Returns the softdevice handle for a given inner GATT handle
  * @param handle inner GATT handle
@@ -298,7 +315,7 @@ BTStatus_t prvBTUnregisterServer( uint8_t ucServerIf )
 BTStatus_t prvBTGattServerInit( const BTGattServerCallbacks_t * pxCallbacks )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
-    ret_code_t xErrCode = nrf_ble_gatt_init( &xGattHandler, NULL );
+    ret_code_t xErrCode = nrf_ble_gatt_init( &xGattHandler, prvBLEGattEventCallback );
 
     if( xErrCode == NRF_SUCCESS )
     {


### PR DESCRIPTION
BLE AFQP test update

Description
-----------
1. Make Pairing request callback with Consent as optional requirement to pass qualification tests.
2. Fix the MTU callback handling in Nordic BLE port, to pass the qualification tests. 
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.