### PR TITLE
OTA e2e test fix for ESP32

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
@@ -896,7 +896,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
     /* Sending the bytes on the network using Network Interface. */
     bytesSend = pNetworkContext->pNetworkInterface->send( pNetworkContext->pNetworkConnection, ( const uint8_t * ) pMessage, bytesToSend );
 
-    if( bytesSend < 0 )
+    if( bytesSend <= 0 )
     {
         /* Network Send Interface return negative value in case of any socket error,
          * unifying the error codes here for socket error and timeout to comply with the MQTT LTS Library.

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
@@ -898,7 +898,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
 
     if( bytesSend <= 0 )
     {
-        /* Network Send Interface return negative value in case of any socket error,
+        /* Network Send Interface returns a negative value or zero in case of any socket error,
          * unifying the error codes here for socket error and timeout to comply with the MQTT LTS Library.
          */
         bytesSend = -1;


### PR DESCRIPTION
OTA e2e test fix for ESP32.

Description
-----------
OTA e2e test fix for ESP32.
Issue: The return of 0 from Network interface was an error. However, it was interpreted as a timeout in transport interface.
Fix: Handle Network interface failure in transport send.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.