### PR TITLE
Remove metadata of old MQTT library

### DIFF
--- a/libraries/c_sdk/standard/mqtt/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt/CMakeLists.txt
@@ -1,4 +1,4 @@
-afr_module()
+afr_module(INTERNAL)
 
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")

--- a/libraries/c_sdk/standard/mqtt/CMakeLists.txt
+++ b/libraries/c_sdk/standard/mqtt/CMakeLists.txt
@@ -1,13 +1,5 @@
 afr_module()
 
-afr_set_lib_metadata(ID "mqtt")
-afr_set_lib_metadata(DESCRIPTION "This library implements the MQTT protocol that enables \
-communication with AWS IoT. MQTT is an ISO standard publish-subscribe-based messaging protocol.")
-afr_set_lib_metadata(DISPLAY_NAME "MQTT")
-afr_set_lib_metadata(CATEGORY "Connectivity")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "true")
-
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")


### PR DESCRIPTION
Follow-up PR from #2554. It additionally removes metadata information of the old MQTT library (present in `libraries/c_sdk/standard/mqtt`) to favor the new MQTT library (present at `libraries/coreMQTT`)