### PR TITLE
Fix metadata configuration issue for coreMQTT

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -57,4 +57,4 @@ foreach(module IN LISTS afr_modules_csdk afr_modules_freertos_plus afr_modules_a
 endforeach()
 
 # Add core_mqtt modules
-include(core_mqtt_module.cmake)
+include(core_mqtt.cmake)

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -1,4 +1,4 @@
-afr_module(NAME "core_mqtt" )
+afr_module(NAME core_mqtt )
 
 afr_set_lib_metadata(ID "core_mqtt")
 afr_set_lib_metadata(DESCRIPTION "This library implements the MQTT protocol that enables \


### PR DESCRIPTION
Fix metadata module name generated by `AFR_METADATA_MODE` flag from `core_mqtt_module` to `core_mqtt`

With the file name as `core_mqtt_module.cmake`, the generated metadata is:
```
core_mqtt_module###ID:::core_mqtt
core_mqtt_module###DESCRIPTION:::This library implements the MQTT protocol that enables communication with AWS IoT. MQTT is an ISO standard publish-subscribe-based messaging protocol.
core_mqtt_module###DISPLAY_NAME:::Core MQTT
core_mqtt_module###CATEGORY:::Connectivity
core_mqtt_module###VERSION:::1.0.0
core_mqtt_module###IS_VISIBLE:::tru
```

With this PR's change (of renaming the file), the correctly generated metadata is:
```
core_mqtt###ID:::core_mqtt
core_mqtt###DESCRIPTION:::This library implements the MQTT protocol that enables communication with AWS IoT. MQTT is an ISO standard publish-subscribe-based messaging protocol.
core_mqtt###DISPLAY_NAME:::Core MQTT
core_mqtt###CATEGORY:::Connectivity
core_mqtt###VERSION:::1.0.0
core_mqtt###IS_VISIBLE:::true
```
The above matches the module name of `AFR::core_mqtt`