### PR TITLE
CORE MQTT Demos: Some boards do not have xPortGetFreeHeapSize() available.

### DIFF
--- a/demos/coreMQTT/mqtt_demo_keep_alive.c
+++ b/demos/coreMQTT/mqtt_demo_keep_alive.c
@@ -641,16 +641,13 @@ int RunCoreMqttKeepAliveDemo( bool awsIotMqttMode,
 
             /* Wait for some time between two iterations to ensure that we do not
              * bombard the broker. */
-            LogInfo( ( "RunCoreMqttKeepAliveDemo() completed successfully. "
-                       "Total free heap is %u.",
-                       xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoRunCount + 1UL ) ) );
             LogInfo( ( "Short delay before starting the next iteration.... " ) );
             vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
         }
         else
         {
-            LogInfo( ( "RunCoreMqttKeepAliveDemo() failed. Total free heap is %u.",
-                       xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoRunCount + 1UL ) ) );
             break;
         }
     }

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -527,15 +527,14 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
         if( xDemoStatus == pdPASS )
         {
             /* Wait for some time between two iterations to ensure that we do not
-             * the broker. */
-            LogInfo( ( "Demo completed an iteration successfully. Total free heap is %u.", xPortGetFreeHeapSize() ) );
+             * bombard the broker. */
+            LogInfo( ( "Demo completed an iteration successfully." ) );
             LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoRunCount + 1UL ) ) );
         }
         else
         {
             /* Terminate the demo due to failure. */
-            LogInfo( ( "Demo failed at iteration %lu. Total free heap is %u.",
-                       ( ulDemoRunCount + 1UL ), xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoRunCount + 1UL ) ) );
             LogInfo( ( "Exiting demo." ) );
             break;
         }

--- a/demos/coreMQTT/mqtt_demo_plaintext.c
+++ b/demos/coreMQTT/mqtt_demo_plaintext.c
@@ -497,16 +497,13 @@ int RunCoreMqttPlaintextDemo( bool awsIotMqttMode,
 
             /* Wait for some time between two iterations to ensure that we do not
              * bombard the broker. */
-            LogInfo( ( "RunCoreMqttPlaintextDemo() completed an iteration successfully. "
-                       "Total free heap is %u.",
-                       xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoRunCount + 1UL ) ) );
             LogInfo( ( "Short delay before starting the next iteration.... " ) );
             vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
         }
         else
         {
-            LogInfo( ( "RunCoreMqttPlaintextDemo() failed. Total free heap is %u.",
-                       xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoRunCount + 1UL ) ) );
             break;
         }
     }

--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -526,15 +526,13 @@ int RunCoreMqttSerializerDemo( bool awsIotMqttMode,
 
             /* Wait for some time between two iterations to ensure that we do not
              * bombard the MQTT broker. */
-            LogInfo( ( "RunCoreMqttSerializerDemo() completed an iteration successfully. "
-                       "Total free heap is %u.", xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoRunCount + 1UL ) ) );
             LogInfo( ( "Short delay before starting the next iteration.... " ) );
             vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
         }
         else
         {
-            LogInfo( ( "RunCoreMqttSerializerDemo() failed. Total free heap is %u.",
-                       xPortGetFreeHeapSize() ) );
+            LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoRunCount + 1UL ) ) );
             break;
         }
     }


### PR DESCRIPTION
Cypress CYW943907AEVAL1F and CYW954907AEVAL1F do not have xPortGetFreeHeapSize() defined because it uses heap_3. 

Another reason to remove this statistic is because the demos in this repo already print out memory statistics for the platform, if supported, after the demo completes: https://github.com/aws/amazon-freertos/blob/master/demos/demo_runner/iot_demo_freertos.c#L323

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.