### PR TITLE
Delete unused configs in the MQTT mutual auth demo configs.

### DIFF
--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -34,10 +34,9 @@
  * memory. It uses QoS1 for sending to and receiving messages from the broker.
  *
  * A mutually authenticated TLS connection is used to connect to the
- * MQTT message broker in this example. Define democonfigMQTT_BROKER_ENDPOINT,
- * democonfigROOT_CA_PEM, democonfigCLIENT_CERTIFICATE_PEM,
- * and democonfigCLIENT_PRIVATE_KEY_PEM in mqtt_demo_mutual_auth_config.h to establish a
- * mutually authenticated connection.
+ * MQTT message broker in this example. Define democonfigMQTT_BROKER_ENDPOINT
+ * and democonfigROOT_CA_PEM, in mqtt_demo_mutual_auth_config.h, and keys, in
+ * aws_clientcredential_keys.h, to establish a mutually authenticated connection.
  */
 
 /**

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -35,8 +35,9 @@
  *
  * A mutually authenticated TLS connection is used to connect to the
  * MQTT message broker in this example. Define democonfigMQTT_BROKER_ENDPOINT
- * and democonfigROOT_CA_PEM, in mqtt_demo_mutual_auth_config.h, and keys, in
- * aws_clientcredential_keys.h, to establish a mutually authenticated connection.
+ * and democonfigROOT_CA_PEM, in mqtt_demo_mutual_auth_config.h, and the client
+ * private key and certificate, in aws_clientcredential_keys.h, to establish a
+ * mutually authenticated connection.
  */
 
 /**

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_keep_alive_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_keep_alive_config.h
@@ -115,9 +115,5 @@
  * #define democonfigMQTT_MAX_DEMO_COUNT                ( insert here. )
  */
 
-/* This demo uses xPortGetFreeHeapSize() to get the remaining heap space left.
- * This Cypress CYW943907AEVAL1F platform uses heap_3 which does not have this
- * function available. */
-#define xPortGetFreeHeapSize()                          0U
 
 #endif /* MQTT_KEEP_ALIVE_CONFIG_H */

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_keep_alive_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_keep_alive_config.h
@@ -115,5 +115,9 @@
  * #define democonfigMQTT_MAX_DEMO_COUNT                ( insert here. )
  */
 
+/* This demo uses xPortGetFreeHeapSize() to get the remaining heap space left.
+ * This Cypress CYW943907AEVAL1F platform uses heap_3 which does not have this
+ * function available. */
+#define xPortGetFreeHeapSize()                          0U
 
 #endif /* MQTT_KEEP_ALIVE_CONFIG_H */

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,6 +55,10 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
+ * 
+ * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  */
 
 /**

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -53,6 +53,11 @@
 /************ End of logging configuration ****************/
 
 /**
+ * To use this demo, please configure the client's certificate and private key
+ * in demos/include/aws_clientcredential_keys.h.
+ */
+
+/**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -105,40 +105,6 @@
  */
 
 /**
- * @brief Client certificate.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding client authentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This certificate should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----\n"\
- * "...base64 data...\n"\
- * "-----END CERTIFICATE-----\n"
- *
- * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
- */
-
-/**
- * @brief Client's private key.
- *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
- * regarding clientauthentication.
- * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
- *
- * @note This private key should be PEM-encoded.
- *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----\n"\
- * "...base64 data...\n"\
- * "-----END RSA PRIVATE KEY-----\n"
- *
- * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
- */
-
-/**
  * @brief Size of the network buffer for MQTT packets.
  */
 #define democonfigNETWORK_BUFFER_SIZE    ( 1024U )


### PR DESCRIPTION
In this repo the client certificate and private key are configured in aws_clientcredential_keys.h only. We delete the unused democonfigCLIENT_CERTIFICATE_PEM and democonfigCLIENT_PRIVATE_KEY_PEM configurations from the mqtt_demo_mutual_auth_config.h files.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.