### PR TITLE
Added repeat mode and secure mode cmdline args support

### DIFF
--- a/tools/echo_server/config.json
+++ b/tools/echo_server/config.json
@@ -2,6 +2,8 @@
     "verbose": false,
     "logging": false,
     "secure-connection": false,
+    "repeat-mode": false,
+    "repeat-interval-seconds": 1,
     "server-port": "9000",
     "server-certificate-location": "./certs/server.pem",
     "server-key-location": "./certs/server.key"

--- a/tools/echo_server/echo_server.go
+++ b/tools/echo_server/echo_server.go
@@ -41,25 +41,25 @@ import (
 
 const (
 	readTimeoutSecond = 300
-	portFlagName = "port"
-	repeatFlagName = "repeat"
-	intervalFlagName = "interval"
-	certFlagName = "cert"
-	keyFlagName = "key"
+	portFlagName      = "port"
+	repeatFlagName    = "repeat"
+	intervalFlagName  = "interval"
+	certFlagName      = "cert"
+	keyFlagName       = "key"
 )
 
 // Argument struct for JSON configuration
 type Argument struct {
-	Verbose    				bool   `json:"verbose"`
-	Logging    				bool   `json:"logging"`
-	Secure     				bool   `json:"secure-connection"`
-	RepeatMode 				bool   `json:"repeat-mode"`
-	RepeatIntervalSeconds	int    `json:"repeat-interval-seconds"`
-	ServerPort 				string `json:"server-port"`
-	ServerCert 				string `json:"server-certificate"`
-	ServerKey  				string `json:"server-key"`
-	ServerCertPath          string `json:"server-certificate-location"`
-	ServerKeyPath           string `json:"server-key-location"`
+	Verbose               bool   `json:"verbose"`
+	Logging               bool   `json:"logging"`
+	Secure                bool   `json:"secure-connection"`
+	RepeatMode            bool   `json:"repeat-mode"`
+	RepeatIntervalSeconds int    `json:"repeat-interval-seconds"`
+	ServerPort            string `json:"server-port"`
+	ServerCert            string `json:"server-certificate"`
+	ServerKey             string `json:"server-key"`
+	ServerCertPath        string `json:"server-certificate-location"`
+	ServerKeyPath         string `json:"server-key-location"`
 }
 
 func secureEcho(config *Argument) {
@@ -272,7 +272,7 @@ func main() {
 
 	secureArgsCount := 0
 	// overwrite config only if the flags are set
-	flag.Visit(func (f *flag.Flag) {
+	flag.Visit(func(f *flag.Flag) {
 		if f.Name == portFlagName {
 			config.ServerPort = *serverPort
 		} else if f.Name == repeatFlagName {

--- a/tools/echo_server/readme.md
+++ b/tools/echo_server/readme.md
@@ -41,6 +41,10 @@ The JSON file contains the following options:
     1. The repeat interval in seconds. When in repeat mode, the echo server will wait for this amount of time until the next echoing.
 1. server-port
     1. Specify which port to open a socket on.
+1. server-certificate
+    1. Server certificate in X509 format. When both `server-certificate` and `server-certificate-location` are specified, this option will be used instead.
+1. server-key
+    1. Server private key in X509 format. When both `server-key` and `server-key-location` are specified, this option will be used instead.
 1. server-certificate-location
     1. Relative or absolute path to the server certificate generated in the credential creation prerequisite.
 1. server-key-location
@@ -54,8 +58,11 @@ The JSON file contains the following options:
     "repeat-mode": false,
     "repeat-interval-seconds": 1,
     "server-port": "9000",
+    "server-certificate": "<cert-content>",
+    "server-key": "<key-content>",
     "server-certificate-location": "./certs/server.pem",
     "server-key-location": "./certs/server.key"
+
 }
 ```
 # Running the Echo Server From the Command Line
@@ -67,9 +74,10 @@ The JSON file contains the following options:
 ## With Server Certificate and Key passed from command line args
 `go run echo_server.go -cert='<x509-cert-content>' -key='<x509-key-content>'`
 
-Note: When using command line args, the echo server will be configured in secure mode if either the `-cert` flag or the `-key` flag is used.
-
-Note: If you wish to run the unsecure and secure TCP tests at the same time, make sure you start a secure and unsecure echo server, this will require changing the configuration (You can create a second "secure" configuration, and pass it to the echo server via the -config flag.), as well as using seperate TCP ports.
+Note:
+- The `-cert` and `-key` flags will overwrite any other server credential settings (`server-certificate`, `server-certificate-location`, `server-key`, `server-key-location`) in config.json file.
+- When using command line args, the echo server will be automatically configured in secure mode if both the `-cert` flag and the `-key` flag are present.
+- If you wish to run the unsecure and secure TCP tests at the same time, make sure you start a secure and unsecure echo server, this will require changing the configuration (You can create a second "secure" configuration, and pass it to the echo server via the -config flag.), as well as using seperate TCP ports.
 
 # Client Device Configuration
 Before running the TCP tests on your device, it is recommended to have already read through the [FreeRTOS getting started guide](https://docs.aws.amazon.com/freertos/latest/userguide/freertos-getting-started.html).

--- a/tools/echo_server/readme.md
+++ b/tools/echo_server/readme.md
@@ -44,7 +44,7 @@ The JSON file contains the following options:
 1. server-certificate
     1. Server certificate in X509 format. When both `server-certificate` and `server-certificate-location` are specified, this option will be used instead.
 1. server-key
-    1. Server private key in X509 format. When both `server-key` and `server-key-location` are specified, this option will be used instead.
+    1. Server private key. When both `server-key` and `server-key-location` are specified, this option will be used instead.
 1. server-certificate-location
     1. Relative or absolute path to the server certificate generated in the credential creation prerequisite.
 1. server-key-location
@@ -62,7 +62,6 @@ The JSON file contains the following options:
     "server-key": "<key-content>",
     "server-certificate-location": "./certs/server.pem",
     "server-key-location": "./certs/server.key"
-
 }
 ```
 # Running the Echo Server From the Command Line

--- a/tools/echo_server/readme.md
+++ b/tools/echo_server/readme.md
@@ -34,7 +34,11 @@ The JSON file contains the following options:
 1. logging
     1. Enable this option to output log all messages received to a file.
 1. secure-connection
-    1. Enable this option to switch to using TLS for the echo server. Note you will have to complete the credential creation prerequisite. 
+    1. Enable this option to switch to using TLS for the echo server. Note you will have to complete the credential creation prerequisite.
+1. repeat-mode
+    1. Enable this option to switch to repeat mode. In repeat mode, the echo server will repeatly echo the same message sent by the client.
+1. repeat-interval-seconds
+    1. The repeat interval in seconds. When in repeat mode, the echo server will wait for this amount of time until the next echoing.
 1. server-port
     1. Specify which port to open a socket on.
 1. server-certificate-location
@@ -47,15 +51,23 @@ The JSON file contains the following options:
     "verbose": false,
     "logging": false,
     "secure-connection": false,
+    "repeat-mode": false,
+    "repeat-interval-seconds": 1,
     "server-port": "9000",
     "server-certificate-location": "./certs/server.pem",
-    "server-key-location": "./certs/server.pem"
+    "server-key-location": "./certs/server.key"
 }
 ```
 # Running the Echo Server From the Command Line
 `go run echo_server.go`
 ## With a Custom Config Location
 `go run echo_server.go -config={config_file_path}`
+## With Repeat Mode on and a repeat interval of 3 seconds
+`go run echo_server.go -repeat=true -interval=3`
+## With Server Certificate and Key passed from command line args
+`go run echo_server.go -cert='<x509-cert-content>' -key='<x509-key-content>'`
+
+Note: When using command line args, the echo server will be configured in secure mode if either the `-cert` flag or the `-key` flag is used.
 
 Note: If you wish to run the unsecure and secure TCP tests at the same time, make sure you start a secure and unsecure echo server, this will require changing the configuration (You can create a second "secure" configuration, and pass it to the echo server via the -config flag.), as well as using seperate TCP ports.
 


### PR DESCRIPTION
Repeat mode and Secure mode cmdline args support for Echo Server

Description
-----------
- Added repeat mode cmdline args support: `-repeat` & `-interval`
- Added secure mode cmdline args support: `-cert` & `-key`
- Updated Readme.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.