### PR TITLE
Disable logging in the coreMQTT library for all aws_test projects.

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"


### PR DESCRIPTION
Positives of this change:  
- Most of the MQTT unit tests perform errors cases and there are too many logs. This was causing the test FAIL and PASS logs to not print.
- With no library logging, the Unity PASS or FAIL for a test case will always print. The CI reads these logs to determine if a test was successful. 

Negatives of this change:  
- If a new change breaks the CSDK v4_beta IoT MQTT unit test, then developers will need to create a new branch with logging turned on. Then they will need to run a custom job in CI to see the failure.

Please see the infineon unit tests below:
```

18:05:59 Executing command: rm C:\i_m\xmc4800_plus_optiga_trust_x-8\amazon-freertos/flash.jlink
18:05:59 Flashing of the board finished.
18:05:59 
18:05:59 ----------------------------------------------------------------------------------------------------
18:05:59 Serial output
18:05:59 ----------------------------------------------------------------------------------------------------
18:06:03 .1 5961 [Tmr Svc] Wi-Fi Connected to AP. Creating tasks which use network...

18:06:04 2 5973 [Tmr Svc] IP Address acquired 192.168.35.220

18:06:04 3 6111 [Tmr Svc] Write certificate...

18:06:08 .---------STARTING TESTS---------
18:06:09 UUID: _uuid_499298b4d37f41b6b6267ac06464ed39
18:06:10 TEST(MQTT_Unit_Receive, DecodeRemainingLength) PASS
18:06:10 TEST(MQTT_Unit_Receive, InvalidPacket) PASS
18:06:10 TEST(MQTT_Unit_Receive, ConnackValid) PASS
18:06:10 TEST(MQTT_Unit_Receive, ConnackInvalid) PASS
18:06:10 TEST(MQTT_Unit_Receive, PublishValid) PASS
18:06:10 TEST(MQTT_Unit_Receive, PublishInvalid) PASS
18:06:10 TEST(MQTT_Unit_Receive, PubackValid) PASS
18:06:10 TEST(MQTT_Unit_Receive, PubackInvalid) PASS
18:06:10 TEST(MQTT_Unit_Receive, SubackValid) PASS
18:06:10 TEST(MQTT_Unit_Receive, SubackInvalid) PASS
18:06:11 TEST(MQTT_Unit_Receive, UnsubackValid) PASS
18:06:11 TEST(MQTT_Unit_Receive, UnsubackInvalid) PASS
18:06:11 TEST(MQTT_Unit_Receive, Pingresp) PASS
18:06:11 
18:06:11 -----------------------
18:06:11 13 Tests 0 Failures 0 Ignored 
18:06:11 OK
18:06:11 -------ALL TESTS FINISHED-------
18:06:11 ----------------------------------------------------------------------------------------------------
18:06:11 PostProcessing Step
18:06:11 ----------------------------------------------------------------------------------------------------
18:06:11 {
18:06:11     "MQTT_Unit_Receive": {
18:06:11         "DecodeRemainingLength": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "InvalidPacket": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "ConnackValid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "ConnackInvalid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "PublishValid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "PublishInvalid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "PubackValid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "PubackInvalid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "SubackValid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "SubackInvalid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "UnsubackValid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "UnsubackInvalid": {
18:06:11             "status": "PASS"
18:06:11         },
18:06:11         "Pingresp": {
18:06:11             "status": "PASS"
18:06:11         }
18:06:11     }
18:06:11 }
18:06:14 Regular expression run condition: Expression=[lab-linux-.*], Label=[lab-win-7]
18:06:14 Run condition [Regular expression match] preventing perform for step [BuilderChain]
18:06:14 Archiving artifacts
18:06:15 Recording fingerprints
18:06:15 Recording test results
18:06:15 [Checks API] No suitable checks publisher found.
18:06:15 Finished: SUCCESS
```
-------

### Other option(s):

#### Increase all board's logging queue size.
PROS:
- We want to show error logs for possibly faster debugging of broken tests straight from CI.

CONS:
- Most boards are at a logging queue size of 15. Microchip is at 32 and still the CI PASS/FAIL message does not print.
- It will take much time making sure that increasing the logging queue size does not have negative impacts on heap usage in other tests.
- Currently if tests break in CI, developers still have to go directly to the board most of the time to debug. 


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.