### PR TITLE
Fix MQTT and Shadow integration test failures on Nuvoton

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/main.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/main.c
@@ -56,7 +56,17 @@
 #define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
 
-#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 20 )
+#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 40 )
+
+#ifdef IOT_NETWORK_RECEIVE_TASK_PRIORITY
+
+/* Keeping the test runner task priority higher than that of the Network receive task
+ * priority so as to make sure that the receive of the incoming packets are only happening
+ * after successfully updating the internal data structures in test runner task for a send. */
+    #define mainTEST_RUNNER_TASK_PRIORITY    ( IOT_NETWORK_RECEIVE_TASK_PRIORITY + 1 )
+#else
+    #define mainTEST_RUNNER_TASK_PRIORITY    ( tskIDLE_PRIORITY )
+#endif
 
 /* The default IP and MAC address used by the demo.  The address configuration
  * defined here will be used if ipconfigUSE_DHCP is 0, or if ipconfigUSE_DHCP is
@@ -123,6 +133,7 @@ static void prvWifiConnect( void );
 static void prvMiscInitialization( void );
 
 /*-----------------------------------------------------------*/
+
 /**
  * @Set up the hardware ready to run this demo.
  */
@@ -133,10 +144,10 @@ static void prvSetupHardware( void );
 /**
  * @brief Application runtime entry point.
  */
-#define mainCHECK_TASK_PRIORITY             ( tskIDLE_PRIORITY + 3UL )
+#define mainCHECK_TASK_PRIORITY      ( tskIDLE_PRIORITY + 3UL )
 
-#define mainCHECK_TASK_STACK_SIZE           ( configMINIMAL_STACK_SIZE )
-#define mainCHECK_DELAY                     ( ( portTickType ) 5000 / portTICK_RATE_MS )
+#define mainCHECK_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE )
+#define mainCHECK_DELAY              ( ( portTickType ) 5000 / portTICK_RATE_MS )
 
 
 int main( void )
@@ -144,17 +155,17 @@ int main( void )
     /* Perform any hardware initialization that does not require the RTOS to be
      * running.  */
     prvMiscInitialization();
-    configPRINTF( ( "FreeRTOS_IPInit\n") );	
+    configPRINTF( ( "FreeRTOS_IPInit\n" ) );
 
     /* Start the scheduler.  Initialization that requires the OS to be running,
      * including the WiFi initialization, is performed in the RTOS daemon task
-     * startup hook. */ 
-         
+     * startup hook. */
+
     /* A simple example to demonstrate key and certificate provisioning in
      * microcontroller flash using PKCS#11 interface. This should be replaced
      * by production ready key provisioning mechanism. */
-    vDevModeKeyProvisioning();     
-    configPRINTF( ( "vTaskStartScheduler\n" ) );  
+    vDevModeKeyProvisioning();
+    configPRINTF( ( "vTaskStartScheduler\n" ) );
     vTaskStartScheduler();
 
     return 0;
@@ -167,29 +178,29 @@ static void prvSetupHardware( void )
     SYS_UnlockReg();
 
     /* Set XT1_OUT(PF.2) and XT1_IN(PF.3) to input mode */
-    PF->MODE &= ~(GPIO_MODE_MODE2_Msk | GPIO_MODE_MODE3_Msk);
+    PF->MODE &= ~( GPIO_MODE_MODE2_Msk | GPIO_MODE_MODE3_Msk );
 
     /* Enable External XTAL (4~24 MHz) */
-    CLK_EnableXtalRC(CLK_PWRCTL_HXTEN_Msk);
+    CLK_EnableXtalRC( CLK_PWRCTL_HXTEN_Msk );
 
     /* Waiting for 12MHz clock ready */
-    CLK_WaitClockReady( CLK_STATUS_HXTSTB_Msk);
+    CLK_WaitClockReady( CLK_STATUS_HXTSTB_Msk );
 
     /* Set core clock as PLL_CLOCK from PLL */
-    CLK_SetCoreClock(FREQ_192MHZ);
+    CLK_SetCoreClock( FREQ_192MHZ );
 
     /* Set both PCLK0 and PCLK1 as HCLK/2 */
     CLK->PCLKDIV = CLK_PCLKDIV_PCLK0DIV2 | CLK_PCLKDIV_PCLK1DIV2;
 
     /* Enable IP clock */
-    CLK_EnableModuleClock(UART0_MODULE);
-    CLK_EnableModuleClock(EMAC_MODULE);
+    CLK_EnableModuleClock( UART0_MODULE );
+    CLK_EnableModuleClock( EMAC_MODULE );
 
     /* Select IP clock source */
-    CLK_SetModuleClock(UART0_MODULE, CLK_CLKSEL1_UART0SEL_HXT, CLK_CLKDIV0_UART0(1));
+    CLK_SetModuleClock( UART0_MODULE, CLK_CLKSEL1_UART0SEL_HXT, CLK_CLKDIV0_UART0( 1 ) );
 
-    // Configure MDC clock rate to HCLK / (127 + 1) = 1.5 MHz if system is running at 192 MHz
-    CLK_SetModuleClock(EMAC_MODULE, 0, CLK_CLKDIV3_EMAC(127));
+    /* Configure MDC clock rate to HCLK / (127 + 1) = 1.5 MHz if system is running at 192 MHz */
+    CLK_SetModuleClock( EMAC_MODULE, 0, CLK_CLKDIV3_EMAC( 127 ) );
 
     /* Update System Core Clock */
     /* User can use SystemCoreClockUpdate() to calculate SystemCoreClock. */
@@ -198,9 +209,9 @@ static void prvSetupHardware( void )
 
 
     /* Set GPB multi-function pins for UART0 RXD and TXD */
-    SYS->GPB_MFPH &= ~(SYS_GPB_MFPH_PB12MFP_Msk | SYS_GPB_MFPH_PB13MFP_Msk);
-    SYS->GPB_MFPH |= (SYS_GPB_MFPH_PB12MFP_UART0_RXD | SYS_GPB_MFPH_PB13MFP_UART0_TXD);
-    // Configure RMII pins
+    SYS->GPB_MFPH &= ~( SYS_GPB_MFPH_PB12MFP_Msk | SYS_GPB_MFPH_PB13MFP_Msk );
+    SYS->GPB_MFPH |= ( SYS_GPB_MFPH_PB12MFP_UART0_RXD | SYS_GPB_MFPH_PB13MFP_UART0_TXD );
+    /* Configure RMII pins */
     SYS->GPA_MFPL |= SYS_GPA_MFPL_PA6MFP_EMAC_RMII_RXERR | SYS_GPA_MFPL_PA7MFP_EMAC_RMII_CRSDV;
     SYS->GPC_MFPL |= SYS_GPC_MFPL_PC6MFP_EMAC_RMII_RXD1 | SYS_GPC_MFPL_PC7MFP_EMAC_RMII_RXD0;
     SYS->GPC_MFPH |= SYS_GPC_MFPH_PC8MFP_EMAC_RMII_REFCLK;
@@ -210,16 +221,16 @@ static void prvSetupHardware( void )
                      SYS_GPE_MFPH_PE11MFP_EMAC_RMII_TXD1 |
                      SYS_GPE_MFPH_PE12MFP_EMAC_RMII_TXEN;
 
-    // Enable high slew rate on all RMII TX output pins
-    PE->SLEWCTL = (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN10_Pos) |
-                  (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN11_Pos) |
-                  (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN12_Pos);
+    /* Enable high slew rate on all RMII TX output pins */
+    PE->SLEWCTL = ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN10_Pos ) |
+                  ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN11_Pos ) |
+                  ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN12_Pos );
 
     /* Lock protected registers */
     SYS_LockReg();
 
     /* Init UART to 115200-8n1 for print message */
-    UART_Open(UART0, 115200);
+    UART_Open( UART0, 115200 );
 }
 
 /*-----------------------------------------------------------*/
@@ -240,13 +251,13 @@ void vApplicationDaemonTaskStartupHook( void )
     {
         /* Connect to the Wi-Fi before running the tests. */
         prvWifiConnect();
-        
+
         /* Create the task to run tests. */
         xTaskCreate( TEST_RUNNER_RunTests_task,
                      "TestRunner",
                      mainTEST_RUNNER_TASK_STACK_SIZE,
                      NULL,
-                     tskIDLE_PRIORITY,
+                     mainTEST_RUNNER_TASK_PRIORITY,
                      NULL );
     }
 }
@@ -254,9 +265,9 @@ void vApplicationDaemonTaskStartupHook( void )
 
 void prvWifiConnect( void )
 {
-    WIFINetworkParams_t  xNetworkParams;
+    WIFINetworkParams_t xNetworkParams;
     WIFIReturnCode_t xWifiStatus;
-    uint8_t ucIpAddr[4] = { 0 };
+    uint8_t ucIpAddr[ 4 ] = { 0 };
 
     xWifiStatus = WIFI_On();
 
@@ -268,7 +279,7 @@ void prvWifiConnect( void )
     {
         configPRINTF( ( "Wi-Fi module failed to initialize.\r\n" ) );
 
-        /* Delay to allow the lower priority logging task to print the above status. 
+        /* Delay to allow the lower priority logging task to print the above status.
          * The while loop below will block the above printing. */
         Sleep( mainLOGGING_WIFI_STATUS_DELAY );
 
@@ -292,7 +303,8 @@ void prvWifiConnect( void )
         configPRINTF( ( "Wi-Fi Connected to AP. Creating tasks which use network...\r\n" ) );
 
         xWifiStatus = WIFI_GetIP( ucIpAddr );
-        if ( eWiFiSuccess == xWifiStatus ) 
+
+        if( eWiFiSuccess == xWifiStatus )
         {
             configPRINTF( ( "IP Address acquired %d.%d.%d.%d\r\n",
                             ucIpAddr[ 0 ], ucIpAddr[ 1 ], ucIpAddr[ 2 ], ucIpAddr[ 3 ] ) );
@@ -300,26 +312,25 @@ void prvWifiConnect( void )
     }
     else
     {
-#if 0
-        /* Connection failed, configure SoftAP. */
-        configPRINTF( ( "Wi-Fi failed to connect to AP %s.\r\n", xNetworkParams.pcSSID ) );
+        #if 0
+            /* Connection failed, configure SoftAP. */
+            configPRINTF( ( "Wi-Fi failed to connect to AP %s.\r\n", xNetworkParams.pcSSID ) );
 
-        xNetworkParams.pcSSID = wificonfigACCESS_POINT_SSID_PREFIX;
-        xNetworkParams.pcPassword = wificonfigACCESS_POINT_PASSKEY;
-        xNetworkParams.xSecurity = wificonfigACCESS_POINT_SECURITY;
-        xNetworkParams.cChannel = wificonfigACCESS_POINT_CHANNEL;
+            xNetworkParams.pcSSID = wificonfigACCESS_POINT_SSID_PREFIX;
+            xNetworkParams.pcPassword = wificonfigACCESS_POINT_PASSKEY;
+            xNetworkParams.xSecurity = wificonfigACCESS_POINT_SECURITY;
+            xNetworkParams.cChannel = wificonfigACCESS_POINT_CHANNEL;
 
-        configPRINTF( ( "Connect to SoftAP %s using password %s. \r\n",
-                        xNetworkParams.pcSSID, xNetworkParams.pcPassword ) );
-
-        while( WIFI_ConfigureAP( &xNetworkParams ) != eWiFiSuccess )
-        {
-            configPRINTF( ( "Connect to SoftAP %s using password %s and configure Wi-Fi. \r\n",
+            configPRINTF( ( "Connect to SoftAP %s using password %s. \r\n",
                             xNetworkParams.pcSSID, xNetworkParams.pcPassword ) );
-        }
 
-        configPRINTF( ( "Wi-Fi configuration successful. \r\n" ) );
-#endif
+            while( WIFI_ConfigureAP( &xNetworkParams ) != eWiFiSuccess )
+            {
+                configPRINTF( ( "Connect to SoftAP %s using password %s and configure Wi-Fi. \r\n",
+                                xNetworkParams.pcSSID, xNetworkParams.pcPassword ) );
+            }
+            configPRINTF( ( "Wi-Fi configuration successful. \r\n" ) );
+        #endif /* if 0 */
     }
 }
 /*-----------------------------------------------------------*/
@@ -354,7 +365,7 @@ void vAssertCalled( const char * pcFile,
 
     const char * pcApplicationHostnameHook( void )
     {
-        /* This function will be called during the DHCP: the machine will be registered 
+        /* This function will be called during the DHCP: the machine will be registered
          * with an IP address plus this name. */
         return clientcredentialIOT_THING_NAME;
     }
@@ -419,14 +430,14 @@ void vApplicationIdleHook( void )
      * cycle of the idle task if configUSE_IDLE_HOOK is set to 1 in
      * FreeRTOSConfig.h.  It must *NOT* attempt to block.  In this case the
      * idle task just sleeps to lower the CPU usage. */
-//    Sleep( ulMSToSleep ); /* Call vTaskDelay in IdleHook will cause vTaskSwitchContext failure*/
-
+/*    Sleep( ulMSToSleep ); / * Call vTaskDelay in IdleHook will cause vTaskSwitchContext failure* / */
 }
 /*-----------------------------------------------------------*/
 
 void vApplicationTickHook( void )
 {
-	static uint32_t tickHookCnt=0; 
-	tickHookCnt++;
+    static uint32_t tickHookCnt = 0;
+
+    tickHookCnt++;
 }
 /*-----------------------------------------------------------*/

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/main.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/main.c
@@ -252,6 +252,10 @@ void vApplicationDaemonTaskStartupHook( void )
         /* Connect to the Wi-Fi before running the tests. */
         prvWifiConnect();
 
+        /* Assert to check if the priority of the test runner task is lesser than
+         * #configMAX_PRIORITIES. */
+        configASSERT( mainTEST_RUNNER_TASK_PRIORITY < configMAX_PRIORITIES );
+
         /* Create the task to run tests. */
         xTaskCreate( TEST_RUNNER_RunTests_task,
                      "TestRunner",

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
@@ -45,7 +45,7 @@
 /* #define IOT_LOG_LEVEL_DEMO                   IOT_LOG_INFO */
 
 /* Set the task pool stack size and priority */
-#define IOT_THREAD_DEFAULT_STACK_SIZE    2048
+#define IOT_THREAD_DEFAULT_STACK_SIZE    1024
 #define IOT_THREAD_DEFAULT_PRIORITY      5
 
 /**


### PR DESCRIPTION
Fix MQTT and Shadow integration test failures on Nuvoton

Description
-----------
Fix MQTT and Shadow integration test failures on Nuvoton
Issues fixed.
1. Network receive task was having higher task priority than the test runner task. This was causing the ack packets for MQTT to be received before the data structure updates are completed after a successful sent from test runner task. By making sure the priority of the test runner task is higher than that of the Network receive task, this issue can be avoided.
2. Last will and testament test was failing due to a lack of memory. Network receive task and the taskpool task were using higher than required stack size for the tests and was causing the memory issues. Reduced it and verified the tests.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.