### PR TITLE
Update CMake configuration of new libraries

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -51,14 +51,12 @@ afr_module_include_dirs(
 file(GLOB afr_modules_csdk "${AFR_MODULES_DIR}/c_sdk/*/*")
 file(GLOB afr_modules_freertos_plus "${AFR_MODULES_DIR}/freertos_plus/*/*")
 file(GLOB afr_modules_abstractions "${AFR_MODULES_DIR}/abstractions/*")
-foreach(module IN LISTS afr_modules_csdk afr_modules_freertos_plus afr_modules_abstractions)
+file(GLOB afr_modules_logging "${AFR_MODULES_DIR}/logging")
+foreach(module IN LISTS afr_modules_csdk afr_modules_freertos_plus afr_modules_abstractions afr_modules_logging)
     if(IS_DIRECTORY "${module}" AND EXISTS "${module}/CMakeLists.txt")
         afr_add_subdirectory("${module}")
     endif()
 endforeach()
-
-# Add logging module
-add_subdirectory(${AFR_MODULES_DIR}/logging)
 
 # Add core_mqtt modules
 include(core_mqtt.cmake)

--- a/libraries/abstractions/retry_utils/CMakeLists.txt
+++ b/libraries/abstractions/retry_utils/CMakeLists.txt
@@ -12,6 +12,7 @@ afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/freertos/retry_utils_freertos.c"
+        "${CMAKE_CURRENT_LIST_DIR}/retry_utils.h"
 )
 
 afr_module_dependencies(

--- a/libraries/abstractions/retry_utils/CMakeLists.txt
+++ b/libraries/abstractions/retry_utils/CMakeLists.txt
@@ -1,8 +1,8 @@
-afr_module(name retry_utils)
+afr_module(NAME retry_utils)
 
 # Metadata for the module.
 afr_set_lib_metadata(ID "retry_utils")
-afr_set_lib_metadata(DESCRIPTION "This library represents the exponential backoff with jitter retruy utility.")
+afr_set_lib_metadata(DESCRIPTION "This library represents the exponential backoff with jitter retry utility.")
 afr_set_lib_metadata(DISPLAY_NAME "Retry Utilities")
 afr_set_lib_metadata(CATEGORY "Utilities")
 afr_set_lib_metadata(VERSION "1.0.0")

--- a/libraries/abstractions/retry_utils/CMakeLists.txt
+++ b/libraries/abstractions/retry_utils/CMakeLists.txt
@@ -1,5 +1,13 @@
 afr_module(name retry_utils)
 
+# Metadata for the module.
+afr_set_lib_metadata(ID "retry_utils")
+afr_set_lib_metadata(DESCRIPTION "This library represents the exponential backoff with jitter retruy utility.")
+afr_set_lib_metadata(DISPLAY_NAME "Retry Utilities")
+afr_set_lib_metadata(CATEGORY "Utilities")
+afr_set_lib_metadata(VERSION "1.0.0")
+afr_set_lib_metadata(IS_VISIBLE "false")
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE

--- a/libraries/abstractions/transport/CMakeLists.txt
+++ b/libraries/abstractions/transport/CMakeLists.txt
@@ -6,6 +6,14 @@ endif()
 # Transport Interface 
 afr_module(NAME transport_interface_secure_sockets)
 
+# Metadata for the module.
+afr_set_lib_metadata(ID "transport_interface_secure_sockets")
+afr_set_lib_metadata(DESCRIPTION "This library implements the transport interface using Secure Sockets.")
+afr_set_lib_metadata(DISPLAY_NAME "Secure Sockets based Transport Interface")
+afr_set_lib_metadata(CATEGORY "Connectivity")
+afr_set_lib_metadata(VERSION "1.0.0")
+afr_set_lib_metadata(IS_VISIBLE "false")
+
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/secure_sockets")
 
 # Include filepaths for source and include.

--- a/libraries/abstractions/transport/CMakeLists.txt
+++ b/libraries/abstractions/transport/CMakeLists.txt
@@ -22,6 +22,7 @@ include( ${CMAKE_CURRENT_LIST_DIR}/transport_interface.cmake )
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PUBLIC
+        "${src_dir}/transport_secure_sockets.h"
         "${src_dir}/transport_secure_sockets.c"
 )
 

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -13,8 +13,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake")
 
 # Create a list of all header files in the coreMQTT library.
 # The list of header files will be added to metadata required
-# for the Online Configuration Wizard (FreeRTOS Device Software)
-# service.
+# for the FreeRTOS Device Software service of downloading 
+# FreeRTOS from the AWS IoT console.
 set(MQTT_HEADER_FILES "")
 foreach(mqtt_public_include_dir ${MQTT_INCLUDE_PUBLIC_DIRS})
     file(GLOB mqtt_public_include_header_files
@@ -28,9 +28,9 @@ afr_module_sources(
     PRIVATE
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
-        # List of files added to the target to include them in metadata
-        # for the Online Configuration Wizard (FreeRTOS Device Software)
-        # service.
+        # List of files added to the target so that these are available
+        # in code downloaded from the FreeRTOS Device Software service
+        # on the AWS IoT console.
         ${CMAKE_CURRENT_LIST_DIR}/core_mqtt.cmake
         ${MQTT_HEADER_FILES}
 )

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -14,6 +14,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake")
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
+        ${MQTT_HEADER_FILES}
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
 )
@@ -30,5 +31,5 @@ afr_module_include_dirs(
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PUBLIC
-        AFR::common
+        AFR::logging
 )

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -13,7 +13,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake")
 
 # Create a list of all header files in the coreMQTT library.
 # The list of header files will be added to metadata required
-# for the Online Configuration Wizard.
+# for the Online Configuration Wizard (FreeRTOS Device Software)
+# service.
 set(MQTT_HEADER_FILES "")
 foreach(mqtt_public_include_dir ${MQTT_INCLUDE_PUBLIC_DIRS})
     file(GLOB mqtt_public_include_header_files
@@ -25,17 +26,19 @@ endforeach()
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
-        ${MQTT_HEADER_FILES}
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
+        # List of files added to the target to include them in metadata
+        # for the Online Configuration Wizard (FreeRTOS Device Software)
+        # service.
+        ${CMAKE_CURRENT_LIST_DIR}/core_mqtt.cmake
+        ${MQTT_HEADER_FILES}
 )
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
     PUBLIC
         ${MQTT_INCLUDE_PUBLIC_DIRS}
-    PRIVATE
-        ${MQTT_INCLUDE_PRIVATE_DIRS}
 )
 
 # Dependency of module on logging stack.

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -13,8 +13,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake")
 
 # Create a list of all header files in the coreMQTT library.
 # The list of header files will be added to metadata required
-# for the FreeRTOS Device Software service of downloading 
-# FreeRTOS from the AWS IoT console.
+# for the FreeRTOS console.
 set(MQTT_HEADER_FILES "")
 foreach(mqtt_public_include_dir ${MQTT_INCLUDE_PUBLIC_DIRS})
     file(GLOB mqtt_public_include_header_files
@@ -29,8 +28,7 @@ afr_module_sources(
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         # List of files added to the target so that these are available
-        # in code downloaded from the FreeRTOS Device Software service
-        # on the AWS IoT console.
+        # in code downloaded from the FreeRTOS console.
         ${CMAKE_CURRENT_LIST_DIR}/core_mqtt.cmake
         ${MQTT_HEADER_FILES}
 )

--- a/libraries/core_mqtt.cmake
+++ b/libraries/core_mqtt.cmake
@@ -11,6 +11,17 @@ afr_set_lib_metadata(IS_VISIBLE "true")
 # Include MQTT library's source and header path variables.
 include("${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake")
 
+# Create a list of all header files in the coreMQTT library.
+# The list of header files will be added to metadata required
+# for the Online Configuration Wizard.
+set(MQTT_HEADER_FILES "")
+foreach(mqtt_public_include_dir ${MQTT_INCLUDE_PUBLIC_DIRS})
+    file(GLOB mqtt_public_include_header_files
+              LIST_DIRECTORIES false
+              ${mqtt_public_include_dir}/* )
+    list(APPEND MQTT_HEADER_FILES ${mqtt_public_include_header_files})
+endforeach()
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE

--- a/libraries/logging/CMakeLists.txt
+++ b/libraries/logging/CMakeLists.txt
@@ -11,14 +11,17 @@ endif()
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
-       # Logging
         "${aws_logging_task}"
         "${CMAKE_CURRENT_LIST_DIR}/iot_logging.c"
+        "${CMAKE_CURRENT_LIST_DIR}/include/iot_logging_task.h"
+        "${CMAKE_CURRENT_LIST_DIR}/include/logging_levels.h"
+        "${CMAKE_CURRENT_LIST_DIR}/include/logging_stack.h"
 )
 
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}
-    PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include"
+    PUBLIC 
+        "${CMAKE_CURRENT_LIST_DIR}/include"
 )
 
 afr_module_dependencies(


### PR DESCRIPTION
The FreeRTOS Device Software console requires that the CMake metadata provide header files path, so that they are included in the downloaded ZIP. Thus, update the `core_mqtt`, `logging`, `retry_utils` and `transport_interface_secure_sockets` CMake targets to include header files in their **source** list