### PR TITLE
Nuvoton MQTT demo fix

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -67,7 +67,12 @@
 #define shadowDemoUPDATE_TASK_STACK_SIZE                             ( configMINIMAL_STACK_SIZE * 5 )
 
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT                  pdMS_TO_TICKS( 12000 )
-#define democonfigMQTT_ECHO_TASK_PRIORITY                            ( tskIDLE_PRIORITY )
+
+/* Keeping the MQTT demo task priority higher than that of the network receive task
+ * priority( #IOT_NETWORK_RECEIVE_TASK_PRIORITY ) so as to make sure that the
+ * receive of the incoming packets are only happening after successfully updating
+ * the internal data structures in MQTT demo task for a send. */
+#define democonfigMQTT_ECHO_TASK_PRIORITY                            ( tskIDLE_PRIORITY + 2 )
 
 /* MQTT Connection sharing demo task priority. */
 #define democonfigCORE_MQTT_CONNECTION_SHARING_DEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )


### PR DESCRIPTION
Nuvoton MQTT demo fix

Description
-----------
Nuvoton MQTT demo fix.
Issues fixed.
Network receive task was having higher task priority than the MQTT demo task. This was causing the ack packets for MQTT to be received before the data structure updates are completed after a successful sent from MQTT demo task. Increasing the priority of the MQTT demo task, this issue can be resolved.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.