### PR TITLE
Fix KeepAlivePeriodic testing logs printed in the MQTT_Unit_API test group

### DIFF
--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -185,6 +185,12 @@ static IotMqttNetworkInfo_t _networkInfo = IOT_MQTT_NETWORK_INFO_INITIALIZER;
  */
 static IotNetworkInterface_t _networkInterface = { 0 };
 
+/**
+ * @brief Buffer holding the keep-alive periodic status string.
+ * This needed in the thread simulating incoming PINGRESP messages.
+ */
+static char pKeepAliveStatus[ KEEP_ALIVE_PERIODIC_STATUS_LENGTH ] = { 0 };
+
 /*-----------------------------------------------------------*/
 
 /* Using initialized connToContext variable. */
@@ -203,7 +209,6 @@ static void _incomingPingresp( void * pArgument )
     static int32_t invokeCount = 0;
     static uint64_t lastInvokeTime = 0;
     uint64_t currentTime = IotClock_GetTimeMs();
-    char pKeepAliveStatus[ KEEP_ALIVE_PERIODIC_STATUS_LENGTH ] = { 0 };
 
     /* The number of characters written in snprintf. */
     int numWritten = 0;

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -98,7 +98,7 @@
 #define TEST_TOPIC_NAME_LENGTH                        ( ( uint16_t ) ( sizeof( TEST_TOPIC_NAME ) - 1 ) ) /**< @brief Length of topic name. */
 
 /*
- * Strings with format specifiers for printing the periodic keep alive status.
+ * Strings with format specifiers for printing the periodic keep-alive status.
  * This needed in the thread simulating incoming PINGRESP messages.
  */
 #define KEEP_ALIVE_PERIODIC_STATUS_MAIN_STRING        "KeepAlivePeriodic %d of %d DONE at %lu ms"
@@ -241,8 +241,8 @@ static void _incomingPingresp( void * pArgument )
         }
         else
         {
-            /* Otherwise write a period with some line endings for pretty
-             * printing. The NULL termintor in the C string is also written. */
+            /* Write a period with some line endings for pretty printing. The
+             * NULL termintor in the C string is also written. */
             memcpy( &( pKeepAliveStatus[ numWritten ] ),
                     KEEP_ALIVE_PERIODIC_STATUS_ENDING_STRING,
                     sizeof( KEEP_ALIVE_PERIODIC_STATUS_ENDING_STRING ) );

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -225,7 +225,7 @@ static void _incomingPingresp( void * pArgument )
                                invokeCount,
                                KEEP_ALIVE_COUNT,
                                ( unsigned long ) IotClock_GetTimeMs() );
-        /* Assert there are not unlikely encoding errors. */
+        /* Assert there are no unlikely encoding errors. */
         TEST_ASSERT( numWritten > 0 );
 
         if( invokeCount > 1 )
@@ -236,7 +236,7 @@ static void _incomingPingresp( void * pArgument )
                                     KEEP_ALIVE_PERIODIC_STATUS_LENGTH - numWritten,
                                     KEEP_ALIVE_PERIODIC_STATUS_INTERVAL_STRING,
                                     ( unsigned long ) ( currentTime - lastInvokeTime ) );
-            /* Assert there are not unlikely encoding errors. */
+            /* Assert there are no unlikely encoding errors. */
             TEST_ASSERT( numWritten > prevNumWritten );
         }
         else

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -33,6 +33,7 @@
 
 /* Standard includes. */
 #include <string.h>
+#include <stdio.h>
 
 /* SDK initialization include. */
 #include "iot_init.h"

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -99,7 +99,7 @@
 
 /*
  * Strings with format specifiers for printing the periodic keep-alive status.
- * This needed in the thread simulating incoming PINGRESP messages.
+ * This is needed in the thread simulating incoming PINGRESP messages.
  */
 #define KEEP_ALIVE_PERIODIC_STATUS_MAIN_STRING        "KeepAlivePeriodic %d of %d DONE at %lu ms"
 #define KEEP_ALIVE_PERIODIC_STATUS_INTERVAL_STRING    " (+ %lu ).\r\n"
@@ -107,7 +107,7 @@
 
 /**
  * @brief The length of the string use to print the keep-alive periodic status.
- * This needed in the thread simulating incoming PINGRESP messages.
+ * This is needed in the thread simulating incoming PINGRESP messages.
  */
 #define KEEP_ALIVE_PERIODIC_STATUS_LENGTH             128
 


### PR DESCRIPTION
This PR reduces the logs printed in the MQTT_Unit_API test.

The **KeepAlivePeriodic** test case starts a thread that simulates PINGRESPs. The test used multiple calls to `UnityPrint` function to print the status about every PINGRESP's sent. In this repo, UnityPrint is mapped to configPRINTF(), which serializes logs via logging queue. As a result, multiple `UnityPrint` calls added 11 messages to the logging queue increasing the chances of dropped messages because of the logging queue being full.

This change combines the multiple `UnityPrint` calls into one by first formatting the log message in a buffer.  The result is just one message added to the logging queue for every PINGRESP sent.

The logs below are from Cypress CY8CKIT_064S0S2_4343W but the change this applies to all boards.

**Previous**   

```
WHD VERSION      : v1.70.0 : v1.70.0 : GCC 9.2 : 2019-12-02 04:14:53 -0600
0 547 [Tmr Svc] Wi-Fi module initialized. Connecting to AP afrlab-test...
.1 8164 [Tmr Svc] Wi-Fi Connected to AP. Creating tasks which use network...
2 8164 [Tmr Svc] IP Address acquired 192.168.35.204
3 9030 [Tmr Svc] Write certificate...
..---------STARTING TESTS---------
UUID: _uuid_a821d3c54f34480d98264dedeee20b8a
TEST(MQTT_Unit_API, OperationCreateDestroy) PASS
TEST(MQTT_Unit_API, OperationWaitTimeout) PASS
TEST(MQTT_Unit_API, ConnectParameters) PASS
TEST(MQTT_Unit_API, ConnectMallocFail) PASS
TEST(MQTT_Unit_API, ConnectRestoreSessionMallocFail) PASS
TEST(MQTT_Unit_API, DisconnectMallocFail) PASS
TEST(MQTT_Unit_API, PublishQoS0Parameters) PASS
TEST(MQTT_Unit_API, PublishQoS0MallocFail) PASS
TEST(MQTT_Unit_API, PublishQoS1) PASS
.TEST(MQTT_Unit_API, SubscribeUnsubscribeParameters) PASS
TEST(MQTT_Unit_API, SubscribeMallocFail) PASS
TEST(MQTT_Unit_API, UnsubscribeMallocFail) PASS
4 21147 [RunTests_] 
5 22747 [iot_threa] KeepAlivePeriodic 6 22747 [iot_threa] 17 22747 [iot_threa]  of 8 22747 [iot_threa] 109 22747 [iot_threa]  DONE at 10 22747 [iot_threa] 2274711 22747 [iot_threa]  ms12 22747 [iot_threa] .13 22747 [iot_threa] 
14 23847 [iot_threa] KeepAlivePeriodic 15 23847 [iot_threa] 216 23847 [iot_threa]  of 17 23847 [iot_threa] 1018 23847 [iot_threa]  DONE at 19 23847 [iot_threa] 2384720 23847 [iot_threa]  ms21 23847 [iot_threa]  (+22 23847 [iot_threa] 110023 23847 [iot_threa]  ms).24 23847 [iot_threa] 
25 24947 [iot_threa] KeepAlivePeriodic 26 24947 [iot_threa] 327 24947 [iot_threa]  of 28 24947 [iot_threa] 1029 24947 [iot_threa]  DONE at 30 24947 [iot_threa] 2494731 24947 [iot_threa]  ms32 24947 [iot_threa]  (+33 24947 [iot_threa] 110034 24947 [iot_threa]  ms).35 24947 [iot_threa] 
.36 26047 [iot_threa] KeepAlivePeriodic 37 26047 [iot_threa] 438 26047 [iot_threa]  of 39 26047 [iot_threa] 1040 26047 [iot_threa]  DONE at 41 26047 [iot_threa] 2604742 26047 [iot_threa]  ms43 26047 [iot_threa]  (+44 26047 [iot_threa] 110045 26047 [iot_threa]  ms).46 26047 [iot_threa] 
47 27147 [iot_threa] KeepAlivePeriodic 48 27147 [iot_threa] 549 27147 [iot_threa]  of 50 27147 [iot_threa] 1051 27147 [iot_threa]  DONE at 52 27147 [iot_threa] 2714753 27147 [iot_threa]  ms54 27147 [iot_threa]  (+55 27147 [iot_threa] 110056 27147 [iot_threa]  ms).57 27147 [iot_threa] 
58 28247 [iot_threa] KeepAlivePeriodic 59 28247 [iot_threa] 660 28247 [iot_threa]  of 61 28247 [iot_threa] 1062 28247 [iot_threa]  DONE at 63 28247 [iot_threa] 2824764 28247 [iot_threa]  ms65 28247 [iot_threa]  (+66 28247 [iot_threa] 110067 28247 [iot_threa]  ms).68 28247 [iot_threa] 
69 29347 [iot_threa] KeepAlivePeriodic 70 29347 [iot_threa] 771 29347 [iot_threa]  of 72 29347 [iot_threa] 1073 29347 [iot_threa]  DONE at
74 
```

**Now**  
```
02:23:35 WLAN MAC Address : C4:AC:59:7B:EB:71
02:23:35 WLAN Firmware    : wl0: Sep  5 2019 23:24:33 version 7.45.98.92 (r722362 CY) FWID 01-f7128517
02:23:35 WLAN CLM         : API: 12.2 Data: 9.10.39 Compiler: 1.29.4 ClmImport: 1.36.3 Creation: 2019-09-05 23:10:00 
02:23:35 WHD VERSION      : v1.70.0 : v1.70.0 : GCC 7.2 : 2019-12-02 04:14:53 -0600
02:23:35 0 551 [Tmr Svc] Wi-Fi module initialized. Connecting to AP afrlab-test...
02:23:35 .1 8172 [Tmr Svc] Wi-Fi Connected to AP. Creating tasks which use network...
02:23:35 2 8172 [Tmr Svc] IP Address acquired 192.168.35.222
02:23:35 3 9032 [Tmr Svc] Write certificate...
02:23:35 ..---------STARTING TESTS---------
02:23:35 UUID: _uuid_632c9ba23daf4b2f9b289bdc63ce5258
02:23:35 TEST(MQTT_Unit_API, OperationCreateDestroy) PASS
02:23:35 TEST(MQTT_Unit_API, OperationWaitTimeout) PASS
02:23:35 TEST(MQTT_Unit_API, ConnectParameters) PASS
02:23:35 TEST(MQTT_Unit_API, ConnectMallocFail) PASS
02:23:35 TEST(MQTT_Unit_API, ConnectRestoreSessionMallocFail) PASS
02:23:35 TEST(MQTT_Unit_API, DisconnectMallocFail) PASS
02:23:35 TEST(MQTT_Unit_API, PublishQoS0Parameters) PASS
02:23:35 TEST(MQTT_Unit_API, PublishQoS0MallocFail) PASS
02:23:35 TEST(MQTT_Unit_API, PublishQoS1) PASS
02:23:35 .TEST(MQTT_Unit_API, SubscribeUnsubscribeParameters) PASS
02:23:35 TEST(MQTT_Unit_API, SubscribeMallocFail) PASS
02:23:35 TEST(MQTT_Unit_API, UnsubscribeMallocFail) PASS
02:23:35 4 21142 [RunTests_] 
02:23:35 5 22742 [iot_threa] KeepAlivePeriodic 1 of 10 DONE at 22742 ms.
02:23:35 6 23842 [iot_threa] KeepAlivePeriodic 2 of 10 DONE at 23842 ms (+ 1100 ).
02:23:35 7 24942 [iot_threa] KeepAlivePeriodic 3 of 10 DONE at 24942 ms (+ 1100 ).
02:23:35 .8 26042 [iot_threa] KeepAlivePeriodic 4 of 10 DONE at 26042 ms (+ 1100 ).
02:23:35 9 27142 [iot_threa] KeepAlivePeriodic 5 of 10 DONE at 27142 ms (+ 1100 ).
02:23:35 10 28242 [iot_threa] KeepAlivePeriodic 6 of 10 DONE at 28242 ms (+ 1100 ).
02:23:35 11 29342 [iot_threa] KeepAlivePeriodic 7 of 10 DONE at 29342 ms (+ 1100 ).
02:23:35 .12 30442 [iot_threa] KeepAlivePeriodic 8 of 10 DONE at 30442 ms (+ 1100 ).
02:23:35 13 31542 [iot_threa] KeepAlivePeriodic 9 of 10 DONE at 31542 ms (+ 1100 ).
02:23:35 14 32642 [iot_threa] KeepAlivePeriodic 10 of 10 DONE at 32642 ms (+ 1100 ).
02:23:35 .TEST(MQTT_Unit_API, KeepAlivePeriodic) PASS
02:23:35 TEST(MQTT_Unit_API, KeepAliveJobCleanup) PASS
02:23:35 TEST(MQTT_Unit_API, WaitAfterDisconnect) PASS
02:23:35 
02:23:35 -----------------------
02:23:35 15 Tests 0 Failures 0 Ignored 
02:23:35 OK
02:23:35 -------ALL TESTS FINISHED-------
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.