### PR TITLE
Remove metadata of internal libraries

### DIFF
--- a/libraries/abstractions/retry_utils/CMakeLists.txt
+++ b/libraries/abstractions/retry_utils/CMakeLists.txt
@@ -1,12 +1,4 @@
-afr_module(NAME retry_utils)
-
-# Metadata for the module.
-afr_set_lib_metadata(ID "retry_utils")
-afr_set_lib_metadata(DESCRIPTION "This library represents the exponential backoff with jitter retry utility.")
-afr_set_lib_metadata(DISPLAY_NAME "Retry Utilities")
-afr_set_lib_metadata(CATEGORY "Utilities")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "false")
+afr_module(NAME retry_utils INTERNAL)
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}

--- a/libraries/abstractions/transport/CMakeLists.txt
+++ b/libraries/abstractions/transport/CMakeLists.txt
@@ -4,15 +4,7 @@ if(AFR_ENABLE_UNIT_TESTS)
 endif()
 
 # Transport Interface 
-afr_module(NAME transport_interface_secure_sockets)
-
-# Metadata for the module.
-afr_set_lib_metadata(ID "transport_interface_secure_sockets")
-afr_set_lib_metadata(DESCRIPTION "This library implements the transport interface using Secure Sockets.")
-afr_set_lib_metadata(DISPLAY_NAME "Secure Sockets based Transport Interface")
-afr_set_lib_metadata(CATEGORY "Connectivity")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "false")
+afr_module(NAME transport_interface_secure_sockets INTERNAL)
 
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/secure_sockets")
 


### PR DESCRIPTION
Remove metadata of `retry_utils` and `transport_interface_secure_sockets` as they are not FreeRTOS console facing libraries