### PR TITLE
Fix demo bug allowing infinite subscribe loop

### DIFF
--- a/demos/coreMQTT/mqtt_demo_basic_tls.c
+++ b/demos/coreMQTT/mqtt_demo_basic_tls.c
@@ -772,6 +772,9 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
             break;
         }
 
+        /* Reset flag before checking suback responses. */
+        xFailedSubscribeToTopic = false;
+
         /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
@@ -792,7 +795,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
         {
             xReturnStatus = pdFAIL;
             LogError( ( "Failed to subscribe to the broker, subscription request"
-                        " retires exhausted. NumberOfAttempts=%ul",
+                        " retries exhausted. NumberOfAttempts=%lu",
                         ( unsigned long ) ( xRetryParams.maxRetryAttempts ) ) );
         }
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );

--- a/demos/coreMQTT/mqtt_demo_keep_alive.c
+++ b/demos/coreMQTT/mqtt_demo_keep_alive.c
@@ -866,6 +866,9 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
             break;
         }
 
+        /* Reset flag before checking suback responses. */
+        xFailedSubscribeToTopic = false;
+
         /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
@@ -885,7 +888,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
         if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
         {
             LogError( ( "Failed to subscribe to the broker: Subscription request"
-                        " retires exhausted. NumberOfAttempts=%ul",
+                        " retries exhausted. NumberOfAttempts=%lu",
                         ( unsigned long ) ( xRetryParams.maxRetryAttempts ) ) );
             xReturnStatus = pdFAIL;
         }

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -762,6 +762,9 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
 
         if( xStatus == pdPASS )
         {
+            /* Reset flag before checking suback responses. */
+            xFailedSubscribeToTopic = false;
+
             /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
              * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
              * either the QoS level granted by the server upon subscription, or acknowledgement of

--- a/demos/coreMQTT/mqtt_demo_plaintext.c
+++ b/demos/coreMQTT/mqtt_demo_plaintext.c
@@ -719,6 +719,9 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
             break;
         }
 
+        /* Reset flag before checking suback responses. */
+        xFailedSubscribeToTopic = false;
+
         /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
@@ -739,7 +742,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
         {
             xReturnStatus = pdFAIL;
             LogError( ( "Failed to subscribe to the broker, subscription request"
-                        " retires exhausted. NumberOfAttempts=%ul",
+                        " retries exhausted. NumberOfAttempts=%lu",
                         ( unsigned long ) ( xRetryParams.maxRetryAttempts ) ) );
         }
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );

--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -755,8 +755,8 @@ static BaseType_t prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The size of the MQTT CONNECT packet must be less than the "
-                    "size of the demo's shared buffer. ConnectPacketSize=%ul,"
-                    "SharedBufferSize=%ul",
+                    "size of the demo's shared buffer. ConnectPacketSize=%lu,"
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -836,8 +836,8 @@ static BaseType_t prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket )
         {
             xStatus = pdFAIL;
             LogError( ( "The length of the incoming packet must not exceed the "
-                        "size of the shared demo buffer. RemainingLength=%ul, "
-                        "SharedBufferSize=%ul",
+                        "size of the shared demo buffer. RemainingLength=%lu, "
+                        "SharedBufferSize=%lu",
                         ( unsigned long ) xIncomingPacket.remainingLength,
                         ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
         }
@@ -927,8 +927,8 @@ static BaseType_t prvMQTTSubscribeToTopic( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The size of the MQTT SUBSCRIBE packet must be less than the "
-                    "size of the demo's shared buffer. ConnectPacketSize=%ul,"
-                    "SharedBufferSize=%ul",
+                    "size of the demo's shared buffer. ConnectPacketSize=%lu,"
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -1031,6 +1031,9 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket )
             break;
         }
 
+        /* Reset flag before checking suback responses. */
+        xFailedSubscribeToTopic = false;
+
         /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
@@ -1051,7 +1054,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket )
         {
             xStatus = pdFAIL;
             LogError( ( "Failed to subscribe to the broker, subscription request"
-                        " retires exhausted. NumberOfAttempts=%ul",
+                        " retries exhausted. NumberOfAttempts=%lu",
                         ( unsigned long ) ( xRetryParams.maxRetryAttempts ) ) );
         }
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
@@ -1136,8 +1139,8 @@ static BaseType_t prvMQTTPublishToTopic( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The size of the MQTT PUBLISH packet must be less than the "
-                    "size of the demo's shared buffer. PublishPacketSize=%ul,"
-                    "SharedBufferSize=%ul",
+                    "size of the demo's shared buffer. PublishPacketSize=%lu,"
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -1238,8 +1241,8 @@ static BaseType_t prvMQTTUnsubscribeFromTopic( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The size of the MQTT UNSUBSCRIBE packet must be less than the "
-                    "size of the demo's shared buffer. UnsubscribePacketSize=%ul,"
-                    "SharedBufferSize=%ul",
+                    "size of the demo's shared buffer. UnsubscribePacketSize=%lu,"
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -1307,8 +1310,8 @@ static BaseType_t prvMQTTKeepAlive( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The length of the ping packet must not exceed the "
-                    "size of the shared demo buffer. PingPacketSize=%ul, "
-                    "SharedBufferSize=%ul",
+                    "size of the shared demo buffer. PingPacketSize=%lu, "
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -1369,8 +1372,8 @@ static BaseType_t prvMQTTDisconnect( Socket_t xMQTTSocket )
     {
         xStatus = pdFAIL;
         LogError( ( "The size of the MQTT DISCONNECT packet must be less than the "
-                    "size of the demo's shared buffer. ConnectPacketSize=%ul,"
-                    "SharedBufferSize=%ul",
+                    "size of the demo's shared buffer. ConnectPacketSize=%lu,"
+                    "SharedBufferSize=%lu",
                     ( unsigned long ) xPacketSize,
                     ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
     }
@@ -1510,8 +1513,8 @@ static BaseType_t prvMQTTProcessIncomingPacket( Socket_t xMQTTSocket )
         {
             xStatus = pdFAIL;
             LogError( ( "The length of the incoming packet must not exceed the "
-                        "size of the shared demo buffer. RemainingLength=%ul, "
-                        "SharedBufferSize=%ul",
+                        "size of the shared demo buffer. RemainingLength=%lu, "
+                        "SharedBufferSize=%lu",
                         ( unsigned long ) xIncomingPacket.remainingLength,
                         ( unsigned long ) mqttexampleSHARED_BUFFER_SIZE ) );
         }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
In most of the demos, `xFailedSubscribeToTopic` is not reset in each iteration of the `while` loop of the subscribe-retry flow. Therefore, if the initial subscribe fails, and a subsequent one succeeds, then the demo would enter an infinite loop as neither `xFailedSubscribeToTopic` nor `xRetryUtilsStatus` are being updated.
 * Also fixed some format specifiers and a typo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
