### PR TITLE
Configure TLS max fragment length extension.

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -44,6 +44,7 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/pk_internal.h"
 #include "mbedtls/debug.h"
+
 #ifdef MBEDTLS_DEBUG_C
     #define tlsDEBUG_VERBOSE    4
 #endif
@@ -902,6 +903,18 @@ BaseType_t TLS_Connect( void * pvContext )
         /* Set the resulting protocol configuration. */
         xResult = mbedtls_ssl_setup( &pxCtx->xMbedSslCtx, &pxCtx->xMbedSslConfig );
     }
+
+    #ifdef MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+    if( 0 == xResult )
+    {
+        /* Enable the max fragment extension. 4096 bytes is currently the largest fragment size permitted.
+         * See RFC 8449 https://tools.ietf.org/html/rfc8449 for more information.
+         *
+         * Smaller values can be found in "mbedtls/include/ssl.h".
+         */
+        xResult = mbedtls_ssl_conf_max_frag_len( &pxCtx->xMbedSslConfig, MBEDTLS_SSL_MAX_FRAG_LEN_4096 );
+    }
+    #endif
 
     /* Set the hostname, if requested. */
     if( ( 0 == xResult ) && ( NULL != pxCtx->pcDestination ) )

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -891,7 +891,6 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
-
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );
@@ -905,15 +904,15 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-    if( 0 == xResult )
-    {
-        /* Enable the max fragment extension. 4096 bytes is currently the largest fragment size permitted.
-         * See RFC 8449 https://tools.ietf.org/html/rfc8449 for more information.
-         *
-         * Smaller values can be found in "mbedtls/include/ssl.h".
-         */
-        xResult = mbedtls_ssl_conf_max_frag_len( &pxCtx->xMbedSslConfig, MBEDTLS_SSL_MAX_FRAG_LEN_4096 );
-    }
+        if( 0 == xResult )
+        {
+            /* Enable the max fragment extension. 4096 bytes is currently the largest fragment size permitted.
+             * See RFC 8449 https://tools.ietf.org/html/rfc8449 for more information.
+             *
+             * Smaller values can be found in "mbedtls/include/ssl.h".
+             */
+            xResult = mbedtls_ssl_conf_max_frag_len( &pxCtx->xMbedSslConfig, MBEDTLS_SSL_MAX_FRAG_LEN_4096 );
+        }
     #endif
 
     /* Set the hostname, if requested. */

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -891,6 +891,7 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
+
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );


### PR DESCRIPTION
Configure TLS extension max fragment length

Description
-----------
The TLS extension for max fragment length was statically enabled, but never configured at runtime. With this
patch, if the feature is enabled in mbed TLS, it is also configured at runtime.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
