### PR TITLE
Fix CMake build failure of Infineon Optiga Trust

### DIFF
--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt
@@ -241,7 +241,7 @@ afr_mcu_port(pkcs11_implementation)
 target_sources(
     AFR::pkcs11_implementation::mcu_port
     INTERFACE
-        "${AFR_VENDORS_DIR}/infineon/secure_elements/pkcs11/core_pkcs11_trustx.c"
+        "${AFR_VENDORS_DIR}/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c"
 )
 target_link_libraries(
     AFR::pkcs11_implementation::mcu_port


### PR DESCRIPTION
Cmake configuration (`cmake .. -DVENDOR=infineon -DBOARD=xmc4800_plus_optiga_trust_x  -DCOMPILER=arm-gcc`)
fails for the **Infineon Optiga Trust** board due to incorrect file name change made at `vendors/infineon/boards/xmc4800_plus_optiga_trust_x/CMakeLists.txt` for PKCS11 file in #2563