### PR TITLE
Fix freertos_cli_plus_uart builds in FreeRTOS console

### DIFF
--- a/demos/cli/CMakeLists.txt
+++ b/demos/cli/CMakeLists.txt
@@ -1,19 +1,21 @@
-# CLI demo using UART
-afr_demo_module(cli_uart)
+if(TARGET AFR::common_io::mcu_port)
+    # CLI demo using UART
+    afr_demo_module(cli_uart)
 
-afr_set_demo_metadata(ID "CLI_UART_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates FreeRTOS-Plus-CLI using UART")
-afr_set_demo_metadata(DISPLAY_NAME "UART FreeRTOS-Plus-CLI Demo")
+    afr_set_demo_metadata(ID "CLI_UART_DEMO")
+    afr_set_demo_metadata(DESCRIPTION "An example that demonstrates FreeRTOS-Plus-CLI using UART")
+    afr_set_demo_metadata(DISPLAY_NAME "UART FreeRTOS-Plus-CLI Demo")
 
-afr_module_sources(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${CMAKE_CURRENT_LIST_DIR}/cli_uart_demo.c"
-)
-afr_module_dependencies(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        AFR::freertos_plus_cli
-        AFR::common_io
-        AFR::freertos_cli_plus_uart
-)
+    afr_module_sources(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            "${CMAKE_CURRENT_LIST_DIR}/cli_uart_demo.c"
+    )
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            AFR::freertos_plus_cli
+            AFR::common_io
+            AFR::freertos_cli_plus_uart
+    )
+endif()

--- a/demos/cli/CMakeLists.txt
+++ b/demos/cli/CMakeLists.txt
@@ -1,3 +1,7 @@
+# ONLY enable the demo if board support AFR::common_io.
+# This prevents build failure of code downloaded from
+# FreeRTOS console for boards that do not support the 
+# common_io module.
 if(TARGET AFR::common_io::mcu_port)
     # CLI demo using UART
     afr_demo_module(cli_uart)

--- a/libraries/freertos_plus/standard/freertos_plus_cli/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_cli/CMakeLists.txt
@@ -29,25 +29,27 @@ afr_module_dependencies(
         AFR::freertos_plus_cli
 )
 
-afr_module(NAME freertos_cli_plus_uart)
+if(TARGET AFR::common_io::mcu_port)
+    afr_module(NAME freertos_cli_plus_uart)
 
-set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
-set(src_dir "${CMAKE_CURRENT_LIST_DIR}/uart")
+    set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
+    set(src_dir "${CMAKE_CURRENT_LIST_DIR}/uart")
 
-afr_module_sources(
-    freertos_cli_plus_uart
-    PRIVATE
-        "${src_dir}/FreeRTOS_CLI_UART.c"
-)
+    afr_module_sources(
+        freertos_cli_plus_uart
+        PRIVATE
+            "${src_dir}/FreeRTOS_CLI_UART.c"
+    )
 
-afr_module_include_dirs(
-    freertos_cli_plus_uart
-    PUBLIC "${inc_dir}"
-)
+    afr_module_include_dirs(
+        freertos_cli_plus_uart
+        PUBLIC "${inc_dir}"
+    )
 
-afr_module_dependencies(
-    freertos_cli_plus_uart
-    PUBLIC
-        AFR::freertos_plus_cli
-        AFR::common_io
-)
+    afr_module_dependencies(
+        freertos_cli_plus_uart
+        PUBLIC
+            AFR::freertos_plus_cli
+            AFR::common_io
+    )
+endif()

--- a/libraries/freertos_plus/standard/freertos_plus_cli/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_cli/CMakeLists.txt
@@ -29,6 +29,10 @@ afr_module_dependencies(
         AFR::freertos_plus_cli
 )
 
+# ONLY enable the module if board support AFR::common_io.
+# This prevents build failures in code downloaded from
+# FreeRTOS console for boards that do not support the 
+# common_io module.
 if(TARGET AFR::common_io::mcu_port)
     afr_module(NAME freertos_cli_plus_uart)
 


### PR DESCRIPTION
Fix builds for `freertos_cli_plus_uart` module in Projects downloaded from FreeRTOS console for boards that do not support `AFR::common_io` module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.