### PR TITLE
Fix missing transport Cmake file in FreeRTOS console

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -77,3 +77,8 @@ endif()
 if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/device_shadow_demo_dependencies.cmake)
   include(device_shadow_demo_dependencies.cmake)
 endif()
+
+# Add transport interface implementation module ONLY if present in FreeRTOS console download.
+if(EXISTS ${AFR_MODULES_DIR}/abstractions/transport/transport_interface_secure_sockets.cmake)
+  include(${AFR_MODULES_DIR}/abstractions/transport/transport_interface_secure_sockets.cmake)
+endif()

--- a/libraries/abstractions/transport/transport_interface_secure_sockets.cmake
+++ b/libraries/abstractions/transport/transport_interface_secure_sockets.cmake
@@ -16,6 +16,10 @@ afr_module_sources(
     PRIVATE
         "${src_dir}/transport_secure_sockets.h"
         "${src_dir}/transport_secure_sockets.c"
+        # Following files are added to the source list to generate their
+        # metadata so that are part of code downloaded from FreeRTOS console.
+        "${CMAKE_CURRENT_LIST_DIR}/transport_interface.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/transport_interface_secure_sockets.cmake"
 )
 
 afr_module_dependencies(


### PR DESCRIPTION
Fix missing `libraries/abstractions/transport/CMakeLists.txt` file by renaming it to `libraries/abstractions/transport/transport_interface_secure_sockets.cmake`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
