### PR TITLE
Hygiene and fixes in CMake metadata for FreeRTOS console

### DIFF
--- a/demos/ble/CMakeLists.txt
+++ b/demos/ble/CMakeLists.txt
@@ -46,6 +46,12 @@ afr_module_dependencies(
         AFR::core_mqtt
         AFR::ble
         AFR::mqtt_ble
+        # Add dependency on the core_mqtt_demo_dependencies metadata module 
+        # so that FreeRTOS console shows this demo when BOTH the core MQTT
+        # (or another library depending on coreMQTT) AND BLE libraries are
+        # selected on the console.
+        AFR::core_mqtt_demo_dependencies
+)
 )
 
 

--- a/demos/ble/CMakeLists.txt
+++ b/demos/ble/CMakeLists.txt
@@ -52,9 +52,6 @@ afr_module_dependencies(
         # selected on the console.
         AFR::core_mqtt_demo_dependencies
 )
-)
-
-
 
 # BLE Number Comparison Demo
 # Only build on boards that support BLE.

--- a/demos/cli/CMakeLists.txt
+++ b/demos/cli/CMakeLists.txt
@@ -1,10 +1,6 @@
 # CLI demo using UART
 afr_demo_module(cli_uart)
 
-afr_set_demo_metadata(ID "CLI_UART_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates FreeRTOS-Plus-CLI using UART")
-afr_set_demo_metadata(DISPLAY_NAME "UART FreeRTOS-Plus-CLI Demo")
-
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE

--- a/demos/coreMQTT/CMakeLists.txt
+++ b/demos/coreMQTT/CMakeLists.txt
@@ -15,6 +15,10 @@ afr_module_sources(
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_serializer.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_keep_alive.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_connection_sharing.c"
+        # Add the CMake file to the source list so that metadata is
+        # generated for it, and it is present in code downloaded from
+        # the FreeRTOS console.
+        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 
 afr_module_dependencies(

--- a/demos/coreMQTT/CMakeLists.txt
+++ b/demos/coreMQTT/CMakeLists.txt
@@ -15,9 +15,10 @@ afr_module_sources(
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_serializer.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_keep_alive.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_connection_sharing.c"
-        # Add the CMake file to the source list so that metadata is
-        # generated for it, and it is present in code downloaded from
-        # the FreeRTOS console.
+        # As the containing directory name (coreMQTT) does not match the
+        # module name (core_mqtt), we add dependency on the CMake file so
+        # that metadata is generated for it, and it is present in code 
+        # downloaded from the FreeRTOS console.
         ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 

--- a/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -1,18 +1,18 @@
 # C SDK Shadow demo
-afr_demo_module(core_mqtt)
-afr_demo_module(core_json)
 afr_demo_module(device_shadow)
 
-afr_set_demo_metadata(ID "SHADOW_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates Shadow")
-afr_set_demo_metadata(DISPLAY_NAME "Shadow Demo")
-
+afr_set_demo_metadata(ID "DEVICE_SHADOW_DEMO")
+afr_set_demo_metadata(DESCRIPTION "An example that demonstrates the use of the Device Shadow library.")
+afr_set_demo_metadata(DISPLAY_NAME "Device Shadow Demo")
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_main.c"
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.c"
+        # Add header files to generate their metadata so that 
+        # they are present in code downloaded from FreeRTOS console.
+        "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.h"
 )
 
 afr_module_dependencies(

--- a/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -10,9 +10,13 @@ afr_module_sources(
     INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_main.c"
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.c"
-        # Add header files to generate their metadata so that 
+        # Add the header file to generate their metadata so that 
         # they are present in code downloaded from FreeRTOS console.
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.h"
+        # Add the CMake file to the source list so that metadata is
+        # generated for it, and it is present in code downloaded from
+        # the FreeRTOS console.
+        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 
 afr_module_dependencies(

--- a/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -13,7 +13,9 @@ afr_module_sources(
         # Add the header file to generate their metadata so that 
         # they are present in code downloaded from FreeRTOS console.
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.h"
-        # Add the CMake file to the source list so that metadata is
+        # As the containing directory name (i.e. device_shadow_for_aws_iot_embedded_sdk)
+        # does not match the module name (i.e. device_shadow), 
+        # we add the CMake file to the source list so that metadata is
         # generated for it, and it is present in code downloaded from
         # the FreeRTOS console.
         ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt

--- a/demos/shadow/CMakeLists.txt
+++ b/demos/shadow/CMakeLists.txt
@@ -1,10 +1,6 @@
 # C SDK Shadow demo
 afr_demo_module(shadow)
 
-afr_set_demo_metadata(ID "SHADOW_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates Shadow")
-afr_set_demo_metadata(DISPLAY_NAME "Shadow Demo")
-
 set(inc_dir "${AFR_MODULES_C_SDK_DIR}/standard/serializer/include")
 
 afr_module_sources(

--- a/libraries/c_sdk/aws/shadow/CMakeLists.txt
+++ b/libraries/c_sdk/aws/shadow/CMakeLists.txt
@@ -1,12 +1,5 @@
 afr_module()
 
-afr_set_lib_metadata(ID "shadow")
-afr_set_lib_metadata(DESCRIPTION "This library enables communication with AWS IoT Thing Shadows.")
-afr_set_lib_metadata(DISPLAY_NAME "Thing Shadow")
-afr_set_lib_metadata(CATEGORY "Amazon Services")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "true")
-
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")

--- a/libraries/core_json.cmake
+++ b/libraries/core_json.cmake
@@ -1,12 +1,5 @@
 afr_module( NAME core_json )
 
-afr_set_lib_metadata(ID "core_json")
-afr_set_lib_metadata(DESCRIPTION "This library is a parser that enforces the ECMA-404 JSON standard.")
-afr_set_lib_metadata(DISPLAY_NAME "Core JSON")
-afr_set_lib_metadata(CATEGORY "Tool")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "false")
-
 # Include Json library's source and header path variables.
 include("${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake")
 

--- a/libraries/core_json.cmake
+++ b/libraries/core_json.cmake
@@ -3,10 +3,25 @@ afr_module( NAME core_json )
 # Include Json library's source and header path variables.
 include("${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake")
 
+# Create a list of all header files in the coreJSON library.
+# The list of header files will be added to metadata required
+# for the FreeRTOS console.
+set(JSON_HEADER_FILES "")
+foreach(json_public_include_dir ${JSON_INCLUDE_PUBLIC_DIRS})
+    file(GLOB json_public_include_header_files
+              LIST_DIRECTORIES false
+              ${json_public_include_dir}/* )
+    list(APPEND JSON_HEADER_FILES ${json_public_include_header_files})
+endforeach()
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${JSON_SOURCES}
+        # List of files added to the target so that these are available
+        # in code downloaded from the FreeRTOS console.
+        ${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake
+        ${JSON_HEADER_FILES}
 )
 
 afr_module_include_dirs(

--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -89,3 +89,14 @@ if(TARGET AFR::secure_sockets::mcu_port)
             AFR::secure_sockets
     )
 endif()
+
+# Add dependency on WiFi module so that WiFi library is auto-included
+# when selecting core MQTT library on FreeRTOS console for boards that
+# support the WiFi library.
+if(TARGET AFR::wifi::mcu_port)
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        PUBLIC
+            AFR::wifi
+    )
+endif()

--- a/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
@@ -33,23 +33,21 @@ afr_module_include_dirs(
         "${AFR_MODULES_C_SDK_DIR}/standard/common/include/private"
 )
 
-if(TARGET ADR::posix)
-    # Test
-    afr_test_module()
-    afr_module_sources(
-        ${AFR_CURRENT_MODULE}
-        INTERFACE
-            "${test_dir}/iot_test_posix_clock.c"
-            "${test_dir}/iot_test_posix_mqueue.c"
-            "${test_dir}/iot_test_posix_pthread.c"
-            "${test_dir}/iot_test_posix_semaphore.c"
-            "${test_dir}/iot_test_posix_stress.c"
-            "${test_dir}/iot_test_posix_timer.c"
-            "${test_dir}/iot_test_posix_unistd.c"
-            "${test_dir}/iot_test_posix_utils.c"
-    )
-    afr_module_dependencies(
-        ${AFR_CURRENT_MODULE}
-        INTERFACE AFR::posix
-    )
-endif()
+# Test
+afr_test_module()
+afr_module_sources(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+        "${test_dir}/iot_test_posix_clock.c"
+        "${test_dir}/iot_test_posix_mqueue.c"
+        "${test_dir}/iot_test_posix_pthread.c"
+        "${test_dir}/iot_test_posix_semaphore.c"
+        "${test_dir}/iot_test_posix_stress.c"
+        "${test_dir}/iot_test_posix_timer.c"
+        "${test_dir}/iot_test_posix_unistd.c"
+        "${test_dir}/iot_test_posix_utils.c"
+)
+afr_module_dependencies(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE AFR::freertos_plus_posix
+)

--- a/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
@@ -49,5 +49,5 @@ afr_module_sources(
 )
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::freertos_plus_posix
+    INTERFACE AFR::posix
 )

--- a/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
@@ -49,5 +49,5 @@ afr_module_sources(
 )
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::posix
+    INTERFACE AFR::freertos_plus_posix
 )

--- a/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
@@ -33,21 +33,23 @@ afr_module_include_dirs(
         "${AFR_MODULES_C_SDK_DIR}/standard/common/include/private"
 )
 
-# Test
-afr_test_module()
-afr_module_sources(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${test_dir}/iot_test_posix_clock.c"
-        "${test_dir}/iot_test_posix_mqueue.c"
-        "${test_dir}/iot_test_posix_pthread.c"
-        "${test_dir}/iot_test_posix_semaphore.c"
-        "${test_dir}/iot_test_posix_stress.c"
-        "${test_dir}/iot_test_posix_timer.c"
-        "${test_dir}/iot_test_posix_unistd.c"
-        "${test_dir}/iot_test_posix_utils.c"
-)
-afr_module_dependencies(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::freertos_plus_posix
-)
+if(TARGET ADR::posix)
+    # Test
+    afr_test_module()
+    afr_module_sources(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            "${test_dir}/iot_test_posix_clock.c"
+            "${test_dir}/iot_test_posix_mqueue.c"
+            "${test_dir}/iot_test_posix_pthread.c"
+            "${test_dir}/iot_test_posix_semaphore.c"
+            "${test_dir}/iot_test_posix_stress.c"
+            "${test_dir}/iot_test_posix_timer.c"
+            "${test_dir}/iot_test_posix_unistd.c"
+            "${test_dir}/iot_test_posix_utils.c"
+    )
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE AFR::posix
+    )
+endif()

--- a/tests/integration_test/CMakeLists.txt
+++ b/tests/integration_test/CMakeLists.txt
@@ -18,16 +18,17 @@ afr_module_dependencies(
 )
 
 # FreeRTOS+TCP Test
-afr_test_module(freertos_tcp_test)
+if(TARGET AFR::freertos_plus_tcp)
+    afr_test_module(freertos_tcp_test)
 
-afr_module_sources(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${CMAKE_CURRENT_LIST_DIR}/test_freertos_tcp.c"
-)
+    afr_module_sources(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            "${CMAKE_CURRENT_LIST_DIR}/test_freertos_tcp.c"
+    )
 
-afr_module_dependencies(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::freertos_plus_tcp
-)
-
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE AFR::freertos_plus_tcp
+    )
+endif()

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -333,7 +333,10 @@ target_sources(
         "${afr_ports_dir}/common_io/iot_i2c.c"
         "${afr_ports_dir}/common_io/iot_spi.c"
         "${afr_ports_dir}/common_io/iot_uart.c"
-         $<${AFR_IS_TESTING}:${afr_ports_dir}/common_io/iot_test_common_io_internal.c>
+        $<${AFR_IS_TESTING}:${afr_ports_dir}/common_io/iot_test_common_io_internal.c>
+        # Add the header file to generate metadata for it so that
+        # it is present in the code downloaded from FreeRTOS console.
+        "${afr_ports_dir}/common_io/include/iot_board_gpio.h" 
 )
 target_include_directories(
     AFR::common_io::mcu_port

--- a/vendors/marvell/boards/mw300_rd/CMakeLists.txt
+++ b/vendors/marvell/boards/mw300_rd/CMakeLists.txt
@@ -216,6 +216,9 @@ target_sources(
     INTERFACE
         "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/BufferManagement/BufferAllocation_2.c"
         "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/NetworkInterface/mw300_rd/NetworkInterface.c"
+        # Header files added to the target so that these are available in code downloaded from the FreeRTOS console.
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/Compiler/GCC/pack_struct_end.h"
+        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/Compiler/GCC/pack_struct_start.h"
 )
 
 # PKCS11


### PR DESCRIPTION
Fixes for FreeRTOS console project download build failures, and improvements for FreeRTOS Console UI workflow.

Description
-----------
Changes include:
* Removal of metadata of old Shadow library and demo.
* Removal of metadata of CLI demo and core JSON library, which are not going to be shown on FreeRTOS console.
* Addition of header files in source list of Espressif and Marvell CMakeLists.txt for fixing missing files issue.
* Add conditional dependency on `AFR::wifi` of `AFR::core_mqtt_demo_dependencies` so that the WiFi library is _auto-included_ when the coreMQTT library is selected on FreeRTOS console.
* Add dependency on `AFR::core_mqtt_demo_dependencies` for MQTT over BLE demo so that the demo isn't shown when coreMQTT is not selected on FreeRTOS console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.