### PR TITLE
Fix NXP test project.

### DIFF
--- a/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.project
+++ b/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.project
@@ -1136,6 +1136,8 @@
 			<name>libraries/freertos_plus/standard/utils/include/iot_system_init.h</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/freertos_plus/standard/utils/include/iot_system_init.h</locationURI>
+		</link>
+		<link>
 			<name>libraries/abstractions/pkcs11/corePKCS11/source/core_pki_utils.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/abstractions/pkcs11/corePKCS11/source/core_pki_utils.c</locationURI>


### PR DESCRIPTION
Fix NXP test project.

Description
-----------
Core PKI utils was mistakenly placed inside of another item in the test project.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.