### PR TITLE
Fix missing core_json.cmake file in FreeRTOS console

### DIFF
--- a/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-# C SDK Shadow demo
+# Device Shadow demo module.
 afr_demo_module(device_shadow)
 
 afr_set_demo_metadata(ID "DEVICE_SHADOW_DEMO")

--- a/libraries/core_json.cmake
+++ b/libraries/core_json.cmake
@@ -21,6 +21,7 @@ afr_module_sources(
         # List of files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
         ${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/core_json.cmake
         ${JSON_HEADER_FILES}
 )
 

--- a/tests/integration_test/CMakeLists.txt
+++ b/tests/integration_test/CMakeLists.txt
@@ -1,21 +1,23 @@
-# MQTT test
-afr_test_module(core_mqtt_integration)
+if(TARGET AFR::core_mqtt)
+    # MQTT test
+    afr_test_module(core_mqtt_integration)
 
-afr_module_sources(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${CMAKE_CURRENT_LIST_DIR}/core_mqtt_system_test.c"
-)
+    afr_module_sources(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            "${CMAKE_CURRENT_LIST_DIR}/core_mqtt_system_test.c"
+    )
 
-afr_module_dependencies(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        AFR::core_mqtt
-        AFR::transport_interface_secure_sockets
-        AFR::common
-        AFR::platform
-        AFR::retry_utils
-)
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            AFR::core_mqtt
+            AFR::transport_interface_secure_sockets
+            AFR::common
+            AFR::platform
+            AFR::retry_utils
+    )
+endif()
 
 # FreeRTOS+TCP Test
 if(TARGET AFR::freertos_plus_tcp)


### PR DESCRIPTION
Fix missing `core_json.cmake` file in FreeRTOS console download when Device Shadow library is selected