### PR TITLE
Remove const qualifier from NetworkContext_t* in send/recv

### DIFF
--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -312,7 +312,7 @@ static BaseType_t prvMQTTProcessIncomingPacket( Socket_t xMQTTSocket );
  * @return Number of bytes received or zero to indicate transportTimeout;
  * negative value on error.
  */
-static int32_t prvTransportRecv( const NetworkContext_t * pxContext,
+static int32_t prvTransportRecv( NetworkContext_t * pxContext,
                                  void * pvBuffer,
                                  size_t xBytesToRecv );
 
@@ -577,7 +577,7 @@ static void prvGracefulShutDown( Socket_t xSocket )
 }
 /*-----------------------------------------------------------*/
 
-static int32_t prvTransportRecv( const NetworkContext_t * pxContext,
+static int32_t prvTransportRecv( NetworkContext_t * pxContext,
                                  void * pvBuffer,
                                  size_t xBytesToRecv )
 {

--- a/libraries/abstractions/platform/include/platform/transport_interface.h
+++ b/libraries/abstractions/platform/include/platform/transport_interface.h
@@ -91,7 +91,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkRecvImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkRecvImplementation( NetworkContext_t * pNetworkContext,
  *                                      void * pBuffer,
  *                                      size_t bytesToRecv )
  * {
@@ -123,7 +123,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkSendImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkSendImplementation( NetworkContext_t * pNetworkContext,
  *                                      const void * pBuffer,
  *                                      size_t bytesToSend )
  * {
@@ -166,7 +166,7 @@ typedef struct NetworkContext NetworkContext_t;
  * @return The number of bytes received or a negative error code.
  */
 /* @[define_transportrecv] */
-typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
                                        void * pBuffer,
                                        size_t bytesToRecv );
 /* @[define_transportrecv] */
@@ -182,7 +182,7 @@ typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
  * @return The number of bytes sent or a negative error code.
  */
 /* @[define_transportsend] */
-typedef int32_t ( * TransportSend_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext,
                                        const void * pBuffer,
                                        size_t bytesToSend );
 /* @[define_transportsend] */

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -96,7 +96,7 @@ static TransportSocketStatus_t connectToServer( Socket_t tcpSocket,
 
 /*-----------------------------------------------------------*/
 
-int32_t SecureSocketsTransport_Send( const NetworkContext_t * pNetworkContext,
+int32_t SecureSocketsTransport_Send( NetworkContext_t * pNetworkContext,
                                      const void * pMessage,
                                      size_t bytesToSend )
 {
@@ -145,7 +145,7 @@ int32_t SecureSocketsTransport_Send( const NetworkContext_t * pNetworkContext,
 
 /*-----------------------------------------------------------*/
 
-int32_t SecureSocketsTransport_Recv( const NetworkContext_t * pNetworkContext,
+int32_t SecureSocketsTransport_Recv( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRecv )
 {

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
@@ -185,7 +185,7 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
  *         0 if the socket times out without reading any bytes;
  *         negative value on error.
  */
-int32_t SecureSocketsTransport_Recv( const NetworkContext_t * pNetworkContext,
+int32_t SecureSocketsTransport_Recv( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRecv );
 
@@ -201,7 +201,7 @@ int32_t SecureSocketsTransport_Recv( const NetworkContext_t * pNetworkContext,
  *
  * @return Number of bytes sent if successful; negative value on error.
  */
-int32_t SecureSocketsTransport_Send( const NetworkContext_t * pNetworkContext,
+int32_t SecureSocketsTransport_Send( NetworkContext_t * pNetworkContext,
                                      const void * pMessage,
                                      size_t bytesToSend );
 

--- a/libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_api.c
+++ b/libraries/c_sdk/aws/shadow/test/unit/aws_iot_tests_shadow_api.c
@@ -490,7 +490,7 @@ static void eventCallback( MQTTContext_t * pContext,
 /**
  * @brief Transport send interface provided to the MQTT context used in calling MQTT LTS APIs.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -529,7 +529,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
@@ -91,7 +91,7 @@ MQTTStatus_t IotBleMqttTransportAcceptData( const NetworkContext_t * pContext );
  * @param[in] bytesToWrite number of bytes to write from the buffer.
  * @return the number of bytes sent.
  */
-int32_t IotBleMqttTransportSend( const NetworkContext_t * pContext,
+int32_t IotBleMqttTransportSend( NetworkContext_t * pContext,
                                  const void * pBuffer,
                                  size_t bytesToWrite );
 
@@ -103,7 +103,7 @@ int32_t IotBleMqttTransportSend( const NetworkContext_t * pContext,
  * @param[in] bytesToRead number of bytes to read from the transport layer.
  * @return the number of bytes successfully read.
  */
-int32_t IotBleMqttTransportReceive( const NetworkContext_t * pContext,
+int32_t IotBleMqttTransportReceive( NetworkContext_t * pContext,
                                     void * pBuffer,
                                     size_t bytesToRead );
 

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
@@ -972,7 +972,7 @@ static MQTTStatus_t handleIncomingPingresp( StreamBufferHandle_t streamBuffer,
  * @param[in] pBuffer A pointer to a buffer containing data to be sent out.
  * @param[in] bytesToWrite number of bytes to write from the buffer.
  */
-int32_t IotBleMqttTransportSend( const NetworkContext_t * pContext,
+int32_t IotBleMqttTransportSend( NetworkContext_t * pContext,
                                  const void * pBuffer,
                                  size_t bytesToWrite )
 {
@@ -1142,7 +1142,7 @@ MQTTStatus_t IotBleMqttTransportAcceptData( const NetworkContext_t * pContext )
  * @param[out] buf A pointer to a buffer where incoming data will be stored.
  * @param[in] bytesToRead number of bytes to read from the transport layer.
  */
-int32_t IotBleMqttTransportReceive( const NetworkContext_t * pContext,
+int32_t IotBleMqttTransportReceive( NetworkContext_t * pContext,
                                     void * pBuffer,
                                     size_t bytesToRead )
 {

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_api.c
@@ -193,7 +193,7 @@ static void eventCallback( MQTTContext_t * pContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv );
 
@@ -206,7 +206,7 @@ static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
  *
  * @return The number of bytes sent or a negative error code.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend );
 
@@ -898,7 +898,7 @@ static void eventCallback( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -923,7 +923,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/libraries/c_sdk/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
+++ b/libraries/c_sdk/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
@@ -447,7 +447,7 @@ static void eventCallback( MQTTContext_t * pContext,
 /**
  * @brief Transport send interface provided to the MQTT context used in calling MQTT LTS APIs.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -486,7 +486,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -557,7 +557,7 @@ static void _decrementReferencesJob( IotTaskPool_t pTaskPool,
 /**
  * @brief Transport send interface provided to the MQTT context used in calling MQTT LTS APIs.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -585,7 +585,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
 /**
  * @brief A transport send function that delays.
  */
-static int32_t transportSendDelay( const NetworkContext_t * pSendContext,
+static int32_t transportSendDelay( NetworkContext_t * pSendContext,
                                    const void * pMessage,
                                    size_t messageLength )
 {
@@ -620,7 +620,7 @@ static int32_t transportSendDelay( const NetworkContext_t * pSendContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
@@ -525,7 +525,7 @@ static void _disconnectCallback( void * pCallbackContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -551,7 +551,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c
@@ -359,7 +359,7 @@ static void eventCallback( MQTTContext_t * pContext,
 /**
  * @brief Transport send interface provided to the MQTT context used in calling MQTT LTS APIs.
  */
-static int32_t transportSend( const NetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -398,7 +398,7 @@ static int32_t transportSend( const NetworkContext_t * pNetworkContext,
  *
  * @return The number of bytes received or a negative error code.
  */
-static int32_t transportRecv( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -418,7 +418,7 @@ static void eventCallback( MQTTContext_t * pContext,
  *
  * @return -1 to represent failure.
  */
-static int32_t failedRecv( const NetworkContext_t * pNetworkContext,
+static int32_t failedRecv( NetworkContext_t * pNetworkContext,
                            void * pBuffer,
                            size_t bytesToRecv );
 
@@ -756,7 +756,7 @@ static MQTTStatus_t publishToTopic( MQTTContext_t * pContext,
                          packetId );
 }
 
-static int32_t failedRecv( const NetworkContext_t * pNetworkContext,
+static int32_t failedRecv( NetworkContext_t * pNetworkContext,
                            void * pBuffer,
                            size_t bytesToRecv )
 {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This follows changes from [https://github.com/FreeRTOS/coreMQTT/pull/86](https://github.com/FreeRTOS/coreMQTT/pull/86) & [https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32](https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32). The const qualifier is removed from send/recv because there are transport implementations that require a member of the network context to be modified such as in the case of mbedtls.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.