### PR TITLE
Make CBMC run with all property checking flags.

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -74,7 +74,17 @@
         "--32",
         "--bounds-check",
         "--pointer-check",
-        "--pointer-primitive-check"
+        "--pointer-primitive-check",
+	"--conversion-check",
+	"--div-by-zero-check",
+	"--float-overflow-check",
+	"--malloc-fail-null",
+	"--malloc-may-fail",
+	"--nan-check",
+	"--pointer-overflow-check",
+	"--signed-overflow-check",
+	"--undefined-shift-check",
+	"--unsigned-overflow-check"
     ],
 
     "FORWARD_SLASH": ["/"],


### PR DESCRIPTION
This pull request adds to the list of undefined behaviors that CBMC checks for, and it runs CBMC with the new model of malloc that allows malloc either to fail and return NULL or return a valid pointer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.