### PR TITLE
Add malloc flags to CBMC proofs

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -74,7 +74,9 @@
         "--32",
         "--bounds-check",
         "--pointer-check",
-        "--pointer-primitive-check"
+        "--pointer-primitive-check",
+	"--malloc-fail-null",
+	"--malloc-may-fail"
     ],
 
     "FORWARD_SLASH": ["/"],


### PR DESCRIPTION
This pull request adds the new CBMC malloc flags to the list of cbmc command line arguments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.