### PR TITLE
Fix core MQTT serializer demo 

### DIFF
--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -547,14 +547,14 @@ int RunCoreMqttSerializerDemo( bool awsIotMqttMode,
 static BaseType_t prvGracefulShutDown( Socket_t xSocket )
 {
     BaseType_t xStatus = pdFAIL;
-    int32_t lSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
+    int32_t lSocketStatus = ( int32_t ) SOCKETS_SOCKET_ERROR;
 
     /* Call Secure Sockets shutdown function to close connection. */
     lSocketStatus = SOCKETS_Shutdown( xSocket, SOCKETS_SHUT_RDWR );
 
     if( lSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
     {
-        LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. %d", lSocketStatus ) );
+        LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. SocketStatus %d.", lSocketStatus ) );
     }
     else
     {
@@ -563,7 +563,7 @@ static BaseType_t prvGracefulShutDown( Socket_t xSocket )
 
         if( lSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {
-            LogError( ( "Failed to close connection: SOCKETS_Close call failed. SocketStatus %d", lSocketStatus ) );
+            LogError( ( "Failed to close connection: SOCKETS_Close call failed. SocketStatus %d.", lSocketStatus ) );
         }
         else
         {

--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -193,8 +193,11 @@ static BaseType_t prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket );
  *
  * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
+ *
+ * @return pdPASS if the graceful shutdown of the socket was successful,
+ * pdFAIL otherwise.
  */
-static void prvGracefulShutDown( Socket_t xSocket );
+static BaseType_t prvGracefulShutDown( Socket_t xSocket );
 
 /**
  * @brief Subscribes to the topic as specified in mqttexampleTOPIC at the top of
@@ -511,7 +514,7 @@ int RunCoreMqttSerializerDemo( bool awsIotMqttMode,
             xStatus = prvMQTTDisconnect( xMQTTSocket );
 
             /* Close the network connection. */
-            prvGracefulShutDown( xMQTTSocket );
+            xStatus = prvGracefulShutDown( xMQTTSocket );
             xIsConnectionEstablished = pdFALSE;
         }
 
@@ -541,8 +544,9 @@ int RunCoreMqttSerializerDemo( bool awsIotMqttMode,
 }
 /*-----------------------------------------------------------*/
 
-static void prvGracefulShutDown( Socket_t xSocket )
+static BaseType_t prvGracefulShutDown( Socket_t xSocket )
 {
+    BaseType_t xStatus = pdFAIL;
     int32_t lSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
 
     /* Call Secure Sockets shutdown function to close connection. */
@@ -561,7 +565,13 @@ static void prvGracefulShutDown( Socket_t xSocket )
         {
             LogError( ( "Failed to close connection: SOCKETS_Close call failed. SocketStatus %d", lSocketStatus ) );
         }
+        else
+        {
+            xStatus = pdPASS;
+        }
     }
+
+    return xStatus;
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/coreMQTT/mqtt_demo_serializer.c
+++ b/demos/coreMQTT/mqtt_demo_serializer.c
@@ -543,35 +543,23 @@ int RunCoreMqttSerializerDemo( bool awsIotMqttMode,
 
 static void prvGracefulShutDown( Socket_t xSocket )
 {
-    uint8_t ucDummy[ 20 ];
-    const TickType_t xShortDelay = pdMS_TO_TICKS( 250 );
-    BaseType_t xShutdownLoopCount = 0;
+    int32_t lSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
 
-    if( xSocket != ( Socket_t ) 0 )
+    /* Call Secure Sockets shutdown function to close connection. */
+    lSocketStatus = SOCKETS_Shutdown( xSocket, SOCKETS_SHUT_RDWR );
+
+    if( lSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
     {
-        if( xSocket != SOCKETS_INVALID_SOCKET )
+        LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. %d", lSocketStatus ) );
+    }
+    else
+    {
+        /* Call Secure Sockets close function to close socket. */
+        lSocketStatus = SOCKETS_Close( xSocket );
+
+        if( lSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {
-            /* Initiate graceful shutdown. */
-            SOCKETS_Shutdown( xSocket, SOCKETS_SHUT_RDWR );
-
-            /* Wait for the socket to disconnect gracefully (indicated by FreeRTOS_recv()
-             * returning a FREERTOS_EINVAL error) before closing the socket. */
-            while( SOCKETS_Recv( xSocket, ucDummy, sizeof( ucDummy ), 0 ) >= 0 )
-            {
-                /* Wait for shutdown to complete.  If a receive block time is used then
-                 * this delay will not be necessary as FreeRTOS_recv() will place the RTOS task
-                 * into the Blocked state anyway. */
-                vTaskDelay( xShortDelay );
-
-                /* Limit the number of FreeRTOS_recv loops to avoid infinite loop. */
-                if( ++xShutdownLoopCount >= mqttexampleMAX_SOCKET_SHUTDOWN_LOOPS )
-                {
-                    break;
-                }
-            }
-
-            /* The socket has shut down and is safe to close. */
-            SOCKETS_Close( xSocket );
+            LogError( ( "Failed to close connection: SOCKETS_Close call failed. SocketStatus %d", lSocketStatus ) );
         }
     }
 }


### PR DESCRIPTION
Fix core MQTT serializer demo 

Description
-----------
Problem: core MQTT serializer demo was failing due to an incorrect shutdown of the secure socket.
Fix: Corrected the shutdown of the secure socket used in core MQTT serializer demo.
Test results : https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1318/

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.