### PR TITLE
Connection sharing demo changes from FreeRTOS

### DIFF
--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -26,18 +26,27 @@
 /*
  * Demo for showing use of the managed MQTT API shared between multiple tasks.
  * This demo uses a thread safe queue to hold commands for interacting with the
- * MQTT API. A command task processes commands from the queue while other tasks
- * enqueue them. This task enters a loop, during which it processes commands from
- * the command queue. If a termination command is received, it will break from
- * the loop. In addition to the command task, this demo uses one task for
- * publishing messages to the MQTT broker and another for receiving them via
- * an MQTT subscription. The publisher task creates a series of publish operations
- * to push to the command queue, which are then executed by the command task.
- * The subscriber task subscribes to a topic filter matching the topics published
- * on by the publisher, and then loops while waiting for publish messages to be
- * received. Each task has a queue to hold received publish messages,
- * and the command task pushes incoming publishes to the queue of each task
- * that is subscribed to the incoming topic.
+ * MQTT API. There are four tasks to note in this demo:
+ *  - A command (main) task for processing commands from the command queue while
+ *    other tasks enqueue them. This task enters a loop, during which it processes
+ *    commands from the command queue. If a termination command is received, it
+ *    will break from the loop.
+ *  - A publisher task for synchronous publishes. This task creates a series of
+ *    publish operations to push to the command queue, which are then executed
+ *    by the command task. This task uses synchronous publishes, meaning it will
+ *    wait for each publish to complete before scheduling the next one.
+ *  - A publisher task for asynchronous publishes. The difference between this
+ *    task and the previous is that it will not wait for completion before
+ *    scheduling the next publish, and checks them after all publishes have been
+ *    enqueued. Note that the distinction between synchronous and asynchronous
+ *    publishes is only in the behavior of the task, not in the actual publish
+ *    command.
+ *  - A subscriber task that creates an MQTT subscription to a topic filter
+ *    matching the topics published on by the publishers. It loops while waiting
+ *    for publish messages to be received.
+ * Tasks can have queues to hold received publish messages, and the command task
+ * will push incoming publishes to the queue of each task that is subscribed to
+ * the incoming topic.
  */
 
 /* Standard includes. */
@@ -132,8 +141,12 @@
 
 /**
  * @brief Timeout for MQTT_ProcessLoop function in milliseconds.
+ *
+ * This demo uses no delay for the process loop, so each invocation will run
+ * one iteration, and will only receive a single packet. However, if there is
+ * no data available on the socket, the entire socket timeout value will elapse.
  */
-#define mqttexamplePROCESS_LOOP_TIMEOUT_MS           ( 200U )
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS           ( 0U )
 
 /**
  * @brief The maximum time interval in seconds which is allowed to elapse
@@ -209,24 +222,29 @@
 #define mqttexampleSUBSCRIBE_TASK_DELAY_MS           400U
 
 /**
- * @brief Delay for the publisher task between synchronous publishes.
+ * @brief Delay for the synchronous publisher task between publishes.
  */
-#define mqttexamplePUBLISH_DELAY_SYNC_MS             500U
+#define mqttexamplePUBLISH_DELAY_SYNC_MS             100U
 
 /**
- * @brief Delay for the publisher task between asynchronous publishes.
+ * @brief Delay for the asynchronous publisher task between publishes.
  */
-#define mqttexamplePUBLISH_DELAY_ASYNC_MS            50U
+#define mqttexamplePUBLISH_DELAY_ASYNC_MS            100U
 
 /**
  * @brief Notification bit indicating completion of publisher task.
  */
-#define mqttexamplePUBLISHER_TASK_COMPLETE_BIT       ( 1U << 1 )
+#define mqttexamplePUBLISHER_SYNC_COMPLETE_BIT       ( 1U << 1 )
+
+/**
+ * @brief Notification bit indicating completion of second publisher task.
+ */
+#define mqttexamplePUBLISHER_ASYNC_COMPLETE_BIT      ( 1U << 2 )
 
 /**
  * @brief Notification bit indicating completion of subscriber task.
  */
-#define mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT       ( 1U << 2 )
+#define mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT       ( 1U << 3 )
 
 /**
  * @brief Notification bit used by subscriber task for subscribe operation.
@@ -258,17 +276,17 @@
 /**
  * @brief Topic filter used by the subscriber task.
  */
-#define mqttexampleSUBSCRIBE_TOPIC_FILTER            "publish/+/filter"
+#define mqttexampleSUBSCRIBE_TOPIC_FILTER            "filter/+/+"
 
 /**
  * @brief Format string used by the publisher task for topic names.
  */
-#define mqttexamplePUBLISH_TOPIC_FORMAT_STRING       "publish/%i/filter"
+#define mqttexamplePUBLISH_TOPIC_FORMAT_STRING       "filter/%s/%i"
 
 /**
  * @brief Format string used by the publisher task for payloads.
  */
-#define mqttexamplePUBLISH_PAYLOAD_FORMAT            "Hello World! %d"
+#define mqttexamplePUBLISH_PAYLOAD_FORMAT            "Hello World! %s: %d"
 
 /*-----------------------------------------------------------*/
 
@@ -365,18 +383,34 @@ typedef struct publishElement
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Initializes an MQTT context, including transport interface and
+ * network buffer.
+ *
+ * @param[in] pxMQTTContext MQTT Context to initialize.
+ * @param[in] pxNetworkContext Network context.
+ *
+ * @return `MQTTSuccess` if the initialization succeeds, else `MQTTBadParameter`.
+ */
+static MQTTStatus_t prvMQTTInit( MQTTContext_t * pxMQTTContext,
+                                 NetworkContext_t * pxNetworkContext );
+
+/**
  * @brief Sends an MQTT Connect packet over the already connected TCP socket.
  *
  * @param[in] pxMQTTContext MQTT context pointer.
- * @param[in] xNetworkContext Network context.
  * @param[in] xCleanSession If a clean session should be established.
  *
  * @return `MQTTSuccess` if connection succeeds, else appropriate error code
  * from MQTT_Connect.
  */
 static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
-                                    NetworkContext_t * pxNetworkContext,
                                     bool xCleanSession );
+
+/**
+ * @brief Resume a session by resending publishes if a session is present in
+ * the broker, or reestablish subscriptions if not.
+ */
+static void prvResumeSession( bool xSessionPresent );
 
 /**
  * @brief Form a TCP connection to a server.
@@ -385,7 +419,7 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
  *
  * @return `pdPASS` if connection succeeds, else `pdFAIL`.
  */
-static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext );
+static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext );
 
 /**
  * @brief Disconnect a TCP connection.
@@ -394,7 +428,15 @@ static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext );
  *
  * @return `pdPASS` if disconnect succeeds, else `pdFAIL`.
  */
-static BaseType_t prvDisconnectNetwork( NetworkContext_t * pxNetworkContext );
+static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext );
+
+/**
+ * @brief Callback for adding a process loop call to a command queue, when data
+ * is available on a socket.
+ *
+ * @param[in] pxSocket Socket with data, unused.
+ */
+static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket );
 
 /**
  * @brief Initialize context for a command.
@@ -547,7 +589,7 @@ static void prvEventCallback( MQTTContext_t * pMqttContext,
  *
  * @return `EXIT_SUCCESS` if successful; else `EXIT_FAILURE`.
  */
-static int prvCommandLoop();
+static int prvCommandLoop( void );
 
 /**
  * @brief Common callback for commands in this demo.
@@ -559,18 +601,46 @@ static int prvCommandLoop();
 static void prvCommandCallback( CommandContext_t * pxContext );
 
 /**
- * @brief The task used to create various publish operations.
+ * @brief Wait for a task notification in a loop.
+ *
+ * @param[in] pulNotification pointer holding notification value.
+ * @param[in] ulExpectedBits Bits to wait for.
+ * @param[in] xClearBits If bits should be cleared.
+ *
+ * @return `true` if notification received without exceeding the timeout,
+ * else `false`.
+ */
+static bool prvNotificationWaitLoop( uint32_t * pulNotification,
+                                     uint32_t ulExpectedBits,
+                                     bool xClearBits );
+
+/**
+ * @brief A task used to create publish operations, waiting for each to complete
+ * before creating the next one.
  *
  * This task creates a series of publish operations to push to a command queue,
  * which are in turn executed serially by the main task. This task demonstrates
- * both synchronous execution - waiting for each publish delivery to complete
- * before proceeding - and asynchronous, where it is not necessary for the
- * publish operation to complete before this task resumes.
+ * synchronous execution, waiting for each publish delivery to complete before
+ * proceeding.
  *
  * @param[in] pvParameters Parameters as passed at the time of task creation. Not
  * used in this example.
  */
-void prvPublishTask( void * pvParameters );
+void prvSyncPublishTask( void * pvParameters );
+
+/**
+ * @brief A task used to create publish operations, without waiting for
+ * completion between each new publish.
+ *
+ * This task creates publish operations asynchronously, meaning it will not
+ * wait for a publish to complete before scheduling the next one. Note there
+ * is no difference in the actual publish operation, only in the behavior of
+ * this task.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+void prvAsyncPublishTask( void * pvParameters );
 
 /**
  * @brief The task used to wait for incoming publishes.
@@ -601,6 +671,11 @@ static uint32_t prvGetTimeMs( void );
 static MQTTContext_t globalMqttContext;
 
 /**
+ * @brief Global Network context.
+ */
+static NetworkContext_t xNetworkContext;
+
+/**
  * @brief List of operations that are awaiting an ack from the broker.
  */
 static AckInfo_t pxPendingAcks[ mqttexamplePENDING_ACKS_MAX_SIZE ];
@@ -626,11 +701,6 @@ static CommandContext_t xResubscribeContext;
 static QueueHandle_t xCommandQueue;
 
 /**
- * @brief Response queue for prvPublishTask.
- */
-static QueueHandle_t xPublisherResponseQueue;
-
-/**
  * @brief Response queue for prvSubscribeTask.
  */
 static QueueHandle_t xSubscriberResponseQueue;
@@ -646,9 +716,14 @@ static QueueHandle_t xDefaultResponseQueue;
 static TaskHandle_t xMainTask;
 
 /**
- * @brief Handle for prvPublishTask.
+ * @brief Handle for prvSyncPublishTask.
  */
-static TaskHandle_t xPublisherTask;
+static TaskHandle_t xSyncPublisherTask;
+
+/**
+ * @brief Handle of prvAsyncPublishTask.
+ */
+static TaskHandle_t xAsyncPublisherTask;
 
 /**
  * @brief Handle for prvSubscribeTask.
@@ -658,7 +733,7 @@ static TaskHandle_t xSubscribeTask;
 /**
  * @brief The network buffer must remain valid for the lifetime of the MQTT context.
  */
-static uint8_t buffer[ mqttexampleNETWORK_BUFFER_SIZE ];
+static uint8_t pcNetworkBuffer[ mqttexampleNETWORK_BUFFER_SIZE ];
 
 /**
  * @brief Global entry time into the application to use as a reference timestamp
@@ -670,18 +745,14 @@ static uint32_t ulGlobalEntryTimeMs;
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
-                                    NetworkContext_t * pxNetworkContext,
-                                    bool xCleanSession )
+static MQTTStatus_t prvMQTTInit( MQTTContext_t * pxMQTTContext,
+                                 NetworkContext_t * pxNetworkContext )
 {
-    MQTTStatus_t xResult = MQTTSuccess;
-    MQTTConnectInfo_t xConnectInfo;
-    bool xSessionPresent = false;
     TransportInterface_t xTransport;
     MQTTFixedBuffer_t xNetworkBuffer;
 
     /* Fill the values for network buffer. */
-    xNetworkBuffer.pBuffer = buffer;
+    xNetworkBuffer.pBuffer = pcNetworkBuffer;
     xNetworkBuffer.size = mqttexampleNETWORK_BUFFER_SIZE;
 
     /* Fill in Transport Interface send and receive function pointers. */
@@ -689,144 +760,53 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
     xTransport.send = SecureSocketsTransport_Send;
     xTransport.recv = SecureSocketsTransport_Recv;
 
-    if( xCleanSession )
+    /* Initialize MQTT library. */
+    return MQTT_Init( pxMQTTContext, &xTransport, prvGetTimeMs, prvEventCallback, &xNetworkBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
+                                    bool xCleanSession )
+{
+    MQTTStatus_t xResult = MQTTSuccess;
+    MQTTConnectInfo_t xConnectInfo;
+    bool xSessionPresent = false;
+
+    /* Many fields are not used in this demo so start with everything at 0. */
+    memset( &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+
+    /* Start with a clean session i.e. direct the MQTT broker to discard any
+     * previous session data. Also, establishing a connection with clean session
+     * will ensure that the broker does not store any data when this client
+     * gets disconnected. */
+    xConnectInfo.cleanSession = xCleanSession;
+
+    /* The client identifier is used to uniquely identify this MQTT client to
+     * the MQTT broker. In a production device the identifier can be something
+     * unique, such as a device serial number. */
+    xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
+    xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+    /* Set MQTT keep-alive period. It is the responsibility of the application
+     * to ensure that the interval between Control Packets being sent does not
+     * exceed the Keep Alive value. In the absence of sending any other Control
+     * Packets, the Client MUST send a PINGREQ Packet. */
+    xConnectInfo.keepAliveSeconds = mqttexampleKEEP_ALIVE_INTERVAL_SECONDS;
+
+    /* Send MQTT CONNECT packet to broker. MQTT's Last Will and Testament feature
+     * is not used in this demo, so it is passed as NULL. */
+    xResult = MQTT_Connect( pxMQTTContext,
+                            &xConnectInfo,
+                            NULL,
+                            mqttexampleCONNACK_RECV_TIMEOUT_MS,
+                            &xSessionPresent );
+
+    LogInfo( ( "Session present: %d", xSessionPresent ) );
+
+    if( ( xResult == MQTTSuccess ) && !xCleanSession )
     {
-        /* Initialize MQTT library. */
-        xResult = MQTT_Init( pxMQTTContext, &xTransport, prvGetTimeMs, prvEventCallback, &xNetworkBuffer );
-    }
-
-    if( xResult == MQTTSuccess )
-    {
-        /* Many fields are not used in this demo so start with everything at 0. */
-        memset( &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
-
-        /* Start with a clean session i.e. direct the MQTT broker to discard any
-         * previous session data. Also, establishing a connection with clean session
-         * will ensure that the broker does not store any data when this client
-         * gets disconnected. */
-        xConnectInfo.cleanSession = xCleanSession;
-
-        /* The client identifier is used to uniquely identify this MQTT client to
-         * the MQTT broker. In a production device the identifier can be something
-         * unique, such as a device serial number. */
-        xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
-        xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
-
-        /* Set MQTT keep-alive period. It is the responsibility of the application to ensure
-         * that the interval between Control Packets being sent does not exceed the Keep Alive value.
-         * In the absence of sending any other Control Packets, the Client MUST send a PINGREQ Packet. */
-        xConnectInfo.keepAliveSeconds = mqttexampleKEEP_ALIVE_INTERVAL_SECONDS;
-
-        /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it
-         * is passed as NULL. */
-        xResult = MQTT_Connect( pxMQTTContext,
-                                &xConnectInfo,
-                                NULL,
-                                mqttexampleCONNACK_RECV_TIMEOUT_MS,
-                                &xSessionPresent );
-    }
-
-    if( xResult == MQTTSuccess )
-    {
-        LogInfo( ( "Session present: %d", xSessionPresent ) );
-
-        /* Resend publishes if session is present. NOTE: It's possible that some
-         * of the operations that were in progress during the network interruption
-         * were subscribes. In that case, we would want to mark those operations
-         * as completing with error and remove them from the list of operations, so
-         * that the calling task can try subscribing again. We do not handle that
-         * case in this demo for simplicity, since only one subscription packet is
-         * sent per iteration of this demo. */
-        if( xSessionPresent )
-        {
-            MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
-            uint16_t packetId = MQTT_PACKET_ID_INVALID;
-            AckInfo_t xFoundAck;
-
-            packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
-
-            while( packetId != MQTT_PACKET_ID_INVALID )
-            {
-                /* Retrieve the operation but do not remove it from the list. */
-                xFoundAck = prvGetAwaitingOperation( packetId, false );
-
-                if( xFoundAck.usPacketId == packetId )
-                {
-                    /* Set the DUP flag. */
-                    xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo->dup = true;
-                    xResult = MQTT_Publish( &globalMqttContext, xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo, packetId );
-
-                    if( xResult != MQTTSuccess )
-                    {
-                        break;
-                    }
-                }
-
-                packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
-            }
-        }
-    }
-
-    if( xResult == MQTTSuccess )
-    {
-        /* If we wanted to resume a session but none existed with the broker, we
-         * should mark all in progress operations as errors so that the tasks that
-         * created them can try again. Also, we will resubscribe to the filters in
-         * the subscription list, so tasks do not unexpectedly lose their subscriptions. */
-        if( !xCleanSession && !xSessionPresent )
-        {
-            int32_t i = 0, j = 0;
-            Command_t xNewCommand;
-            bool xCommandCreated = false;
-            BaseType_t xCommandAdded;
-
-            /* We have a clean session, so clear all operations pending acknowledgments. */
-            for( i = 0; i < mqttexamplePENDING_ACKS_MAX_SIZE; i++ )
-            {
-                if( pxPendingAcks[ i ].usPacketId != MQTT_PACKET_ID_INVALID )
-                {
-                    if( pxPendingAcks[ i ].xOriginalCommand.vCallback != NULL )
-                    {
-                        /* Bad response to indicate network error. */
-                        pxPendingAcks[ i ].xOriginalCommand.pxCmdContext->xReturnStatus = MQTTBadResponse;
-                        pxPendingAcks[ i ].xOriginalCommand.vCallback( pxPendingAcks[ i ].xOriginalCommand.pxCmdContext );
-                    }
-
-                    /* Now remove it from the list. */
-                    prvGetAwaitingOperation( pxPendingAcks[ i ].usPacketId, true );
-                }
-            }
-
-            /* Populate the array of MQTTSubscribeInfo_t. It's possible there may be
-             * repeated subscriptions in the list. This is fine, since clients
-             * are able to subscribe to a topic with an existing subscription. */
-            for( i = 0; i < mqttexampleSUBSCRIPTIONS_MAX_COUNT; i++ )
-            {
-                if( pxSubscriptions[ i ].usFilterLength != 0 )
-                {
-                    pxResendSubscriptions[ j ].pTopicFilter = pxSubscriptions[ i ].pcSubscriptionFilter;
-                    pxResendSubscriptions[ j ].topicFilterLength = pxSubscriptions[ i ].usFilterLength;
-                    pxResendSubscriptions[ j ].qos = MQTTQoS1;
-                    j++;
-                }
-            }
-
-            /* Resubscribe if needed. */
-            if( j > 0 )
-            {
-                prvInitializeCommandContext( &xResubscribeContext );
-                xResubscribeContext.pxSubscribeInfo = pxResendSubscriptions;
-                xResubscribeContext.ulSubscriptionCount = j;
-                /* Set to NULL so existing queues will not be overwritten. */
-                xResubscribeContext.pxResponseQueue = NULL;
-                xResubscribeContext.xTaskToNotify = NULL;
-                xCommandCreated = prvCreateCommand( SUBSCRIBE, &xResubscribeContext, prvCommandCallback, &xNewCommand );
-                configASSERT( xCommandCreated == true );
-                /* Send to the front of the queue so we will resubscribe as soon as possible. */
-                xCommandAdded = xQueueSendToFront( xCommandQueue, &xNewCommand, mqttexampleDEMO_TICKS_TO_WAIT );
-                configASSERT( xCommandAdded == pdTRUE );
-            }
-        }
+        prvResumeSession( xSessionPresent );
     }
 
     return xResult;
@@ -834,7 +814,109 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext )
+static void prvResumeSession( bool xSessionPresent )
+{
+    MQTTStatus_t xResult;
+
+    /* Resend publishes if session is present. NOTE: It's possible that some
+     * of the operations that were in progress during the network interruption
+     * were subscribes. In that case, we would want to mark those operations
+     * as completing with error and remove them from the list of operations, so
+     * that the calling task can try subscribing again. We do not handle that
+     * case in this demo for simplicity, since only one subscription packet is
+     * sent per iteration of this demo. */
+    if( xSessionPresent )
+    {
+        MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+        uint16_t packetId = MQTT_PACKET_ID_INVALID;
+        AckInfo_t xFoundAck;
+
+        packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
+
+        while( packetId != MQTT_PACKET_ID_INVALID )
+        {
+            /* Retrieve the operation but do not remove it from the list. */
+            xFoundAck = prvGetAwaitingOperation( packetId, false );
+
+            if( xFoundAck.usPacketId == packetId )
+            {
+                /* Set the DUP flag. */
+                xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo->dup = true;
+                xResult = MQTT_Publish( &globalMqttContext, xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo, packetId );
+
+                if( xResult != MQTTSuccess )
+                {
+                    break;
+                }
+            }
+
+            packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
+        }
+    }
+
+    /* If we wanted to resume a session but none existed with the broker, we
+     * should mark all in progress operations as errors so that the tasks that
+     * created them can try again. Also, we will resubscribe to the filters in
+     * the subscription list, so tasks do not unexpectedly lose their subscriptions. */
+    else
+    {
+        int32_t i = 0, j = 0;
+        Command_t xNewCommand;
+        bool xCommandCreated = false;
+        BaseType_t xCommandAdded;
+
+        /* We have a clean session, so clear all operations pending acknowledgments. */
+        for( i = 0; i < mqttexamplePENDING_ACKS_MAX_SIZE; i++ )
+        {
+            if( pxPendingAcks[ i ].usPacketId != MQTT_PACKET_ID_INVALID )
+            {
+                if( pxPendingAcks[ i ].xOriginalCommand.vCallback != NULL )
+                {
+                    /* Bad response to indicate network error. */
+                    pxPendingAcks[ i ].xOriginalCommand.pxCmdContext->xReturnStatus = MQTTBadResponse;
+                    pxPendingAcks[ i ].xOriginalCommand.vCallback( pxPendingAcks[ i ].xOriginalCommand.pxCmdContext );
+                }
+
+                /* Now remove it from the list. */
+                prvGetAwaitingOperation( pxPendingAcks[ i ].usPacketId, true );
+            }
+        }
+
+        /* Populate the array of MQTTSubscribeInfo_t. It's possible there may be
+         * repeated subscriptions in the list. This is fine, since clients
+         * are able to subscribe to a topic with an existing subscription. */
+        for( i = 0; i < mqttexampleSUBSCRIPTIONS_MAX_COUNT; i++ )
+        {
+            if( pxSubscriptions[ i ].usFilterLength != 0 )
+            {
+                pxResendSubscriptions[ j ].pTopicFilter = pxSubscriptions[ i ].pcSubscriptionFilter;
+                pxResendSubscriptions[ j ].topicFilterLength = pxSubscriptions[ i ].usFilterLength;
+                pxResendSubscriptions[ j ].qos = MQTTQoS1;
+                j++;
+            }
+        }
+
+        /* Resubscribe if needed. */
+        if( j > 0 )
+        {
+            prvInitializeCommandContext( &xResubscribeContext );
+            xResubscribeContext.pxSubscribeInfo = pxResendSubscriptions;
+            xResubscribeContext.ulSubscriptionCount = j;
+            /* Set to NULL so existing queues will not be overwritten. */
+            xResubscribeContext.pxResponseQueue = NULL;
+            xResubscribeContext.xTaskToNotify = NULL;
+            xCommandCreated = prvCreateCommand( SUBSCRIBE, &xResubscribeContext, prvCommandCallback, &xNewCommand );
+            configASSERT( xCommandCreated == true );
+            /* Send to the front of the queue so we will resubscribe as soon as possible. */
+            xCommandAdded = xQueueSendToFront( xCommandQueue, &xNewCommand, mqttexampleDEMO_TICKS_TO_WAIT );
+            configASSERT( xCommandAdded == pdTRUE );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
 {
     bool xConnected = false;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
@@ -856,7 +938,8 @@ static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext )
     xSocketConfig.pRootCa = democonfigROOT_CA_PEM;
     xSocketConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
 
-    /* Initialize reconnect attempts and interval. */
+    /* We will use a retry mechanism with an exponential backoff mechanism and
+     * jitter. We initialize reconnect attempts and interval here. */
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
 
@@ -869,13 +952,13 @@ static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext )
         /* Establish a TCP connection with the MQTT broker. This example connects to
          * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
          * democonfigMQTT_BROKER_PORT at the top of this file. */
-        LogInfo( ( "Create a TCP connection to %s:%d.",
+        LogInfo( ( "Creating a TCP connection to %s:%d.",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
 
         xNetworkStatus = SecureSocketsTransport_Connect( pxNetworkContext, &xServerInfo, &xSocketConfig );
 
-        xConnected = ( xNetworkStatus == TRANSPORT_SOCKET_STATUS_SUCCESS );
+        xConnected = ( xNetworkStatus == TRANSPORT_SOCKET_STATUS_SUCCESS ) ? true : false;
 
         if( !xConnected )
         {
@@ -889,16 +972,58 @@ static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext )
         }
     } while( ( xConnected != true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 
+    /* Set the socket wakeup callback. */
+    if( xConnected )
+    {
+        ( void ) SOCKETS_SetSockOpt( pxNetworkContext->tcpSocket,
+                                     0, /* Level - Unused. */
+                                     SOCKETS_SO_WAKEUP_CALLBACK,
+                                     ( void * ) prvMQTTClientSocketWakeupCallback,
+                                     sizeof( &( prvMQTTClientSocketWakeupCallback ) ) );
+    }
+
     return ( xConnected ) ? pdPASS : pdFAIL;
 }
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvDisconnectNetwork( NetworkContext_t * pxNetworkContext )
+static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext )
 {
+    LogInfo( ( "Disconnecting TCP connection.\n" ) );
+
+    /* Set the wakeup callback to NULL since the socket will disconnect. */
+    ( void ) SOCKETS_SetSockOpt( pxNetworkContext->tcpSocket,
+                                 0, /* Level - Unused. */
+                                 SOCKETS_SO_WAKEUP_CALLBACK,
+                                 NULL,
+                                 sizeof( void * ) );
+
     TransportSocketStatus_t xNetworkStatus = SecureSocketsTransport_Disconnect( pxNetworkContext );
 
     return ( xNetworkStatus == TRANSPORT_SOCKET_STATUS_SUCCESS ) ? pdPASS : pdFAIL;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket )
+{
+    BaseType_t xResult;
+    Command_t xCommand;
+
+    /* Just to avoid compiler warnings.  The socket is not used but the function
+     * prototype cannot be changed because this is a callback function. */
+    ( void ) pxSocket;
+
+    configASSERT( xCommandQueue );
+
+    /* A socket used by the MQTT task may need attention.  Send an event
+     * to the MQTT task to make sure the task is not blocked on xCommandQueue. */
+    if( uxQueueMessagesWaiting( xCommandQueue ) == ( UBaseType_t ) 0 )
+    {
+        prvCreateCommand( PROCESSLOOP, NULL, NULL, &xCommand );
+        xResult = prvAddCommandToQueue( &xCommand );
+        configASSERT( xResult == pdTRUE );
+    }
 }
 
 /*-----------------------------------------------------------*/
@@ -1103,8 +1228,10 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
     switch( pxCommand->xCommandType )
     {
         case PROCESSLOOP:
+
+            /* The process loop will run at the end of every command, so we don't
+             * need to call it again here. */
             LogDebug( ( "Running Process Loop." ) );
-            xStatus = MQTT_ProcessLoop( &globalMqttContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
             break;
 
         case PUBLISH:
@@ -1177,17 +1304,17 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
 
         case RECONNECT:
             /* Reconnect TCP. */
-            xNetworkResult = prvDisconnectNetwork( globalMqttContext.transportInterface.pNetworkContext );
+            xNetworkResult = prvSocketDisconnect( &xNetworkContext );
 
             if( xNetworkResult == pdPASS )
             {
-                xNetworkResult = prvConnectNetwork( globalMqttContext.transportInterface.pNetworkContext );
+                xNetworkResult = prvSocketConnect( &xNetworkContext );
             }
 
             if( xNetworkResult == pdPASS )
             {
                 /* MQTT Connect with a persistent session. */
-                xStatus = prvMQTTConnect( &globalMqttContext, globalMqttContext.transportInterface.pNetworkContext, false );
+                xStatus = prvMQTTConnect( &globalMqttContext, false );
             }
             else
             {
@@ -1230,6 +1357,13 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
         }
     }
 
+    /* Run a single iteration of the process loop if there were no errors and
+     * the MQTT connection still exists. */
+    if( ( xStatus == MQTTSuccess ) && ( globalMqttContext.connectStatus == MQTTConnected ) )
+    {
+        xStatus = MQTT_ProcessLoop( &globalMqttContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+    }
+
     return xStatus;
 }
 
@@ -1258,7 +1392,7 @@ static void prvHandleIncomingPublish( MQTTPublishInfo_t * pxPublishInfo )
 
             if( xIsMatched )
             {
-                LogDebug( ( "Adding publish to response queue for %.*s",
+                LogDebug( ( "Adding publish to response queue for %.*s\n",
                             pxSubscriptions[ i ].usFilterLength,
                             pxSubscriptions[ i ].pcSubscriptionFilter ) );
                 xPublishCopied = prvCopyPublishToQueue( pxPublishInfo, pxSubscriptions[ i ].pxResponseQueue );
@@ -1423,7 +1557,7 @@ static void prvEventCallback( MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
-static int prvCommandLoop()
+static int prvCommandLoop( void )
 {
     Command_t xCommand;
     Command_t xNewCommand;
@@ -1434,10 +1568,16 @@ static int prvCommandLoop()
     BaseType_t xCommandAdded = pdTRUE;
     int ret = EXIT_SUCCESS;
 
-    /* Loop while the queue is not empty. If a process loop command exists in the
-     * queue, then it should never become empty as it will be re-added. */
-    while( xQueueReceive( xCommandQueue, &xCommand, mqttexampleDEMO_TICKS_TO_WAIT ) != pdFALSE )
+    /* Loop until we receive a terminate command. */
+    for( ; ; )
     {
+        /* If there is no command in the queue, try again. */
+        if( xQueueReceive( xCommandQueue, &xCommand, mqttexampleDEMO_TICKS_TO_WAIT ) == pdFALSE )
+        {
+            LogInfo( ( "No commands in the queue. Trying again." ) );
+            continue;
+        }
+
         pxCommand = &xCommand;
 
         xStatus = prvProcessCommand( pxCommand );
@@ -1465,23 +1605,8 @@ static int prvCommandLoop()
             }
         }
 
+        /* Keep a count of processed operations, for debug logs. */
         lNumProcessed++;
-
-        if( pxCommand->xCommandType == PROCESSLOOP )
-        {
-            /* Add process loop back to end of queue. */
-            prvCreateCommand( PROCESSLOOP, NULL, NULL, &xNewCommand );
-            xCommandAdded = prvAddCommandToQueue( &xNewCommand );
-
-            /* Ensure the command was re-added. */
-            if( xCommandAdded != pdTRUE )
-            {
-                ret = EXIT_FAILURE;
-                break;
-            }
-
-            lNumProcessed--;
-        }
 
         /* Delay after sending a subscribe. This is to so that the broker
          * creates a subscription for us before processing our next publish,
@@ -1499,7 +1624,7 @@ static int prvCommandLoop()
             break;
         }
 
-        LogDebug( ( "Processed %d non-Process Loop operations.", lNumProcessed ) );
+        LogDebug( ( "Processed %d operations.", lNumProcessed ) );
     }
 
     /* Make sure we exited the loop due to receiving a terminate command and not
@@ -1539,23 +1664,44 @@ static void prvCommandCallback( CommandContext_t * pxContext )
 
 /*-----------------------------------------------------------*/
 
-void prvPublishTask( void * pvParameters )
+static bool prvNotificationWaitLoop( uint32_t * pulNotification,
+                                     uint32_t ulExpectedBits,
+                                     bool xClearBits )
+{
+    uint32_t ulWaitCounter = 0U;
+    bool ret = true;
+
+    while( ( *pulNotification & ulExpectedBits ) != ulExpectedBits )
+    {
+        xTaskNotifyWait( 0,
+                         ( xClearBits ) ? ulExpectedBits : 0,
+                         pulNotification,
+                         mqttexampleDEMO_TICKS_TO_WAIT );
+
+        if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
+        {
+            LogError( ( "Loop exceeded maximum wait time.\n" ) );
+            ret = false;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+void prvSyncPublishTask( void * pvParameters )
 {
     ( void ) pvParameters;
     Command_t xCommand;
     MQTTPublishInfo_t xPublishInfo = { 0 };
-    MQTTPublishInfo_t pxPublishes[ mqttexamplePUBLISH_COUNT ];
     char payloadBuf[ mqttexampleDEMO_BUFFER_SIZE ];
     char topicBuf[ mqttexampleDEMO_BUFFER_SIZE ];
     CommandContext_t xContext;
     uint32_t ulNotification = 0U;
     BaseType_t xCommandAdded = pdTRUE;
-    /* The following arrays are used to hold pointers to dynamically allocated memory. */
-    char * payloadBuffers[ mqttexamplePUBLISH_COUNT ];
-    char * topicBuffers[ mqttexamplePUBLISH_COUNT ];
-    CommandContext_t * pxContexts[ mqttexamplePUBLISH_COUNT ] = { 0 };
     int i = 0;
-    uint32_t ulWaitCounter = 0;
     int status = EXIT_SUCCESS;
 
     /* We use QoS 1 so that the operation won't be counted as complete until we
@@ -1564,16 +1710,15 @@ void prvPublishTask( void * pvParameters )
     xPublishInfo.pTopicName = topicBuf;
     xPublishInfo.pPayload = payloadBuf;
 
-    /* Do synchronous publishes for first half. */
-    for( i = 0; i < mqttexamplePUBLISH_COUNT / 2; i++ )
+    /* Synchronous publishes. In case mqttexamplePUBLISH_COUNT is odd, round up. */
+    for( int i = 0; i < ( ( mqttexamplePUBLISH_COUNT + 1 ) / 2 ); i++ )
     {
-        snprintf( payloadBuf, mqttexampleDEMO_BUFFER_SIZE, mqttexamplePUBLISH_PAYLOAD_FORMAT, i + 1 );
+        snprintf( payloadBuf, mqttexampleDEMO_BUFFER_SIZE, mqttexamplePUBLISH_PAYLOAD_FORMAT, "Sync", i + 1 );
         xPublishInfo.payloadLength = ( uint16_t ) strlen( payloadBuf );
-        snprintf( topicBuf, mqttexampleDEMO_BUFFER_SIZE, mqttexamplePUBLISH_TOPIC_FORMAT_STRING, i + 1 );
+        snprintf( topicBuf, mqttexampleDEMO_BUFFER_SIZE, mqttexamplePUBLISH_TOPIC_FORMAT_STRING, "sync", i + 1 );
         xPublishInfo.topicNameLength = ( uint16_t ) strlen( topicBuf );
 
         prvInitializeCommandContext( &xContext );
-        xContext.pxResponseQueue = xPublisherResponseQueue;
         xContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
         xContext.ulNotificationBit = 1 << i;
         xContext.pxPublishInfo = &xPublishInfo;
@@ -1589,19 +1734,13 @@ void prvPublishTask( void * pvParameters )
             break;
         }
 
-        ulWaitCounter = 0;
+        LogInfo( ( "Waiting for publish %d to complete.", i + 1 ) );
 
-        while( ( ulNotification & ( 1U << i ) ) != ( 1U << i ) )
+        if( prvNotificationWaitLoop( &ulNotification, ( 1U << i ), true ) != true )
         {
-            LogInfo( ( "Waiting for publish %d to complete.", i + 1 ) );
-            xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
-
-            if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-            {
-                LogError( ( "Synchronous publish loop iteration %d exceeded maximum wait time.", ( i + 1 ) ) );
-                status = EXIT_FAILURE;
-                break;
-            }
+            LogError( ( "Synchronous publish loop iteration %d"
+                        " exceeded maximum wait time.\n", ( i + 1 ) ) );
+            status = EXIT_FAILURE;
         }
 
         if( status != EXIT_SUCCESS )
@@ -1613,23 +1752,62 @@ void prvPublishTask( void * pvParameters )
         vTaskDelay( pdMS_TO_TICKS( mqttexamplePUBLISH_DELAY_SYNC_MS ) );
     }
 
-    /* Asynchronous publishes for second half. Although not necessary, we use dynamic
+    LogInfo( ( "Finished publishing\n" ) );
+
+    /* Clear this task's notifications. */
+    xTaskNotifyStateClear( NULL );
+    ulNotification = ulTaskNotifyValueClear( NULL, ~( 0U ) );
+
+    if( status == EXIT_SUCCESS )
+    {
+        /* Notify main task this task has completed successfully. */
+        xTaskNotify( xMainTask, mqttexamplePUBLISHER_SYNC_COMPLETE_BIT, eSetBits );
+    }
+
+    /* Delete this task. */
+    LogInfo( ( "Deleting Sync Publisher task." ) );
+    vTaskDelete( NULL );
+}
+
+/*-----------------------------------------------------------*/
+
+void prvAsyncPublishTask( void * pvParameters )
+{
+    ( void ) pvParameters;
+    Command_t xCommand;
+    MQTTPublishInfo_t pxPublishes[ mqttexamplePUBLISH_COUNT / 2 ];
+    uint32_t ulNotification = 0U;
+    uint32_t ulExpectedNotifications = 0U;
+    BaseType_t xCommandAdded = pdTRUE;
+    /* The following arrays are used to hold pointers to dynamically allocated memory. */
+    char * payloadBuffers[ mqttexamplePUBLISH_COUNT / 2 ];
+    char * topicBuffers[ mqttexamplePUBLISH_COUNT / 2 ];
+    CommandContext_t * pxContexts[ mqttexamplePUBLISH_COUNT / 2 ] = { 0 };
+    int i = 0;
+    int status = EXIT_SUCCESS;
+
+    /* Add a delay. The main task will not be sending publishes for this interval
+     * anyway, as we want to give the broker ample time to process the
+     * subscription. */
+    vTaskDelay( mqttexampleSUBSCRIBE_TASK_DELAY_MS );
+
+    /* Asynchronous publishes. Although not necessary, we use dynamic
      * memory here to avoid declaring many static buffers. */
-    for( i = mqttexamplePUBLISH_COUNT >> 1; ( i < mqttexamplePUBLISH_COUNT ) && ( status == EXIT_SUCCESS ); i++ )
+    for( i = 0; ( i < mqttexamplePUBLISH_COUNT >> 1 ) && ( status == EXIT_SUCCESS ); i++ )
     {
         pxContexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
         prvInitializeCommandContext( pxContexts[ i ] );
-        pxContexts[ i ]->pxResponseQueue = xPublisherResponseQueue;
         pxContexts[ i ]->xTaskToNotify = xTaskGetCurrentTaskHandle();
 
         /* Set the notification bit to be the publish number. This prevents this demo
          * from having more than 32 publishes. If many publishes are desired, semaphores
          * can be used instead of task notifications. */
         pxContexts[ i ]->ulNotificationBit = 1U << i;
+        ulExpectedNotifications |= 1U << i;
         payloadBuffers[ i ] = ( char * ) pvPortMalloc( mqttexampleDYNAMIC_BUFFER_SIZE );
         topicBuffers[ i ] = ( char * ) pvPortMalloc( mqttexampleDYNAMIC_BUFFER_SIZE );
-        snprintf( payloadBuffers[ i ], mqttexampleDYNAMIC_BUFFER_SIZE, mqttexamplePUBLISH_PAYLOAD_FORMAT, i + 1 );
-        snprintf( topicBuffers[ i ], mqttexampleDYNAMIC_BUFFER_SIZE, mqttexamplePUBLISH_TOPIC_FORMAT_STRING, i + 1 );
+        snprintf( payloadBuffers[ i ], mqttexampleDYNAMIC_BUFFER_SIZE, mqttexamplePUBLISH_PAYLOAD_FORMAT, "Async", i + 1 );
+        snprintf( topicBuffers[ i ], mqttexampleDYNAMIC_BUFFER_SIZE, mqttexamplePUBLISH_TOPIC_FORMAT_STRING, "async", i + 1 );
         /* Set publish info. */
         memset( &( pxPublishes[ i ] ), 0x00, sizeof( MQTTPublishInfo_t ) );
         pxPublishes[ i ].pPayload = payloadBuffers[ i ];
@@ -1648,6 +1826,7 @@ void prvPublishTask( void * pvParameters )
         /* Ensure command was added to queue. */
         if( xCommandAdded == pdTRUE )
         {
+            /* Short delay so we do not bombard the broker with publishes. */
             LogInfo( ( "Publish operation queued. Sleeping for %d ms.\n", mqttexamplePUBLISH_DELAY_ASYNC_MS ) );
             vTaskDelay( pdMS_TO_TICKS( mqttexamplePUBLISH_DELAY_ASYNC_MS ) );
         }
@@ -1658,36 +1837,23 @@ void prvPublishTask( void * pvParameters )
         }
     }
 
-    LogInfo( ( "Finished publishing\n" ) );
+    LogInfo( ( "Finished async publishes.\n" ) );
 
-    for( i = 0; ( i < mqttexamplePUBLISH_COUNT ) && ( status == EXIT_SUCCESS ); i++ )
+    if( status == EXIT_SUCCESS )
     {
-        if( pxContexts[ i ] == NULL )
+        /* Receive all task notifications. We may receive notifications in a
+         * different order, so we have two loops. If all notifications have been
+         * received, we can break early. */
+        if( prvNotificationWaitLoop( &ulNotification, ulExpectedNotifications, false ) != true )
         {
-            /* Don't try to free anything that wasn't initialized. */
-            continue;
+            LogError( ( "Async publisher wait exceeded maximum wait time." ) );
+            status = EXIT_FAILURE;
         }
+    }
 
-        ulWaitCounter = 0;
-
-        while( ( ulNotification & ( 1U << i ) ) != ( 1U << i ) )
-        {
-            LogInfo( ( "Waiting to free publish context %d.", i + 1 ) );
-            xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
-
-            if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-            {
-                LogError( ( "Loop free iteration %d exceeded maximum wait time.", ( i + 1 ) ) );
-                status = EXIT_FAILURE;
-                break;
-            }
-        }
-
-        if( status != EXIT_SUCCESS )
-        {
-            break;
-        }
-
+    for( i = 0; ( i < mqttexamplePUBLISH_COUNT / 2 ) && ( status == EXIT_SUCCESS ); i++ )
+    {
+        LogInfo( ( "Freeing publish context %d.", i + 1 ) );
         vPortFree( pxContexts[ i ] );
         vPortFree( topicBuffers[ i ] );
         vPortFree( payloadBuffers[ i ] );
@@ -1697,15 +1863,16 @@ void prvPublishTask( void * pvParameters )
 
     /* Clear this task's notifications. */
     xTaskNotifyStateClear( NULL );
+    ulNotification = ulTaskNotifyValueClear( NULL, ~( 0U ) );
 
     if( status == EXIT_SUCCESS )
     {
         /* Notify main task this task has completed successfully. */
-        xTaskNotify( xMainTask, mqttexamplePUBLISHER_TASK_COMPLETE_BIT, eSetBits );
+        xTaskNotify( xMainTask, mqttexamplePUBLISHER_ASYNC_COMPLETE_BIT, eSetBits );
     }
 
     /* Delete this task. */
-    LogInfo( ( "Deleting Publisher task." ) );
+    LogInfo( ( "Deleting Async Publisher task." ) );
     vTaskDelete( NULL );
 }
 
@@ -1751,24 +1918,18 @@ void prvSubscribeTask( void * pvParameters )
      * Since this demo uses multiple tasks, we do not retry failed subscriptions, as the
      * server has likely already processed our first publish, and so this demo will not
      * complete successfully. */
-    while( ( ulNotification & mqttexampleSUBSCRIBE_COMPLETE_BIT ) != mqttexampleSUBSCRIBE_COMPLETE_BIT )
-    {
-        LogInfo( ( "Waiting for subscribe operation to complete." ) );
-        xTaskNotifyWait( 0, mqttexampleSUBSCRIBE_COMPLETE_BIT, &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
+    LogInfo( ( "Waiting for subscribe operation to complete." ) );
 
-        if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-        {
-            LogError( ( "Subscribe Loop exceeded maximum wait time." ) );
-            status = EXIT_FAILURE;
-            break;
-        }
+    if( prvNotificationWaitLoop( &ulNotification, mqttexampleSUBSCRIBE_COMPLETE_BIT, true ) != true )
+    {
+        LogError( ( "Subscribe Loop exceeded maximum wait time." ) );
+        status = EXIT_FAILURE;
     }
-
-    LogInfo( ( "Operation wait complete.\n" ) );
-
-    /* Ensure the subscription succeeded. */
-    if( status == EXIT_SUCCESS )
+    else
     {
+        LogInfo( ( "Operation wait complete.\n" ) );
+
+        /* Ensure the subscription succeeded. */
         status = ( xContext.xReturnStatus == MQTTSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
@@ -1784,23 +1945,22 @@ void prvSubscribeTask( void * pvParameters )
             pxReceivedPublish = &( xReceivedPublish.xPublishInfo );
             pxReceivedPublish->pTopicName = ( const char * ) xReceivedPublish.pcTopicNameBuf;
             pxReceivedPublish->pPayload = xReceivedPublish.pcPayloadBuf;
-            LogInfo( ( "Received publish on topic %.*s", pxReceivedPublish->topicNameLength, pxReceivedPublish->pTopicName ) );
-            LogInfo( ( "Message payload: %.*s\n", ( int ) pxReceivedPublish->payloadLength, ( const char * ) pxReceivedPublish->pPayload ) );
+            LogInfo( ( "Received publish on topic %.*s\nMessage payload: %.*s\n",
+                       pxReceivedPublish->topicNameLength,
+                       pxReceivedPublish->pTopicName,
+                       ( int ) pxReceivedPublish->payloadLength,
+                       ( const char * ) pxReceivedPublish->pPayload ) );
             usNumReceived++;
             /* Reset the wait counter every time a publish is received. */
             ulWaitCounter = 0;
         }
 
-        /* Break if all publishes have been received. */
+        /* Since this is an infinite loop, we want to break if all publishes have
+         * been received. */
         if( usNumReceived >= mqttexamplePUBLISH_COUNT )
         {
             break;
         }
-
-        LogInfo( ( "No messages queued, received %u publishes, sleeping for %d ms\n",
-                   usNumReceived,
-                   mqttexampleSUBSCRIBE_TASK_DELAY_MS ) );
-        vTaskDelay( pdMS_TO_TICKS( mqttexampleSUBSCRIBE_TASK_DELAY_MS ) );
 
         /* Break if we have been stuck in this loop for too long. The total wait
          * here will be ( (loop delay + queue check delay) * `mqttexampleMAX_WAIT_ITERATIONS` ).
@@ -1809,9 +1969,17 @@ void prvSubscribeTask( void * pvParameters )
          * the last publish. */
         if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
         {
-            LogError( ( "Publish receive loop exceeded maximum wait time." ) );
+            LogError( ( "Publish receive loop exceeded maximum wait time.\n" ) );
             status = EXIT_FAILURE;
+            break;
         }
+
+        /* Delay a bit to give more time for publish messages to be received. */
+        LogInfo( ( "No messages queued, received %u publish%s, sleeping for %d ms\n",
+                   usNumReceived,
+                   ( usNumReceived == 1 ) ? "" : "es",
+                   mqttexampleSUBSCRIBE_TASK_DELAY_MS ) );
+        vTaskDelay( pdMS_TO_TICKS( mqttexampleSUBSCRIBE_TASK_DELAY_MS ) );
     }
 
     LogInfo( ( "Finished receiving\n" ) );
@@ -1830,20 +1998,13 @@ void prvSubscribeTask( void * pvParameters )
         xCommandAdded = prvAddCommandToQueue( &xCommand );
         /* Ensure command was added to queue. */
         configASSERT( xCommandAdded == pdTRUE );
-        LogInfo( ( "Starting wait on operation\n" ) );
-        ulWaitCounter = 0;
 
-        while( ( ulNotification & mqttexampleUNSUBSCRIBE_COMPLETE_BIT ) != mqttexampleUNSUBSCRIBE_COMPLETE_BIT )
+        LogInfo( ( "Waiting for unsubscribe operation to complete." ) );
+
+        if( prvNotificationWaitLoop( &ulNotification, mqttexampleUNSUBSCRIBE_COMPLETE_BIT, true ) != true )
         {
-            LogInfo( ( "Waiting for unsubscribe operation to complete." ) );
-            xTaskNotifyWait( 0, mqttexampleUNSUBSCRIBE_COMPLETE_BIT, &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
-
-            if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-            {
-                LogError( ( "Unsubscribe loop exceeded maximum wait time." ) );
-                status = EXIT_FAILURE;
-                break;
-            }
+            LogError( ( "Unsubscribe Loop exceeded maximum wait time." ) );
+            status = EXIT_FAILURE;
         }
 
         LogInfo( ( "Operation wait complete.\n" ) );
@@ -1875,15 +2036,15 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
                                       void * pNetworkCredentialInfo,
                                       const void * pNetworkInterface )
 {
-    NetworkContext_t xNetworkContext = { 0 };
     BaseType_t xNetworkStatus = pdFAIL;
     BaseType_t xResult = pdFALSE;
     BaseType_t xNetworkConnectionCreated = pdFALSE;
     uint32_t ulNotification = 0;
-    Command_t xCommand;
     MQTTStatus_t xMQTTStatus;
+    uint32_t ulExpectedNotifications = mqttexamplePUBLISHER_SYNC_COMPLETE_BIT |
+                                       mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT |
+                                       mqttexamplePUBLISHER_ASYNC_COMPLETE_BIT;
     uint32_t ulDemoCount = 0;
-    uint32_t ulWaitCounter = 0;
     int ret = EXIT_SUCCESS;
 
     ( void ) awsIotMqttMode;
@@ -1900,39 +2061,40 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
     xCommandQueue = xQueueCreate( mqttexampleCOMMAND_QUEUE_SIZE, sizeof( Command_t ) );
     /* Create response queues for each task. */
     xSubscriberResponseQueue = xQueueCreate( mqttexamplePUBLISH_QUEUE_SIZE, sizeof( PublishElement_t ) );
-    /* Publish task doesn't receive anything in this demo, so it doesn't need a large queue. */
-    xPublisherResponseQueue = xQueueCreate( 1, sizeof( PublishElement_t ) );
 
     /* In this demo, send publishes on non-subscribed topics to this queue.
      * Note that this value is not meant to be changed after `prvCommandLoop` has
      * been called, since access to this variable is not protected by thread
      * synchronization primitives. */
-    xDefaultResponseQueue = xPublisherResponseQueue;
+    xDefaultResponseQueue = xQueueCreate( 1, sizeof( PublishElement_t ) );
 
     /* Connect to the broker. We connect here with the "clean session" flag set
      * to true in order to clear any prior state in the broker. We will disconnect
      * and later form a persistent session, so that it may be resumed if the
      * network suddenly disconnects. */
-    LogInfo( ( "Creating a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-    xNetworkStatus = prvConnectNetwork( &xNetworkContext );
+    xNetworkStatus = prvSocketConnect( &xNetworkContext );
 
     ret = EXIT_FAILURE;
 
     if( xNetworkStatus == pdPASS )
     {
-        LogInfo( ( "Clearing broker state." ) );
-        xMQTTStatus = prvMQTTConnect( &globalMqttContext, &xNetworkContext, true );
+        LogInfo( ( "Creating a clean session to clear any broker state information." ) );
+        xMQTTStatus = prvMQTTInit( &globalMqttContext, &xNetworkContext );
 
         if( xMQTTStatus == MQTTSuccess )
         {
-            /* Disconnect. */
-            xMQTTStatus = MQTT_Disconnect( &globalMqttContext );
+            xMQTTStatus = prvMQTTConnect( &globalMqttContext, true );
 
             if( xMQTTStatus == MQTTSuccess )
             {
-                LogInfo( ( "Disconnecting TCP connection." ) );
-                xNetworkStatus = prvDisconnectNetwork( &xNetworkContext );
-                ret = ( xNetworkStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+                /* Disconnect. */
+                xMQTTStatus = MQTT_Disconnect( &globalMqttContext );
+
+                if( xMQTTStatus == MQTTSuccess )
+                {
+                    xNetworkStatus = prvSocketDisconnect( &xNetworkContext );
+                    ret = ( xNetworkStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+                }
             }
         }
     }
@@ -1943,24 +2105,15 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
         memset( pxPendingAcks, 0x00, mqttexamplePENDING_ACKS_MAX_SIZE * sizeof( AckInfo_t ) );
         memset( pxSubscriptions, 0x00, mqttexampleSUBSCRIPTIONS_MAX_COUNT * sizeof( SubscriptionElement_t ) );
 
-        /* Create inital process loop command. */
-        prvCreateCommand( PROCESSLOOP, NULL, NULL, &xCommand );
-        xResult = prvAddCommandToQueue( &xCommand );
-        ret = ( xResult == pdTRUE ) ? EXIT_SUCCESS : EXIT_FAILURE;
-
-        if( ret == EXIT_SUCCESS )
-        {
-            LogInfo( ( "Creating a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-            /* Connect to the broker. */
-            xNetworkStatus = prvConnectNetwork( &xNetworkContext );
-            ret = ( xNetworkStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
-        }
+        /* Connect to the broker. */
+        xNetworkStatus = prvSocketConnect( &xNetworkContext );
+        ret = ( xNetworkStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
 
         if( ret == EXIT_SUCCESS )
         {
             xNetworkConnectionCreated = pdTRUE;
             /* Form an MQTT connection with a persistent session. */
-            xMQTTStatus = prvMQTTConnect( &globalMqttContext, &xNetworkContext, false );
+            xMQTTStatus = prvMQTTConnect( &globalMqttContext, false );
             ret = ( xMQTTStatus == MQTTSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
@@ -1976,7 +2129,13 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
 
         if( ret == EXIT_SUCCESS )
         {
-            xResult = xTaskCreate( prvPublishTask, "Publisher", mqttexampleTASK_STACK_SIZE, NULL, tskIDLE_PRIORITY, &xPublisherTask );
+            xResult = xTaskCreate( prvSyncPublishTask, "SyncPublisher", mqttexampleTASK_STACK_SIZE, NULL, tskIDLE_PRIORITY, &xSyncPublisherTask );
+            ret = ( xResult == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
+
+        if( ret == EXIT_SUCCESS )
+        {
+            xResult = xTaskCreate( prvAsyncPublishTask, "AsyncPublisher", mqttexampleTASK_STACK_SIZE, NULL, tskIDLE_PRIORITY, &xAsyncPublisherTask );
             ret = ( xResult == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
@@ -1988,50 +2147,30 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
 
         if( ret == EXIT_SUCCESS )
         {
-            ulWaitCounter = 0;
+            /* Delete created queues. Wait for tasks to exit before cleaning up. */
+            LogInfo( ( "Waiting for tasks to exit." ) );
 
-            /* Wait for tasks to exit before cleaning up. */
-            while( ( ulNotification & mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT ) != mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT )
+            if( prvNotificationWaitLoop( &ulNotification, ulExpectedNotifications, false ) != true )
             {
-                LogInfo( ( "Waiting for subscribe task to exit." ) );
-                xTaskNotifyWait( 0, mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT, &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
-
-                if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-                {
-                    LogError( ( "Subscribe task exceeded maximum wait time." ) );
-                    ret = EXIT_FAILURE;
-                    break;
-                }
-            }
-
-            ulWaitCounter = 0;
-
-            /* Wait for publishing task to exit before cleaning up. */
-            while( ( ulNotification & mqttexamplePUBLISHER_TASK_COMPLETE_BIT ) != mqttexamplePUBLISHER_TASK_COMPLETE_BIT )
-            {
-                LogInfo( ( "Waiting for publish task to exit." ) );
-                xTaskNotifyWait( 0, mqttexamplePUBLISHER_TASK_COMPLETE_BIT, &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
-
-                if( ++ulWaitCounter > mqttexampleMAX_WAIT_ITERATIONS )
-                {
-                    LogError( ( "Publish task exceeded maximum wait time." ) );
-                    ret = EXIT_FAILURE;
-                    break;
-                }
+                LogError( ( "Exceeded maximum wait time waiting for task deletion." ) );
+                ret = EXIT_FAILURE;
             }
 
             /* Reset queues. */
             xQueueReset( xCommandQueue );
-            xQueueReset( xPublisherResponseQueue );
+            xQueueReset( xDefaultResponseQueue );
             xQueueReset( xSubscriberResponseQueue );
         }
+
+        /* Clear task notifications. */
+        ulNotification = ulTaskNotifyValueClear( NULL, ~( 0U ) );
 
         /* Close network connection even if failure occurred elsewhere. */
         if( xNetworkConnectionCreated == pdTRUE )
         {
             LogInfo( ( "Disconnecting TCP connection." ) );
-            xNetworkStatus = prvDisconnectNetwork( &xNetworkContext );
-            ret = ( xNetworkStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+            xNetworkStatus = prvSocketDisconnect( &xNetworkContext );
+            ret = ( xNetworkStatus == pdPASS ) ? ret : EXIT_FAILURE;
             xNetworkConnectionCreated = pdFALSE;
         }
 
@@ -2043,7 +2182,7 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
         }
         else
         {
-            LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoCount + 1UL ) ) );
+            LogError( ( "Demo failed at iteration %lu.", ( ulDemoCount + 1UL ) ) );
         }
     }
 
@@ -2053,9 +2192,9 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
         vQueueDelete( xCommandQueue );
     }
 
-    if( xPublisherResponseQueue != NULL )
+    if( xDefaultResponseQueue != NULL )
     {
-        vQueueDelete( xPublisherResponseQueue );
+        vQueueDelete( xDefaultResponseQueue );
     }
 
     if( xSubscriberResponseQueue != NULL )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Copy changes from https://github.com/FreeRTOS/FreeRTOS/pull/362. Changes include:
* Add a daemon socket listener so that the process loop will only execute if data is available on the socket.
* Set process loop timeout to 0 so that other commands do not have to wait for a process loop that isn't doing anything.
* Creates an additional publisher task to show multiple tasks publishing simultaneously.
* Clarify what is meant by "synchronous" and "asynchronous" publishes.
* Fix possible race condition in task notification waits.
* Move task notification wait loops to its own function.
* The prvMQTTConnect function was doing more than just connecting, so it was split into more functions.
* Minor name changes for clarity.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
