### PR TITLE
Fix Device Shadow demo build on Cypress64 IDE

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
@@ -307,9 +307,10 @@ SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt_state.c\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt.c
 
-# Device Shadow
+# Device Shadow and core JSON
 SOURCES+=\
-	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c\
+	$(CY_AFR_ROOT)/libraries/coreJSON/source/core_json.c
 
 INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/common\
@@ -337,6 +338,7 @@ INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/include\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/portable\
 	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/include\
+	$(CY_AFR_ROOT)/libraries/coreJSON/source/include\
 
 ################################################################################
 # libraries (freertos_plus)

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
@@ -307,6 +307,10 @@ SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt_state.c\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt.c
 
+# Device Shadow
+SOURCES+=\
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c
+
 INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/common\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/common/include\
@@ -332,6 +336,7 @@ INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/aws/defender/include\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/include\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/portable\
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/include\
 
 ################################################################################
 # libraries (freertos_plus)

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_demos/afr.mk
@@ -181,7 +181,8 @@ SOURCES+=\
 	$(wildcard $(CY_AFR_ROOT)/demos/coreMQTT/*.c)\
 	$(wildcard $(CY_AFR_ROOT)/demos/network_manager/*.c)\
 	$(wildcard $(CY_AFR_ROOT)/demos/tcp/*.c)\
-	$(wildcard $(CY_AFR_ROOT)/demos/shadow/*.c)
+	$(wildcard $(CY_AFR_ROOT)/demos/shadow/*.c)\
+	$(wildcard $(CY_AFR_ROOT)/demos/device_shadow_for_aws_iot_embedded_sdk/*.c)
 
 INCLUDES+=\
 	$(CY_EXTAPP_PATH)/common\
@@ -190,7 +191,8 @@ INCLUDES+=\
 	$(CY_AFR_ROOT)/demos/https\
 	$(CY_AFR_ROOT)/demos/include\
 	$(CY_AFR_ROOT)/demos/network_manager\
-	$(CY_AFR_ROOT)/demos/tcp
+	$(CY_AFR_ROOT)/demos/tcp\
+	$(CY_AFR_ROOT)/demos/device_shadow_for_aws_iot_embedded_sdk\
 
 ################################################################################
 # libraries (3rd party)

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -316,6 +316,10 @@ SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt_state.c\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt.c
 
+# Device Shadow
+SOURCES+=\
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c
+
 # Test code
 SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/mock/iot_tests_mqtt_mock.c\
@@ -323,6 +327,7 @@ SOURCES+=\
 	$(wildcard $(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/system/*.c)\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c\
 	$(CY_AFR_ROOT)/tests/integration_test/core_mqtt_system_test.c
+	$(CY_AFR_ROOT)/tests/integration_test/shadow_system_test.c
 
 INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/common\
@@ -357,6 +362,7 @@ INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/aws/defender/src/private\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/include\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/portable\
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/include\
 
 ################################################################################
 # libraries (freertos_plus)

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -327,7 +327,7 @@ SOURCES+=\
 	$(wildcard $(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/unit/*.c)\
 	$(wildcard $(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/system/*.c)\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c\
-	$(CY_AFR_ROOT)/tests/integration_test/core_mqtt_system_test.c
+	$(CY_AFR_ROOT)/tests/integration_test/core_mqtt_system_test.c\
 	$(CY_AFR_ROOT)/tests/integration_test/shadow_system_test.c
 
 INCLUDES+=\

--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -316,9 +316,10 @@ SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt_state.c\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/core_mqtt.c
 
-# Device Shadow
+# Device Shadow and core JSON
 SOURCES+=\
-	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c
+	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/shadow.c\
+	$(CY_AFR_ROOT)/libraries/coreJSON/source/core_json.c
 
 # Test code
 SOURCES+=\
@@ -363,6 +364,7 @@ INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/include\
 	$(CY_AFR_ROOT)/libraries/coreMQTT/source/portable\
 	$(CY_AFR_ROOT)/libraries/device_shadow_for_aws_iot_embedded_sdk/source/include\
+	$(CY_AFR_ROOT)/libraries/coreJSON/source/include\
 
 ################################################################################
 # libraries (freertos_plus)


### PR DESCRIPTION
Fix linker issue `undefined reference to RunDeviceShadowDemo` linker error in Cypress64 MTB build from FreeRTOS console download due to missing demo and library files in the project makefile. 
Also, update the `aws_tests` Makefile with the library and test files of Device Shadow