### PR TITLE
MQTT mutual auth demo fix

### DIFF
--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -497,11 +497,14 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
 
         /**************************** Disconnect. ******************************/
 
-        /* Send an MQTT Disconnect packet over the already connected TLS over TCP connection.
-         * There is no corresponding response for the disconnect packet. After sending
-         * disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.", democonfigMQTT_BROKER_ENDPOINT ) );
-        xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        if( xDemoStatus == pdPASS )
+        {
+            /* Send an MQTT Disconnect packet over the already connected TLS over TCP connection.
+             * There is no corresponding response for the disconnect packet. After sending
+             * disconnect, client must close the network connection. */
+            LogInfo( ( "Disconnecting the MQTT connection with %s.", democonfigMQTT_BROKER_ENDPOINT ) );
+            xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        }
 
         /* We will always close the network connection, even if an error may have occurred during
          * demo execution, to clean up the system resources that it may have consumed. */
@@ -598,6 +601,10 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
             LogWarn( ( "Connection to the broker failed. Status=%d ."
                        "Retrying connection with backoff and jitter.", xNetworkStatus ) );
             xStatus = pdFAIL;
+
+            LogInfo( ( "Retry attempt %ul out of maximum retry attempts %ul.",
+                       ( xReconnectParams.attemptsDone + 1 ),
+                       MAX_RETRY_ATTEMPTS ) );
             xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );
         }
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -602,7 +602,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
                        "Retrying connection with backoff and jitter.", xNetworkStatus ) );
             xStatus = pdFAIL;
 
-            LogInfo( ( "Retry attempt %ul out of maximum retry attempts %ul.",
+            LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
                        ( xReconnectParams.attemptsDone + 1 ),
                        MAX_RETRY_ATTEMPTS ) );
             xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );


### PR DESCRIPTION
MQTT mutual auth demo fix

Description
-----------
MQTT mutual auth demo fix.
Problem: MQTTDisconnect() was getting called in an error path and resulting in internal errors.
Fix: Avoid calling MQTTDisconnect in error path.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.