### PR TITLE
Auto-include BLE for MQTT library for FreeRTOS console

### DIFF
--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -100,3 +100,14 @@ if(TARGET AFR::wifi::mcu_port)
             AFR::wifi
     )
 endif()
+
+# Add dependency on BLE module so that the BLE library is auto-included
+# when selecting core MQTT library on FreeRTOS console for boards that
+# support BLE.
+if(BLE_SUPPORTED)
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        PUBLIC
+            AFR::ble
+    )
+endif()


### PR DESCRIPTION
Add dependency on `AFR::ble` for `AFR::core_mqtt_demo_dependencies` metadata module (relevant to FreeRTOS console) so that when MQTT library is selected on the FreeRTOS console, it auto-includes the BLE library on BLE capable boards.
This allows the **MQTT over BLE** demo to be displayed when MQTT is selected, and **Shadow over BLE** demo to be displayed when Device Shadow library is selected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.