### PR TITLE
Remove unused client credentials configuration in HTTP demos

### DIFF
--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -1086,7 +1086,9 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 
-    /* Set the connection configurations. */
+    /* Set the connection configurations.
+     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     _connConfig.pAddress = pAddress;
     _connConfig.addressLen = addressLen;
     _connConfig.port = IOT_DEMO_HTTPS_PORT;
@@ -1094,10 +1096,6 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     _connConfig.caCertLen = sizeof( IOT_DEMO_HTTPS_TRUSTED_ROOT_CA );
     _connConfig.userBuffer.pBuffer = _pConnUserBuffer;
     _connConfig.userBuffer.bufferLen = sizeof( _pConnUserBuffer );
-    _connConfig.pClientCert = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pClientCert;
-    _connConfig.clientCertLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->clientCertSize;
-    _connConfig.pPrivateKey = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pPrivateKey;
-    _connConfig.privateKeyLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->privateKeySize;
     _connConfig.pNetworkInterface = pNetworkInterface;
 
     /* Initialize the request pool by setting up constant request information shared by all requests. */

--- a/demos/https/iot_demo_https_s3_download_async.c
+++ b/demos/https/iot_demo_https_s3_download_async.c
@@ -1087,7 +1087,7 @@ int RunHttpsAsyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Set the connection configurations.
-     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * Note: TLS Connection to AWS S3 service does not need a client certificate.
      * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     _connConfig.pAddress = pAddress;
     _connConfig.addressLen = addressLen;

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -300,7 +300,7 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     }
 
     /* Set the connection configurations.
-     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * Note: TLS Connection to AWS S3 service does not need a client certificate.
      * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;

--- a/demos/https/iot_demo_https_s3_download_sync.c
+++ b/demos/https/iot_demo_https_s3_download_sync.c
@@ -299,7 +299,9 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 
-    /* Set the connection configurations. */
+    /* Set the connection configurations.
+     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;
     connConfig.port = IOT_DEMO_HTTPS_PORT;
@@ -307,10 +309,6 @@ int RunHttpsSyncDownloadDemo( bool awsIotMqttMode,
     connConfig.caCertLen = sizeof( IOT_DEMO_HTTPS_TRUSTED_ROOT_CA );
     connConfig.userBuffer.pBuffer = _pConnUserBuffer;
     connConfig.userBuffer.bufferLen = sizeof( _pConnUserBuffer );
-    connConfig.pClientCert = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pClientCert;
-    connConfig.clientCertLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->clientCertSize;
-    connConfig.pPrivateKey = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pPrivateKey;
-    connConfig.privateKeyLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->privateKeySize;
     connConfig.pNetworkInterface = pNetworkInterface;
 
     /* Set the configurations needed for a synchronous request. */

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -350,7 +350,7 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
     }
 
     /* Set the connection configurations.
-     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * Note: TLS Connection to AWS S3 service does not need a client certificate.
      * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;

--- a/demos/https/iot_demo_https_s3_upload_async.c
+++ b/demos/https/iot_demo_https_s3_upload_async.c
@@ -349,7 +349,9 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 
-    /* Set the connection configurations. */
+    /* Set the connection configurations.
+     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;
     connConfig.port = IOT_DEMO_HTTPS_PORT;
@@ -357,10 +359,6 @@ int RunHttpsAsyncUploadDemo( bool awsIotMqttMode,
     connConfig.caCertLen = sizeof( IOT_DEMO_HTTPS_TRUSTED_ROOT_CA );
     connConfig.userBuffer.pBuffer = _pConnUserBuffer;
     connConfig.userBuffer.bufferLen = sizeof( _pConnUserBuffer );
-    connConfig.pClientCert = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pClientCert;
-    connConfig.clientCertLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->clientCertSize;
-    connConfig.pPrivateKey = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pPrivateKey;
-    connConfig.privateKeyLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->privateKeySize;
     connConfig.pNetworkInterface = pNetworkInterface;
 
     asyncInfo.callbacks.writeCallback = _writeCallback;

--- a/demos/https/iot_demo_https_s3_upload_sync.c
+++ b/demos/https/iot_demo_https_s3_upload_sync.c
@@ -279,7 +279,9 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
         IOT_SET_AND_GOTO_CLEANUP( EXIT_FAILURE );
     }
 
-    /* Set the connection configurations. */
+    /* Set the connection configurations.
+     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;
     connConfig.port = IOT_DEMO_HTTPS_PORT;
@@ -287,10 +289,6 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
     connConfig.caCertLen = sizeof( IOT_DEMO_HTTPS_TRUSTED_ROOT_CA );
     connConfig.userBuffer.pBuffer = _pConnUserBuffer;
     connConfig.userBuffer.bufferLen = sizeof( _pConnUserBuffer );
-    connConfig.pClientCert = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pClientCert;
-    connConfig.clientCertLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->clientCertSize;
-    connConfig.pPrivateKey = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->pPrivateKey;
-    connConfig.privateKeyLen = ( ( IotNetworkCredentials_t * ) pNetworkCredentialInfo )->privateKeySize;
     connConfig.pNetworkInterface = pNetworkInterface;
 
     /* Set the configurations needed for a synchronous request. */

--- a/demos/https/iot_demo_https_s3_upload_sync.c
+++ b/demos/https/iot_demo_https_s3_upload_sync.c
@@ -280,7 +280,7 @@ int RunHttpsSyncUploadDemo( bool awsIotMqttMode,
     }
 
     /* Set the connection configurations.
-     * Note: TLS Connection to AWS S3 service does not client certificate.
+     * Note: TLS Connection to AWS S3 service does not need a client certificate.
      * The client authentication is performed at the HTTP protocol layer with a pre-signed URL. */
     connConfig.pAddress = pAddress;
     connConfig.addressLen = addressLen;


### PR DESCRIPTION
The HTTP demos connecting to S3 contain connection congifuration logic with client certificate and private key. This is not required as the AWS S3 TLS connection does not require client certificate. The client authentication is performed through use of _pre-signed URLs_ in the demos instead.