### PR TITLE
Fix demos on Marvell

### DIFF
--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -57,7 +57,7 @@ const AppVersion32_t xAppFirmwareVersion = {
 
 /* Logging Task Defines. */
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 32 )
-#define mainLOGGING_TASK_STACK_SIZE         ( 1536 )
+#define mainLOGGING_TASK_STACK_SIZE         ( 512 )
 
 /* Startup defines. */
 #define mainSTARTUP_TASK_STACK_SIZE     ( 1024 )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -57,7 +57,7 @@ const AppVersion32_t xAppFirmwareVersion = {
 
 /* Logging Task Defines. */
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 32 )
-#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
+#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 6 )
 
 /* Startup defines. */
 #define mainSTARTUP_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 4 )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -57,17 +57,14 @@ const AppVersion32_t xAppFirmwareVersion = {
 
 /* Logging Task Defines. */
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 32 )
-#define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 6 )
+#define mainLOGGING_TASK_STACK_SIZE         ( 1536 )
 
 /* Startup defines. */
-#define mainSTARTUP_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 4 )
+#define mainSTARTUP_TASK_STACK_SIZE     ( 1024 )
 
 /* The task delay for allowing the lower priority logging task to print out Wi-Fi 
  * failure status before blocking indefinitely. */
 #define mainLOGGING_WIFI_STATUS_DELAY       pdMS_TO_TICKS( 1000 )
-
-/* Unit test defines. */
-#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 16 )
 
 /* The name of the devices for xApplicationDNSQueryHook. */
 #define mainDEVICE_NICK_NAME				"mw300_rd" /* FIX ME.*/

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -52,7 +52,7 @@
 #define CONFIG_MQTT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigDEMO_STACKSIZE    ( 2048 )
 #define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
 #define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
 
@@ -72,41 +72,41 @@
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT                  pdMS_TO_TICKS( 12000 )
 
 /* MQTT echo task example parameters. */
-#define democonfigMQTT_ECHO_TASK_STACK_SIZE                          ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigMQTT_ECHO_TASK_STACK_SIZE                          ( 2048 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                            ( tskIDLE_PRIORITY + 5 )
 
 /* IoT simple subscribe/publish example task parameters. */
-#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE                       ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE                       ( 1280 )
 #define democonfigMQTT_SUB_PUB_TASK_PRIORITY                         ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 8 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE               ( 2048 )
 #define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* MQTT Connection sharing demo task priority. */
 #define democonfigCORE_MQTT_CONNECTION_SHARING_DEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 5 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( 1280 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */
 #define democonfigSHADOW_DEMO_NUM_TASKS                              ( 1 )
 
 /* TCP Echo Client tasks single example parameters. */
-#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE              ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SINGLE_TASK_STACK_SIZE              ( 1024 )
 #define democonfigTCP_ECHO_TASKS_SINGLE_TASK_PRIORITY                ( tskIDLE_PRIORITY + 1 )
 
 /* OTA Update task example parameters. */
-#define democonfigOTA_UPDATE_TASK_STACK_SIZE                         ( 4 * configMINIMAL_STACK_SIZE )
+#define democonfigOTA_UPDATE_TASK_STACK_SIZE                         ( 1024 )
 #define democonfigOTA_UPDATE_TASK_TASK_PRIORITY                      ( tskIDLE_PRIORITY )
 
 /* Simple TCP Echo Server task example parameters */
-#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE                    ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigTCP_ECHO_SERVER_TASK_STACK_SIZE                    ( 1536 )
 #define democonfigTCP_ECHO_SERVER_TASK_PRIORITY                      ( tskIDLE_PRIORITY )
 
 /* TCP Echo Client tasks multi task example parameters. */
-#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE            ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_STACK_SIZE            ( 1024 )
 #define democonfigTCP_ECHO_TASKS_SEPARATE_TASK_PRIORITY              ( tskIDLE_PRIORITY )
 
 /* Send AWS IoT MQTT traffic encrypted to destination port 443. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -87,7 +87,7 @@
 #define democonfigCORE_MQTT_CONNECTION_SHARING_DEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 6 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 5 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -87,7 +87,7 @@
 #define democonfigCORE_MQTT_CONNECTION_SHARING_DEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 3 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 6 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -80,7 +80,7 @@
 #define democonfigMQTT_SUB_PUB_TASK_PRIORITY                         ( tskIDLE_PRIORITY )
 
 /* Greengrass discovery example task parameters. */
-#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 16 )
+#define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 8 )
 #define democonfigGREENGRASS_DISCOVERY_TASK_PRIORITY                 ( tskIDLE_PRIORITY )
 
 /* MQTT Connection sharing demo task priority. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_demo_config.h
@@ -87,7 +87,7 @@
 #define democonfigCORE_MQTT_CONNECTION_SHARING_DEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
 
 /* Shadow demo task parameters. */
-#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 4 )
+#define democonfigSHADOW_DEMO_TASK_STACK_SIZE                        ( configMINIMAL_STACK_SIZE * 3 )
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY )
 
 /* Number of shadow light switch tasks running. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
@@ -39,9 +39,9 @@
  * no logs will be printed. */
 #define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_NONE
 #define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
-#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_ERROR
 #define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_ERROR
 #define IOT_LOG_LEVEL_MQTT                      IOT_LOG_ERROR
 #define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_ERROR
 #define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_ERROR
@@ -50,8 +50,6 @@
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           1024
 #define IOT_THREAD_DEFAULT_PRIORITY             5
-
-#define IOT_NETWORK_RECEIVE_TASK_STACK_SIZE           1024
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
@@ -37,19 +37,21 @@
  * level for all libraries; the library-specific settings override the global
  * setting. If both the library-specific and global settings are undefined,
  * no logs will be printed. */
-#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_INFO
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_NONE
 #define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
 #define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_NONE
-#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_INFO
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_ERROR
 #define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_NONE
-#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_INFO
-#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_INFO
-#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_INFO
-#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_INFO
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_ERROR
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_ERROR
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_ERROR
 
 /* Platform thread stack size and priority. */
-#define IOT_THREAD_DEFAULT_STACK_SIZE           2048
+#define IOT_THREAD_DEFAULT_STACK_SIZE           1024
 #define IOT_THREAD_DEFAULT_PRIORITY             5
+
+#define IOT_NETWORK_RECEIVE_TASK_STACK_SIZE           1024
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
@@ -48,7 +48,7 @@
 #define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_INFO
 
 /* Platform thread stack size and priority. */
-#define IOT_THREAD_DEFAULT_STACK_SIZE           3840
+#define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 
 /* Include the common configuration file for FreeRTOS. */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
@@ -51,6 +51,7 @@
 #define IOT_THREAD_DEFAULT_STACK_SIZE           1024
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 
+#define IOT_NETWORK_RECEIVE_TASK_STACK_SIZE     1024
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"
 

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/iot_config.h
@@ -39,9 +39,9 @@
  * no logs will be printed. */
 #define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_NONE
 #define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
-#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_NONE
 #define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_NONE
 #define IOT_LOG_LEVEL_MQTT                      IOT_LOG_ERROR
 #define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_ERROR
 #define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_ERROR


### PR DESCRIPTION
Fix demos on Marvell. This PR is the same as the PR #2617. #2617 is targeted to RC and this to master.

Description
-----------
Fix demos on Marvell
Problem: Many demos were failing in Marvell board due to lack of memory in heap while establishing a TLS connection.
Root Cause: Establishing a TLS connection requires a good amount of memory in the HEAP. The tasks created with xTaskCreate() function also allocates the memory for the stack in the heap. Marvell's heap(~73KB) was running out of space due to these allocations.
Fix: Optimized the stack sizes for different tasks for the demo and verified the demos.

The demo verification CI job can be found here
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1312/

The stack high water mark are analyzed using the jobs
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1356/
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1358/
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1362/

Please find the minimum value of the stack high water mark for each of the tasks in different demo runs below.
Taskpool task - 727
Network receive task - 804
GGD Demo task - 531
Logging task - 409
Shadow task - 423

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.