### PR TITLE
Update timeout for BLE demo and integration test

### DIFF
--- a/demos/ble/shadow_ble/shadow_demo_ble_transport.c
+++ b/demos/ble/shadow_ble/shadow_demo_ble_transport.c
@@ -77,7 +77,7 @@
 /**
  * @brief Timeout for MQTT_ProcessLoop in milliseconds.
  */
-#define mqttexamplePROCESS_LOOP_TIMEOUT_MS    ( 500U )
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS    ( 2000U )
 
 
 /**
@@ -94,7 +94,7 @@
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
  */
-#define mqttexampleCONNACK_RECV_TIMEOUT_MS    ( 1000U )
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS    ( 2000U )
 
 /**
  * @brief Milliseconds per second.

--- a/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
+++ b/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
@@ -177,14 +177,9 @@
 #define TRANSPORT_BUFFER_SIZE                 ( 256U )
 
 /**
- * @brief Transport timeout in milliseconds for transport send and receive.
- */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS        ( 200U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
-#define CONNACK_RECV_TIMEOUT_MS               ( 1000U )
+#define CONNACK_RECV_TIMEOUT_MS               ( 2000U )
 
 /**
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
@@ -204,7 +199,7 @@
  * PUBLISH message and ack responses for QoS 1 and QoS 2 communications
  * with the broker.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS          ( 700U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS          ( 2000U )
 
 /**
  * @brief The MQTT message published in this example.


### PR DESCRIPTION
Update timeout for BLE demos and tests.

PR is equivalent to  #2634

Description
-----------
The timeout values for BLE transport in MQTT demos were too short considering BLE connection interval for certain devices. Increased the timeout to adequate values.
Removed unused transport interface timeout parameter.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.