### PR TITLE
Fix TI issue of Server Cert validation in MQTT demos

### DIFF
--- a/demos/coreMQTT/mqtt_demo_basic_tls.c
+++ b/demos/coreMQTT/mqtt_demo_basic_tls.c
@@ -84,7 +84,7 @@
  * @brief The root CA certificate belonging to the broker.
  */
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
+    #define democonfigROOT_CA_PEM    "Please provide Root CA for the MQTT Basic TLS demo."
 #endif
 
 /**

--- a/demos/coreMQTT/mqtt_demo_basic_tls.c
+++ b/demos/coreMQTT/mqtt_demo_basic_tls.c
@@ -82,9 +82,13 @@
 
 /**
  * @brief The root CA certificate belonging to the broker.
+ *
+ * @note This demo cannot be run against AWS IoT as it requires client authentication
+ * for TLS connection. Please define a valid value of the server Root CA certificate relevant to
+ * the MQTT broker that supports server-only authentication for this demo.
  */
 #ifndef democonfigROOT_CA_PEM
-    #error "Please define democonfigROOT_CA_PEM to provide server Root CA certificate for the MQTT Basic TLS demo."
+    #define democonfigROOT_CA_PEM    "Please define a valid Root CA cert for this macro."
 #endif
 
 /**

--- a/demos/coreMQTT/mqtt_demo_basic_tls.c
+++ b/demos/coreMQTT/mqtt_demo_basic_tls.c
@@ -84,7 +84,7 @@
  * @brief The root CA certificate belonging to the broker.
  */
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    "Please provide Root CA for the MQTT Basic TLS demo."
+    #error "Please define democonfigROOT_CA_PEM to provide server Root CA certificate for the MQTT Basic TLS demo."
 #endif
 
 /**

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -92,11 +92,8 @@
     #define democonfigMQTT_BROKER_PORT    clientcredentialMQTT_BROKER_PORT
 #endif
 
-/* Use Starfield Root CA as the default Root CA because the TI C3220 Launchpad board
- * requires that the Root CA certificate have its certificate self-signed. The Amazon Root CAs
- * are cross-signed by Starfield Root CA.*/
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+    #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
 #endif
 
 /**

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -92,8 +92,11 @@
     #define democonfigMQTT_BROKER_PORT    clientcredentialMQTT_BROKER_PORT
 #endif
 
+/* Use Starfield Root CA as the default Root CA because the TI C3220 Launchpad board
+ * requires that the Root CA certificate have its certificate self-signed. The Amazon Root CAs
+ * are cross-signed by Starfield Root CA.*/
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
+    #define democonfigROOT_CA_PEM    tlsSTARFIELD_ROOT_CERTIFICATE_PEM
 #endif
 
 /**

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -90,10 +90,16 @@
  *   - keyCLIENT_PRIVATE_KEY_PEM for client private key.
  */
 
+/**
+ * @brief The MQTT broker endpoint used for this demo.
+ */
 #ifndef democonfigMQTT_BROKER_ENDPOINT
     #define democonfigMQTT_BROKER_ENDPOINT    clientcredentialMQTT_BROKER_ENDPOINT
 #endif
 
+/**
+ * @brief The root CA certificate belonging to the broker.
+ */
 #ifndef democonfigROOT_CA_PEM
     #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
 #endif

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -94,11 +94,8 @@
     #define democonfigMQTT_BROKER_ENDPOINT    clientcredentialMQTT_BROKER_ENDPOINT
 #endif
 
-/* Use Starfield Root CA as the default Root CA because the TI C3220 Launchpad board
- * requires that the Root CA certificate have its certificate self-signed. The Amazon Root CAs
- * are cross-signed by Starfield Root CA.*/
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+    #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
 #endif
 
 #ifndef democonfigCLIENT_IDENTIFIER

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -94,8 +94,11 @@
     #define democonfigMQTT_BROKER_ENDPOINT    clientcredentialMQTT_BROKER_ENDPOINT
 #endif
 
+/* Use Starfield Root CA as the default Root CA because the TI C3220 Launchpad board
+ * requires that the Root CA certificate have its certificate self-signed. The Amazon Root CAs
+ * are cross-signed by Starfield Root CA.*/
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM    tlsATS1_ROOT_CERTIFICATE_PEM
+    #define democonfigROOT_CA_PEM    tlsSTARFIELD_ROOT_CERTIFICATE_PEM
 #endif
 
 #ifndef democonfigCLIENT_IDENTIFIER

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -101,8 +101,11 @@
     #define BROKER_PORT    clientcredentialMQTT_BROKER_PORT
 #endif
 
+/* Use Starfield Root CA as the default Root CA because the TI C3220 Launchpad board
+ * requires that the Root CA certificate have its certificate self-signed. The Amazon Root CAs
+ * are cross-signed by Starfield Root CA.*/
 #ifndef SERVER_ROOT_CA_CERT
-    #define SERVER_ROOT_CA_CERT    tlsATS1_ROOT_CERTIFICATE_PEM
+    #define SERVER_ROOT_CA_CERT    tlsSTARFIELD_ROOT_CERTIFICATE_PEM
 #endif /* ifndef SERVER_ROOT_CA_CERT_NON_AWS */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_connection_sharing_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_connection_sharing_config.h
@@ -93,8 +93,30 @@
  */
 
 /**
+ * @brief Server's root CA certificate.
+ *
+ * This certificate is used to identify the AWS IoT server and is publicly available.
+ * Refer to the AWS documentation available in the link below for information about the
+ * Server Root CAs.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * @note The TI C3220 Launchpad board requires that the Root CA have its certificate self-signed. As mentioned in the
+ * above link, the Amazon Root CAs are cross-signed by the Starfield Root CA. Thus, ONLY the Starfield Root CA
+ * can be used to connect to the ATS endpoints on AWS IoT for the TI board.
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ */
+#define democonfigROOT_CA_PEM            tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+
+/**
  * @brief The maximum number of times to run the demo's task creation loop.
  */
-#define democonfigMQTT_MAX_DEMO_COUNT   ( 3 )
+#define democonfigMQTT_MAX_DEMO_COUNT    ( 3 )
 
 #endif /* MQTT_DEMO_CONNECTION_SHARING_CONFIG_H */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_demo_mutual_auth_config.h
@@ -55,7 +55,7 @@
 /**
  * To use this demo, please configure the client's certificate and private key
  * in demos/include/aws_clientcredential_keys.h.
- * 
+ *
  * For the AWS IoT MQTT broker, refer to the AWS documentation below for details
  * regarding client authentication.
  * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
@@ -98,10 +98,14 @@
 /**
  * @brief Server's root CA certificate.
  *
- * For AWS IoT MQTT broker, this certificate is used to identify the AWS IoT
- * server and is publicly available. Refer to the AWS documentation available
- * in the link below.
+ * This certificate is used to identify the AWS IoT server and is publicly available.
+ * Refer to the AWS documentation available in the link below for information about the
+ * Server Root CAs.
  * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * @note The TI C3220 Launchpad board requires that the Root CA have its certificate self-signed. As mentioned in the
+ * above link, the Amazon Root CAs are cross-signed by the Starfield Root CA. Thus, ONLY the Starfield Root CA
+ * can be used to connect to the ATS endpoints on AWS IoT for the TI board.
  *
  * @note This certificate should be PEM-encoded.
  *
@@ -110,8 +114,8 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  *
- * #define democonfigROOT_CA_PEM    "...insert here..."
  */
+#define democonfigROOT_CA_PEM            tlsSTARFIELD_ROOT_CERTIFICATE_PEM
 
 /**
  * @brief Size of the network buffer for MQTT packets.


### PR DESCRIPTION
### Problem

MQTT Mutual Auth and MQTT Connection sharing demos, and the `coreMQTT_Integration_AWS_IoT_Compatible` tests fail on the TI board with the following error:
```
21 43338 [pthread] [SimpleLinkSockEventHandler ERROR]: Root CA in file system did not sign the chain.

22 43349 [pthread] [SimpleLinkSockEventHandler ERROR]: Handshake Failed - socket 0, reason: -688.
```

### Cause
The TI board requires that a custom Root CA provided have its certificate self-signed (i.e. the Root CA not be "_issued" by another CA), otherwise, it treats the CA as an _intermediate_ CA. 
More details on the TI board TLS stack is provided in this customer issue on the TI forum: https://e2e.ti.com/support/wireless-connectivity/wifi/f/968/t/789112\?CC3220SF-SL-ERROR-BSD-ESEC-ASN-NO-SIGNER-E-688-

### Solution
Update the TI specific config files for the demos to use the ** Starfield Class 2 Certification Authority** as the Root CA.