### PR TITLE
afr.cmake: Add BUILD_CLONE_SUBMODULES option

### DIFF
--- a/tools/cmake/afr.cmake
+++ b/tools/cmake/afr.cmake
@@ -27,19 +27,23 @@ set(NETWORK_MANAGER_SOURCES
     "Network manager common source files."
 )
 
+option(BUILD_CLONE_SUBMODULES "Clone any required Git submodules. When OFF, submodules must be manually cloned." ON)
+
 # Set regular version and Git commit version.
 set(AFR_VERSION "${PROJECT_VERSION}")
 set(AFR_VERSION_VCS "Unknown" CACHE INTERNAL "")
 # Check if we're in a Git repository.
 find_package(Git)
 if(Git_FOUND AND EXISTS "${AFR_ROOT_DIR}/.git")
-    message(STATUS "Submodule update")
-    # TODO: Update submodule only if it hasn't been checked out (check if directory is empty).
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
-    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-        message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    if(${BUILD_CLONE_SUBMODULES})
+        message(STATUS "Submodule update")
+        # TODO: Update submodule only if it hasn't been checked out (check if directory is empty).
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        endif()
     endif()
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" "describe" "--always" WORKING_DIRECTORY "${AFR_ROOT_DIR}"


### PR DESCRIPTION
This option is similar to the option under the same name already used
in some submodules of the repository. If set to OFF, it skips automatic
submodule update during building. This is useful for focused builds
of particular targets, which use only a subset of submodules (which
then need to be updated externally). In particular in continuous
integration contexts, this can save build time/bandwidth.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.