### PR TITLE
short circuit eWiFiFailure for pxIPConfig == NULL

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi_lwip.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi_lwip.c
@@ -481,10 +481,14 @@ WIFIReturnCode_t WIFI_Disconnect( void )
 
 WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPInfo )
 {
-    configASSERT(pxIPInfo != NULL);
+    if( pxIPInfo == NULL )
+    {
+        return eWiFiFailure;
+    }
+
     if (cy_rtos_get_mutex(&wifiMutex, wificonfigMAX_SEMAPHORE_WAIT_TIME_MS) == CY_RSLT_SUCCESS)
     {
-        if ( pxIPInfo == NULL && netInterface == NULL)
+        if ( netInterface == NULL)
         {
             cy_rtos_set_mutex(&wifiMutex);
             return eWiFiFailure;

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/wifi/iot_wifi.c
@@ -1472,7 +1472,7 @@ WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPConfig )
     ip4_addr_t      ip4_addr;
     struct netif    *iface;
 
-    if( NULL == ( iface = netif_find( "st2" ) ) )
+    if( NULL == ( iface = netif_find( "st2" ) ) || NULL == pxIPConfig )
     {
         return eWiFiFailure;
     }

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/wifi/iot_wifi.c
@@ -552,7 +552,10 @@ WIFIReturnCode_t WIFI_GetHostIP( char * pcHost,
  */
 WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPInfo )
 {
-    configASSERT( pxIPInfo != NULL );
+    if( pxIPInfo == NULL )
+    {
+        return eWiFiFailure;
+    }
 
     memset( pxIPInfo, 0x00, sizeof( WIFIIPConfiguration_t ) );
     pxIPInfo->xIPAddress.ulAddress[0] = FreeRTOS_GetIPAddress();

--- a/vendors/st/boards/stm32l475_discovery/ports/wifi/iot_wifi.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/wifi/iot_wifi.c
@@ -474,8 +474,12 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
 WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * xIPConfig )
 {
     WIFIReturnCode_t xRetVal = eWiFiFailure;
+    
+    if( xIPConfig == NULL )
+    {
+        return eWiFiFailure;
+    }    
 
-    configASSERT( xIPConfig != NULL );
     memset( xIPConfig, 0, sizeof( WIFIIPConfiguration_t ) );
 
     /* Try to acquire the semaphore. */

--- a/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
@@ -899,10 +899,6 @@ WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * xIPConfig )
 {
     WIFIReturnCode_t xRetVal = eWiFiSuccess;
     int16_t sRetCode;
-
-    configASSERT( xIPConfig != NULL );
-    memset(xIPConfig, 0, sizeof( WIFIIPConfiguration_t ) );
-
     unsigned long ulDestinationIP = 0;
     unsigned long ulSubMask = 0;
     unsigned long ulDefGateway = 0;
@@ -914,7 +910,7 @@ WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * xIPConfig )
                                                    &ulDefGateway,
                                                    &ulDns );
 
-    if( sRetCode != 0 )
+    if( sRetCode != 0 || xIPConfig == NULL )
     {
         xRetVal = eWiFiFailure;
     }

--- a/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
@@ -916,6 +916,8 @@ WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * xIPConfig )
     }
     else
     {
+        memset(xIPConfig, 0, sizeof( WIFIIPConfiguration_t ) );
+
         /*fill the return buffer.*/
         uint8_t * pucIPv4Addr = ( uint8_t * )&xIPConfig->xIPAddress.ulAddress[ 0 ];
         *( pucIPv4Addr ) = SL_IPV4_BYTE( ulDestinationIP, 3 );


### PR DESCRIPTION
Specifically return `eWiFiFailure` for WIFI_GetIPInfo( NULL ).
Some implementations were asserting, or returning otherwise.

**Testing:**
`Full_WiFi` tests suites for affected boards. See testing results:
 - [cypress](https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1385/)
 - [mediatek](https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/1386/).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [n/a (vendor code)] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.