### PR TITLE
Fixed the BLE_Unit_MQTT_Serialize MTB Build Failure. (#2630)

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -329,6 +329,7 @@ SOURCES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c\
 	$(CY_AFR_ROOT)/tests/integration_test/core_mqtt_system_test.c\
 	$(CY_AFR_ROOT)/tests/integration_test/shadow_system_test.c
+	
 
 INCLUDES+=\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/common\
@@ -411,7 +412,8 @@ SOURCES+=\
 	$(wildcard $(CY_AFR_ROOT)/libraries/abstractions/ble_hal/test/src/*.c)\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/ble/test/iot_test_ble_end_to_end.c\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c\
-	$(CY_AFR_ROOT)/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c
+	$(CY_AFR_ROOT)/libraries/c_sdk/standard/ble/test/iot_test_wifi_provisioning.c\
+	$(CY_AFR_ROOT)/libraries/c_sdk/standard/ble/test/iot_test_ble_mqtt_serialize.c
 
 INCLUDES+=\
 	$(CY_AFR_BOARD_PATH)/ports/ble\


### PR DESCRIPTION
* Fixed the BLE_Unit_MQTT_Serialize MTB Build Failure.

* Remove the file path to a proper place in the afr.mk file.

* Move ble_mqtt_serialize under BLE supported section.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.