### PR TITLE
NimBLE AFR: Save full AFR service instead of only service pointers

### DIFF
--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -514,6 +514,7 @@ void vESPBTGATTServerCleanup( void )
         for( index = 0; index < serviceCnt; index++ )
         {
             prvCleanupService( &espServices[ index ] );
+            vPortFree( ( void * ) afrServices[ index ] );
         }
 
         serviceCnt = 0;
@@ -844,6 +845,7 @@ BTStatus_t prvAddServiceBlob( uint8_t ucServerIf,
     struct ble_gatt_svc_def * pSvc = NULL;
     uint16_t handle = 0;
     uint16_t attributeCount = 0;
+    BTService_t * afrFullService = NULL;
 
     if( ( pxService == 0 ) || ( pxService->xNumberOfAttributes == 0 ) )
     {
@@ -856,7 +858,17 @@ BTStatus_t prvAddServiceBlob( uint8_t ucServerIf,
         if( serviceCnt < MAX_SERVICES )
         {
             pSvc = &espServices[ serviceCnt ];
-            afrServices[ serviceCnt ] = pxService;
+            afrFullService = pvPortCalloc( 1, sizeof( BTService_t ) );
+            if ( afrFullService == NULL )
+            {
+                xStatus = eBTStatusNoMem;
+            }
+            else
+            {
+                memcpy( afrFullService, pxService, sizeof( BTService_t ) );
+            }
+
+            afrServices[ serviceCnt ] = afrFullService;
         }
         else
         {


### PR DESCRIPTION
<!--- Title -->

AFR: Allocate memory to save services internally instead of depending on upper layer. 

Description
-----------
<!--- Describe your changes in detail -->

- For each service allocate full AFR service space (`BTService_t`), save the content received from upper layer.
- Free the space when cleaning up GATT.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.