### PR TITLE
Update BLE demo and test configs

### DIFF
--- a/demos/ble/shadow_ble/shadow_demo_ble_transport.c
+++ b/demos/ble/shadow_ble/shadow_demo_ble_transport.c
@@ -77,7 +77,7 @@
 /**
  * @brief Timeout for MQTT_ProcessLoop in milliseconds.
  */
-#define mqttexamplePROCESS_LOOP_TIMEOUT_MS    ( 2000U )
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS    ( 5000U )
 
 
 /**
@@ -94,7 +94,7 @@
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
  */
-#define mqttexampleCONNACK_RECV_TIMEOUT_MS    ( 2000U )
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS    ( 5000U )
 
 /**
  * @brief Milliseconds per second.

--- a/demos/include/iot_demo_runner.h
+++ b/demos/include/iot_demo_runner.h
@@ -164,6 +164,22 @@
     #endif
 #elif defined( CONFIG_BLE_GATT_SERVER_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             vGattDemoSvcInit
+    #if defined( democonfigNETWORK_TYPES )
+        #undef democonfigNETWORK_TYPES
+        #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
+    #endif
+#elif defined( CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED )
+    #define DEMO_entryFUNCTION             RunMQTTBLETransportDemo
+    #if defined( democonfigNETWORK_TYPES )
+        #undef democonfigNETWORK_TYPES
+        #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
+    #endif
+#elif defined( CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED )
+    #define DEMO_entryFUNCTION             RunShadowBLETransportDemo
+    #if defined( democonfigNETWORK_TYPES )
+        #undef democonfigNETWORK_TYPES
+        #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
+    #endif
 #elif defined( CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             RunHttpsSyncDownloadDemo
 #elif defined( CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED )
@@ -172,10 +188,7 @@
     #define DEMO_entryFUNCTION             RunHttpsSyncUploadDemo
 #elif defined( CONFIG_HTTPS_ASYNC_UPLOAD_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             RunHttpsAsyncUploadDemo
-#elif defined( CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION             RunMQTTBLETransportDemo
-#elif defined( CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED )
-    #define DEMO_entryFUNCTION             RunShadowBLETransportDemo
+
 #elif defined( CONFIG_CLI_UART_DEMO_ENABLED )
     #define DEMO_entryFUNCTION             vRunCLIUartDemo
 #else /* if defined( CONFIG_MQTT_DEMO_ENABLED ) */

--- a/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
+++ b/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
@@ -179,7 +179,7 @@
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
-#define CONNACK_RECV_TIMEOUT_MS               ( 2000U )
+#define CONNACK_RECV_TIMEOUT_MS               ( 5000U )
 
 /**
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
@@ -199,7 +199,7 @@
  * PUBLISH message and ack responses for QoS 1 and QoS 2 communications
  * with the broker.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS          ( 2000U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS          ( 5000U )
 
 /**
  * @brief The MQTT message published in this example.

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/aws_demo_config.h
@@ -43,6 +43,9 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_POSIX_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
+ *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *          CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED
+ *          CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
@@ -69,7 +72,6 @@
 
 #define democonfigMQTT_SUB_PUB_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 5 )
 #define democonfigMQTT_SUB_PUB_TASK_PRIORITY           ( tskIDLE_PRIORITY )
-
 
 /* Timeout used when performing MQTT operations that do not need extra time
  * to perform a TLS negotiation. */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_demo_config.h
@@ -44,14 +44,13 @@
  *          CONFIG_DEFENDER_DEMO_ENABLED
  *          CONFIG_OTA_UPDATE_DEMO_ENABLED
  *          CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+ *          CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED
+ *          CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED
  *          CONFIG_HTTPS_SYNC_DOWNLOAD_DEMO_ENABLED
  *          CONFIG_HTTPS_ASYNC_DOWNLOAD_DEMO_ENABLED
  *          CONFIG_HTTPS_SYNC_UPLOAD_DEMO_ENABLED
  *          CONFIG_HTTPS_ASYNC_UPLOAD_DEMO_ENABLED
  *          CONFIG_CLI_UART_DEMO_ENABLED
- *          CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED
- *          CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED
- *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
 #define CONFIG_CORE_MQTT_MUTUAL_AUTH_DEMO_ENABLED
@@ -59,26 +58,11 @@
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE    ( configMINIMAL_STACK_SIZE * 8 )
 #define democonfigDEMO_PRIORITY     ( tskIDLE_PRIORITY + 5 )
-#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
+#define democonfigNETWORK_TYPES     ( AWSIOT_NETWORK_TYPE_WIFI )
 
 #if defined( CONFIG_MQTT_DEMO_ENABLED )
     #undef democonfigNETWORK_TYPES
     #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_WIFI | AWSIOT_NETWORK_TYPE_BLE )
-#endif
-
-#if defined( CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED )
-    #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
-#endif
-
-#if defined( CONFIG_SHADOW_BLE_TRANSPORT_DEMO_ENABLED )
-    #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES    ( AWSIOT_NETWORK_TYPE_BLE )
-#endif
-
-#if defined( CONFIG_OTA_UPDATE_DEMO_ENABLED )
-    #undef democonfigNETWORK_TYPES
-    #define democonfigNETWORK_TYPES                                  ( AWSIOT_NETWORK_TYPE_WIFI )
 #endif
 
 #define democonfigGREENGRASS_DISCOVERY_TASK_STACK_SIZE               ( configMINIMAL_STACK_SIZE * 12 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
@@ -37,7 +37,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED
+#define CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                                     ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
@@ -37,7 +37,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED 
+#define CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                                     ( configMINIMAL_STACK_SIZE * 8 )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_demo_config.h
@@ -37,7 +37,7 @@
  *
  *  These defines are used in iot_demo_runner.h for demo selection */
 
-#define CONFIG_BLE_GATT_SERVER_DEMO_ENABLED
+#define CONFIG_MQTT_BLE_TRANSPORT_DEMO_ENABLED 
 
 /* Default configuration for all demos. Individual demos can override these below */
 #define democonfigDEMO_STACKSIZE                                     ( configMINIMAL_STACK_SIZE * 8 )


### PR DESCRIPTION
Update BLE demo and test configs


Description
-----------

Moved network type for BLE demo to the common demo runner config.
Increase timeouts from demo to 5 seconds.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.