### PR TITLE
CY8CKIT_064S0S2_4343W: Fix aws_tests for OTA tests

### DIFF
--- a/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_kit_utils.cmake
@@ -639,7 +639,6 @@ function(cy_kit_generate)
         # common ota sources
         target_sources(AFR::ota::mcu_port INTERFACE
             "${cy_ota_dir}/ports/${AFR_BOARD_NAME}/aws_ota_pal.c"
-            "${AFR_DEMOS_DIR}/ota/aws_iot_ota_update_demo.c"
             "${MCUBOOT_CYFLASH_PAL_DIR}/cy_flash_map.c"
             "${MCUBOOT_CYFLASH_PAL_DIR}/cy_flash_psoc6.c"
             "${MCUBOOT_CYFLASH_PAL_DIR}/flash_qspi/flash_qspi.c"
@@ -680,6 +679,7 @@ function(cy_kit_generate)
                 "${AFR_DEMOS_DIR}/demo_runner/iot_demo_runner.c"
                 "${AFR_DEMOS_DIR}/network_manager/aws_iot_demo_network.c"
                 "${AFR_DEMOS_DIR}/network_manager/aws_iot_network_manager.c"
+                "${AFR_DEMOS_DIR}/ota/aws_iot_ota_update_demo.c"
             )
 
             # add extra includes
@@ -718,6 +718,9 @@ function(cy_kit_generate)
             set(APP_VERSION_MAJOR 0)
             set(APP_VERSION_MINOR 9)
             set(APP_VERSION_BUILD 0)
+            target_include_directories( AFR::ota::mcu_port INTERFACE
+                "${AFR_DEMOS_DIR}/ota/aws_iot_ota_update_demo.c"
+            )
             # add extra includes
             target_include_directories(AFR::ota::mcu_port INTERFACE
                 "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/test"


### PR DESCRIPTION
CY8CKIT_064S0S2_4343W: Fix aws_tests for OTA tests

Description
-----------
OTA PAL and Agent tests were failing to build due to a OTA demo
source file being included. This patch removes the source file
from aws_tests builds.

Signed-off-by: Raymond Ngun <raymond.ngun@cypress.com>

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.