### PR TITLE
Initialize the local variable to fix the BLE_Unit_MQTT_Serialize hang…

### DIFF
--- a/libraries/c_sdk/standard/ble/test/iot_test_ble_mqtt_serialize.c
+++ b/libraries/c_sdk/standard/ble/test/iot_test_ble_mqtt_serialize.c
@@ -653,9 +653,9 @@ static void prvCreatePUBLISHPacket( uint8_t * pBuffer,
 TEST( BLE_Unit_MQTT_Serialize, DeserializePUBLISH )
 {
     MQTTBLEStatus_t status;
-    uint8_t buffer[ TEST_MESG_LEN ];
+    uint8_t buffer[ TEST_MESG_LEN ] = { 0 };
     size_t length = TEST_MESG_LEN;
-    MQTTBLEPublishInfo_t publishInfo;
+    MQTTBLEPublishInfo_t publishInfo = { 0 };
     uint16_t packetIdentifier;
 
 
@@ -761,7 +761,7 @@ TEST( BLE_Unit_MQTT_Serialize, DeserializePUBLISH_QOS0 )
     MQTTBLEStatus_t status = MQTTBLESuccess;
     uint8_t buffer[ TEST_MESG_LEN ] = { 0 };
     size_t length = TEST_MESG_LEN;
-    MQTTBLEPublishInfo_t publishInfo;
+    MQTTBLEPublishInfo_t publishInfo = { 0 };
     uint16_t packetIdentifier;
 
 
@@ -840,7 +840,7 @@ static void prvCreateSUBACKPacket( uint8_t * pBuffer,
 TEST( BLE_Unit_MQTT_Serialize, DeserializeSUBACK )
 {
     MQTTBLEStatus_t status;
-    uint8_t buffer[ TEST_MESG_LEN ];
+    uint8_t buffer[ TEST_MESG_LEN ] = { 0 };
     size_t length = TEST_MESG_LEN;
     uint16_t packetIdentifier;
     uint8_t statusCode;
@@ -853,6 +853,7 @@ TEST( BLE_Unit_MQTT_Serialize, DeserializeSUBACK )
     TEST_ASSERT_EQUAL( TEST_QOS1, statusCode );
 
     /** Malformed message **/
+    memset( buffer, 0x00, TEST_MESG_LEN );
     length = TEST_MESG_LEN;
     prvCreateSUBACKPacket( buffer, &length, TEST_QOS1, TEST_PACKET_IDENTIFIER, 2 );
     buffer[ 0 ] = 0x00;

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
@@ -237,8 +237,8 @@ int main( void )
                      ucMACAddress );
 #endif /* CY_USE_FREERTOS_TCP */
 
-    /* Add 20s delay to let serial port establish a connection to PC before starting the tests */
-    vTaskDelay( pdMS_TO_TICKS( 1000 ) * 20 );
+    /* Add 5s delay to let serial port establish a connection to PC before starting the tests */
+    vTaskDelay( pdMS_TO_TICKS( 1000 ) * 5 );
 
     /* Start the scheduler.  Initialization that requires the OS to be running,
      * including the Wi-Fi initialization, is performed in the RTOS daemon task


### PR DESCRIPTION
Description
-----------
Initialize the local variable to fix the BLE_Unit_MQTT_Serialize test that may occasionally hang up during run-time.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.