### PR TITLE
Fix CMake build failure of GreenGrass demo

### DIFF
--- a/demos/greengrass_connectivity/CMakeLists.txt
+++ b/demos/greengrass_connectivity/CMakeLists.txt
@@ -14,4 +14,5 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         AFR::greengrass
+        AFR::mqtt
 )


### PR DESCRIPTION
With the removal of the old MQTT demo in #2628, the Greengrass demo which has a hard-dependency on the MQTT library is facing CMake project build failures. This PR adds a CMake dependency on the `AFR::mqtt` module for the Greengrass demo to fix the build failure.