### PR TITLE
Fix category of Device Shadow library for FreeRTOS console

### DIFF
--- a/libraries/device_shadow_demo_dependencies.cmake
+++ b/libraries/device_shadow_demo_dependencies.cmake
@@ -53,7 +53,7 @@ afr_set_lib_metadata(ID "device_shadow_demo_dependencies")
 afr_set_lib_metadata(DESCRIPTION "This library enables you to store and retrieve the \
 current state (the \"shadow\") of every registered device on AWS IoT.")
 afr_set_lib_metadata(DISPLAY_NAME "Device Shadow")
-afr_set_lib_metadata(CATEGORY "Connectivity")
+afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 


### PR DESCRIPTION
Fix metadata of Device Shadow library represented by the `device_shadow_demo_dependencies` CMake target to use "Amazon Services" as the category to display on FreeRTOS console