### PR TITLE
CY8CKIT-064S0S2-4343W: Fix OTA TAR capability

### DIFF
--- a/vendors/cypress/MTB/ota/ports/CY8CKIT_064S0S2_4343W/aws_ota_pal.c
+++ b/vendors/cypress/MTB/ota/ports/CY8CKIT_064S0S2_4343W/aws_ota_pal.c
@@ -49,7 +49,6 @@
 #include "sysflash/sysflash.h"
 #include "flash_map_backend/flash_map_backend.h"
 #include "cy_pdl.h"
-#include "aws_application_version.h"
 #include "aws_ota_codesigner_certificate.h"
 #include "mbedtls/base64.h"
 #include "mbedtls/sha256.h"
@@ -64,6 +63,17 @@
 #include "cy_smif_psoc6.h"
 
 #include "untar.h"
+
+/* define CY_TEST_APP_VERSION_IN_TAR to test application version in TAR archive at start of OTA image download
+ * NOTE: This requires that the user set the version numbers in the header file and
+ *          in the Makefile and that they match.
+ *          APP_VERSION_MAJOR
+ *          APP_VERSION_MINOR
+ *          APP_VERSION_BUILD
+ */
+#ifdef CY_TEST_APP_VERSION_IN_TAR
+#include "aws_application_version.h"
+#endif
 
 /* For tarball support */
 /**
@@ -832,6 +842,7 @@ int16_t prvPAL_WriteBlock( OTA_FileContext_t * const C,
         }
 
         /* with the tarball we get a version - check if it is > current so we can bail early */
+#ifdef CY_TEST_APP_VERSION_IN_TAR
         if (ota_untar_context.version[0] != 0)
         {
             /* example version string "<major>.<minor>.<build>" */
@@ -867,6 +878,7 @@ int16_t prvPAL_WriteBlock( OTA_FileContext_t * const C,
                 }
             }
         }
+#endif  /* CY_TEST_APP_VERSION_IN_TAR */
     }
     else
     {

--- a/vendors/cypress/MTB/psoc6/psoc6make/make/scripts/sign_tar.bash
+++ b/vendors/cypress/MTB/psoc6/psoc6make/make/scripts/sign_tar.bash
@@ -123,8 +123,9 @@ cd $CY_OUTPUT_PATH
 #==============================================================================
 # "Normal" OTA tarballs (binaries DO NOT include cybootloader magic, etc)
 # get size of binary file for components.json
-BIN_CM0_SIZE=$(ls -l $CY_OUTPUT_FILE_CM0_NAME_BIN | awk '{printf $6}')
-BIN_CM4_SIZE=$(ls -l $CY_OUTPUT_FILE_CM4_NAME_BIN | awk '{printf $6}')
+# the size entry in the "ls -g -o" list is in the 3rd position
+BIN_CM0_SIZE=$(ls -g -o $CY_OUTPUT_FILE_CM0_NAME_BIN | awk '{printf $3}')
+BIN_CM4_SIZE=$(ls -g -o $CY_OUTPUT_FILE_CM4_NAME_BIN | awk '{printf $3}')
 
 #---------------------------------------
 # CM4-only "normal" OTA Image tarball
@@ -153,8 +154,9 @@ tar -cf $CY_CM4_CM0_TAR $CY_COMPONENTS_JSON_NAME $CY_OUTPUT_FILE_CM0_NAME_BIN $C
 #==============================================================================
 # "upgrade" OTA tarballs (includes cybootloader magic, etc)
 # get size of binary file for components.json for "upgrade" files
-BIN_CM0_UPGRADE_SIZE=$(ls -l "$CY_OUTPUT_FILE_CM0_UPGRADE_BIN" | awk '{printf $6}')
-BIN_CM4_UPGRADE_SIZE=$(ls -l "$CY_OUTPUT_FILE_CM4_UPGRADE_BIN" | awk '{printf $6}')
+# the size entry in the "ls -g -o" list may is in the 3rd position
+BIN_CM0_UPGRADE_SIZE=$(ls -g -o $CY_OUTPUT_FILE_CM0_UPGRADE_BIN | awk '{printf $3}')
+BIN_CM4_UPGRADE_SIZE=$(ls -g -o $CY_OUTPUT_FILE_CM4_UPGRADE_BIN | awk '{printf $3}')
 
 #---------------------------------------
 # CM4-only "upgrade" OTA Image tarball


### PR DESCRIPTION
CY8CKIT-064S0S2-4343W: Fix OTA TAR capability

Description
-----------
Fixes versioning when using TAR feature in OTA.

Signed-off-by: Raymond Ngun <raymond.ngun@cypress.com>

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.