### PR TITLE
Hygiene changes in metadata text of OTA library

### DIFF
--- a/libraries/freertos_plus/aws/ota/CMakeLists.txt
+++ b/libraries/freertos_plus/aws/ota/CMakeLists.txt
@@ -3,7 +3,7 @@ afr_module()
 afr_set_lib_metadata(ID "ota")
 afr_set_lib_metadata(DESCRIPTION "This library provides the interface to the over-the-air update agent, which allows devices to receive software updates securely via MQTT.")
 afr_set_lib_metadata(DISPLAY_NAME "OTA Updates")
-afr_set_lib_metadata(CATEGORY "Update")
+afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 

--- a/libraries/freertos_plus/aws/ota/CMakeLists.txt
+++ b/libraries/freertos_plus/aws/ota/CMakeLists.txt
@@ -1,7 +1,7 @@
 afr_module()
 
 afr_set_lib_metadata(ID "ota")
-afr_set_lib_metadata(DESCRIPTION "This library provides the interface to the over-the-air update agent, which allows devices to receive software updates securely via MQTT.")
+afr_set_lib_metadata(DESCRIPTION "This library provides the interface to the over-the-air update agent, which allows devices to receive software updates securely via MQTT or HTTP.")
 afr_set_lib_metadata(DISPLAY_NAME "OTA Updates")
 afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")


### PR DESCRIPTION
Update metadata of OTA library for the following FreeRTOS console hygiene changes:
* Show the library as an **Amazon Services** category library to be consistent with other AWS-specific libraries that use the category name
* Update its description to mention that it can be used with both **MQTT** and **HTTP** protocols.