### PR TITLE
Update transport timeout value to 500ms in demos

### DIFF
--- a/demos/coreMQTT/mqtt_demo_basic_tls.c
+++ b/demos/coreMQTT/mqtt_demo_basic_tls.c
@@ -179,7 +179,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 500U )
 
 /**
  * @brief Milliseconds per second.

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -162,7 +162,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200 )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 500U )
 
 /**
  * @brief Milliseconds per second.

--- a/demos/coreMQTT/mqtt_demo_keep_alive.c
+++ b/demos/coreMQTT/mqtt_demo_keep_alive.c
@@ -170,7 +170,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 500U )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -188,7 +188,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS         ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS         ( 500U )
 
 /**
  * @brief Milliseconds per second.

--- a/demos/coreMQTT/mqtt_demo_plaintext.c
+++ b/demos/coreMQTT/mqtt_demo_plaintext.c
@@ -156,7 +156,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 500U )
 
 #define _MILLISECONDS_PER_SECOND                     ( 1000U )                                         /**< @brief Milliseconds per second. */
 #define _MILLISECONDS_PER_TICK                       ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */

--- a/demos/device_shadow_for_aws/shadow_demo_helpers.c
+++ b/demos/device_shadow_for_aws/shadow_demo_helpers.c
@@ -99,7 +99,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 500U )
 
 /**
  * @brief Maximum number of outgoing publishes maintained in the application


### PR DESCRIPTION
Update all coreMQTT demos and the Device Shadow demo to use **500ms** as the transport send/receive timeout values. This PR is related to https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1330