### PR TITLE
Update the otaconfigMAX_NUM_BLOCKS_REQUEST values

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/aws_ota_agent_config.h
@@ -73,18 +73,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_ota_agent_config.h
@@ -73,18 +73,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/aws_ota_agent_config.h
@@ -70,19 +70,40 @@
  * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
  */
 #define otaconfigMAX_THINGNAME_LEN              64U
+
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        1U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         1U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/aws_ota_agent_config.h
@@ -71,4 +71,38 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64
 
+/**
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
+ *
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
+ *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_ota_agent_config.h
@@ -71,4 +71,38 @@
  */
 #define otaconfigMAX_THINGNAME_LEN              64
 
+/**
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
+ *
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
+ *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
+ *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         1U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         1U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/aws_ota_agent_config.h
@@ -73,16 +73,36 @@
 
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
 #define otaconfigMAX_NUM_BLOCKS_REQUEST      1U
 

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_ota_agent_config.h
@@ -73,16 +73,36 @@
 
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
 #define otaconfigMAX_NUM_BLOCKS_REQUEST      1U
 

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/aws_ota_agent_config.h
@@ -77,18 +77,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST  2U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST  4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_ota_agent_config.h
@@ -77,18 +77,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,16 +72,36 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
 #define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,18 +72,38 @@
 #define otaconfigMAX_THINGNAME_LEN              64U
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         8U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.

--- a/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_ota_agent_config.h
@@ -72,17 +72,37 @@
 #define otaconfigMAX_THINGNAME_LEN              64  /* FIX ME. */
 
 /**
- * @brief The maximum number of data blocks requested from OTA streaming service.
+ * @brief The maximum number of data blocks requested per request from the OTA
+ * streaming service.
  *
- *  This configuration parameter is sent with data requests and represents the maximum number of
- *  data blocks the service will send in response. The maximum limit for this must be calculated
- *  from the maximum data response limit (128 KB from service) divided by the block size.
- *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
- *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
- *  how many data blocks response is expected for each data requests.
- *  Please note that this must be set larger than zero.
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in a single response.
+ * The amount of data requested and therefore received in a single response
+ * (in bytes) is equal to:
  *
+ * (otaconfigMAX_NUM_BLOCKS_REQUEST * ( pow(2,otaconfigLOG2_FILE_BLOCK_SIZE) )
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be less than the
+ * standard default size of 16KB, then the amount of bytes being requested has
+ * to be less than the the size of the incoming TLS I/O buffer.
+ * <br><br>
+ *
+ * For example, if the device has otaconfigLOG2_FILE_BLOCK_SIZE set to '12',
+ * then each data block will be 4096 bytes large. If the device also has a
+ * incoming TLS I/O bufferthat is 8KB large, then the
+ * otaconfigMAX_NUM_BLOCKS_REQUEST must be set to '1' so that the data received
+ * in one response doesn't surpass the size of the incoming TLS I/O buffer.
+ *
+ * @note If the device has a incoming TLS I/O buffer set to be equal to the
+ * standard default size of 16Kb, then the maximum limit for this must be
+ * calculated from the maximum data response limit (128 KB from service)
+ * divided by the block size. For example if block size is set as 1 KB then the
+ * maximum number of data blocks that we can request is 128/1 = 128 blocks.
+ * Configure this parameter to this maximum limit or lower based on how many
+ * data blocks response is expected for each data requests.
+ *
+ * @note This must be set to a value larger than zero.
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         128U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
 
 #endif /* _AWS_OTA_AGENT_CONFIG_H_ */


### PR DESCRIPTION
Update the otaconfigMAX_NUM_BLOCKS_REQUEST values

Description
-----------
* Updated the otaconfigMAX_NUM_BLOCKS_REQUEST value in ota config files for demos and tests. The values were updated relative to the data block size to prevent the device from requesting more data than it can buffer at once.
* Updated the description of the otaconfigMAX_NUM_BLOCKS_REQUEST OTA config parameter.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.