### PR TITLE
Fix MQTT LWT tests failure due to MQTT keep alive timeout

### DIFF
--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -212,7 +212,7 @@
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
  * broker.
  */
-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS      ( 5U )
+#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS      ( 20U )
 
 /**
  * @brief The number of milliseconds to wait for AWS IoT Core Message Broker

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -212,7 +212,7 @@
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
  * broker.
  */
-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS      ( 20U )
+#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS      ( 60U )
 
 /**
  * @brief The number of milliseconds to wait for AWS IoT Core Message Broker


### PR DESCRIPTION
Fix MQTT LWT tests failure due to MQTT keep alive timeout.

Description
-----------
Fix MQTT LWT tests failure due to MQTT keep alive timeout.
Problem: LWT tests were consistently failing on boards with slower stack.
Root cause: The MQTT connection established were getting timing out and closed by the broker on boards with slower network stacks.
Fix: Increase the keep alive timeout.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.