### PR TITLE
Update Shim README to point to header file instead doc.

### DIFF
--- a/libraries/c_sdk/standard/mqtt/README.md
+++ b/libraries/c_sdk/standard/mqtt/README.md
@@ -1,6 +1,6 @@
 # MQTT Shim for MQTT V2.x.x APIs
 
-This MQTT shim library supports backward compatibility for the MQTT V2.x.x APIs using the [coreMQTT library](../../../coreMQTT/README.md). All the [APIs in MQTT v2.x.x](https://docs.aws.amazon.com/freertos/latest/lib-ref/c-sdk/mqtt/index.html) are supported in this shim implementation. 
+This MQTT shim library supports backward compatibility for the MQTT V2.x.x APIs using the [coreMQTT library](../../../coreMQTT/README.md). All the [APIs in MQTT v2.x.x](include/iot_mqtt.h) are supported in this shim implementation. 
 This shim will be supported only as a short term solution to provide backward compatibility. We recommend using the redesigned [coreMQTT library](../../../coreMQTT/README.md) for applications requiring long term support.
 
 


### PR DESCRIPTION
Update MQTT Shim README to point to header file instead doc.

Description
-----------
Update MQTT Shim README to point to header file instead doc.
Root cause: The legacy documentation for the v2.x.x APIs are not accurate for the list of APIs as those are pointing to the CSDK  v4_beta version of APIs. Point the README to header file which has the accurate description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.