### PR TITLE
Fix OTA E2E test failures

### DIFF
--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -446,6 +446,7 @@ static void _httpReadReadyCallback( void * pPrivateData,
     /* Bail out if this callback is invoked after http downloader stopped. */
     if( _httpDownloader.state == OTA_HTTP_STOPPED )
     {
+        IotHttpsClient_CancelResponseAsync( responseHandle );
         return;
     }
 
@@ -1192,10 +1193,15 @@ OTA_Err_t _AwsIotOTA_CleanupData_HTTP( OTA_AgentContext_t * pAgentCtx )
     /* Unused parameters. */
     ( void ) pAgentCtx;
 
+    /* Return status. */
+    IotHttpsReturnCode_t httpsStatus = IOT_HTTPS_OK;
+
     /* Disconnect from the S3 server. */
-    if( IOT_HTTPS_OK != IotHttpsClient_Disconnect( _httpDownloader.httpConnection.connectionHandle ) )
+    httpsStatus = IotHttpsClient_Disconnect( _httpDownloader.httpConnection.connectionHandle );
+
+    if( IOT_HTTPS_OK != httpsStatus )
     {
-        IotLogError( "Failed to disconnect from S3 server." );
+        IotLogError( "Failed to disconnect from S3 server. Error code: %d.", httpsStatus );
     }
 
     _httpDownloader.httpConnection.connectionHandle = NULL;

--- a/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
+++ b/libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c
@@ -1201,7 +1201,7 @@ OTA_Err_t _AwsIotOTA_CleanupData_HTTP( OTA_AgentContext_t * pAgentCtx )
 
     if( IOT_HTTPS_OK != httpsStatus )
     {
-        IotLogError( "Failed to disconnect from S3 server. Error code: %d.", httpsStatus );
+        IotLogDebug( "Failed to disconnect from S3 server. Error code: %d.", httpsStatus );
     }
 
     _httpDownloader.httpConnection.connectionHandle = NULL;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Directly return from callback if invoked after http backend stopped.
- Never call http connect in callback since the OTA agent thread may stop the data plane.
- Disconnect from S3 when OTA agent cleans up the http data plane.
- Cancel http request if http downloader is already stopped.
- Only free OTA http buffer when OTA agent is stopping.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.