### PR TITLE
Create a macro for semaphore delay.

### DIFF
--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -40,8 +40,8 @@
 #include "semphr.h"
 #include "task.h"
 
-#define testIotTIMER_DEFAULT_DELAY_US    500
-#define testIotTIMER_SLEEP_DELAY_MS      1
+#define testIotTIMER_DEFAULT_DELAY_US     500
+#define testIotTIMER_SLEEP_DELAY_MS       1
 
 /*
  * @brief timeout for the semaphore to be invoked by the iot_timer. 4 times larger to account

--- a/libraries/abstractions/common_io/test/test_iot_timer.c
+++ b/libraries/abstractions/common_io/test/test_iot_timer.c
@@ -43,6 +43,12 @@
 #define testIotTIMER_DEFAULT_DELAY_US    500
 #define testIotTIMER_SLEEP_DELAY_MS      1
 
+/*
+ * @brief timeout for the semaphore to be invoked by the iot_timer. 4 times larger to account
+ * for timer resolution variances.
+ */
+#define testIotTIMER_CALLBACK_DELAY_US    ( testIotTIMER_DEFAULT_DELAY_US * 4 )
+
 
 /*-----------------------------------------------------------*/
 
@@ -298,7 +304,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Callback )
         TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
         /* Wait for the Delay callback to be called. */
-        lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, portMAX_DELAY );
+        lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, testIotTIMER_CALLBACK_DELAY_US );
         TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
 
         /* Get the time in micro seconds
@@ -357,7 +363,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_NoCallback )
         if( lRetVal != IOT_TIMER_FUNCTION_NOT_SUPPORTED )
         {
             /* Wait for the Delay.  Make sure callback is not called. */
-            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, 2 * testIotTIMER_DEFAULT_DELAY_US );
+            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, testIotTIMER_CALLBACK_DELAY_US );
             TEST_ASSERT_NOT_EQUAL( pdTRUE, lRetVal );
         }
     }
@@ -410,7 +416,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_StartAgain )
         if( lRetVal != IOT_TIMER_FUNCTION_NOT_SUPPORTED )
         {
             /* Wait for the Delay.  Make sure callback is not called. */
-            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, 2 * testIotTIMER_DEFAULT_DELAY_US );
+            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, testIotTIMER_CALLBACK_DELAY_US );
             TEST_ASSERT_NOT_EQUAL( pdTRUE, lRetVal );
 
             /* Start the timer again*/
@@ -418,7 +424,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_StartAgain )
             TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
             /* Wait for the Delay.  Make sure callback is called. */
-            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, 2 * testIotTIMER_DEFAULT_DELAY_US );
+            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, testIotTIMER_CALLBACK_DELAY_US );
             TEST_ASSERT_EQUAL( pdTRUE, lRetVal );
         }
     }
@@ -469,7 +475,7 @@ TEST( TEST_IOT_TIMER, AFWP_IotTimer_Cancel )
             TEST_ASSERT_EQUAL( IOT_TIMER_SUCCESS, lRetVal );
 
             /* Wait for the Delay.  Make sure callback is not called. */
-            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, 2 * testIotTIMER_DEFAULT_DELAY_US );
+            lRetVal = xSemaphoreTake( xtestIotTimerSemaphore, testIotTIMER_CALLBACK_DELAY_US );
             TEST_ASSERT_NOT_EQUAL( pdTRUE, lRetVal );
         }
     }


### PR DESCRIPTION
Create a macro for semaphore delay.

Description
-----------
Create a macro for semaphore delay. Related issue #2567 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.