### PR TITLE
Fix HTTP CBMC proofs failure

### DIFF
--- a/tools/cbmc/proofs/CMakeLists.txt
+++ b/tools/cbmc/proofs/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND cbmc_compile_includes
     ${CMAKE_SOURCE_DIR}/demos/include
     ${CMAKE_SOURCE_DIR}/freertos_kernel/include
     ${CMAKE_SOURCE_DIR}/freertos_kernel/portable/MSVC-MingW
-    ${CMAKE_SOURCE_DIR}/libraries/3rdparty/http_parser
+    ${CMAKE_SOURCE_DIR}/libraries/coreHTTP/source/3rdparty/http_parser
     ${CMAKE_SOURCE_DIR}/libraries/3rdparty/jsmn
     ${CMAKE_SOURCE_DIR}/libraries/3rdparty/mbedtls/include/mbedtls
     ${CMAKE_SOURCE_DIR}/libraries/3rdparty/pkcs11

--- a/tools/cbmc/proofs/HTTP/CMakeLists.txt
+++ b/tools/cbmc/proofs/HTTP/CMakeLists.txt
@@ -1,7 +1,7 @@
 list(PREPEND cbmc_compile_includes
     ${CMAKE_SOURCE_DIR}/libraries/c_sdk/standard/https/include
     ${CMAKE_SOURCE_DIR}/libraries/c_sdk/standard/https/src/private
-    ${CMAKE_SOURCE_DIR}/libraries/3rdparty/http_parser
+    ${CMAKE_SOURCE_DIR}/libraries/coreHTTP/source/3rdparty/http_parser
     ${CMAKE_SOURCE_DIR}/libraries/c_sdk/standard/common/include
     ${CMAKE_SOURCE_DIR}/libraries/abstractions/platform/include
     ${CMAKE_SOURCE_DIR}/libraries/abstractions/platform/freertos/include

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_AddHeader/Makefile.json
@@ -31,7 +31,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Connect/Makefile.json
@@ -34,7 +34,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_Disconnect/Makefile.json
@@ -34,7 +34,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadContentLength/Makefile.json
@@ -26,7 +26,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadHeader/Makefile.json
@@ -32,7 +32,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_ReadResponseStatus/Makefile.json
@@ -26,7 +26,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
+++ b/tools/cbmc/proofs/HTTP/IotHttpsClient_SendSync/Makefile.json
@@ -33,7 +33,7 @@
   [
     "$(FREERTOS)/libraries/c_sdk/standard/https/include",
     "$(FREERTOS)/libraries/c_sdk/standard/https/src/private",
-    "$(FREERTOS)/libraries/3rdparty/http_parser",
+    "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
     "$(FREERTOS)/libraries/c_sdk/standard/common/include/",
     "$(FREERTOS)/libraries/abstractions/platform/include/",
     "$(FREERTOS)/libraries/abstractions/platform/freertos/include/",

--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -61,7 +61,7 @@
         "$(FREERTOS)/libraries/3rdparty/mbedtls_utils",
         "$(FREERTOS)/libraries/3rdparty/mbedtls_config",
         "$(FREERTOS)/libraries/3rdparty/tinycbor",
-        "$(FREERTOS)/libraries/3rdparty/http_parser",
+        "$(FREERTOS)/libraries/coreHTTP/source/3rdparty/http_parser",
         "$(FREERTOS)/libraries/3rdparty/jsmn",
 
         "$(FREERTOS)/tools/cbmc/include",


### PR DESCRIPTION
The HTTP CBMC proofs are failing due to absence of the `libraries/3rdparty/http_parser` submodule removed in #2702. This PR fixes the CBMC failures by updating the proof to use `libraries/coreHTTP/source/3rdparty/http_parser` as the location for the http_parser