### PR TITLE
Fix memory leak in tearDown of integration tests

### DIFF
--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -883,17 +883,19 @@ void testSetUp()
 /* Called after each test method. */
 void testTearDown()
 {
-    MQTTStatus_t status;
+    MQTTStatus_t mqttStatus;
+    TransportSocketStatus_t transportStatus;
 
     /* Terminate MQTT connection. */
-    status = MQTT_Disconnect( &context );
+    mqttStatus = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
-    ( void ) SecureSocketsTransport_Disconnect( &networkContext );
+    transportStatus = SecureSocketsTransport_Disconnect( &networkContext );
 
-    /* Make any assertions at the end that may prevent #SecureSocketsTransport_Disconnect
-     * from being called and ultimately cause a memory leak. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* Make any assertions at the end so that all memory is deallocated before
+     * the end of this function. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_SUCCESS, transportStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -883,11 +883,17 @@ void testSetUp()
 /* Called after each test method. */
 void testTearDown()
 {
+    MQTTStatus_t status;
+
     /* Terminate MQTT connection. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Disconnect( &context ) );
+    status = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
     ( void ) SecureSocketsTransport_Disconnect( &networkContext );
+
+    /* Make any assertions at the end that may prevent #SecureSocketsTransport_Disconnect
+     * from being called and ultimately cause a memory leak. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
 }
 
 /*-----------------------------------------------------------*/

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -817,11 +817,17 @@ TEST_SETUP( deviceShadow_Integration )
 
 TEST_TEAR_DOWN( deviceShadow_Integration )
 {
+    MQTTStatus_t status;
+
     /* Terminate MQTT connection. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Disconnect( &context ) );
+    status = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
     ( void ) SecureSocketsTransport_Disconnect( &networkContext );
+
+    /* Make any assertions at the end that may prevent #SecureSocketsTransport_Disconnect
+     * from being called and ultimately cause a memory leak. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
 }
 
 /* ========================== Test Cases ============================ */

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -817,17 +817,19 @@ TEST_SETUP( deviceShadow_Integration )
 
 TEST_TEAR_DOWN( deviceShadow_Integration )
 {
-    MQTTStatus_t status;
+    MQTTStatus_t mqttStatus;
+    TransportSocketStatus_t transportStatus;
 
     /* Terminate MQTT connection. */
-    status = MQTT_Disconnect( &context );
+    mqttStatus = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
-    ( void ) SecureSocketsTransport_Disconnect( &networkContext );
+    transportStatus = SecureSocketsTransport_Disconnect( &networkContext );
 
-    /* Make any assertions at the end that may prevent #SecureSocketsTransport_Disconnect
-     * from being called and ultimately cause a memory leak. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* Make any assertions at the end so that all memory is deallocated before
+     * the end of this function. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_SUCCESS, transportStatus );
 }
 
 /* ========================== Test Cases ============================ */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
If the assertion on the returned status of `MQTT_Disconnect` fails, then `SecureSocketsTransport_Disconnect` will never be called. This means that the memory will remain allocated while a new connection will be established for the next test case, causing a memory leak.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.