### PR TITLE
Improve metadata mechanism for submoduled libraries cmake files

### DIFF
--- a/demos/coreMQTT/CMakeLists.txt
+++ b/demos/coreMQTT/CMakeLists.txt
@@ -6,6 +6,11 @@ afr_set_demo_metadata(ID "CORE_MQTT_MUTUAL_AUTH_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the MQTT library")
 afr_set_demo_metadata(DISPLAY_NAME "coreMQTT Demos")
 
+# Add the CMakeLists.txt file of module to metadata list.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
@@ -15,11 +20,6 @@ afr_module_sources(
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_serializer.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_keep_alive.c"
         "${CMAKE_CURRENT_LIST_DIR}/mqtt_demo_connection_sharing.c"
-        # As the containing directory name (coreMQTT) does not match the
-        # module name (core_mqtt), we add dependency on the CMake file so
-        # that metadata is generated for it, and it is present in code 
-        # downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 
 afr_module_dependencies(

--- a/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/demos/device_shadow_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -5,6 +5,11 @@ afr_set_demo_metadata(ID "DEVICE_SHADOW_DEMO")
 afr_set_demo_metadata(DESCRIPTION "An example that demonstrates the use of the Device Shadow library.")
 afr_set_demo_metadata(DISPLAY_NAME "Device Shadow Demo")
 
+# Add the CMakeLists.txt file of module to metadata list.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
@@ -13,12 +18,6 @@ afr_module_sources(
         # Add the header file to generate their metadata so that 
         # they are present in code downloaded from FreeRTOS console.
         "${CMAKE_CURRENT_LIST_DIR}/shadow_demo_helpers.h"
-        # As the containing directory name (i.e. device_shadow_for_aws_iot_embedded_sdk)
-        # does not match the module name (i.e. device_shadow), 
-        # we add the CMake file to the source list so that metadata is
-        # generated for it, and it is present in code downloaded from
-        # the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 
 afr_module_dependencies(

--- a/libraries/abstractions/transport/transport_interface_secure_sockets.cmake
+++ b/libraries/abstractions/transport/transport_interface_secure_sockets.cmake
@@ -11,15 +11,17 @@ set(src_dir "${CMAKE_CURRENT_LIST_DIR}/secure_sockets")
 # Include filepaths for source and include.
 include( ${CMAKE_CURRENT_LIST_DIR}/transport_interface.cmake )
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/transport_interface.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/transport_interface_secure_sockets.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         "${src_dir}/transport_secure_sockets.h"
         "${src_dir}/transport_secure_sockets.c"
-        # Following files are added to the source list to generate their
-        # metadata so that are part of code downloaded from FreeRTOS console.
-        "${CMAKE_CURRENT_LIST_DIR}/transport_interface.cmake"
-        "${CMAKE_CURRENT_LIST_DIR}/transport_interface_secure_sockets.cmake"
 )
 
 afr_module_dependencies(

--- a/libraries/core_http_demo_dependencies.cmake
+++ b/libraries/core_http_demo_dependencies.cmake
@@ -15,14 +15,18 @@ foreach(http_public_include_dir ${HTTP_INCLUDE_PUBLIC_DIRS})
     list(APPEND HTTP_HEADER_FILES ${http_public_include_header_files})
 endforeach()
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/coreHTTP/httpFilePaths.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${HTTP_SOURCES}
         ${HTTP_SERIALIZER_SOURCES}
-        # List of files added to the target so that these are available
+        # Header files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/coreHTTP/httpFilePaths.cmake
         ${HTTP_HEADER_FILES}
 )
 
@@ -56,6 +60,11 @@ afr_set_lib_metadata(CATEGORY "Connectivity")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/core_http_demo_dependencies.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -63,9 +72,6 @@ afr_module_sources(
         # core_http_demo_dependencies target; otherwise, it gives the 
         # "Cannot determine link language for target" error.
         ${HTTP_SOURCES}
-        # This file is added to the target so that it is available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/core_http_demo_dependencies.cmake
 )
 
 # Add dependencies of the coreHTTP demos in this target

--- a/libraries/core_json.cmake
+++ b/libraries/core_json.cmake
@@ -14,14 +14,18 @@ foreach(json_public_include_dir ${JSON_INCLUDE_PUBLIC_DIRS})
     list(APPEND JSON_HEADER_FILES ${json_public_include_header_files})
 endforeach()
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/core_json.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${JSON_SOURCES}
-        # List of files added to the target so that these are available
+        # List of header files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/coreJSON/jsonFilePaths.cmake
-        ${CMAKE_CURRENT_LIST_DIR}/core_json.cmake
         ${JSON_HEADER_FILES}
 )
 

--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -15,14 +15,16 @@ foreach(mqtt_public_include_dir ${MQTT_INCLUDE_PUBLIC_DIRS})
     list(APPEND MQTT_HEADER_FILES ${mqtt_public_include_header_files})
 endforeach()
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
-        # List of files added to the target so that these are available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/coreMQTT/mqttFilePaths.cmake
         ${MQTT_HEADER_FILES}
 )
 
@@ -57,6 +59,11 @@ afr_set_lib_metadata(CATEGORY "Connectivity")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/core_mqtt_demo_dependencies.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -64,9 +71,6 @@ afr_module_sources(
         # core_mqtt_demo_dependencies target; otherwise, it gives the 
         # "Cannot determine link language for target" error.
         ${MQTT_SOURCES}
-        # This file is added to the target so that it is available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/core_mqtt_demo_dependencies.cmake
 )
 
 # Add dependencies of the coreMQTT demos in this target

--- a/libraries/device_defender_demo_dependencies.cmake
+++ b/libraries/device_defender_demo_dependencies.cmake
@@ -15,13 +15,16 @@ foreach(defender_public_include_dir ${DEFENDER_INCLUDE_PUBLIC_DIRS})
     list(APPEND DEVICE_DEFENDER_HEADER_FILES ${defender_public_include_header_files})
 endforeach()
 
+afr_module_cmake_files(${AFR_CURRENT_MODULE}
+    ${CMAKE_CURRENT_LIST_DIR}/device_defender_for_aws/defenderFilePaths.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${DEFENDER_SOURCES}
-        # List of files added to the target so that these are available
+        # List of header files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/device_defender_for_aws/defenderFilePaths.cmake
         ${DEVICE_DEFENDER_HEADER_FILES}
 )
 
@@ -56,6 +59,10 @@ afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 
+afr_module_cmake_files(${AFR_CURRENT_MODULE}
+    ${CMAKE_CURRENT_LIST_DIR}/device_defender_demo_dependencies.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -63,9 +70,6 @@ afr_module_sources(
         # device_defender_demo_dependencies target; otherwise, it gives the 
         # "Cannot determine link language for target" error.
         ${DEFENDER_SOURCES}
-        # This file is added to the target so that it is available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/device_defender_demo_dependencies.cmake
 )
 
 # Add dependencies of the Device Defender demo in this target

--- a/libraries/device_shadow_demo_dependencies.cmake
+++ b/libraries/device_shadow_demo_dependencies.cmake
@@ -15,13 +15,17 @@ foreach(shadow_public_include_dir ${SHADOW_INCLUDE_PUBLIC_DIRS})
     list(APPEND DEVICE_SHADOW_HEADER_FILES ${shadow_public_include_header_files})
 endforeach()
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/device_shadow_for_aws_iot_embedded_sdk/shadowFilePaths.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${SHADOW_SOURCES}
-        # List of files added to the target so that these are available
+        # Header files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/device_shadow_for_aws_iot_embedded_sdk/shadowFilePaths.cmake
         ${DEVICE_SHADOW_HEADER_FILES}
 )
 
@@ -49,6 +53,11 @@ afr_module_dependencies(
 # Device Shadow demo can be downloaded.
 afr_module(NAME device_shadow_demo_dependencies )
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/device_shadow_demo_dependencies.cmake
+)
+
 afr_set_lib_metadata(ID "device_shadow_demo_dependencies")
 afr_set_lib_metadata(DESCRIPTION "This library enables you to store and retrieve the \
 current state (the \"shadow\") of every registered device on AWS IoT.")
@@ -64,9 +73,6 @@ afr_module_sources(
         # device_shadow_demo_dependencies target; otherwise, it gives the 
         # "Cannot determine link language for target" error.
         ${SHADOW_SOURCES}
-        # This file is added to the target so that it is available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/device_shadow_demo_dependencies.cmake
 )
 
 # Add dependencies of the Device Shadow demo in this target

--- a/libraries/freertos_plus/standard/freertos_plus_tcp.cmake
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp.cmake
@@ -9,6 +9,11 @@ set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/freertos_plus_tcp/include")
 # for the FreeRTOS console.
 file(GLOB FREERTOS_PLUS_TCP_HEADER_FILES "${inc_dir}/*.h")
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/freertos_plus_tcp.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -21,10 +26,9 @@ afr_module_sources(
         "${src_dir}/FreeRTOS_TCP_IP.c"
         "${src_dir}/FreeRTOS_TCP_WIN.c"
         "${src_dir}/FreeRTOS_UDP_IP.c"
-        # List of files added to the target so that these are available
+        # Header files are added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
         ${FREERTOS_PLUS_TCP_HEADER_FILES}
-        ${CMAKE_CURRENT_LIST_DIR}/freertos_plus_tcp.cmake
 )
 
 afr_module_include_dirs(

--- a/libraries/jobs_demo_dependencies.cmake
+++ b/libraries/jobs_demo_dependencies.cmake
@@ -15,13 +15,17 @@ foreach(jobs_public_include_dir ${JOBS_INCLUDE_PUBLIC_DIRS})
     list(APPEND JOBS_HEADER_FILES ${jobs_public_include_header_files})
 endforeach()
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/jobs_for_aws/jobsFilePaths.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${JOBS_SOURCES}
-        # List of files added to the target so that these are available
+        # Header files added to the target so that these are available
         # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/jobs_for_aws/jobsFilePaths.cmake
         ${JOBS_HEADER_FILES}
 )
 
@@ -49,6 +53,11 @@ afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")
 afr_set_lib_metadata(IS_VISIBLE "true")
 
+# Add cmake files of module to metadata.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/jobs_demo_dependencies.cmake
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -56,9 +65,6 @@ afr_module_sources(
         # jobs_demo_dependencies target; otherwise, it gives the 
         # "Cannot determine link language for target" error.
         ${JOBS_SOURCES}
-        # This file is added to the target so that it is available
-        # in code downloaded from the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/jobs_demo_dependencies.cmake
 )
 
 # Add dependencies of the Jobs demo in this target

--- a/tools/cmake/afr_metadata.cmake
+++ b/tools/cmake/afr_metadata.cmake
@@ -152,6 +152,21 @@ function(afr_add_subdirectory module_name)
   afr_cache_append(AFR_METADATA_CMAKE_FILES "${module_name}/CMakeLists.txt")
 endfunction()
 
+# Function to add module-specific CMake files to metadata.
+# This function should be to add cmake files to metadata when:
+# 1. When the module name does not match its parent folder name
+#                 OR/AND
+# 2. A non-CMakeLists.txt file needs to be added to metadata.
+# Thif function sets the AFR_MODULE_${module_name}_CMAKE_FILES cache
+# variable.
+function(afr_module_cmake_files module_name)
+    set(prop_var AFR_MODULE_${module_name}_CMAKE_FILES)
+    if(NOT DEFINED ${prop_var})
+        set(${prop_var} "" CACHE INTERNAL "")
+    endif()
+    afr_cache_append(${prop_var} ${ARGN})
+endfunction()
+
 function(afr_write_metadata)
     set(ide_dir "${AFR_METADATA_OUTPUT_DIR}/ide")
     set(console_dir "${AFR_METADATA_OUTPUT_DIR}/console")
@@ -199,6 +214,19 @@ function(afr_write_metadata)
         # Skip kernel, we already got the metadata from other kernel modules.
         if("${module}" STREQUAL "kernel")
             continue()
+        endif()
+
+        # Check if module contains module-specifc cmake files.
+        set(prop_var AFR_MODULE_${module}_CMAKE_FILES)
+        if(DEFINED ${prop_var})
+            set(cmake_files "")
+            # Add cmake files associated with this module to the metadata file 
+            # containing list of all cmake files.
+            foreach(cmake_file IN LISTS ${prop_var})
+                list(APPEND cmake_files "${cmake_file}")
+            endforeach()
+            
+            file(APPEND "${cmake_files_file}" "${cmake_files}")
         endif()
         string(FIND ${module} ::mcu_port __idx)
         if(__idx EQUAL -1)


### PR DESCRIPTION
### Issue
The existing CMake configurations of the submoduled libraries add their `*.cmake`/`CMakeLists.txt` files to the generated metadata by explicitly including them in the source list of demo/library modules definition. 
This causes when using the internal tool to auto-update the IDE project files for file additions/deletions in the codebase because the tool adds the CMake files (by utilizing the "sources" list from CMake configuration) to project files. Some IDE builds face build failures with presence of cmake files in the project files.

### Solution
Introduce a new CMake function, `afr_module_cmake_files` to add module-specific CMake files to metadata. This function creates an internal CMake CACHE list variable per module of the form, `AFR_MODULE_<module_name>_CMAKE_FILES`  if the new function is called by a CMake module. 
If the CMake module is _enabled_ (i.e. present in `AFR_MODULES_ENABLED`) within the CMake configuration (with `cmake .. -DVENDOR=<vendor> ..` command), then the new module-specific cmake list (if created through the new function call) is inspected to add the registered cmake files to metadata.

### Verification
I have verified that the new function adds the cmake files registered through the `afr_module_cmake_files` function to the `metadata/console/cmake_files.txt` file that is generated when using the `-DAFR_METADATA_MODE=1 flag in the `cmake ..` command