### PR TITLE
Fix Jobs demo CMake configuration

### DIFF
--- a/demos/jobs_for_aws/CMakeLists.txt
+++ b/demos/jobs_for_aws/CMakeLists.txt
@@ -5,16 +5,15 @@ afr_set_demo_metadata(ID "JOBS_DEMO")
 afr_set_demo_metadata(DESCRIPTION "An example that demonstrates the use of the AWS IoT Jobs library.")
 afr_set_demo_metadata(DISPLAY_NAME "Jobs Demo")
 
+# Add the CMakeLists.txt file of module to metadata list.
+afr_module_cmake_files(${AFR_CURRENT_MODULE} 
+    ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/jobs_demo.c"
-        # As the containing directory name (i.e. jobs_for_aws)
-        # does not match the module name (i.e. jobs), 
-        # we add the CMake file to the source list so that metadata is
-        # generated for it, and it is present in code downloaded from
-        # the FreeRTOS console.
-        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
 )
 
 afr_module_include_dirs(


### PR DESCRIPTION
The `CMakeLists.txt` is present in the source list of the Jobs demo module. With the changes in #2732, the cmake files do not need to be added to source list for metadata inclusion. This PR updates the CMake configuration to use the `afr_module_cmake_files` function to add the `demos/jobs_for_aws/CMakeLists.txt` file to the metadata list.