### PR TITLE
Nuvoton: M487 OTA support

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
@@ -374,7 +374,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot; CONFIG_MEDTLS_USE_AFR_MEMORY RVDS_ARMCM4_NUC4xx __little_endian__=1 NDEBUG</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/device_defender_for_aws;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/jsmn</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/device_defender_for_aws;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/freertos_plus/aws/ota/src</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -583,6 +583,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/retarget.c</FilePath>
 						</File>
+                        <File>
+                          <FileName>spim.c</FileName>
+                          <FileType>1</FileType>
+                          <FilePath>..\..\..\..\..\vendors\nuvoton\sdk\StdDriver\src\spim.c</FilePath>
+                        </File>
 					</Files>
 				</Group>
 				<Group>
@@ -2855,6 +2860,61 @@
 						</File>
 					</Files>
 				</Group>
+                <Group>
+                  <GroupName>libraries/freertos_plus/aws/ota/src/</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_iot_ota_agent.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_interface.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_cbor.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_mqtt.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_http.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
+                <Group>
+                  <GroupName>vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_ota_pal.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota\aws_ota_pal.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_ota_pal_spim.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota\aws_ota_pal_spim.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
+                <Group>
+                  <GroupName>demos/ota</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_iot_ota_update_demo.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
 			</Groups>
 		</Target>
 	</Targets>

--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
@@ -377,7 +377,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot;  CONFIG_MEDTLS_USE_AFR_MEMORY RVDS_ARMCM4_NUC4xx __little_endian__=1 NDEBUG M487_ETH_DEMO</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/tools/tcp_utilities/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../demos/common/http_demo_helpers;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/common/pkcs11_helpers;../../../../../demos/device_defender_for_aws;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../tests/integration_test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/tools/tcp_utilities/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../demos/common/http_demo_helpers;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/common/pkcs11_helpers;../../../../../demos/device_defender_for_aws;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../tests/integration_test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/c_sdk/aws/defender/include;../../../../../libraries/c_sdk/standard/mqtt/include;../../../../../libraries/c_sdk/standard/serializer/include;../../../../../libraries/c_sdk/aws/shadow/include;../../../../../libraries/c_sdk/standard/https/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../libraries/freertos_plus/aws/ota/include;../../../../../libraries/freertos_plus/aws/ota/src;</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -581,6 +581,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/retarget.c</FilePath>
 						</File>
+            <File>
+              <FileName>spim.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\sdk\StdDriver\src\spim.c</FilePath>
+            </File>
 					</Files>
 				</Group>
 				<Group>
@@ -2920,10 +2925,65 @@
 							<FileName>jsmn.c</FileName>
 							<FileType>1</FileType>
 							<FilePath>../../../../../libraries/3rdparty/jsmn/jsmn.c</FilePath>
-						</File>
-					</Files>
-				</Group>
-			</Groups>
+                    </File>
+                  </Files>
+                </Group>
+                <Group>
+                  <GroupName>libraries/freertos_plus/aws/ota/src/</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_iot_ota_agent.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_interface.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_cbor.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_mqtt.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_iot_ota_http.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
+                <Group>
+                  <GroupName>vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_ota_pal.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota\aws_ota_pal.c</FilePath>
+                    </File>
+                    <File>
+                      <FileName>aws_ota_pal_spim.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota\aws_ota_pal_spim.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
+                <Group>
+                  <GroupName>demos/ota</GroupName>
+                  <Files>
+                    <File>
+                      <FileName>aws_iot_ota_update_demo.c</FileName>
+                      <FileType>1</FileType>
+                      <FilePath>..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c</FilePath>
+                    </File>
+                  </Files>
+                </Group>
+            </Groups>
 		</Target>
 	</Targets>
 </Project>

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -118,6 +118,7 @@ target_sources(
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/uart.c"
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/retarget.c"
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/gpio.c"
+        "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/spim.c"        
         "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
         "${AFR_KERNEL_DIR}/portable/RVDS/ARM_CM4F/port.c"
         "${board_dir}/application_code/nuvoton_code/entropy_hardware_poll.c"
@@ -149,6 +150,30 @@ target_sources(
         "${afr_ports_dir}/pkcs11/core_pkcs11_pal.c"
 )
 
+# OTA
+afr_mcu_port(ota)
+target_sources(
+    AFR::ota::mcu_port
+    INTERFACE 
+        "${afr_ports_dir}/ota/aws_ota_pal.c"
+        "${afr_ports_dir}/ota/aws_ota_pal_spim.c"
+)
+target_include_directories(
+    AFR::ota::mcu_port
+    INTERFACE
+            "${AFR_ROOT_DIR}/libraries/abstractions/pkcs11/corePKCS11/source/portable/mbedtls/include"
+            "${AFR_ROOT_DIR}/libraries/abstractions/pkcs11/corePKCS11/source/include"
+            "${AFR_ROOT_DIR}//libraries/3rdparty/pkcs11"
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/include"
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/src"
+)
+target_link_libraries(
+    AFR::ota::mcu_port
+    INTERFACE
+        AFR::crypto
+        AFR::ota_mqtt
+        AFR::ota_http
+)
 
 if(AFR_ENABLE_ETH)
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -161,9 +161,8 @@ target_sources(
 target_include_directories(
     AFR::ota::mcu_port
     INTERFACE
-            "${AFR_ROOT_DIR}/libraries/abstractions/pkcs11/corePKCS11/source/portable/mbedtls/include"
             "${AFR_ROOT_DIR}/libraries/abstractions/pkcs11/corePKCS11/source/include"
-            "${AFR_ROOT_DIR}//libraries/3rdparty/pkcs11"
+            "${AFR_ROOT_DIR}/libraries/3rdparty/pkcs11"
             "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/include"
             "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/src"
 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
@@ -159,8 +159,9 @@ int main( void )
     prvMiscInitialization();
     configPRINTF( ( "FreeRTOS App Ver:%x\n", xAppFirmwareVersion));    
     configPRINTF( ( "FreeRTOS_IPInit\n" ) );	
+#ifndef CONFIG_OTA_UPDATE_DEMO_ENABLED
     xTaskCreate( vCheckTask, "Check", mainCHECK_TASK_STACK_SIZE, NULL, mainCHECK_TASK_PRIORITY, NULL );	
-
+#endif
     /* A simple example to demonstrate key and certificate provisioning in
      * microcontroller flash using PKCS#11 interface. This should be replaced
      * by production ready key provisioning mechanism. */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -56,7 +56,7 @@
 #define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
-#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 119 * 1024 ) )
+#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 116 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                      ( 16 )
 #define configUSE_TRACE_FACILITY                     1
 #define configUSE_16_BIT_TICKS                       0

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -27,6 +27,10 @@
 #ifndef FREERTOS_CONFIG_H
 #define FREERTOS_CONFIG_H
 
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+
 /*-----------------------------------------------------------
 * Application specific definitions.
 *

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
@@ -1,0 +1,151 @@
+/*
+ * FreeRTOS V1.4.8
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_ota_agent_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef _AWS_OTA_AGENT_CONFIG_H_
+#define _AWS_OTA_AGENT_CONFIG_H_
+
+/**
+ * @brief The number of words allocated to the stack for the OTA agent.
+ */
+#define otaconfigSTACK_SIZE                     1500U //3584U
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA service so we will only send
+ * the request message after being idle for this amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+
+/**
+ * @brief The OTA agent task priority. Normally it runs at a low priority.
+ */
+#define otaconfigAGENT_PRIORITY                 tskIDLE_PRIORITY
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the broker.
+ * Likewise, the OTA agent requires the developer to construct and pass in the Thing name when
+ * initializing the OTA agent. The agent uses this size to allocate static storage for the
+ * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ *  This configuration parameter is sent with data requests and represents the maximum number of
+ *  data blocks the service will send in response. The maximum limit for this must be calculated
+ *  from the maximum data response limit (128 KB from service) divided by the block size.
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
+ *  how many data blocks response is expected for each data requests.
+ *  Please note that this must be set larger than zero.
+ *
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+
+/**
+ * @brief The maximum number of requests allowed to send without a response before we abort.
+ *
+ * This configuration parameter sets the maximum number of times the requests are made over
+ * the selected communication channel before aborting and returning error.
+ *
+ */
+#define otaconfigMAX_NUM_REQUEST_MOMENTUM       32U
+
+/**
+ * @brief The number of data buffers reserved by the OTA agent.
+ *
+ * This configurations parameter sets the maximum number of static data buffers used by
+ * the OTA agent for job and file data blocks received.
+ */
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
+
+/**
+ * @brief Allow update to same or lower version.
+ *
+ * Set this to 1 to allow downgrade or same version update.This configurations parameter
+ * disables version check and allows update to a same or lower version.This is provided for
+ * testing purpose and it is recommended to always update to higher version and keep this
+ * configuration disabled.
+ */
+#define otaconfigAllowDowngrade              0U
+
+/**
+ * @brief The protocol selected for OTA control operations.
+
+ * This configurations parameter sets the default protocol for all the OTA control
+ * operations like requesting OTA job, updating the job status etc.
+ *
+ * Note - Only MQTT is supported at this time for control operations.
+ */
+#define configENABLED_CONTROL_PROTOCOL       ( OTA_CONTROL_OVER_MQTT )
+
+/**
+ * @brief The protocol selected for OTA data operations.
+
+ * This configurations parameter sets the protocols selected for the data operations
+ * like requesting file blocks from the service.
+ *
+ * Note - Both MQTT and HTTP is supported for data transfer. This configuration parameter
+ * can be set to following -
+ * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
+ * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
+ * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ */
+#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )//( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+
+ /**
+  * @brief The preferred protocol selected for OTA data operations.
+  *
+  * Primary data protocol will be the protocol used for downloading file if more than
+  * one protocol is selected while creating OTA job. Default primary data protocol is MQTT
+  * and following update here to switch to HTTP as primary.
+  *
+  * Note - use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
+  */
+
+#define configOTA_PRIMARY_DATA_PROTOCOL     ( OTA_DATA_OVER_MQTT )
+
+#endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
@@ -33,8 +33,9 @@
 
 /**
  * @brief The number of words allocated to the stack for the OTA agent.
+ * For M487 paltform, Stack size 1500 words is enough for OTA demo & test.
  */
-#define otaconfigSTACK_SIZE                     1500U //3584U
+#define otaconfigSTACK_SIZE                     1500U
 
 /**
  * @brief Log base 2 of the size of the file data block message (excluding the header).
@@ -81,9 +82,11 @@
  *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
  *  how many data blocks response is expected for each data requests.
  *  Please note that this must be set larger than zero.
+ *  For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford number > 2 .
  *
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         2U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.
@@ -99,6 +102,7 @@
  *
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
+ * For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford number > 2 .
  */
 #define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
 
@@ -133,8 +137,9 @@
  * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
  * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
  * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ * For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford OTA_DATA_OVER_HTTP.
  */
-#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )//( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )
 
  /**
   * @brief The preferred protocol selected for OTA data operations.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_ota_agent_config.h
@@ -31,6 +31,10 @@
 #ifndef _AWS_OTA_AGENT_CONFIG_H_
 #define _AWS_OTA_AGENT_CONFIG_H_
 
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+
 /**
  * @brief The number of words allocated to the stack for the OTA agent.
  * For M487 paltform, Stack size 1500 words is enough for OTA demo & test.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
@@ -58,7 +58,7 @@
 #define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 100 )
-#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 252 * 512 ) )
+#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 124 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                      ( 16 )
 #define configUSE_TRACE_FACILITY                     1
 #define configUSE_16_BIT_TICKS                       0

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/FreeRTOSConfig.h
@@ -29,6 +29,11 @@
 #include "unity_internals.h"
 #include "aws_test_runner_config.h"
 
+
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+
 /*-----------------------------------------------------------
 * Application specific definitions.
 *

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_ota_agent_config.h
@@ -1,0 +1,151 @@
+/*
+ * FreeRTOS V1.4.8
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_ota_agent_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef _AWS_OTA_AGENT_CONFIG_H_
+#define _AWS_OTA_AGENT_CONFIG_H_
+
+/**
+ * @brief The number of words allocated to the stack for the OTA agent.
+ */
+#define otaconfigSTACK_SIZE                     1500U //3584U
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA service so we will only send
+ * the request message after being idle for this amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+
+/**
+ * @brief The OTA agent task priority. Normally it runs at a low priority.
+ */
+#define otaconfigAGENT_PRIORITY                 tskIDLE_PRIORITY
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the broker.
+ * Likewise, the OTA agent requires the developer to construct and pass in the Thing name when
+ * initializing the OTA agent. The agent uses this size to allocate static storage for the
+ * Thing name used in all OTA base topics. Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ *  This configuration parameter is sent with data requests and represents the maximum number of
+ *  data blocks the service will send in response. The maximum limit for this must be calculated
+ *  from the maximum data response limit (128 KB from service) divided by the block size.
+ *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
+ *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
+ *  how many data blocks response is expected for each data requests.
+ *  Please note that this must be set larger than zero.
+ *
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+
+/**
+ * @brief The maximum number of requests allowed to send without a response before we abort.
+ *
+ * This configuration parameter sets the maximum number of times the requests are made over
+ * the selected communication channel before aborting and returning error.
+ *
+ */
+#define otaconfigMAX_NUM_REQUEST_MOMENTUM       32U
+
+/**
+ * @brief The number of data buffers reserved by the OTA agent.
+ *
+ * This configurations parameter sets the maximum number of static data buffers used by
+ * the OTA agent for job and file data blocks received.
+ */
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
+
+/**
+ * @brief Allow update to same or lower version.
+ *
+ * Set this to 1 to allow downgrade or same version update.This configurations parameter
+ * disables version check and allows update to a same or lower version.This is provided for
+ * testing purpose and it is recommended to always update to higher version and keep this
+ * configuration disabled.
+ */
+#define otaconfigAllowDowngrade              0U
+
+/**
+ * @brief The protocol selected for OTA control operations.
+
+ * This configurations parameter sets the default protocol for all the OTA control
+ * operations like requesting OTA job, updating the job status etc.
+ *
+ * Note - Only MQTT is supported at this time for control operations.
+ */
+#define configENABLED_CONTROL_PROTOCOL       ( OTA_CONTROL_OVER_MQTT )
+
+/**
+ * @brief The protocol selected for OTA data operations.
+
+ * This configurations parameter sets the protocols selected for the data operations
+ * like requesting file blocks from the service.
+ *
+ * Note - Both MQTT and HTTP is supported for data transfer. This configuration parameter
+ * can be set to following -
+ * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
+ * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
+ * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ */
+#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )//( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+
+ /**
+  * @brief The preferred protocol selected for OTA data operations.
+  *
+  * Primary data protocol will be the protocol used for downloading file if more than
+  * one protocol is selected while creating OTA job. Default primary data protocol is MQTT
+  * and following update here to switch to HTTP as primary.
+  *
+  * Note - use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
+  */
+
+#define configOTA_PRIMARY_DATA_PROTOCOL     ( OTA_DATA_OVER_MQTT )
+
+#endif /* _AWS_OTA_AGENT_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_ota_agent_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_ota_agent_config.h
@@ -33,8 +33,9 @@
 
 /**
  * @brief The number of words allocated to the stack for the OTA agent.
+ * For M487 paltform, Stack size 1500 words is enough for OTA demo & test.
  */
-#define otaconfigSTACK_SIZE                     1500U //3584U
+#define otaconfigSTACK_SIZE                     1500U
 
 /**
  * @brief Log base 2 of the size of the file data block message (excluding the header).
@@ -80,10 +81,11 @@
  *  For example if block size is set as 1 KB then the maximum number of data blocks that we can
  *  request is 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower based on
  *  how many data blocks response is expected for each data requests.
+ *  For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford number > 2 .
  *  Please note that this must be set larger than zero.
  *
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST         4U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         2U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.
@@ -99,6 +101,7 @@
  *
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
+ * For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford number > 2 .
  */
 #define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
 
@@ -133,8 +136,9 @@
  * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
  * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
  * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ * For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford OTA_DATA_OVER_HTTP.
  */
-#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )//( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+#define configENABLED_DATA_PROTOCOLS         ( OTA_DATA_OVER_MQTT )
 
  /**
   * @brief The preferred protocol selected for OTA data operations.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
@@ -1,0 +1,85 @@
+/*
+ * FreeRTOS V1.1.4
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_test_ota_config.h
+ * @brief Port-specific variables for firmware Over-the-Air Update tests. */
+
+#ifndef _AWS_TEST_OTA_CONFIG_H_
+#define _AWS_TEST_OTA_CONFIG_H_
+
+ /**
+ * @brief Path to cert for OTA PAL test. Used to verify signature.
+ * If applicable, the device must be pre-provisioned with this certificate. Please see
+ * test/common/ota/test_files for the set of certificates.
+ *
+ * In the Windows Simultor this is the path to the certificate on your machine. The path currently
+ * here is relative to the FreeRTOS root. If you are debugging locally, Visual Studio may have
+ * your path set as the project directory. In that case this can be changed to:
+ *
+ * #define otatestpalCERTIFICATE_FILE  "..\\..\\..\\..\\..\\libraries\\freertos_plus\\aws\\ota\\test\\test_files\\ecdsa-sha256-signer.crt.pem"
+ */
+#define otatestpalCERTIFICATE_FILE    "libraries\\freertos_plus\\aws\\ota\\test\\test_files\\ecdsa-sha256-signer.crt.pem"
+
+ /**
+ * @brief Some devices have a hard-coded name for the firmware image to boot.
+ */
+#define otatestpalFIRMWARE_FILE  "dummy.bin"
+
+/**
+ * @brief Some boards OTA PAL layers will use the file names passed into it for the
+ * image and the certificates because their non-volatile memory is abstracted by a
+ * file system. Set this to 1 if that is the case for your device.
+ */
+#define otatestpalUSE_FILE_SYSTEM     0
+
+/**
+ * @brief 1 if prvPAL_CheckFileSignature() is implemented in aws_ota_pal.c.
+ */
+#define otatestpalCHECK_FILE_SIGNATURE_SUPPORTED           1
+
+/**
+ * @brief 1 if prvPAL_ReadAndAssumeCertificate() is implemented in aws_ota_pal.c.
+ */
+#define otatestpalREAD_AND_ASSUME_CERTIFICATE_SUPPORTED    1
+
+/**
+ * @brief 1 if using PKCS #11 to access the code sign certificate from NVM.
+ */
+#define otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11    0
+
+ /**
+ * @brief Include of signature testing data applicable to this device.
+ */
+#include "aws_test_ota_pal_ecdsa_sha256_signature.h"
+
+/**
+ * @brief Define a valid and invalid signature verification method for this
+ * platform (Windows). These are used for generating test JSON docs.
+ */
+#define otatestVALID_SIG_METHOD                         "sig-sha256-ecdsa"
+#define otatestINVALID_SIG_METHOD                       "sig-sha256-rsa"
+
+#endif /* ifndef _AWS_TEST_OTA_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
@@ -30,6 +30,10 @@
 #ifndef _AWS_TEST_OTA_CONFIG_H_
 #define _AWS_TEST_OTA_CONFIG_H_
 
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+
  /**
  * @brief Path to cert for OTA PAL test. Used to verify signature.
  * If applicable, the device must be pre-provisioned with this certificate. Please see

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_runner_config.h
@@ -36,11 +36,11 @@
 #define testrunnerFULL_BLE_ENABLED                    testrunnerUNSUPPORTED
 #define testrunnerFULL_BLE_END_TO_END_TEST_ENABLED    testrunnerUNSUPPORTED
 #define testrunnerFULL_OTA_CBOR_ENABLED               testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_AGENT_ENABLED              testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_PAL_ENABLED                testrunnerUNSUPPORTED
 #define testrunnerFULL_MEMORYLEAK_ENABLED             testrunnerUNSUPPORTED
 
 /* Supported tests. 0 = Disabled, 1 = Enabled */
+#define testrunnerFULL_OTA_AGENT_ENABLED              1
+#define testrunnerFULL_OTA_PAL_ENABLED                1
 #define testrunnerFULL_TASKPOOL_ENABLED               0
 #define testrunnerFULL_CBOR_ENABLED                   0
 #define testrunnerFULL_CRYPTO_ENABLED                 0
@@ -56,13 +56,13 @@
 #define testrunnerFULL_CORE_HTTP_ENABLED              0
 #define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED      0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED       0
-#define testrunnerFULL_MQTTv4_ENABLED                 0
+#define testrunnerFULL_MQTTv4_ENABLED                 1
 #define testrunnerFULL_WIFI_ENABLED                   0
 #define testrunnerFULL_PKCS11_ENABLED                 0
 #define testrunnerFULL_POSIX_ENABLED                  0
 #define testrunnerFULL_SHADOW_ENABLED                 0
 #define testrunnerFULL_SHADOWv4_ENABLED               0
-#define testrunnerFULL_TCP_ENABLED                    1
+#define testrunnerFULL_TCP_ENABLED                    0
 #define testrunnerFULL_TLS_ENABLED                    0
 #define testrunnerFULL_SERIALIZER_ENABLED             0
 #define testrunnerUTIL_PLATFORM_CLOCK_ENABLED         0

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal.c
@@ -1,0 +1,886 @@
+/*
+ * FreeRTOS OTA PAL for Nuvoton Numaker-IoT-M487
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* OTA PAL implementation for M487 platform. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "FreeRTOS.h"
+#include "core_pkcs11.h"
+#include "iot_crypto.h"
+#include "aws_iot_ota_pal.h"
+#include "core_pkcs11_config.h"
+#include "aws_ota_codesigner_certificate.h"
+#include "NuMicro.h"
+
+/* Specify the OTA signature algorithm we support on this platform. */
+const char cOTA_JSON_FileSignatureKey[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ] = "sig-sha256-ecdsa";
+
+/* definitions shared with the resident bootloader. */
+#define AWS_BOOT_IMAGE_SIGNATURE         "@AFRTOS"
+#define AWS_BOOT_IMAGE_SIGNATURE_SIZE    ( 7U )
+
+/* PAL error codes. */
+
+#define AWS_BOOT_FLAG_IMG_NEW               0xffU /* 11111111b A new image that hasn't yet been run. */
+#define AWS_BOOT_FLAG_IMG_PENDING_COMMIT    0xfeU /* 11111110b Image is pending commit and is ready for self test. */
+#define AWS_BOOT_FLAG_IMG_VALID             0xfcU /* 11111100b The image was accepted as valid by the self test code. */
+#define AWS_BOOT_FLAG_IMG_INVALID           0xf8U /* 11111000b The image was NOT accepted by the self test code. */
+
+#define NVT_OTA_META_BASE                   ( 0x70000UL )      /* OTA meta data storage start address in APROM  */
+#define NVT_BOOT_IMG_HEAD_BASE              (NVT_OTA_META_BASE)
+#define NVT_BOOT_IMG_TRAIL_BASE             (NVT_OTA_META_BASE + FMC_FLASH_PAGE_SIZE)
+
+/*
+ * Image Header.
+ */
+
+typedef union
+{
+    uint32_t ulAlign[ 2 ]; /* Force image header to be 8 bytes. */
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+    struct
+    {
+        char cImgSignature[ AWS_BOOT_IMAGE_SIGNATURE_SIZE ]; /* Signature identifying a valid application: AWS_BOOT_IMAGE_SIGNATURE. */
+        uint8_t ucImgFlags;                                  /* Flags from the AWS_BOOT_IMAGE_FLAG_IMG*, above. */
+    };                                                       
+} BootImageHeader_t;
+
+
+/* Boot application image descriptor.
+ * Total size is 32 bytes (NVM programming does 4 bytes at a time)
+ * This is the descriptor used by the bootloader
+ * to maintain the application images.
+ */
+typedef struct
+{
+    BootImageHeader_t xImgHeader; /* Application image header (8 bytes). */
+    uint32_t ulSequenceNum;       /* OTA sequence number. Higher is newer. */
+    /* Use byte pointers for image addresses so pointer math doesn't use incorrect scalars. */
+    const uint8_t * pvStartAddr;  /* Image start address. */
+    const uint8_t * pvEndAddr;    /* Image end address. */
+    const uint8_t * pvExecAddr;   /* Execution start address. */
+    uint32_t ulHardwareID;        /* Unique Hardware ID. */
+    uint32_t ulReserved;          /* Reserved. *//*lint -e754 -e830 intentionally unreferenced alignment word. */
+} BootImageDescriptor_t;
+
+//static BootImageDescriptor_t xCurBootImgDesc;         /* current Boot Image in progress. */
+
+/*
+ * Image Trailer.
+ */
+typedef struct
+{
+    uint8_t aucSignatureType[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ]; /* Signature Type. */
+    uint32_t ulSignatureSize;                                    /* Signature size. */
+    uint8_t aucSignature[ kOTA_MaxSignatureSize ];               /* Signature */
+} BootImageTrailer_t;
+
+typedef struct
+{
+    const OTA_FileContext_t * pxCurOTAFile; /* Current OTA file to be processed. */
+    uint32_t ulImageOffset;              /* offset/address of the application image. */
+} OTA_OperationDescriptor_t;
+
+/* NOTE that this implementation supports only one OTA at a time since it uses a single static instance. */
+static OTA_OperationDescriptor_t xCurOTAOpDesc;         /* current OTA operation in progress. */
+static OTA_OperationDescriptor_t * pxCurOTADesc = NULL; /* pointer to current OTA operation. */
+
+static OTA_Err_t prvPAL_CheckFileSignature( OTA_FileContext_t * const C );
+static uint8_t * prvPAL_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize );
+
+/*-----------------------------------------------------------*/
+
+static __inline bool_t prvContextValidate( OTA_FileContext_t * C )
+{
+    return( ( pxCurOTADesc != NULL ) && ( C != NULL ) &&
+            ( pxCurOTADesc->pxCurOTAFile == C ) &&
+            ( C->pucFile == ( uint8_t * ) pxCurOTADesc ) ); /*lint !e9034 This preserves the abstraction layer. */
+}
+
+static __inline void prvContextClose( OTA_FileContext_t * C )
+{
+    if( NULL != C )
+    {
+        C->pucFile = NULL;
+    }
+
+    xCurOTAOpDesc.pxCurOTAFile = NULL;
+    pxCurOTADesc = NULL;
+}
+
+static bool_t prvFLASH_update(uint32_t u32StartAddr, uint8_t * pucData, uint32_t ulDataSize)
+{
+    uint32_t    u32Addr;               /* flash address */
+    uint32_t    u32data;               /* flash data    */
+    uint32_t    *pDataSrc;             /* flash data    */    
+    uint32_t    u32EndAddr = (u32StartAddr + ulDataSize);
+    uint32_t    u32Pattern = 0xFFFFFFFF;
+    bool_t result = pdFALSE;
+    
+    DEFINE_OTA_METHOD_NAME( "prvFLASH_update" );
+
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    FMC_Open();                        /* Enable FMC ISP function */
+    FMC_ENABLE_AP_UPDATE();            /* Enable APROM update. */
+    FMC_Erase(u32StartAddr);    
+     /* Verify if each data word from flash u32StartAddr to u32EndAddr be 0xFFFFFFFF.  */
+    for (u32Addr = u32StartAddr; u32Addr < u32EndAddr; u32Addr += 4)
+    {
+        u32data = FMC_Read(u32Addr);   /* Read a flash word from address u32Addr. */
+
+        if (u32data != u32Pattern )     /* Verify if data matched. */
+        {
+            OTA_LOG_L1( "[%s] FMC_Read data verify failed at address 0x%x, read=0x%x, expect=0x%x\n", OTA_METHOD_NAME, u32Addr, u32data, u32Pattern);   
+            result = pdFALSE;                 /* data verify failed */
+            goto lexit;
+        }
+    }
+    
+    pDataSrc = (uint32_t *) pucData;
+    /* Fill flash range from u32StartAddr to u32EndAddr */
+    for (u32Addr = u32StartAddr; u32Addr < u32EndAddr; u32Addr += 4)
+    {
+        FMC_Write(u32Addr, *pDataSrc);          /* Program flash */
+        //printf("#### FMC write: 0x%x, val:0x%x \n", u32Addr, *pDataSrc);
+        pDataSrc++;
+    }    
+    result = pdTRUE; 
+    
+lexit:   
+    FMC_DISABLE_AP_UPDATE();           /* Disable APROM update. */
+    FMC_Close();                       /* Disable FMC ISP function */
+    /* Lock protected registers */
+    SYS_LockReg();   
+    
+    return result;
+    
+}
+
+static bool_t prvSPI_FLASH_EraseBank()
+{
+#define SPI_BANK_START  0x00
+#define SPI_BANK_SIZE   0x80000
+  bool_t result = pdFALSE;
+  // FIX ME
+  /* Erase SPI flash 512KB bank before program. */
+  result = NVT_SPI_Flash_Bank_Erase(SPI_BANK_START, SPI_BANK_SIZE);
+  return result;
+}
+
+static bool_t prvContextUpdateImageHeaderAndTrailer( OTA_FileContext_t * C )
+{    
+    DEFINE_OTA_METHOD_NAME( "prvContextUpdateImageHeaderAndTrailer" );
+
+    bool_t bProgResult;
+    BootImageHeader_t xImgHeader;
+    BootImageDescriptor_t * pxImgDesc;
+    BootImageDescriptor_t xImgDesc;    
+    BootImageTrailer_t xImgTrailer;
+
+    /* Pointer to the boot image header in the flash. */
+    pxImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+    xImgDesc = *pxImgDesc;
+    xImgDesc.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_NEW;
+    
+    /* Write Boot header to flash. */
+    bProgResult = prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, 
+                                    (uint8_t *)&xImgDesc, 
+                                    sizeof( BootImageDescriptor_t) );
+    
+    OTA_LOG_L1( "[%s] OTA Sequence Number: %d\r\n", OTA_METHOD_NAME, pxImgDesc->ulSequenceNum );
+    OTA_LOG_L1( "[%s] Image - Start: 0x%08x, End: 0x%08x\r\n", OTA_METHOD_NAME,
+                pxImgDesc->pvStartAddr, pxImgDesc->pvEndAddr );
+
+    /* If header write is successful write trailer. */
+    if( bProgResult )
+    {
+        /* Create image trailer. */
+        memcpy( xImgTrailer.aucSignatureType, cOTA_JSON_FileSignatureKey, sizeof( cOTA_JSON_FileSignatureKey ) );
+        xImgTrailer.ulSignatureSize = C->pxSignature->usSize;
+        memcpy( xImgTrailer.aucSignature, C->pxSignature->ucData, C->pxSignature->usSize );
+
+        /* Write trailer to flash. */
+        bProgResult = prvFLASH_update(NVT_BOOT_IMG_TRAIL_BASE, (uint8_t *)&xImgTrailer, sizeof( xImgTrailer));        
+        OTA_LOG_L1( "[%s] Writing Trailer at: 0x%08x\n", OTA_METHOD_NAME, NVT_BOOT_IMG_TRAIL_BASE );
+    }
+
+    return bProgResult;
+}
+
+
+
+/* Attempt to create a new receive file for the file chunks as they come in. */
+
+OTA_Err_t prvPAL_CreateFileForRx( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CreateFileForRx" );
+
+    OTA_Err_t eResult = kOTA_Err_Uninitialized; /* For MISRA mandatory. */
+
+    if( C != NULL )
+    {
+        if( NVT_SPI_Flash_Init() == ( bool_t ) pdFALSE )
+        {
+            eResult = kOTA_Err_RxFileCreateFailed;
+            OTA_LOG_L1( "[%s] ERROR - Failed to init SPI Flash.\r\n", OTA_METHOD_NAME );
+            return eResult;
+        }
+         
+        /* Erase SPI flash 512KB bank before program. */
+        if( prvSPI_FLASH_EraseBank() == ( bool_t ) pdFALSE )
+        {
+            OTA_LOG_L1( "[%s] Error: Failed to erase the flash!\r\n", OTA_METHOD_NAME );
+            eResult = kOTA_Err_RxFileCreateFailed;
+        }
+        else
+        {
+            pxCurOTADesc = &xCurOTAOpDesc;
+            pxCurOTADesc->pxCurOTAFile = C;
+            pxCurOTADesc->ulImageOffset = 0;
+            OTA_LOG_L1( "[%s] Receive file created.\r\n", OTA_METHOD_NAME );
+            C->pucFile = ( uint8_t * ) pxCurOTADesc;
+            
+            /* Update Boot Descriptor */
+            BootImageDescriptor_t xDescCopy;
+            memcpy(xDescCopy.xImgHeader.cImgSignature, AWS_BOOT_IMAGE_SIGNATURE, AWS_BOOT_IMAGE_SIGNATURE_SIZE);
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+            xDescCopy.pvStartAddr = 0x00;
+            xDescCopy.pvEndAddr = xDescCopy.pvStartAddr + C->ulFileSize -1;
+            xDescCopy.pvExecAddr = 0x00;
+
+            if( pdFALSE == prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                            sizeof( BootImageDescriptor_t) ) )
+            {
+                OTA_LOG_L1( "[%s] ERROR - FMC write failed\r\n", OTA_METHOD_NAME );
+            } 
+            else 
+            {
+            
+                eResult = kOTA_Err_None;
+            }
+        }
+    }
+    else
+    {
+        eResult = kOTA_Err_RxFileCreateFailed;
+        OTA_LOG_L1( "[%s] ERROR - Invalid context provided.\r\n", OTA_METHOD_NAME );
+    }
+
+    return eResult; /*lint !e480 !e481 Exiting function without calling fclose.
+                     * Context file handle state is managed by this API. */
+}
+
+
+/* Abort receiving the specified OTA update by closing the file. */
+
+OTA_Err_t prvPAL_Abort( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_Abort" );
+
+    /* Check for null file handle since we may call this before a file is actually opened. */
+    prvContextClose( C );
+    OTA_LOG_L1( "[%s] Abort - OK\r\n", OTA_METHOD_NAME );
+
+    return kOTA_Err_None;
+}
+
+/* Write a block of data to the specified file. 
+   Returns the number of bytes written on success or negative error code.
+*/
+int16_t prvPAL_WriteBlock( OTA_FileContext_t * const C,
+                           uint32_t ulOffset,
+                           uint8_t * const pacData,
+                           uint32_t ulBlockSize )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_WriteBlock" );
+
+    int32_t lResult = 0;
+
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+#if 0
+        /* If execute image not generate boot-descriptor by utility, 1st block will have no boot-desc info */
+        /* OTA image 1st block contain Boot Image Descriptor info */
+        if( ulOffset == 0 ) 
+        {
+            BootImageDescriptor_t xDescCopy;
+            const BootImageDescriptor_t * pxAppImgDesc;
+            pxAppImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+            xDescCopy = *pxAppImgDesc;           /* Copy image descriptor from flash into RAM struct. */
+            memcpy((uint8_t *)&(xDescCopy.ulSequenceNum), pacData, 
+            sizeof(xDescCopy) - sizeof(BootImageHeader_t) );
+            if( pdFALSE == prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                            sizeof( BootImageDescriptor_t) ) )
+            {
+                OTA_LOG_L1( "[%s] ERROR - FMC write failed\r\n", OTA_METHOD_NAME );
+            }
+        }
+#endif        
+        lResult = NVT_SPI_Flash_Block_Write(ulOffset, pacData, ulBlockSize);
+
+        if( lResult < 0 )
+        {
+                OTA_LOG_L1( "[%s] ERROR - SPI Flash write failed\r\n", OTA_METHOD_NAME );
+                /* Mask to return a negative value. */
+                lResult = -1; /*lint !e40 !e9027
+                                                                * Errno is being used in accordance with host API documentation.
+                                                                * Bitmasking is being used to preserve host API error with library status code. */
+        }
+    }
+    else /* Invalid context or file pointer provided. */
+    {
+        OTA_LOG_L1( "[%s] ERROR - Invalid context.\r\n", OTA_METHOD_NAME );
+        lResult = -1; /*TODO: Need a negative error code from the PAL here. */
+    }
+
+    return ( int16_t ) lResult;
+}
+
+/* Close the specified file. This shall authenticate the file if it is marked as secure. */
+
+OTA_Err_t prvPAL_CloseFile( OTA_FileContext_t * const C )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CloseFile" );
+
+    OTA_Err_t eResult = kOTA_Err_None;
+    int32_t lWindowsError = 0;
+
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+        if( C->pxSignature != NULL )
+        {
+            /* Verify the file signature, close the file and return the signature verification result. */
+            eResult = prvPAL_CheckFileSignature( C );
+        }
+        else
+        {
+            OTA_LOG_L1( "[%s] ERROR - NULL OTA Signature structure.\r\n", OTA_METHOD_NAME );
+            eResult = kOTA_Err_SignatureCheckFailed;
+        }
+
+        if( eResult == kOTA_Err_None )
+        {
+            OTA_LOG_L1( "[%s] %s signature verification passed.\r\n", OTA_METHOD_NAME, cOTA_JSON_FileSignatureKey );
+            if( prvContextUpdateImageHeaderAndTrailer( C ) == ( bool_t ) pdTRUE )
+            {
+                OTA_LOG_L1( "[%s] Image header updated.\r\n", OTA_METHOD_NAME );
+            }
+            else
+            {
+                OTA_LOG_L1( "[%s] ERROR: Failed to update the image header.\r\n", OTA_METHOD_NAME );
+                eResult = kOTA_Err_FileClose;
+            }
+        }
+        else
+        {
+            OTA_LOG_L1( "[%s] ERROR - Failed to pass %s signature verification: %d.\r\n", OTA_METHOD_NAME,
+                        cOTA_JSON_FileSignatureKey, eResult );
+
+			/* If we fail to verify the file signature that means the image is not valid. We need to set the image state to aborted. */
+			prvPAL_SetPlatformImageState( eOTA_ImageState_Aborted );
+
+        }
+    }
+    else /* Invalid OTA Context. */
+    {
+        /* FIXME: Invalid error code for a null file context and file handle. */
+        OTA_LOG_L1( "[%s] ERROR - Invalid context.\r\n", OTA_METHOD_NAME );
+        eResult = kOTA_Err_FileClose;
+    }
+    
+    prvContextClose( C );
+    return eResult;
+}
+
+
+/* Verify the signature of the specified file. */
+
+static OTA_Err_t prvPAL_CheckFileSignature( OTA_FileContext_t * const C )
+{
+#ifdef __ICCARM__
+#pragma data_alignment=4
+    uint8_t  ucBuff[512];
+#else
+    uint8_t  ucBuff[512] __attribute__((aligned(4)));
+#endif
+
+    DEFINE_OTA_METHOD_NAME( "prvPAL_CheckFileSignature" );
+
+    OTA_Err_t eResult = kOTA_Err_None;
+    uint32_t ulBytesRead, ulOffset;
+    uint32_t ulSignerCertSize;
+    uint8_t * pucBuf, * pucSignerCert;
+    void * pvSigVerifyContext;
+
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+        /* Verify an ECDSA-SHA256 signature. */
+        if( pdFALSE == CRYPTO_SignatureVerificationStart( &pvSigVerifyContext, cryptoASYMMETRIC_ALGORITHM_ECDSA, cryptoHASH_ALGORITHM_SHA256 ) )
+        {
+            eResult = kOTA_Err_SignatureCheckFailed;
+        }
+        else
+        {
+            OTA_LOG_L1( "[%s] Started %s signature verification, file: %s\r\n", OTA_METHOD_NAME,
+                        cOTA_JSON_FileSignatureKey, ( const char * ) C->pucCertFilepath );
+            pucSignerCert = prvPAL_ReadAndAssumeCertificate( ( const uint8_t * const ) C->pucCertFilepath, &ulSignerCertSize );
+
+            if( pucSignerCert != NULL )
+            {
+                /* if ulFileSize not correct, alternative by  xCurBootImgDesc.pvEndAddr - prvStAddr + (sizeof( BootImageDescriptor_t) - sizeof( BootImageHeader_t)) */
+                for( ulOffset=0; ulOffset < C->ulFileSize; ulOffset+= sizeof(ucBuff) )
+                {
+                    if( (C->ulFileSize - ulOffset) > sizeof(ucBuff) )
+                        ulBytesRead = NVT_SPI_Flash_Block_Read(ulOffset, ucBuff, sizeof(ucBuff));
+                    else
+                        ulBytesRead = NVT_SPI_Flash_Block_Read(ulOffset, ucBuff, (C->ulFileSize - ulOffset));
+                    /* Include the file chunk in the signature validation. Zero size is OK. */
+                    CRYPTO_SignatureVerificationUpdate( pvSigVerifyContext, ucBuff, ulBytesRead );
+                }
+
+                if( CRYPTO_SignatureVerificationFinal( pvSigVerifyContext, ( char * ) pucSignerCert,
+                                                       ulSignerCertSize, C->pxSignature->ucData, 
+                                                       C->pxSignature->usSize ) == pdFALSE )
+                {
+                    eResult = kOTA_Err_SignatureCheckFailed;
+                    OTA_LOG_L1( "[%s] ERROR - Signature Verification Failed.\r\n", OTA_METHOD_NAME );
+                    /* Erase the image as signature verification failed.*/
+//                    prvSPI_FLASH_EraseBank();
+                }
+                else
+                {
+                    eResult = kOTA_Err_None;
+                }
+ 
+            }
+            else
+            {
+                eResult = kOTA_Err_BadSignerCert;
+            }
+        }
+    }
+    else
+    {
+        /* FIXME: Invalid error code for a NULL file context. */
+        OTA_LOG_L1( "[%s] ERROR - Invalid OTA file context.\r\n", OTA_METHOD_NAME );
+        /* Invalid OTA context or file pointer. */
+        eResult = kOTA_Err_NullFilePtr;
+    }
+
+    /* Free the signer certificate that we now own after prvPAL_ReadAndAssumeCertificate(). */
+    if( pucSignerCert != NULL )
+    {
+        vPortFree( pucSignerCert );
+    }
+ 
+    return eResult;
+}
+
+
+static CK_RV prvGetCertificateHandle( CK_FUNCTION_LIST_PTR pxFunctionList,
+                                      CK_SESSION_HANDLE xSession,
+                                      const char * pcLabelName,
+                                      CK_OBJECT_HANDLE_PTR pxCertHandle )
+{
+    CK_ATTRIBUTE xTemplate;
+    CK_RV xResult = CKR_OK;
+    CK_ULONG ulCount = 0;
+    CK_BBOOL xFindInit = CK_FALSE;
+
+    /* Get the certificate handle. */
+    if( 0 == xResult )
+    {
+        xTemplate.type = CKA_LABEL;
+        xTemplate.ulValueLen = strlen( pcLabelName ) + 1;
+        xTemplate.pValue = ( char * ) pcLabelName;
+        xResult = pxFunctionList->C_FindObjectsInit( xSession, &xTemplate, 1 );
+    }
+
+    if( 0 == xResult )
+    {
+        xFindInit = CK_TRUE;
+        xResult = pxFunctionList->C_FindObjects( xSession,
+                                                 ( CK_OBJECT_HANDLE_PTR ) pxCertHandle,
+                                                 1,
+                                                 &ulCount );
+    }
+
+    if( CK_TRUE == xFindInit )
+    {
+        xResult = pxFunctionList->C_FindObjectsFinal( xSession );
+    }
+
+    return xResult;
+}
+
+/* Note that this function mallocs a buffer for the certificate to reside in,
+ * and it is the responsibility of the caller to free the buffer. */
+static CK_RV prvGetCertificate( const char * pcLabelName,
+                                uint8_t ** ppucData,
+                                uint32_t * pulDataSize )
+{
+    /* Find the certificate */
+    CK_OBJECT_HANDLE xHandle;
+    CK_RV xResult;
+    CK_FUNCTION_LIST_PTR xFunctionList;
+    CK_SLOT_ID xSlotId;
+    CK_ULONG xCount = 1;
+    CK_SESSION_HANDLE xSession;
+    CK_ATTRIBUTE xTemplate = { 0 };
+    uint8_t * pucCert = NULL;
+    CK_BBOOL xSessionOpen = CK_FALSE;
+
+    xResult = C_GetFunctionList( &xFunctionList );
+
+    if( CKR_OK == xResult )
+    {
+        xResult = xFunctionList->C_Initialize( NULL );
+    }
+
+    if( ( CKR_OK == xResult ) || ( CKR_CRYPTOKI_ALREADY_INITIALIZED == xResult ) )
+    {
+        xResult = xFunctionList->C_GetSlotList( CK_TRUE, &xSlotId, &xCount );
+    }
+
+    if( CKR_OK == xResult )
+    {
+        xResult = xFunctionList->C_OpenSession( xSlotId, CKF_SERIAL_SESSION, NULL, NULL, &xSession );
+    }
+
+    if( CKR_OK == xResult )
+    {
+        xSessionOpen = CK_TRUE;
+        xResult = prvGetCertificateHandle( xFunctionList, xSession, pcLabelName, &xHandle );
+    }
+
+    if( ( xHandle != 0 ) && ( xResult == CKR_OK ) ) /* 0 is an invalid handle */
+    {
+        /* Get the length of the certificate */
+        xTemplate.type = CKA_VALUE;
+        xTemplate.pValue = NULL;
+        xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
+
+        if( xResult == CKR_OK )
+        {
+            pucCert = pvPortMalloc( xTemplate.ulValueLen );
+        }
+
+        if( ( xResult == CKR_OK ) && ( pucCert == NULL ) )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        if( xResult == CKR_OK )
+        {
+            xTemplate.pValue = pucCert;
+            xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
+
+            if( xResult == CKR_OK )
+            {
+                *ppucData = pucCert;
+                *pulDataSize = xTemplate.ulValueLen;
+            }
+            else
+            {
+                vPortFree( pucCert );
+            }
+        }
+    }
+    else /* Certificate was not found. */
+    {
+        *ppucData = NULL;
+        *pulDataSize = 0;
+    }
+
+    if( xSessionOpen == CK_TRUE )
+    {
+        ( void ) xFunctionList->C_CloseSession( xSession );
+    }
+
+    return xResult;
+}
+
+
+/* Read the specified signer certificate from the FMC into a local buffer. The allocated
+ * memory becomes the property of the caller who is responsible for freeing it.
+ */
+
+static uint8_t * prvPAL_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_ReadAndAssumeCertificate" );
+
+    uint8_t * pucCertData;
+    uint32_t ulCertSize;
+    uint8_t * pucSignerCert = NULL;
+    CK_RV xResult;
+
+    xResult = prvGetCertificate( ( const char * ) pucCertName, &pucSignerCert, ulSignerCertSize );
+
+    if( ( xResult == CKR_OK ) && ( pucSignerCert != NULL ) )
+    {
+        OTA_LOG_L1( "[%s] Using cert with label: %s OK\r\n", OTA_METHOD_NAME, ( const char * ) pucCertName );
+    }
+    else
+    {
+        OTA_LOG_L1( "[%s] No such certificate file: %s. Using aws_ota_codesigner_certificate.h.\r\n", OTA_METHOD_NAME,
+                    ( const char * ) pucCertName );
+
+        /* Allocate memory for the signer certificate plus a terminating zero so we can copy it and return to the caller. */
+        ulCertSize = sizeof( signingcredentialSIGNING_CERTIFICATE_PEM );
+        pucSignerCert = pvPortMalloc( ulCertSize + 1 );                       /*lint !e9029 !e9079 !e838 malloc proto requires void*. */
+        pucCertData = ( uint8_t * ) signingcredentialSIGNING_CERTIFICATE_PEM; /*lint !e9005 we don't modify the cert but it could be set by PKCS11 so it's not const. */
+
+        if( pucSignerCert != NULL )
+        {
+            memcpy( pucSignerCert, pucCertData, ulCertSize );
+            /* The crypto code requires the terminating zero to be part of the length so add 1 to the size. */
+            pucSignerCert[ ulCertSize ] = 0U;
+            *ulSignerCertSize = ulCertSize + 1U;
+        }
+        else
+        {
+            OTA_LOG_L1( "[%s] Error: No memory for certificate of size %d!\r\n", OTA_METHOD_NAME, ulCertSize );
+        }
+    }
+
+    return pucSignerCert;
+}
+
+
+/*-----------------------------------------------------------*/
+#define OTA_DELAY       ( ( portTickType ) 1000 / portTICK_RATE_MS )
+
+OTA_Err_t prvPAL_ResetDevice( void )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_ResetDevice" );
+    
+    portTickType xLastExecutionTime = xTaskGetTickCount();
+    OTA_LOG_L1( "[%s] Resetting the device.\r\n", OTA_METHOD_NAME );
+
+    /* Short delay for debug log output before reset. */
+    vTaskDelayUntil( &xLastExecutionTime, OTA_DELAY );
+
+    /* Unlock protected registers before setting Brown-out detector function and Power-down mode */    
+    SYS_UnlockReg();
+    FMC_Open();
+    // Boot From LD-ROM
+    /*
+        CONFIG0[7:6]
+        00 = Boot from LDROM with IAP mode.
+        01 = Boot from LDROM without IAP mode.
+        10 = Boot from APROM with IAP mode.
+        11 = Boot from APROM without IAP mode.
+    */
+    uint32_t  au32Config[2];
+    if( FMC_ReadConfig(au32Config, 2) < 0)
+    {
+          OTA_LOG_L1( " Read FMC config failed.\r\n");
+    }
+    if( (au32Config[0] & 0x40) )        /* Check if it's boot from APROM/LDROM with IAP. */
+    {
+        FMC_ENABLE_CFG_UPDATE();       /* Enable User Configuration update. */
+        au32Config[0] &= ~0x40;        /* Select IAP boot mode. */
+        FMC_WriteConfig(au32Config, 2);/* Update User Configuration CONFIG0 and CONFIG1. */
+        SYS_ResetChip();    /* Perform chip reset to make new User Config take effect. */
+    }
+    /* Remap to LD-ROM*/
+    FMC_SetVectorPageAddr(FMC_LDROM_BASE);    // Remap to LD-ROM address       
+    SYS_ResetCPU();
+    while(1);
+    
+    /* We shouldn't actually get here if the board supports the auto reset.
+     * But, it doesn't hurt anything if we do although someone will need to
+     * reset the device for the new image to boot. */
+    return kOTA_Err_None;
+}
+
+/*-----------------------------------------------------------*/
+
+OTA_Err_t prvPAL_ActivateNewImage( void )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_ActivateNewImage" );
+
+    OTA_LOG_L1( "[%s] Activating the new MCU image.\r\n", OTA_METHOD_NAME );
+    return prvPAL_ResetDevice();
+}
+
+
+/*
+ * Set the final state of the last transferred (final) OTA file (or bundle).
+ * The state of the OTA image is stored in FMC header.
+ */
+
+OTA_Err_t prvPAL_SetPlatformImageState( OTA_ImageState_t eState )
+{
+    DEFINE_OTA_METHOD_NAME( "prvPAL_SetPlatformImageState" );
+    BootImageDescriptor_t xDescCopy;
+    OTA_Err_t eResult = kOTA_Err_Uninitialized;
+
+    /* Descriptor handle for the image. */
+    const BootImageDescriptor_t * pxAppImgDesc;
+    pxAppImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+    xDescCopy = *pxAppImgDesc;                    /* Copy image descriptor from flash into RAM struct. */
+
+    
+    if( (eState == eOTA_ImageState_Unknown) || (eState > eOTA_LastImageState) )
+    {
+        OTA_LOG_L1( "[%s] ERROR - Invalid image state provided.\r\n", OTA_METHOD_NAME );
+        eResult = kOTA_Err_BadImageState;
+    } /*lint !e481 Allow fopen and fclose calls in this context. */
+    else /* Image state valid. */    
+    /* This should be an image launched in self test mode! */
+//    if( xDescCopy.xImgHeader.ucImgFlags == AWS_BOOT_FLAG_IMG_PENDING_COMMIT )
+    {
+        if( eState == eOTA_ImageState_Accepted )
+        {
+            /* Mark the image as valid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_VALID;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == ( bool_t ) pdTRUE )
+            {
+                OTA_LOG_L1( "[%s] Accepted and committed final image.\r\n", OTA_METHOD_NAME );
+                eResult = kOTA_Err_None;
+            }
+            else
+            {
+                OTA_LOG_L1( "[%s] Accepted final image but commit failed (%d).\r\n", OTA_METHOD_NAME);
+                eResult = ( uint32_t ) kOTA_Err_CommitFailed;
+            }
+        }
+        else if( eState == eOTA_ImageState_Rejected )
+        {
+            /* Mark the image as invalid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == ( bool_t ) pdTRUE )
+            {
+                OTA_LOG_L1( "[%s] Rejected image.\r\n", OTA_METHOD_NAME );
+
+                eResult = kOTA_Err_None;
+            }
+            else
+            {
+                OTA_LOG_L1( "[%s] Failed updating the flags.\r\n", OTA_METHOD_NAME );
+                eResult = ( uint32_t ) kOTA_Err_RejectFailed;
+            }
+        }
+        else if( eState == eOTA_ImageState_Aborted )
+        {
+            /* Mark the image as invalid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == ( bool_t ) pdTRUE )
+            {
+                OTA_LOG_L1( "[%s] Aborted image.\r\n", OTA_METHOD_NAME );
+
+                eResult = kOTA_Err_None;
+            }
+            else
+            {
+                OTA_LOG_L1( "[%s] Failed updating the flags.\r\n", OTA_METHOD_NAME);
+                eResult = ( uint32_t ) kOTA_Err_AbortFailed ;
+            }
+        }
+        else if( eState == eOTA_ImageState_Testing )
+        {
+            eResult = kOTA_Err_None;
+        }
+        else
+        {
+            OTA_LOG_L1( "[%s] Unknown state received %d.\r\n", OTA_METHOD_NAME, ( int32_t ) eState );
+            eResult = kOTA_Err_BadImageState;
+        }
+    }
+
+    OTA_LOG_L1( "[%s] image state [%d] ---Flag[0x%x].\r\n", OTA_METHOD_NAME, eState, xDescCopy.xImgHeader.ucImgFlags);
+    return eResult;
+}
+
+/* Get the state of the currently running image.
+ *
+ * This is simulated by looking for and reading the state from
+ * FMC Boot Image Header.
+ *
+ * We read this at OTA_Init time so we can tell if the MCU image is in self
+ * test mode. If it is, we expect a successful connection to the OTA services
+ * within a reasonable amount of time. If we don't satisfy that requirement,
+ * we assume there is something wrong with the firmware and reset the device,
+ * causing it to rollback to the previous code. On Windows, this is not
+ * fully simulated as there is no easy way to reset the simulated device.
+ */
+OTA_PAL_ImageState_t prvPAL_GetPlatformImageState( void )
+{
+    BootImageDescriptor_t xDescCopy;
+    OTA_PAL_ImageState_t eImageState = eOTA_PAL_ImageState_Unknown; //eOTA_PAL_ImageState_Invalid;
+    const BootImageDescriptor_t * pxAppImgDesc;
+    DEFINE_OTA_METHOD_NAME( "prvPAL_GetPlatformImageState" );
+
+    pxAppImgDesc = ( const BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE; /*lint !e923 !e9027 !e9029 !e9033 !e9079 !e9078 !e9087 Please see earlier lint comment header. */
+    xDescCopy = *pxAppImgDesc;
+
+    /**
+     *  Check if valid magic code is present for the application image.
+     */
+    if( memcmp( pxAppImgDesc->xImgHeader.cImgSignature,
+                AWS_BOOT_IMAGE_SIGNATURE,
+                AWS_BOOT_IMAGE_SIGNATURE_SIZE ) == 0 )
+    {
+
+        switch( xDescCopy.xImgHeader.ucImgFlags )
+        {
+            case AWS_BOOT_FLAG_IMG_PENDING_COMMIT:
+                eImageState = eOTA_PAL_ImageState_PendingCommit;
+                break;
+            case AWS_BOOT_FLAG_IMG_VALID:
+            case AWS_BOOT_FLAG_IMG_NEW:
+                eImageState = eOTA_PAL_ImageState_Valid;
+                break;
+
+            default:
+                eImageState = eOTA_PAL_ImageState_Invalid;
+                break;
+        }
+            
+        
+    }
+    OTA_LOG_L1( "[%s] image state [%d] -- Flag[0x%x].\r\n", OTA_METHOD_NAME, eImageState, xDescCopy.xImgHeader.ucImgFlags);
+    return eImageState;
+}
+
+/*-----------------------------------------------------------*/
+
+/* Provide access to private members for testing. */
+#ifdef FREERTOS_ENABLE_UNIT_TESTS
+#include "aws_ota_pal_test_access_define.h"
+#endif

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal.c
@@ -764,8 +764,9 @@ OTA_Err_t prvPAL_SetPlatformImageState( OTA_ImageState_t eState )
             /* Mark the image as valid */
             xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_VALID;
 
-            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
-                                sizeof( BootImageDescriptor_t) ) == ( bool_t ) pdTRUE )
+            if( (xCurOTAOpDesc.pxCurOTAFile == NULL) &&
+                (prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == ( bool_t ) pdTRUE) )
             {
                 OTA_LOG_L1( "[%s] Accepted and committed final image.\r\n", OTA_METHOD_NAME );
                 eResult = kOTA_Err_None;

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal_spim.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota/aws_ota_pal_spim.c
@@ -1,0 +1,214 @@
+/*
+ * FreeRTOS OTA PAL for Nuvoton Numaker-IoT-M487
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+ /* OTA SPI Flash implementation for M487 platform. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "FreeRTOS.h"
+#include "aws_iot_ota_pal.h"
+
+#include "NuMicro.h"
+
+#define USE_4_BYTES_MODE            0            /* SPI Flash W25Q20 does not support 4-bytes address mode. */
+
+#define FLASH_BANK_UB               (8*64*1024)    /* Flash bank boundary. Depend on the physical flash. */
+#define FLASH_BLOCK_SIZE            (64*1024)
+
+#define BUFFER_SIZE                 512//2048
+
+#ifdef __ICCARM__
+#pragma data_alignment=4
+static uint8_t  spi_buff[BUFFER_SIZE];
+#else
+static uint8_t  spi_buff[BUFFER_SIZE] __attribute__((aligned(4)));
+#endif
+
+bool_t NVT_SPI_Flash_Init(void)
+{
+    uint8_t     idBuf[3];
+    bool_t result = pdFALSE;
+
+    DEFINE_OTA_METHOD_NAME( "NVT_SPI_Flash_Init" );    
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    /* Enable SPIM module clock */
+    CLK_EnableModuleClock(SPIM_MODULE);
+    
+    /* Init SPIM multi-function pins, MOSI(PC.0), MISO(PC.1), CLK(PC.2), SS(PC.3), D3(PC.4), and D2(PC.5) */
+    SYS->GPC_MFPL &= ~(SYS_GPC_MFPL_PC0MFP_Msk | SYS_GPC_MFPL_PC1MFP_Msk | SYS_GPC_MFPL_PC2MFP_Msk |
+                       SYS_GPC_MFPL_PC3MFP_Msk | SYS_GPC_MFPL_PC4MFP_Msk | SYS_GPC_MFPL_PC5MFP_Msk);
+    SYS->GPC_MFPL |= SYS_GPC_MFPL_PC0MFP_SPIM_MOSI | SYS_GPC_MFPL_PC1MFP_SPIM_MISO |
+                     SYS_GPC_MFPL_PC2MFP_SPIM_CLK | SYS_GPC_MFPL_PC3MFP_SPIM_SS |
+                     SYS_GPC_MFPL_PC4MFP_SPIM_D3 | SYS_GPC_MFPL_PC5MFP_SPIM_D2;
+    PC->SMTEN |= GPIO_SMTEN_SMTEN2_Msk;
+
+    /* Set SPIM I/O pins as high slew rate up to 80 MHz. */
+    PC->SLEWCTL = (PC->SLEWCTL & 0xFFFFF000) |
+                  (0x1<<GPIO_SLEWCTL_HSREN0_Pos) | (0x1<<GPIO_SLEWCTL_HSREN1_Pos) |
+                  (0x1<<GPIO_SLEWCTL_HSREN2_Pos) | (0x1<<GPIO_SLEWCTL_HSREN3_Pos) |
+                  (0x1<<GPIO_SLEWCTL_HSREN4_Pos) | (0x1<<GPIO_SLEWCTL_HSREN5_Pos);
+
+    SPIM_SET_CLOCK_DIVIDER(1);        /* Set SPIM clock as HCLK divided by 2 */
+
+    SPIM_SET_RXCLKDLY_RDDLYSEL(0);    /* Insert 0 delay cycle. Adjust the sampling clock of received data to latch the correct data. */
+    SPIM_SET_RXCLKDLY_RDEDGE();       /* Use SPI input clock rising edge to sample received data. */
+
+    SPIM_SET_DCNUM(8);                /* Set 8 dummy cycle. */
+
+    if (SPIM_InitFlash(1) != 0)        /* Initialized SPI flash */
+    {
+        OTA_LOG_L1("[%s] SPIM flash initialize failed!\n", OTA_METHOD_NAME);
+        goto lexit;
+    }
+
+    SPIM_ReadJedecId(idBuf, sizeof (idBuf), 1);
+    OTA_LOG_L1("[%s] SPIM get JEDEC ID=0x%02X, 0x%02X, 0x%02X\n", OTA_METHOD_NAME, idBuf[0], idBuf[1], idBuf[2]);
+    if( (idBuf[0] != 0xef) || (idBuf[1] != 0x40) || (idBuf[2] != 0x16) )
+    {
+        OTA_LOG_L1("[%s] SPIM get wrong JEDEC ID\n", OTA_METHOD_NAME);
+        goto lexit;
+    }    
+    SPIM_Enable_4Bytes_Mode(USE_4_BYTES_MODE, 1);
+    result = pdTRUE;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();    
+    return result;
+}
+
+bool_t NVT_SPI_Flash_Bank_Erase(uint32_t startAddress, uint32_t bankSize)
+{
+    uint32_t    i, offset;             /* variables */
+    uint32_t    *pData;
+    bool_t result = pdFALSE;
+
+    DEFINE_OTA_METHOD_NAME( "NVT_SPI_Flash_Bank_Erase" ); 
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    /*
+     *  Erase flash page
+     */
+    if( (startAddress + bankSize) > FLASH_BANK_UB )
+    {
+        OTA_LOG_L1("[%s] FAILED!\n", OTA_METHOD_NAME);
+        OTA_LOG_L1("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", OTA_METHOD_NAME, (startAddress + bankSize), FLASH_BANK_UB);
+        goto lexit;
+    }
+    OTA_LOG_L1("[%s] Erase SPI flash bank 0x%x ~ 0x%x ...", OTA_METHOD_NAME, startAddress, (startAddress + bankSize));
+    for (offset = 0; offset < bankSize; offset += FLASH_BLOCK_SIZE )
+    {
+      SPIM_EraseBlock(startAddress+offset, USE_4_BYTES_MODE, OPCODE_BE_64K, 1, 1);
+    }
+    OTA_LOG_L1("[%s] done.\n", OTA_METHOD_NAME);
+
+    /*
+     *  Verify flash page be erased
+     */
+    OTA_LOG_L1("[%s] Verify SPI flash block 0x%x be erased...", OTA_METHOD_NAME, startAddress);
+    for (offset = 0; offset < bankSize; offset += BUFFER_SIZE)
+    {
+        memset(spi_buff, 0, BUFFER_SIZE);
+        SPIM_IO_Read(startAddress+offset, USE_4_BYTES_MODE, BUFFER_SIZE, spi_buff, OPCODE_FAST_READ, 1, 1, 1, 1);
+
+        pData = (uint32_t *)spi_buff;
+        for (i = 0; i < BUFFER_SIZE; i += 4, pData++)
+        {
+            if (*pData != 0xFFFFFFFF)
+            {
+                OTA_LOG_L1("[%s] FAILED!\n", OTA_METHOD_NAME);
+                OTA_LOG_L1("[%s] Flash address 0x%x, read 0x%x!\n", OTA_METHOD_NAME, startAddress+offset+i, *pData);
+                goto lexit;
+            }
+        }
+    }
+    result = pdTRUE;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();    
+    return result;
+}
+
+/* Write a block of data to the specified file. 
+   Returns the number of bytes written on success or negative error code.
+*/
+int32_t NVT_SPI_Flash_Block_Write(uint32_t ulOffset,
+                           uint8_t * const pacData,
+                           uint32_t ulBlockSize )
+{
+    int32_t lResult = 0;
+
+    DEFINE_OTA_METHOD_NAME( "NVT_SPI_Flash_Block_Write" ); 
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    if( (ulOffset + ulBlockSize) > FLASH_BANK_UB )
+    {
+        OTA_LOG_L1("[%s] FAILED!\n", OTA_METHOD_NAME);
+        OTA_LOG_L1("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", OTA_METHOD_NAME, (ulOffset + ulBlockSize), FLASH_BANK_UB);
+        lResult = -1;
+        goto lexit;
+    }
+    SPIM_IO_Write(ulOffset, USE_4_BYTES_MODE, ulBlockSize, pacData, OPCODE_PP, 1, 1, 1);
+    lResult = ulBlockSize;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();   
+    return lResult;
+}
+
+/* Read a block of data to the specified file. 
+   Returns the number of bytes read on success or negative error code.
+*/
+int32_t NVT_SPI_Flash_Block_Read(uint32_t ulOffset,
+                           uint8_t* pacData,
+                           uint32_t ulBlockSize )
+{
+    int32_t lResult = 0;
+
+    DEFINE_OTA_METHOD_NAME( "NVT_SPI_Flash_Block_Read" ); 
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    if( (ulOffset + ulBlockSize) > FLASH_BANK_UB )
+    {
+        OTA_LOG_L1("[%s] FAILED!\n");
+        OTA_LOG_L1("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", OTA_METHOD_NAME, (ulOffset + ulBlockSize), FLASH_BANK_UB);
+        lResult = -1;
+        goto lexit;
+    }
+    SPIM_IO_Read(ulOffset, USE_4_BYTES_MODE, ulBlockSize, pacData, OPCODE_FAST_DUAL_READ, 1, 1, 2, 1);
+    lResult = ulBlockSize;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();   
+    return lResult;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR purpose is not to ask any qualification logo and not plan to process OCW.
It is one normal PR to support \ \amazon-freertos\vendors\vendor\boards\board\ports\ota for OTA-Agent job protocol. 

<!--- Describe your changes in detail -->

This PR add ports of M487 ota and it's verified by aws_test including FULL_OTA_AGENT_ENABLED, FULL_OTA_PAL_ENABLED and MQTTv4_ENABLED.
To run aws_test by cmake, the command line as: `$ cmake -DVENDOR=nuvoton -DBOARD=numaker_iot_m487_wifi -DCOMPILER=arm-keil -S. -Bbuild -G"Unix Makefiles" -DAFR_ENABLE_TESTS=1`
Attached the test log file for your reference.
[aws_test_log.txt](https://github.com/aws/amazon-freertos/files/5551167/aws_test_log.txt)


About loader part, we have one for customer reference and our chip has H/W secure boot capacity, it really depends on customer requirement. The loader’s major implementation is how to cooperate with OTA-client and secure boot could rely on M487 solution https://www.nuvoton.com/support/technical-support/technical-articles/TSNuvotonTechBlog-000086/.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

@yngki 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.