### PR TITLE
Disable logging for HTTP unit tests

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_http_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_http_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_http_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/core_http_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_http_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_http_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_http_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_http_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_http_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_http_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_http_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_http_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_http_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/pc/boards/windows/aws_tests/config_files/core_http_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_http_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_http_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_http_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/vendor/boards/board/aws_tests/config_files/core_http_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/core_http_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/core_http_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This simply disables unit-test logs, which don't add much substance as errors are forced by these tests. This is done to fix an issue where boards stop printing test results from having to print too many logs. The same was also done for MQTT tests. Note that integration tests for HTTP currently do not log anything besides the test results, so they won't be affected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.