### PR TITLE
Add retries for coreMQTT demos in case of a failure in a loop.

### DIFF
--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -2198,7 +2198,7 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
     else
     {
         ret = EXIT_FAILURE;
-        LogInfo( ( "Demo run is failure with %lu successful loops out of total %lu loops.",
+        LogInfo( ( "Demo run failed with %lu successful loops out of total %lu loops.",
                    ( ulDemoSuccessCount ),
                    democonfigMQTT_MAX_DEMO_COUNT ) );
     }

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -2198,9 +2198,11 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
     else
     {
         ret = EXIT_FAILURE;
-        LogInfo( ( "Demo run failed with %lu successful loops out of total %lu loops.",
-                   ( ulDemoSuccessCount ),
-                   democonfigMQTT_MAX_DEMO_COUNT ) );
+        LogInfo( ( "Demo run failed with %lu failed loops out of total %lu loops."
+                   " RequiredSuccessCounts=%lu.",
+                   ( democonfigMQTT_MAX_DEMO_COUNT - ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT,
+                   ( ( democonfigMQTT_MAX_DEMO_COUNT / 2 ) + 1 ) ) );
     }
 
     return ret;

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -2018,12 +2018,13 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
     BaseType_t xNetworkStatus = pdFAIL;
     BaseType_t xResult = pdFALSE;
     BaseType_t xNetworkConnectionCreated = pdFALSE;
-    uint32_t ulNotification = 0;
+    uint32_t ulNotification = 0UL;
     MQTTStatus_t xMQTTStatus;
     uint32_t ulExpectedNotifications = mqttexamplePUBLISHER_SYNC_COMPLETE_BIT |
                                        mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT |
                                        mqttexamplePUBLISHER_ASYNC_COMPLETE_BIT;
-    uint32_t ulDemoCount = 0;
+    uint32_t ulDemoCount = 0UL;
+    uint32_t ulDemoSuccessCount = 0UL;
     int ret = EXIT_SUCCESS;
 
     ( void ) awsIotMqttMode;
@@ -2078,7 +2079,7 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
         }
     }
 
-    for( ulDemoCount = 0; ( ulDemoCount < democonfigMQTT_MAX_DEMO_COUNT ) && ( ret == EXIT_SUCCESS ); ulDemoCount++ )
+    for( ulDemoCount = 0UL; ( ulDemoCount < democonfigMQTT_MAX_DEMO_COUNT ); ulDemoCount++ )
     {
         /* Clear the lists of subscriptions and pending acknowledgments. */
         memset( pxPendingAcks, 0x00, mqttexamplePENDING_ACKS_MAX_SIZE * sizeof( AckInfo_t ) );
@@ -2156,13 +2157,17 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
         if( ret == EXIT_SUCCESS )
         {
             LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoCount + 1UL ) ) );
-            LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
-            vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
+            ulDemoSuccessCount++;
         }
         else
         {
+            /* Demo loop will be repeated for democonfigMQTT_MAX_DEMO_COUNT
+             * times even if current loop resulted in a failure. */
             LogError( ( "Demo failed at iteration %lu.", ( ulDemoCount + 1UL ) ) );
         }
+
+        LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
+        vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
     }
 
     /* Delete queues. */
@@ -2179,6 +2184,23 @@ int RunCoreMqttConnectionSharingDemo( bool awsIotMqttMode,
     if( xSubscriberResponseQueue != NULL )
     {
         vQueueDelete( xSubscriberResponseQueue );
+    }
+
+    /* Demo run is considered successful if more than half of
+     * #democonfigMQTT_MAX_DEMO_COUNT is successful. */
+    if( ulDemoSuccessCount > ( democonfigMQTT_MAX_DEMO_COUNT / 2 ) )
+    {
+        ret = EXIT_SUCCESS;
+        LogInfo( ( "Demo run is successful with %lu successful loops out of total %lu loops.",
+                   ( ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT ) );
+    }
+    else
+    {
+        ret = EXIT_FAILURE;
+        LogInfo( ( "Demo run is failure with %lu successful loops out of total %lu loops.",
+                   ( ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT ) );
     }
 
     return ret;

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -317,7 +317,7 @@ static void prvEventCallback( MQTTContext_t * pxMQTTContext,
  * @param[in] pxMQTTContext MQTT context pointer.
  * @param[in] usPacketType Packet type to wait for.
  *
- * @return The return status from call to #MQTT_ProcessLoop API. 
+ * @return The return status from call to #MQTT_ProcessLoop API.
  */
 static MQTTStatus_t prvWaitForPacket( MQTTContext_t * pxMQTTContext,
                                       uint16_t usPacketType );
@@ -362,10 +362,10 @@ static uint16_t usUnsubscribePacketIdentifier;
  * @note Only on receiving incoming PUBLISH, SUBACK, and UNSUBACK, this
  * variable is updated. For MQTT packets PUBACK and PINGRESP, the variable is
  * not updated since there is no need to specifically wait for it in this demo.
- * A single variable suffices as this demo uses single task and requests one operation 
- * (of PUBLISH, SUBSCRIBE, UNSUBSCRIBE) at a time before expecting response from 
- * the broker. Hence it is not possible to receive multiple packets of type PUBLISH, 
- * SUBACK, and UNSUBACK in a single call of #prvWaitForPacket. 
+ * A single variable suffices as this demo uses single task and requests one operation
+ * (of PUBLISH, SUBSCRIBE, UNSUBSCRIBE) at a time before expecting response from
+ * the broker. Hence it is not possible to receive multiple packets of type PUBLISH,
+ * SUBACK, and UNSUBACK in a single call of #prvWaitForPacket.
  * For a multi task application, consider a different method to wait for the packet, if needed.
  */
 static uint16_t usPacketTypeReceived = 0U;
@@ -595,9 +595,11 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
     else
     {
         xDemoStatus = pdFAIL;
-        LogInfo( ( "Demo run is failure with %lu successful loops out of total %lu loops.",
-                   ( ulDemoSuccessCount ),
-                   democonfigMQTT_MAX_DEMO_COUNT ) );
+        LogInfo( ( "Demo run failed with %lu failed loops out of total %lu loops."
+                   " RequiredSuccessCounts=%lu.",
+                   ( democonfigMQTT_MAX_DEMO_COUNT - ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT,
+                   ( ( democonfigMQTT_MAX_DEMO_COUNT / 2 ) + 1 ) ) );
     }
 
     return ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -163,7 +163,13 @@
 /**
  * @brief Timeout for MQTT_ProcessLoop in milliseconds.
  */
-#define mqttexamplePROCESS_LOOP_TIMEOUT_MS                ( 500U )
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS                ( 700U )
+
+/**
+ * @brief The maximum number of times to call MQTT_ProcessLoop() when polling
+ * for a specific packet from the broker.
+ */
+#define MQTT_PROCESS_LOOP_PACKET_WAIT_COUNT_MAX           ( 30U )
 
 /**
  * @brief Keep alive time reported to the broker while establishing
@@ -304,6 +310,26 @@ static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,
                               MQTTDeserializedInfo_t * pxDeserializedInfo );
 
+/**
+ * @brief Helper function to wait for a specific incoming packet from the
+ * broker.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ * @param[in] usPacketType Packet type to wait for.
+ *
+ * @return #MQTTBadParameter if context is NULL;
+ * #MQTTRecvFailed if a network error occurs during reception;
+ * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
+ * #MQTTBadResponse if an invalid packet is received;
+ * #MQTTKeepAliveTimeout if the server has not sent a PINGRESP before
+ * #MQTT_PINGRESP_TIMEOUT_MS milliseconds;
+ * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
+ * invalid transition for the internal state machine;
+ * #MQTTSuccess on success.
+ */
+static MQTTStatus_t prvWaitForPacket( MQTTContext_t * pxMQTTContext,
+                                      uint16_t usPacketType );
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -341,7 +367,7 @@ static uint16_t usUnsubscribePacketIdentifier;
 /**
  * @brief MQTT packet type expected to be received from the MQTT broker.
  */
-static uint16_t usPacketTypeExpected = 0U;
+static uint16_t usPacketTypeReceived = 0U;
 
 /**
  * @brief A pair containing a topic filter and its SUBACK status.
@@ -466,16 +492,16 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
             if( xDemoStatus == pdPASS )
             {
                 /* Process incoming publish echo, since application subscribed to the same
-                 * topic, the broker will send publish message back to the application. */
+                 * topic, the broker will send publish message back to the application.
+                 * #prvWaitForPacket will try to receive an incoming PUBLISH packet from broker.
+                 * Please note that PUBACK for the outgoing PUBLISH may also be received before
+                 * receiving an incoming PUBLISH. */
                 LogInfo( ( "Attempt to receive publish message from broker." ) );
-                xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+                xMQTTStatus = prvWaitForPacket( &xMQTTContext, MQTT_PACKET_TYPE_PUBLISH );
 
                 if( xMQTTStatus != MQTTSuccess )
                 {
                     xDemoStatus = pdFAIL;
-                    LogError( ( "MQTT_ProcessLoop failed: LoopDuration=%u, Error=%s",
-                                mqttexamplePROCESS_LOOP_TIMEOUT_MS,
-                                MQTT_Status_strerror( xMQTTStatus ) ) );
                 }
             }
 
@@ -495,14 +521,11 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
         if( xDemoStatus == pdPASS )
         {
             /* Process incoming UNSUBACK packet from the broker. */
-            xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+            xMQTTStatus = prvWaitForPacket( &xMQTTContext, MQTT_PACKET_TYPE_UNSUBACK );
 
             if( xMQTTStatus != MQTTSuccess )
             {
                 xDemoStatus = pdFAIL;
-                LogError( ( "Failed to receive UNSUBACK packet from broker: ProcessLoopDuration=%u, Error=%s",
-                            mqttexamplePROCESS_LOOP_TIMEOUT_MS,
-                            MQTT_Status_strerror( xMQTTStatus ) ) );
             }
         }
 
@@ -788,12 +811,11 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
              * receiving Publish message before subscribe ack is zero; but application
              * must be ready to receive any packet.  This demo uses the generic packet
              * processing function everywhere to highlight this fact. */
-            xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+            xResult = prvWaitForPacket( pxMQTTContext, MQTT_PACKET_TYPE_SUBACK );
 
             if( xResult != MQTTSuccess )
             {
-                LogError( ( "Failed to receive SUBACK response for SUBSCRIBE request: ProcessLoopDuration=%u, Error=%s",
-                            mqttexamplePROCESS_LOOP_TIMEOUT_MS, MQTT_Status_strerror( xResult ) ) );
+                xStatus = pdFAIL;
             }
         }
 
@@ -912,11 +934,18 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
     {
         case MQTT_PACKET_TYPE_PUBACK:
             LogInfo( ( "PUBACK received for packet Id %u.", usPacketId ) );
+
+            /* Update the packet type received to PUBACK. */
+            usPacketTypeReceived = MQTT_PACKET_TYPE_PUBACK;
+
             /* Make sure ACK packet identifier matches with Request packet identifier. */
             configASSERT( usPublishPacketIdentifier == usPacketId );
             break;
 
         case MQTT_PACKET_TYPE_SUBACK:
+
+            /* Update the packet type received to SUBACK. */
+            usPacketTypeReceived = MQTT_PACKET_TYPE_SUBACK;
 
             /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
              * It contains the status code indicating server approval/rejection for the subscription to the single topic
@@ -940,12 +969,20 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 
         case MQTT_PACKET_TYPE_UNSUBACK:
             LogInfo( ( "Unsubscribed from the topic %s.", mqttexampleTOPIC ) );
+
+            /* Update the packet type received to UNSUBACK. */
+            usPacketTypeReceived = MQTT_PACKET_TYPE_UNSUBACK;
+
             /* Make sure ACK packet identifier matches with Request packet identifier. */
             configASSERT( usUnsubscribePacketIdentifier == usPacketId );
             break;
 
         case MQTT_PACKET_TYPE_PINGRESP:
             LogInfo( ( "Ping Response successfully received." ) );
+
+            /* Update the packet type received to UNSUBACK. */
+            usPacketTypeReceived = MQTT_PACKET_TYPE_PINGRESP;
+
             break;
 
         /* Any other packet type is invalid. */
@@ -960,6 +997,9 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo )
 {
     configASSERT( pxPublishInfo != NULL );
+
+    /* Set the global for indicating that an incoming publish is received. */
+    usPacketTypeReceived = MQTT_PACKET_TYPE_PUBLISH;
 
     /* Process incoming Publish. */
     LogInfo( ( "Incoming QoS : %d\n", pxPublishInfo->qos ) );
@@ -1020,6 +1060,37 @@ static uint32_t prvGetTimeMs( void )
     ulTimeMs = ( uint32_t ) ( ulTimeMs - ulGlobalEntryTimeMs );
 
     return ulTimeMs;
+}
+
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t prvWaitForPacket( MQTTContext_t * pxMQTTContext,
+                                      uint16_t usPacketType )
+{
+    uint8_t ucCount = 0U;
+    MQTTStatus_t xMQTTStatus = MQTTSuccess;
+
+    /* Reset the packet type received. */
+    usPacketTypeReceived = 0U;
+
+    while( ( usPacketTypeReceived != usPacketType ) &&
+           ( ucCount++ < MQTT_PROCESS_LOOP_PACKET_WAIT_COUNT_MAX ) &&
+           ( xMQTTStatus == MQTTSuccess ) )
+    {
+        /* Event callback will set #usPacketTypeReceived when receiving appropriate packet. This
+         * will wait for at most mqttexamplePROCESS_LOOP_TIMEOUT_MS. */
+        xMQTTStatus = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+    }
+
+    if( ( xMQTTStatus != MQTTSuccess ) || ( usPacketTypeReceived != usPacketType ) )
+    {
+        LogError( ( "MQTT_ProcessLoop failed to receive packet: Packet type=%02X LoopDuration=%u, Status=%s",
+                    usPacketType,
+                    ( mqttexamplePROCESS_LOOP_TIMEOUT_MS * ucCount ),
+                    MQTT_Status_strerror( xMQTTStatus ) ) );
+    }
+
+    return xMQTTStatus;
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -1085,7 +1085,7 @@ static MQTTStatus_t prvWaitForPacket( MQTTContext_t * pxMQTTContext,
 
     if( ( xMQTTStatus != MQTTSuccess ) || ( usPacketTypeReceived != usPacketType ) )
     {
-        LogError( ( "MQTT_ProcessLoop failed to receive packet: Packet type=%02X LoopDuration=%u, Status=%s",
+        LogError( ( "MQTT_ProcessLoop failed to receive packet: Packet type=%02X, LoopDuration=%u, Status=%s",
                     usPacketType,
                     ( mqttexamplePROCESS_LOOP_TIMEOUT_MS * ucCount ),
                     MQTT_Status_strerror( xMQTTStatus ) ) );

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -980,7 +980,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
         case MQTT_PACKET_TYPE_PINGRESP:
             LogInfo( ( "Ping Response successfully received." ) );
 
-            /* Update the packet type received to UNSUBACK. */
+            /* Update the packet type received to PINGRESP. */
             usPacketTypeReceived = MQTT_PACKET_TYPE_PINGRESP;
 
             break;

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -317,15 +317,7 @@ static void prvEventCallback( MQTTContext_t * pxMQTTContext,
  * @param[in] pxMQTTContext MQTT context pointer.
  * @param[in] usPacketType Packet type to wait for.
  *
- * @return #MQTTBadParameter if context is NULL;
- * #MQTTRecvFailed if a network error occurs during reception;
- * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
- * #MQTTBadResponse if an invalid packet is received;
- * #MQTTKeepAliveTimeout if the server has not sent a PINGRESP before
- * #MQTT_PINGRESP_TIMEOUT_MS milliseconds;
- * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
- * invalid transition for the internal state machine;
- * #MQTTSuccess on success.
+ * @return The return status from call to #MQTT_ProcessLoop API. 
  */
 static MQTTStatus_t prvWaitForPacket( MQTTContext_t * pxMQTTContext,
                                       uint16_t usPacketType );
@@ -370,10 +362,11 @@ static uint16_t usUnsubscribePacketIdentifier;
  * @note Only on receiving incoming PUBLISH, SUBACK, and UNSUBACK, this
  * variable is updated. For MQTT packets PUBACK and PINGRESP, the variable is
  * not updated since there is no need to specifically wait for it in this demo.
- * This demo uses single task and hence it is not possible to receive multiple
- * packets of type PUBLISH, SUBACK, and UNSUBACK in a single call of
- * #prvWaitForPacket. For a multi task application, consider a different method
- * to wait for the packet, if needed.
+ * A single variable suffices as this demo uses single task and requests one operation 
+ * (of PUBLISH, SUBSCRIBE, UNSUBSCRIBE) at a time before expecting response from 
+ * the broker. Hence it is not possible to receive multiple packets of type PUBLISH, 
+ * SUBACK, and UNSUBACK in a single call of #prvWaitForPacket. 
+ * For a multi task application, consider a different method to wait for the packet, if needed.
  */
 static uint16_t usPacketTypeReceived = 0U;
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -127,7 +127,7 @@
  * demo.
  */
 #ifndef democonfigMQTT_MAX_DEMO_COUNT
-    #define democonfigMQTT_MAX_DEMO_COUNT    ( 3 )
+    #define democonfigMQTT_MAX_DEMO_COUNT    ( 5 )
 #endif
 /*-----------------------------------------------------------*/
 
@@ -393,7 +393,7 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
     NetworkContext_t xNetworkContext = { 0 };
     MQTTContext_t xMQTTContext = { 0 };
     MQTTStatus_t xMQTTStatus;
-    uint32_t ulDemoRunCount = 0;
+    uint32_t ulDemoRunCount = 0UL, ulDemoSuccessCount = 0UL;
     TransportSocketStatus_t xNetworkStatus;
     BaseType_t xIsConnectionEstablished = pdFALSE;
 
@@ -539,17 +539,36 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
              * bombard the broker. */
             LogInfo( ( "Demo completed an iteration successfully." ) );
             LogInfo( ( "Demo iteration %lu completed successfully.", ( ulDemoRunCount + 1UL ) ) );
+
+            /* Update success count. */
+            ulDemoSuccessCount++;
         }
         else
         {
-            /* Terminate the demo due to failure. */
+            /* Demo loop will be repeated for democonfigMQTT_MAX_DEMO_COUNT
+             * times even if current loop resulted in a failure. */
             LogInfo( ( "Demo failed at iteration %lu.", ( ulDemoRunCount + 1UL ) ) );
-            LogInfo( ( "Exiting demo." ) );
-            break;
         }
 
         LogInfo( ( "Short delay before starting the next iteration.... " ) );
         vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS_TICKS );
+    }
+
+    /* Demo run is considered successful if more than half of
+     * #democonfigMQTT_MAX_DEMO_COUNT is successful. */
+    if( ulDemoSuccessCount > ( democonfigMQTT_MAX_DEMO_COUNT / 2 ) )
+    {
+        xDemoStatus = pdPASS;
+        LogInfo( ( "Demo run is successful with %lu successful loops out of total %lu loops.",
+                   ( ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT ) );
+    }
+    else
+    {
+        xDemoStatus = pdFAIL;
+        LogInfo( ( "Demo run is failure with %lu successful loops out of total %lu loops.",
+                   ( ulDemoSuccessCount ),
+                   democonfigMQTT_MAX_DEMO_COUNT ) );
     }
 
     return ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -365,7 +365,15 @@ static uint16_t usSubscribePacketIdentifier;
 static uint16_t usUnsubscribePacketIdentifier;
 
 /**
- * @brief MQTT packet type expected to be received from the MQTT broker.
+ * @brief MQTT packet type received from the MQTT broker.
+ *
+ * @note Only on receiving incoming PUBLISH, SUBACK, and UNSUBACK, this
+ * variable is updated. For MQTT packets PUBACK and PINGRESP, the variable is
+ * not updated since there is no need to specifically wait for it in this demo.
+ * This demo uses single task and hence it is not possible to receive multiple
+ * packets of type PUBLISH, SUBACK, and UNSUBACK in a single call of
+ * #prvWaitForPacket. For a multi task application, consider a different method
+ * to wait for the packet, if needed.
  */
 static uint16_t usPacketTypeReceived = 0U;
 
@@ -934,10 +942,6 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
     {
         case MQTT_PACKET_TYPE_PUBACK:
             LogInfo( ( "PUBACK received for packet Id %u.", usPacketId ) );
-
-            /* Update the packet type received to PUBACK. */
-            usPacketTypeReceived = MQTT_PACKET_TYPE_PUBACK;
-
             /* Make sure ACK packet identifier matches with Request packet identifier. */
             configASSERT( usPublishPacketIdentifier == usPacketId );
             break;
@@ -979,9 +983,6 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 
         case MQTT_PACKET_TYPE_PINGRESP:
             LogInfo( ( "Ping Response successfully received." ) );
-
-            /* Update the packet type received to PINGRESP. */
-            usPacketTypeReceived = MQTT_PACKET_TYPE_PINGRESP;
 
             break;
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -127,7 +127,7 @@
  * demo.
  */
 #ifndef democonfigMQTT_MAX_DEMO_COUNT
-    #define democonfigMQTT_MAX_DEMO_COUNT    ( 5 )
+    #define democonfigMQTT_MAX_DEMO_COUNT    ( 3 )
 #endif
 /*-----------------------------------------------------------*/
 
@@ -337,6 +337,11 @@ static uint16_t usSubscribePacketIdentifier;
  * request.
  */
 static uint16_t usUnsubscribePacketIdentifier;
+
+/**
+ * @brief MQTT packet type expected to be received from the MQTT broker.
+ */
+static uint16_t usPacketTypeExpected = 0U;
 
 /**
  * @brief A pair containing a topic filter and its SUBACK status.


### PR DESCRIPTION
Add retries for coreMQTT demos in case of a failure in a loop.

Description
-----------
Add retries for coreMQTT demos in case of a failure in a loop. Find the summary of the changes in this PR

1. Both Mutual auth and Connection sharing demos are updated to retry even if a loop of demo execution is failed. The demo success is decided based on if count of successful loops > total demo loops/2 or not.
2. Mutual auth demo is updated to wait for the reception of a packet instead of timing out really quick. MQTT_ProcessLoop is called a few times to attempt to receive an ACK packet or incoming PUBLISH packet before timing out. In some tests, we have observed that there are a few instances in which MQTT_ProcessLoop times out before receiving any packet. With this change more attempts are done to receive a packet from broker.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.