### PR TITLE
Shim from HTTP V1 library to coreHTTP (HTTPClient_Send)

### DIFF
--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2412,6 +2412,7 @@ IotHttpsReturnCode_t IotHttpsClient_Init( void )
         }
     #endif /* if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY != 1 */
     dispatchQueue = NULL;
+
     /* Delete the tasks that send requests from the dispatch queue. */
     for( dispatchTaskIndex = 0; dispatchTaskIndex < IOT_HTTPS_DISPATCH_TASK_COUNT; ++dispatchTaskIndex )
     {
@@ -2425,6 +2426,7 @@ IotHttpsReturnCode_t IotHttpsClient_Init( void )
             httpsDispatchTask[ dispatchTaskIndex ] = NULL;
         }
     }
+
     HTTPS_FUNCTION_CLEANUP_END();
 }
 
@@ -2586,6 +2588,7 @@ void IotHttpsClient_Cleanup( void )
         }
     #endif /* if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY != 1 */
     dispatchQueue = NULL;
+
     /* Delete the tasks that send requests from the dispatch queue. */
     for( dispatchTaskIndex = 0; dispatchTaskIndex < IOT_HTTPS_DISPATCH_TASK_COUNT; ++dispatchTaskIndex )
     {

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -43,7 +43,7 @@
  * The minimum path is "/" because we cannot know how long the application requested path is is going to be.
  * CONNECT is the longest string length HTTP method according to RFC 2616.
  */
-#define HTTPS_PARTIAL_REQUEST_LINE                        HTTPS_CONNECT_METHOD " " HTTPS_EMPTY_PATH " " HTTPS_PROTOCOL_VERSION
+#define HTTPS_PARTIAL_REQUEST_LINE        HTTPS_CONNECT_METHOD " " HTTPS_EMPTY_PATH " " HTTPS_PROTOCOL_VERSION
 
 /**
  * @brief The User-Agent header line string.
@@ -52,7 +52,7 @@
  * "User-Agent: <configured-user-agent>\r\n"
  * This is used for the calculation of the requestUserBufferMinimumSize.
  */
-#define HTTPS_USER_AGENT_HEADER_LINE                      HTTPS_USER_AGENT_HEADER HTTPS_HEADER_FIELD_SEPARATOR IOT_HTTPS_USER_AGENT HTTPS_END_OF_HEADER_LINES_INDICATOR
+#define HTTPS_USER_AGENT_HEADER_LINE      HTTPS_USER_AGENT_HEADER HTTPS_HEADER_FIELD_SEPARATOR IOT_HTTPS_USER_AGENT HTTPS_END_OF_HEADER_LINES_INDICATOR
 
 /**
  * @brief The Host header line with the field only and not the value.
@@ -62,27 +62,7 @@
  * This is used for the calculation of the requestUserBufferMinimumSize. The Host value is not specified because we
  * cannot anticipate what server the client is making requests to.
  */
-#define HTTPS_PARTIAL_HOST_HEADER_LINE                    HTTPS_HOST_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_END_OF_HEADER_LINES_INDICATOR
-
-/**
- * String constants for the Connection header and possible values.
- *
- * This is used for writing headers automatically during the sending of the HTTP request.
- * "Connection: keep-alive\r\n" is written automatically for a persistent connection.
- * "Connection: close\r\n" is written automatically for a non-persistent connection.
- */
-#define HTTPS_CONNECTION_KEEP_ALIVE_HEADER_LINE           HTTPS_CONNECTION_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_CONNECTION_KEEP_ALIVE_HEADER_VALUE HTTPS_END_OF_HEADER_LINES_INDICATOR /**< @brief String literal for "Connection: keep-alive\r\n". */
-#define HTTPS_CONNECTION_CLOSE_HEADER_LINE                HTTPS_CONNECTION_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_CONNECTION_CLOSE_HEADER_VALUE HTTPS_END_OF_HEADER_LINES_INDICATOR      /**< @brief String literal for "Connection: close\r\n". */
-
-/**
- * @brief The length of the "Connection: keep-alive\r\n" header.
- *
- * This is used for sizing a local buffer for the final headers to send that include the "Connection: keep-alive\r\n"
- * header line.
- *
- * This is used to initialize a local array for the final headers to send.
- */
-#define HTTPS_CONNECTION_KEEP_ALIVE_HEADER_LINE_LENGTH    ( 24 )
+#define HTTPS_PARTIAL_HOST_HEADER_LINE    HTTPS_HOST_HEADER HTTPS_HEADER_FIELD_SEPARATOR HTTPS_END_OF_HEADER_LINES_INDICATOR
 
 /**
  * Indicates for the http-parser parsing execution function to tell it to keep parsing or to stop parsing.
@@ -90,8 +70,8 @@
  * A value of 0 means the parser should keep parsing if there is more unparsed length.
  * A value greater than 0 tells the parser to stop parsing.
  */
-#define KEEP_PARSING                                      ( ( int ) 0 ) /**< @brief Indicator in the http-parser callback to keep parsing when the function returns. */
-#define STOP_PARSING                                      ( ( int ) 1 ) /**< @brief Indicator in the http-parser callback to stop parsing when the function returns. */
+#define KEEP_PARSING                      ( ( int ) 0 )                 /**< @brief Indicator in the http-parser callback to keep parsing when the function returns. */
+#define STOP_PARSING                      ( ( int ) 1 )                 /**< @brief Indicator in the http-parser callback to stop parsing when the function returns. */
 
 /*-----------------------------------------------------------*/
 
@@ -337,40 +317,6 @@ static void _networkDisconnect( _httpsConnection_t * pHttpsConnection );
 static void _networkDestroy( _httpsConnection_t * pHttpsConnection );
 
 /**
- * @brief Add a header to the current HTTP request.
- *
- * The headers are stored in reqHandle->pHeaders.
- *
- * @param[in] pHttpsRequest - HTTP request context.
- * @param[in] pName - The name of the header to add.
- * @param[in] nameLen - The length of the header name string.
- * @param[in] pValue - The buffer containing the value string.
- * @param[in] valueLen - The length of the header value string.
- *
- * @return #IOT_HTTPS_OK if the header was added to the request successfully.
- *         #IOT_HTTPS_INSUFFICIENT_MEMORY if there was not enough room in the IotHttpsRequestHandle_t->pHeaders.
- */
-static IotHttpsReturnCode_t _addHeader( _httpsRequest_t * pHttpsRequest,
-                                        const char * pName,
-                                        uint32_t nameLen,
-                                        const char * pValue,
-                                        uint32_t valueLen );
-
-/**
- * @brief Send data on the network.
- *
- * @param[in] pHttpsConnection - HTTP connection context.
- * @param[in] pBuf - The buffer containing the data to send.
- * @param[in] len - The length of the data to send.
- *
- * @return #IOT_HTTPS_OK if the data sent successfully.
- *         #IOT_HTTPS_NETWORK_ERROR if there was an error sending the data on the network.
- */
-static IotHttpsReturnCode_t _networkSend( _httpsConnection_t * pHttpsConnection,
-                                          uint8_t * pBuf,
-                                          size_t len );
-
-/**
  * @brief Receive data on the network.
  *
  * @param[in] pHttpsConnection - HTTP connection context.
@@ -560,19 +506,19 @@ static TaskHandle_t httpsDispatchTask[ IOT_HTTPS_DISPATCH_TASK_COUNT ];
  */
 static QueueHandle_t dispatchQueue;
 
-#ifdef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
+#if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY == 1
 
 /**
  * @brief Structure that will hold the TCB of a dispatch task.
  */
-    StaticTask_t dispatchTaskBuffer;
+    static StaticTask_t dispatchTaskBuffer;
 
 /**
  * @brief Buffer that the dispatch task will use as its stack. Note this is
  * an array of StackType_t variables. The size of StackType_t is dependent on
  * the RTOS port.
  */
-    StackType_t dispatchTaskStack[ IOT_HTTPS_DISPATCH_TASK_STACK_SIZE ];
+    static StackType_t dispatchTaskStack[ IOT_HTTPS_DISPATCH_TASK_STACK_SIZE ];
 
 /**
  * @brief A data structure to contain a statically allocated queue.
@@ -582,7 +528,7 @@ static QueueHandle_t dispatchQueue;
 /**
  * @brief A buffer to hold static memory for the dispatch queue.
  */
-    uint8_t dispatchQueueStorageBuffer[ IOT_HTTPS_DISPATCH_QUEUE_SIZE * sizeof( _httpsRequest_t * ) ];
+    static uint8_t dispatchQueueStorageBuffer[ IOT_HTTPS_DISPATCH_QUEUE_SIZE * sizeof( _httpsRequest_t * ) ];
 #endif /* ifdef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY */
 
 /**
@@ -1670,86 +1616,6 @@ static void _networkDestroy( _httpsConnection_t * pHttpsConnection )
 
 /*-----------------------------------------------------------*/
 
-static IotHttpsReturnCode_t _addHeader( _httpsRequest_t * pHttpsRequest,
-                                        const char * pName,
-                                        uint32_t nameLen,
-                                        const char * pValue,
-                                        uint32_t valueLen )
-{
-    HTTPS_FUNCTION_ENTRY( IOT_HTTPS_OK );
-
-    int headerFieldSeparatorLen = HTTPS_HEADER_FIELD_SEPARATOR_LENGTH;
-    uint32_t additionalLength = nameLen + headerFieldSeparatorLen + valueLen + HTTPS_END_OF_HEADER_LINES_INDICATOR_LENGTH;
-    uint32_t possibleLastHeaderAdditionalLength = HTTPS_END_OF_HEADER_LINES_INDICATOR_LENGTH;
-
-    /* Check if there is enough space to add the header field and value
-     * (name:value\r\n). We need to add a "\r\n" at the end of headers. The use of
-     * possibleLastHeaderAdditionalLength is to make sure that there is always
-     * space for the last "\r\n". */
-    if( ( additionalLength + possibleLastHeaderAdditionalLength ) > ( ( uint32_t ) ( pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur ) ) )
-    {
-        IotLogError( "There is %d space left in the header buffer, but we want to add %d more of header.",
-                     pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur,
-                     additionalLength + possibleLastHeaderAdditionalLength );
-        HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_INSUFFICIENT_MEMORY );
-    }
-
-    memcpy( pHttpsRequest->pHeadersCur, pName, nameLen );
-    pHttpsRequest->pHeadersCur += nameLen;
-    memcpy( pHttpsRequest->pHeadersCur, HTTPS_HEADER_FIELD_SEPARATOR, headerFieldSeparatorLen );
-    pHttpsRequest->pHeadersCur += headerFieldSeparatorLen;
-    memcpy( pHttpsRequest->pHeadersCur, pValue, valueLen );
-    pHttpsRequest->pHeadersCur += valueLen;
-    memcpy( pHttpsRequest->pHeadersCur, HTTPS_END_OF_HEADER_LINES_INDICATOR, HTTPS_END_OF_HEADER_LINES_INDICATOR_LENGTH );
-    pHttpsRequest->pHeadersCur += HTTPS_END_OF_HEADER_LINES_INDICATOR_LENGTH;
-    IotLogDebug( "Wrote header: \"%s: %.*s\r\n\". Space left in request user buffer: %d",
-                 pName,
-                 valueLen,
-                 pValue,
-                 pHttpsRequest->pHeadersEnd - pHttpsRequest->pHeadersCur );
-
-    HTTPS_FUNCTION_EXIT_NO_CLEANUP();
-}
-
-/*-----------------------------------------------------------*/
-
-static IotHttpsReturnCode_t _networkSend( _httpsConnection_t * pHttpsConnection,
-                                          uint8_t * pBuf,
-                                          size_t len )
-{
-    HTTPS_FUNCTION_ENTRY( IOT_HTTPS_OK );
-
-    size_t numBytesSent = 0;
-    size_t numBytesSentTotal = 0;
-    size_t sendLength = len;
-
-    while( numBytesSentTotal < sendLength )
-    {
-        numBytesSent = pHttpsConnection->pNetworkInterface->send( pHttpsConnection->pNetworkConnection,
-                                                                  &( pBuf[ numBytesSentTotal ] ),
-                                                                  sendLength - numBytesSentTotal );
-
-        /* pNetworkInterface->send returns 0 on error. */
-        if( numBytesSent == 0 )
-        {
-            IotLogError( "Error in sending the HTTPS headers. Error code: %d", numBytesSent );
-            break;
-        }
-
-        numBytesSentTotal += numBytesSent;
-    }
-
-    if( numBytesSentTotal != sendLength )
-    {
-        IotLogError( "Error sending data on the network. We sent %d but there were total %d.", numBytesSentTotal, sendLength );
-        HTTPS_SET_AND_GOTO_CLEANUP( IOT_HTTPS_NETWORK_ERROR );
-    }
-
-    HTTPS_FUNCTION_EXIT_NO_CLEANUP();
-}
-
-/*-----------------------------------------------------------*/
-
 static IotHttpsReturnCode_t _networkRecv( _httpsConnection_t * pHttpsConnection,
                                           uint8_t * pBuf,
                                           size_t bufLen,
@@ -2122,8 +1988,6 @@ static IotHttpsReturnCode_t _sendHttpsHeadersAndBody( _httpsConnection_t * pHttp
         HTTPS_GOTO_CLEANUP();
     }
 
-    IotLogDebug( "Sent HTTPS headers for request %p.", pHttpsRequest );
-
     HTTPS_FUNCTION_EXIT_NO_CLEANUP();
 }
 
@@ -2481,11 +2345,11 @@ IotHttpsReturnCode_t IotHttpsClient_Init( void )
     _httpParserSettings.on_message_complete = _httpParserOnMessageCompleteCallback;
 
     /* Allocate the dispatch queue. */
-    #ifdef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
+    #if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY == 1
         dispatchQueue = xQueueCreateStatic( IOT_HTTPS_DISPATCH_QUEUE_SIZE,
                                             sizeof( _httpsRequest_t * ),
                                             dispatchQueueStorageBuffer,
-                                            dispatchQueueBuffer );
+                                            &dispatchQueueBuffer );
     #else
         dispatchQueue = xQueueCreate( IOT_HTTPS_DISPATCH_QUEUE_SIZE, sizeof( _httpsRequest_t * ) );
     #endif
@@ -2500,7 +2364,7 @@ IotHttpsReturnCode_t IotHttpsClient_Init( void )
     /* Start tasks that send requests from the dispatch queue. */
     for( dispatchTaskIndex = 0; dispatchTaskIndex < IOT_HTTPS_DISPATCH_TASK_COUNT; ++dispatchTaskIndex )
     {
-        #ifdef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
+        #if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY == 1
             httpsDispatchTask[ dispatchTaskIndex ] = xTaskCreateStatic( _dispatchTaskRoutine,
                                                                         "iot_thread",
                                                                         IOT_HTTPS_DISPATCH_TASK_STACK_SIZE,
@@ -2693,7 +2557,10 @@ void IotHttpsClient_Cleanup( void )
     /* Delete the tasks that send requests from the dispatch queue. */
     for( dispatchTaskIndex = 0; dispatchTaskIndex < IOT_HTTPS_DISPATCH_TASK_COUNT; ++dispatchTaskIndex )
     {
-        vTaskDelete( httpsDispatchTask[ dispatchTaskIndex ] );
+        if( httpsDispatchTask[ dispatchTaskIndex ] != NULL )
+        {
+            vTaskDelete( httpsDispatchTask[ dispatchTaskIndex ] );
+        }
     }
 }
 

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2197,7 +2197,7 @@ static void _dispatchTaskRoutine( void * pParameters )
 
     for( ; ; )
     {
-        /* If there is no command in the queue, try again. */
+        /* If there are no requests in the dispatch queue, try again. */
         if( xQueueReceive( dispatchQueue,
                            &pHttpsRequest,
                            IOT_HTTPS_QUEUE_RECV_TICKS ) == pdFALSE )

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2177,7 +2177,7 @@ static void _dispatchTaskRoutine( void * pParameters )
                            &pHttpsRequest,
                            IOT_HTTPS_QUEUE_RECV_TICKS ) == pdFALSE )
         {
-            IotLogDebug( ( "No requests to send. Trying again." ) );
+            IotLogDebug( "No requests to send. Trying again." );
             continue;
         }
 

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -560,6 +560,37 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
 static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResponse );
 
 /**
+ * @brief A dummy function for transport interface receive.
+ *
+ * HTTP V1 library handles receiving from the network and hence transport
+ * implementation for receive is not used by the coreHTTP library. This
+ * dummy implementation is used for passing a non-NULL parameter to
+ * `HTTPClient_Send()`.
+ *
+ * @param[in] pNetworkContext Implementation-defined network context.
+ * @param[in] pBuffer Buffer to receive the data into.
+ * @param[in] bytesToRecv Number of bytes requested from the network.
+ *
+ * @return -1 to always return an error.
+ */
+static int32_t transportRecv( NetworkContext_t * pNetworkContext,
+                              void * pBuffer,
+                              size_t bytesToRecv );
+
+/**
+ * @brief Function for sending data over the network.
+ *
+ * @param[in] pNetworkContext Implementation-defined network context.
+ * @param[in] pBuffer Buffer containing the bytes to send over the network stack.
+ * @param[in] bytesToSend Number of bytes to send over the network.
+ *
+ * @return The number of bytes sent or a negative error code.
+ */
+static int32_t transportSend( NetworkContext_t * pNetworkContext,
+                              const void * pMessage,
+                              size_t bytesToSend );
+
+/**
  * @brief Schedule the task to send the the HTTP request.
  *
  * @param[in] pHttpsRequest - HTTP request context.
@@ -1069,7 +1100,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Defining the structure for network context used for sending the packets on the network.
+ * @brief Defining a network context for sending packets through the network interface.
  * The declaration of the structure is mentioned in the transport_interface.h file.
  */
 struct NetworkContext

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -468,7 +468,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResp
 /**
  * @brief A dummy function for the transport interface receive.
  *
- * HTTP V1 library handles receiving from the network and hence transport
+ * HTTP V1 library handles receiving from the network and hence the transport
  * implementation for receive is not used by the coreHTTP library. This
  * dummy implementation is used for passing a non-NULL parameter to
  * `HTTPClient_Send()`.

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -2316,7 +2316,7 @@ IotHttpsReturnCode_t IotHttpsClient_Init( void )
 
         /* An array that holds the stack of each dispatch task.
          * The size of StackType_t is dependent on the RTOS port. */
-        static StackType_t dispatchTaskStack[ IOT_HTTPS_DISPATCH_TASK_STACK_SIZE ][ IOT_HTTPS_DISPATCH_TASK_COUNT ];
+        static StackType_t dispatchTaskStack[ IOT_HTTPS_DISPATCH_TASK_COUNT ][ IOT_HTTPS_DISPATCH_TASK_STACK_SIZE ];
 
         /* A data structure to contain a statically allocated queue. */
         static StaticQueue_t dispatchQueueBuffer;

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -466,7 +466,7 @@ static IotHttpsReturnCode_t _receiveHttpsBodyAsync( _httpsResponse_t * pHttpsRes
 static IotHttpsReturnCode_t _receiveHttpsBodySync( _httpsResponse_t * pHttpsResponse );
 
 /**
- * @brief A dummy function for transport interface receive.
+ * @brief A dummy function for the transport interface receive.
  *
  * HTTP V1 library handles receiving from the network and hence transport
  * implementation for receive is not used by the coreHTTP library. This

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -29,11 +29,14 @@
 /* The config header is always included first. */
 #include "iot_config.h"
 
-/* Standard Includes. */
+/* Standard includes. */
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+/* Kernel includes. */
+#include "queue.h"
 
 /* coreHTTP includes. */
 #include "core_http_client.h"
@@ -44,14 +47,8 @@
 /* HTTPS Client library includes. */
 #include "iot_https_client.h"
 
-/* Task pool include. */
-#include "iot_taskpool.h"
-
 /* Linear containers (lists and queues) include. */
 #include "iot_linear_containers.h"
-
-/* Types include. */
-#include "types/iot_taskpool_types.h"
 
 /* Platform layer includes. */
 #include "platform/iot_threads.h"
@@ -399,8 +396,6 @@ typedef struct _httpsConnection
     IotMutex_t connectionMutex;                 /**< @brief Mutex protecting operations on this entire connection context. */
     IotDeQueue_t reqQ;                          /**< @brief The queue for the requests that are not finished yet. */
     IotDeQueue_t respQ;                         /**< @brief The queue for the responses that are waiting to be processed. */
-    IotTaskPoolJobStorage_t taskPoolJobStorage; /**< @brief An asynchronous operation requires storage for the task pool job. */
-    IotTaskPoolJob_t taskPoolJob;               /**< @brief The task pool job identifier for an asynchronous request. */
 } _httpsConnection_t;
 
 /**

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -158,7 +158,9 @@
  */
 #if IOT_STATIC_MEMORY_ONLY == 1
     #include "private/iot_static_memory.h"
-    #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 1 ) /* Whether the dispatch queue and tasks should use statically allocated memory. */
+    #ifndef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
+        #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 1 ) /* Whether the dispatch queue and tasks should use statically allocated memory. */
+    #endif
 #endif
 
 /**

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -170,37 +170,37 @@
  * Provide default values for undefined configuration constants.
  */
 #ifndef AWS_IOT_HTTPS_ENABLE_METRICS
-    #define AWS_IOT_HTTPS_ENABLE_METRICS           ( 1 )
+    #define AWS_IOT_HTTPS_ENABLE_METRICS            ( 1 )
 #endif
 #ifndef IOT_HTTPS_MAX_FLUSH_BUFFER_SIZE
-    #define IOT_HTTPS_MAX_FLUSH_BUFFER_SIZE        ( 1024 )
+    #define IOT_HTTPS_MAX_FLUSH_BUFFER_SIZE         ( 1024 )
 #endif
 #ifndef IOT_HTTPS_RESPONSE_WAIT_MS
-    #define IOT_HTTPS_RESPONSE_WAIT_MS             ( 1000 )
+    #define IOT_HTTPS_RESPONSE_WAIT_MS              ( 1000 )
 #endif
 #ifndef IOT_HTTPS_MAX_HOST_NAME_LENGTH
-    #define IOT_HTTPS_MAX_HOST_NAME_LENGTH         ( 255 ) /* Per FQDN, the maximum host name length is 255 bytes. */
+    #define IOT_HTTPS_MAX_HOST_NAME_LENGTH          ( 255 ) /* Per FQDN, the maximum host name length is 255 bytes. */
 #endif
 #ifndef IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH
-    #define IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH    ( 255 ) /* The maximum alpn protocols length is chosen arbitrarily. */
+    #define IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH     ( 255 ) /* The maximum alpn protocols length is chosen arbitrarily. */
 #endif
 #ifndef IOT_HTTPS_QUEUE_RECV_TICKS
-    #define IOT_HTTPS_QUEUE_RECV_TICKS             (portMAX_DELAY) /* The ticks to wait for a #xQueueReceive to complete. */
+    #define IOT_HTTPS_QUEUE_RECV_TICKS              ( portMAX_DELAY ) /* The ticks to wait for a #xQueueReceive to complete. */
 #endif
 #ifndef IOT_HTTPS_QUEUE_SEND_TICKS
-    #define IOT_HTTPS_QUEUE_SEND_TICKS             (0U) /* The ticks to wait for a #xQueueSendToBack to complete. */
+    #define IOT_HTTPS_QUEUE_SEND_TICKS              ( 0U ) /* The ticks to wait for a #xQueueSendToBack to complete. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_QUEUE_SIZE
-    #define IOT_HTTPS_DISPATCH_QUEUE_SIZE          ( 6U ) /* The size of the queue containing requests ready to send to the server. */
+    #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           ( 6U ) /* The size of the queue containing requests ready to send to the server. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_COUNT
-    #define IOT_HTTPS_DISPATCH_TASK_COUNT          ( 3U ) /* The number of tasks that send requests from the queue. */
+    #define IOT_HTTPS_DISPATCH_TASK_COUNT           ( 3U ) /* The number of tasks that send requests from the queue. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_STACK_SIZE
-    #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
+    #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_PRIORITY
-    #define IOT_HTTPS_DISPATCH_TASK_PRIORITY       ( tskIDLE_PRIORITY ) /* The priority of each dispatch task. */
+    #define IOT_HTTPS_DISPATCH_TASK_PRIORITY        ( tskIDLE_PRIORITY ) /* The priority of each dispatch task. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
     #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 0 ) /* The dispatch queue and tasks will not use static memory by default. */

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -519,7 +519,7 @@ typedef struct _httpsRequest
     IotHttpsClientCallbacks_t * pCallbacks;     /**< @brief Pointer to the asynchronous request callbacks. */
     bool cancelled;                             /**< @brief Set this to true to stop the response processing in the asynchronous workflow. */
     IotHttpsReturnCode_t bodyTxStatus;          /**< @brief The status of network sending the HTTPS body to be returned during the #IotHttpsClientCallbacks_t.writeCallback. */
-    bool scheduled;                             /**< @brief Set to true when this request has already been scheduled to the task pool. */
+    bool scheduled;                             /**< @brief Set to true when this request has already been added to the dispatch queue. */
 } _httpsRequest_t;
 
 /*-----------------------------------------------------------*/

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -159,7 +159,7 @@
 #if IOT_STATIC_MEMORY_ONLY == 1
     #include "private/iot_static_memory.h"
     #ifndef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
-        #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 1 ) /* Whether the dispatch queue and tasks should use statically allocated memory. */
+        #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 1 ) /* Use static memory for dispatch queue and tasks. */
     #endif
 #endif
 
@@ -185,10 +185,10 @@
     #define IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH    ( 255 ) /* The maximum alpn protocols length is chosen arbitrarily. */
 #endif
 #ifndef IOT_HTTPS_QUEUE_RECV_TICKS
-    #define IOT_HTTPS_QUEUE_RECV_TICKS             pdMS_TO_TICKS( 200U ) /* The ticks to wait for a #xQueueReceive to complete. */
+    #define IOT_HTTPS_QUEUE_RECV_TICKS             (portMAX_DELAY) /* The ticks to wait for a #xQueueReceive to complete. */
 #endif
 #ifndef IOT_HTTPS_QUEUE_SEND_TICKS
-    #define IOT_HTTPS_QUEUE_SEND_TICKS             portMAX_DELAY /* The ticks to wait for a #xQueueSendToBack to complete. */
+    #define IOT_HTTPS_QUEUE_SEND_TICKS             (0U) /* The ticks to wait for a #xQueueSendToBack to complete. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_QUEUE_SIZE
     #define IOT_HTTPS_DISPATCH_QUEUE_SIZE          ( 6U ) /* The size of the queue containing requests ready to send to the server. */
@@ -201,6 +201,9 @@
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_PRIORITY
     #define IOT_HTTPS_DISPATCH_TASK_PRIORITY       ( tskIDLE_PRIORITY ) /* The priority of each dispatch task. */
+#endif
+#ifndef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
+    #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 0 ) /* The dispatch queue and tasks will not use static memory by default. */
 #endif
 
 /* Provide the User-Agent Value definition fom coreHTTP. */
@@ -217,8 +220,8 @@
 #if IOT_HTTPS_DISPATCH_QUEUE_SIZE < 1
     #error "IOT_HTTPS_DISPATCH_QUEUE_SIZE must be at least 1."
 #endif
-#if defined( IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY ) && configSUPPORT_STATIC_ALLOCATION != 1
-    #error "IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY is defined but configSUPPORT_STATIC_ALLOCATION is not set to 1."
+#if IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY == 1 && configSUPPORT_STATIC_ALLOCATION != 1
+    #error "IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY is 1, but configSUPPORT_STATIC_ALLOCATION is not set to 1."
 #endif
 
 /**

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -158,6 +158,7 @@
  */
 #if IOT_STATIC_MEMORY_ONLY == 1
     #include "private/iot_static_memory.h"
+    #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 1 ) /* Whether the dispatch queue and tasks should use statically allocated memory. */
 #endif
 
 /**
@@ -196,8 +197,11 @@
 #ifndef IOT_HTTPS_DISPATCH_TASK_STACK_SIZE
     #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
 #endif
+#ifndef IOT_HTTPS_DISPATCH_TASK_PRIORITY
+    #define IOT_HTTPS_DISPATCH_TASK_PRIORITY       ( tskIDLE_PRIORITY ) /* The priority of each dispatch task. */
+#endif
 
-/* Provide the User-Agent Value definition from coreHTTP. */
+/* Provide the User-Agent Value definition fom coreHTTP. */
 #ifdef HTTP_USER_AGENT_VALUE
     #define IOT_HTTPS_USER_AGENT    HTTP_USER_AGENT_VALUE
 #endif
@@ -205,11 +209,14 @@
 /** @endcond */
 
 /* Error checking of macro configurations. */
+#if IOT_HTTPS_DISPATCH_TASK_COUNT < 1
+    #error "IOT_HTTPS_DISPATCH_TASK_COUNT must be at least 1."
+#endif
 #if IOT_HTTPS_DISPATCH_QUEUE_SIZE < 1
     #error "IOT_HTTPS_DISPATCH_QUEUE_SIZE must be at least 1."
 #endif
-#if IOT_HTTPS_DISPATCH_TASK_COUNT < 1
-    #error "IOT_HTTPS_DISPATCH_TASK_COUNT must be at least 1."
+#if defined( IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY ) && configSUPPORT_STATIC_ALLOCATION != 1
+    #error "IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY is defined but configSUPPORT_STATIC_ALLOCATION is not set to 1."
 #endif
 
 /**

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -181,12 +181,36 @@
 #ifndef IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH
     #define IOT_HTTPS_MAX_ALPN_PROTOCOLS_LENGTH    ( 255 ) /* The maximum alpn protocols length is chosen arbitrarily. */
 #endif
+#ifndef IOT_HTTPS_QUEUE_RECV_TICKS
+    #define IOT_HTTPS_QUEUE_RECV_TICKS             pdMS_TO_TICKS( 200U ) /* The ticks to wait for a #xQueueReceive to complete. */
+#endif
+#ifndef IOT_HTTPS_QUEUE_SEND_TICKS
+    #define IOT_HTTPS_QUEUE_SEND_TICKS             portMAX_DELAY /* The ticks to wait for a #xQueueSendToBack to complete. */
+#endif
+#ifndef IOT_HTTPS_DISPATCH_QUEUE_SIZE
+    #define IOT_HTTPS_DISPATCH_QUEUE_SIZE          ( 6U ) /* The size of the queue containing requests ready to send to the server. */
+#endif
+#ifndef IOT_HTTPS_DISPATCH_TASK_COUNT
+    #define IOT_HTTPS_DISPATCH_TASK_COUNT          ( 3U ) /* The number of tasks that send requests from the queue. */
+#endif
+#ifndef IOT_HTTPS_DISPATCH_TASK_STACK_SIZE
+    #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
+#endif
+
 /* Provide the User-Agent Value definition from coreHTTP. */
 #ifdef HTTP_USER_AGENT_VALUE
     #define IOT_HTTPS_USER_AGENT    HTTP_USER_AGENT_VALUE
 #endif
 
 /** @endcond */
+
+/* Error checking of macro configurations. */
+#if IOT_HTTPS_DISPATCH_QUEUE_SIZE < 1
+    #error "IOT_HTTPS_DISPATCH_QUEUE_SIZE must be at least 1."
+#endif
+#if IOT_HTTPS_DISPATCH_TASK_COUNT < 1
+    #error "IOT_HTTPS_DISPATCH_TASK_COUNT must be at least 1."
+#endif
 
 /**
  * @brief The HTTP protocol version of this library is HTTP/1.1.
@@ -392,10 +416,10 @@ typedef struct _httpsConnection
      * disconnect with a network error, or an explicit disconnect with a call to @ref https_client_function_disconnect.
      */
     bool isConnected;
-    bool isDestroyed;                           /**< @brief true if the connection is already destroyed and we should call anymore  */
-    IotMutex_t connectionMutex;                 /**< @brief Mutex protecting operations on this entire connection context. */
-    IotDeQueue_t reqQ;                          /**< @brief The queue for the requests that are not finished yet. */
-    IotDeQueue_t respQ;                         /**< @brief The queue for the responses that are waiting to be processed. */
+    bool isDestroyed;           /**< @brief true if the connection is already destroyed and we should call anymore  */
+    IotMutex_t connectionMutex; /**< @brief Mutex protecting operations on this entire connection context. */
+    IotDeQueue_t reqQ;          /**< @brief The queue for the requests that are not finished yet. */
+    IotDeQueue_t respQ;         /**< @brief The queue for the responses that are waiting to be processed. */
 } _httpsConnection_t;
 
 /**

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -425,7 +425,7 @@ typedef struct _httpsConnection
      * disconnect with a network error, or an explicit disconnect with a call to @ref https_client_function_disconnect.
      */
     bool isConnected;
-    bool isDestroyed;           /**< @brief true if the connection is already destroyed and we should call anymore  */
+    bool isDestroyed;           /**< @brief true if the connection is already destroyed and we should not make calls on it anymore.  */
     IotMutex_t connectionMutex; /**< @brief Mutex protecting operations on this entire connection context. */
     IotDeQueue_t reqQ;          /**< @brief The queue for the requests that are not finished yet. */
     IotDeQueue_t respQ;         /**< @brief The queue for the responses that are waiting to be processed. */

--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -200,7 +200,7 @@
     #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_PRIORITY
-    #define IOT_HTTPS_DISPATCH_TASK_PRIORITY        ( tskIDLE_PRIORITY ) /* The priority of each dispatch task. */
+    #define IOT_HTTPS_DISPATCH_TASK_PRIORITY        ( IOT_THREAD_DEFAULT_PRIORITY ) /* Priority is deliberately chosen to match the original taskpool's priority. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY
     #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    ( 0 ) /* The dispatch queue and tasks will not use static memory by default. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This updates the HTTP V1 deprecated library to call `HTTPClient_Send` from the coreHTTP LTS library in order to send HTTP requests. In addition, task pool is removed as a dependency in order to allow for statically allocated tasks. This is done by using a dispatch queue to hold HTTP requests that are ready to be sent to the server.  

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.