### PR TITLE
Fix an issue in retry logic in coreMQTT mutual auth demo.

### DIFF
--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -671,6 +671,22 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 
+    if( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
+    {
+        LogError( ( "Failed to create a TLS connection to %s:%u. xNetworkStatus =%u,"
+                    " Retry attempts done=%lu.",
+                    democonfigMQTT_BROKER_ENDPOINT,
+                    democonfigMQTT_BROKER_PORT,
+                    xNetworkStatus,
+                    xReconnectParams.attemptsDone ) );
+    }
+    else
+    {
+        LogInfo( ( "Established TLS connection to %s:%u.",
+                   democonfigMQTT_BROKER_ENDPOINT,
+                   democonfigMQTT_BROKER_PORT ) );
+    }
+
     return xStatus;
 }
 /*-----------------------------------------------------------*/

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -663,29 +663,20 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
                        MAX_RETRY_ATTEMPTS ) );
             xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );
         }
+        else
+        {
+            LogInfo( ( "Established TLS connection to %s:%u.",
+                       democonfigMQTT_BROKER_ENDPOINT,
+                       democonfigMQTT_BROKER_PORT ) );
+            xStatus = pdPASS;
+        }
 
-        if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
+        if( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) &&
+            ( xRetryUtilsStatus == RetryUtilsRetriesExhausted ) )
         {
             LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-            xNetworkStatus = TRANSPORT_SOCKET_STATUS_CONNECT_FAILURE;
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
-
-    if( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
-    {
-        LogError( ( "Failed to create a TLS connection to %s:%u. xNetworkStatus =%u,"
-                    " Retry attempts done=%lu.",
-                    democonfigMQTT_BROKER_ENDPOINT,
-                    democonfigMQTT_BROKER_PORT,
-                    xNetworkStatus,
-                    xReconnectParams.attemptsDone ) );
-    }
-    else
-    {
-        LogInfo( ( "Established TLS connection to %s:%u.",
-                   democonfigMQTT_BROKER_ENDPOINT,
-                   democonfigMQTT_BROKER_PORT ) );
-    }
 
     return xStatus;
 }


### PR DESCRIPTION
Fix an issue in retry logic in coreMQTT mutual auth demo.

Description
-----------
Fix an issue in retry logic in coreMQTT mutual auth demo.
Issue: The retry logic was returning pdFAIL as status even if the retry logic and connect is successful.
Fix: Update the status to pdPASS if a retry attempt succeeds.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.