### PR TITLE
Remove FreeRTOS console visibility of old HTTP and Defender modules

### DIFF
--- a/demos/defender/CMakeLists.txt
+++ b/demos/defender/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Device Defender demo
 afr_demo_module(defender)
 
-afr_set_demo_metadata(ID "DEFENDER_DEMO")
-afr_set_demo_metadata(DESCRIPTION "An example that demonstrates reporting metrics to AWS IoT with Device Defender")
-afr_set_demo_metadata(DISPLAY_NAME "Device Defender")
-
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE

--- a/demos/https/CMakeLists.txt
+++ b/demos/https/CMakeLists.txt
@@ -1,11 +1,6 @@
 # AFR HTTPS demo
 afr_demo_module(https)
 
-# The synchronous download demo is the default enabled demo.
-afr_set_demo_metadata(ID "HTTPS_SYNC_DOWNLOAD_DEMO")
-afr_set_demo_metadata(DESCRIPTION "Examples that demonstrate the HTTPS Client")
-afr_set_demo_metadata(DISPLAY_NAME "HTTPS Client Demos")
-
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE

--- a/libraries/c_sdk/aws/defender/CMakeLists.txt
+++ b/libraries/c_sdk/aws/defender/CMakeLists.txt
@@ -1,12 +1,5 @@
 afr_module()
 
-afr_set_lib_metadata(ID "defender")
-afr_set_lib_metadata(DESCRIPTION "This library enables metrics reporting with AWS IoT Device Defender.")
-afr_set_lib_metadata(DISPLAY_NAME "Device Defender")
-afr_set_lib_metadata(CATEGORY "Amazon Services")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "true")
-
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")

--- a/libraries/c_sdk/standard/https/CMakeLists.txt
+++ b/libraries/c_sdk/standard/https/CMakeLists.txt
@@ -1,12 +1,5 @@
 afr_module()
 
-afr_set_lib_metadata(ID "https")
-afr_set_lib_metadata(DESCRIPTION "This library implements the HTTPS client side protocol.")
-afr_set_lib_metadata(DISPLAY_NAME "HTTPS Client")
-afr_set_lib_metadata(CATEGORY "Connectivity")
-afr_set_lib_metadata(VERSION "1.0.0")
-afr_set_lib_metadata(IS_VISIBLE "true")
-
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")


### PR DESCRIPTION
Remove visibtility of the old HTTP (at `libraries/c_sdk/standard/https` ) and old Defender ( at `libraries/c_sdk/aws/defender` ) libraries and their demos by removing the metadata configuration.
This is done as their refactored library counterparts, `coreHTTP` and `device_defender_for_aws` will be shown on the FreeRTOS console.