### PR TITLE
Add retries to device shadow demo if a demo iteration is failed.

### DIFF
--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -456,9 +456,9 @@ BaseType_t EstablishMqttSession( MQTTContext_t * pxMqttContext,
                                  MQTTEventCallback_t eventCallback )
 {
     BaseType_t xReturnStatus = pdPASS;
-    MQTTStatus_t eMqttStatus;
-    MQTTConnectInfo_t xConnectInfo;
-    TransportInterface_t xTransport;
+    MQTTStatus_t eMqttStatus = MQTTSuccess;
+    MQTTConnectInfo_t xConnectInfo = { 0 };
+    TransportInterface_t xTransport = { 0 };
     bool sessionPresent = false;
 
     assert( pxMqttContext != NULL );
@@ -475,6 +475,7 @@ BaseType_t EstablishMqttSession( MQTTContext_t * pxMqttContext,
         LogError( ( "Failed to connect to MQTT broker %.*s.",
                     strlen( democonfigMQTT_BROKER_ENDPOINT ),
                     democonfigMQTT_BROKER_ENDPOINT ) );
+        xReturnStatus = pdFAIL;
     }
     else
     {

--- a/demos/device_shadow_for_aws/shadow_demo_main.c
+++ b/demos/device_shadow_for_aws/shadow_demo_main.c
@@ -804,7 +804,7 @@ int RunDeviceShadowDemo( bool awsIotMqttMode,
         }
     } while( xDemoStatus != pdPASS );
 
-    return ( ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE );
+    return( ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/device_shadow_for_aws/shadow_demo_main.c
+++ b/demos/device_shadow_for_aws/shadow_demo_main.c
@@ -164,8 +164,7 @@
 #define THING_NAME_LENGTH    ( ( uint16_t ) ( sizeof( THING_NAME ) - 1 ) )
 
 /**
- * @brief The maximum number of times to run the subscribe publish loop in this
- * demo.
+ * @brief The maximum number of times to run the loop in this demo.
  */
 #ifndef SHADOW_MAX_DEMO_COUNT
     #define SHADOW_MAX_DEMO_COUNT    ( 3 )

--- a/demos/device_shadow_for_aws/shadow_demo_main.c
+++ b/demos/device_shadow_for_aws/shadow_demo_main.c
@@ -790,7 +790,7 @@ int RunDeviceShadowDemo( bool awsIotMqttMode,
         {
             LogInfo( ( "Demo iteration %lu is successful.", ulDemoRunCount ) );
         }
-        /* Attempt to retry a failed iteration of demo for upto #SHADOW_MAX_DEMO_COUNT times. */
+        /* Attempt to retry a failed iteration of demo for up to #SHADOW_MAX_DEMO_COUNT times. */
         else if( ulDemoRunCount < SHADOW_MAX_DEMO_COUNT )
         {
             LogWarn( ( "Demo iteration %lu failed. Retrying...", ulDemoRunCount ) );
@@ -802,9 +802,9 @@ int RunDeviceShadowDemo( bool awsIotMqttMode,
             LogError( ( "All %d demo iterations failed.", SHADOW_MAX_DEMO_COUNT ) );
             break;
         }
-    }while( xDemoStatus != pdPASS );
+    } while( xDemoStatus != pdPASS );
 
-    return( ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE );
+    return ( ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Add retries to device shadow demo if a demo iteration is failed.

Description
-----------
Add retries to device shadow demo if a demo iteration is failed.
This change is to make the Shadow demo retry in case of a failure in a demo iteration. 

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.