### PR TITLE
Add retries to Jobs demo if a failure occurs.

### DIFF
--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -214,6 +214,19 @@
  */
 #define MAKE_STATUS_REPORT( x )    "{\"status\":\"" x "\"}"
 
+/**
+ * @brief The maximum number of times to run the loop in this demo.
+ */
+#ifndef JOBS_MAX_DEMO_COUNT
+    #define JOBS_MAX_DEMO_COUNT    ( 3 )
+#endif
+
+/**
+ * @brief Time in ticks to wait between each cycle of the demo implemented
+ * by RunJobsDemo(), in case a retry is required.
+ */
+#define DELAY_BETWEEN_DEMO_ITERATIONS_TICKS    ( pdMS_TO_TICKS( 5000U ) )
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -704,6 +717,8 @@ int RunJobsDemo( bool awsIotMqttMode,
                  const void * pNetworkInterface )
 {
     BaseType_t xDemoStatus = pdPASS;
+    uint32_t ulDemoRunCount = 0UL;
+    BaseType_t retryDemoLoop = pdFALSE;
 
     /* Remove compiler warnings about unused parameters. */
     ( void ) awsIotMqttMode;
@@ -712,119 +727,163 @@ int RunJobsDemo( bool awsIotMqttMode,
     ( void ) pNetworkCredentialInfo;
     ( void ) pNetworkInterface;
 
-    /* Establish an MQTT connection with AWS IoT over a mutually authenticated TLS session. */
-    xDemoStatus = EstablishMqttSession( &xMqttContext,
-                                        &xNetworkContext,
-                                        &xBuffer,
-                                        prvEventCallback );
-
-    if( xDemoStatus == pdFAIL )
+    /* This demo runs a single loop unless there are failures in the demo execution.
+     * In case of failures in the demo execution, demo loop will be retried for up to
+     * JOBS_MAX_DEMO_COUNT times. */
+    do
     {
-        /* Log error to indicate connection failure. */
-        LogError( ( "Failed to connect to AWS IoT broker." ) );
-    }
-    else
-    {
-        /* Print out a short user guide to the console. The default logging
-         * limit of 255 characters can be changed in demo_logging.c, but breaking
-         * up the only instance of a 1000+ character string is more practical. */
-        LogInfo( ( "\r\n"
-                   "/*-----------------------------------------------------------*/\r\n"
-                   "\r\n"
-                   "The Jobs demo is now ready to accept Jobs.\r\n"
-                   "Jobs may be created using the AWS IoT console or AWS CLI.\r\n"
-                   "See the following link for more information.\r\n" ) );
-        LogInfo( ( "\r"
-                   "https://docs.aws.amazon.com/cli/latest/reference/iot/create-job.html\r\n"
-                   "\r\n"
-                   "This demo expects Job documents to have an \"action\" JSON key.\r\n"
-                   "The following actions are currently supported:\r\n" ) );
-        LogInfo( ( "\r"
-                   " - print          \r\n"
-                   "   Logs a message to the local console. The Job document must also contain a \"message\".\r\n"
-                   "   For example: { \"action\": \"print\", \"message\": \"Hello world!\"} will cause\r\n"
-                   "   \"Hello world!\" to be printed on the console.\r\n" ) );
-        LogInfo( ( "\r"
-                   " - publish        \r\n"
-                   "   Publishes a message to an MQTT topic. The Job document must also contain a \"message\" and \"topic\".\r\n" ) );
-        LogInfo( ( "\r"
-                   "   For example: { \"action\": \"publish\", \"topic\": \"demo/jobs\", \"message\": \"Hello world!\"} will cause\r\n"
-                   "   \"Hello world!\" to be published to the topic \"demo/jobs\".\r\n" ) );
-        LogInfo( ( "\r"
-                   " - exit           \r\n"
-                   "   Exits the demo program. This program will run until { \"action\": \"exit\" } is received.\r\n"
-                   "\r\n"
-                   "/*-----------------------------------------------------------*/\r\n" ) );
+        /* Establish an MQTT connection with AWS IoT over a mutually authenticated TLS session. */
+        xDemoStatus = EstablishMqttSession( &xMqttContext,
+                                            &xNetworkContext,
+                                            &xBuffer,
+                                            prvEventCallback );
 
-        /* Subscribe to the NextJobExecutionChanged API topic to receive notifications about the next pending
-         * job in the queue for the Thing resource used by this demo. */
-        if( SubscribeToTopic( &xMqttContext,
-                              NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ),
-                              sizeof( NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) - 1 ) != pdPASS )
+        if( xDemoStatus == pdFAIL )
+        {
+            /* Log error to indicate connection failure. */
+            LogError( ( "Failed to connect to AWS IoT broker." ) );
+        }
+        else
+        {
+            /* Print out a short user guide to the console. The default logging
+             * limit of 255 characters can be changed in demo_logging.c, but breaking
+             * up the only instance of a 1000+ character string is more practical. */
+            LogInfo( ( "\r\n"
+                       "/*-----------------------------------------------------------*/\r\n"
+                       "\r\n"
+                       "The Jobs demo is now ready to accept Jobs.\r\n"
+                       "Jobs may be created using the AWS IoT console or AWS CLI.\r\n"
+                       "See the following link for more information.\r\n" ) );
+            LogInfo( ( "\r"
+                       "https://docs.aws.amazon.com/cli/latest/reference/iot/create-job.html\r\n"
+                       "\r\n"
+                       "This demo expects Job documents to have an \"action\" JSON key.\r\n"
+                       "The following actions are currently supported:\r\n" ) );
+            LogInfo( ( "\r"
+                       " - print          \r\n"
+                       "   Logs a message to the local console. The Job document must also contain a \"message\".\r\n"
+                       "   For example: { \"action\": \"print\", \"message\": \"Hello world!\"} will cause\r\n"
+                       "   \"Hello world!\" to be printed on the console.\r\n" ) );
+            LogInfo( ( "\r"
+                       " - publish        \r\n"
+                       "   Publishes a message to an MQTT topic. The Job document must also contain a \"message\" and \"topic\".\r\n" ) );
+            LogInfo( ( "\r"
+                       "   For example: { \"action\": \"publish\", \"topic\": \"demo/jobs\", \"message\": \"Hello world!\"} will cause\r\n"
+                       "   \"Hello world!\" to be published to the topic \"demo/jobs\".\r\n" ) );
+            LogInfo( ( "\r"
+                       " - exit           \r\n"
+                       "   Exits the demo program. This program will run until { \"action\": \"exit\" } is received.\r\n"
+                       "\r\n"
+                       "/*-----------------------------------------------------------*/\r\n" ) );
+
+            /* Subscribe to the NextJobExecutionChanged API topic to receive notifications about the next pending
+             * job in the queue for the Thing resource used by this demo. */
+            if( SubscribeToTopic( &xMqttContext,
+                                  NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ),
+                                  sizeof( NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) - 1 ) != pdPASS )
+            {
+                xDemoStatus = pdFAIL;
+                LogError( ( "Failed to subscribe to NextJobExecutionChanged API of AWS IoT Jobs service: Topic=%s",
+                            NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) );
+            }
+        }
+
+        if( xDemoStatus == pdPASS )
+        {
+            /* Publish to AWS IoT Jobs on the StartNextPendingJobExecution API to request the next pending job.
+             *
+             * Note: It is not required to make MQTT subscriptions to the response topics of the
+             * StartNextPendingJobExecution API because the AWS IoT Jobs service sends responses for
+             * the PUBLISH commands on the same MQTT connection irrespective of whether the client has subscribed
+             * to the response topics or not.
+             * This demo processes incoming messages from the response topics of the API in the prvEventCallback()
+             * handler that is supplied to the coreMQTT library. */
+            if( PublishToTopic( &xMqttContext,
+                                START_NEXT_JOB_TOPIC( democonfigTHING_NAME ),
+                                sizeof( START_NEXT_JOB_TOPIC( democonfigTHING_NAME ) ) - 1,
+                                NULL,
+                                0 ) != pdPASS )
+            {
+                xDemoStatus = pdFAIL;
+                LogError( ( "Failed to publish to StartNextPendingJobExecution API of AWS IoT Jobs service: "
+                            "Topic=%s", START_NEXT_JOB_TOPIC( democonfigTHING_NAME ) ) );
+            }
+        }
+
+        /* Keep on running the demo until we receive a job for the "exit" action to exit the demo. */
+        while( ( xExitActionJobReceived == pdFALSE ) &&
+               ( xDemoEncounteredError == pdFALSE ) &&
+               ( xDemoStatus == pdPASS ) )
+        {
+            MQTTStatus_t xMqttStatus = MQTTSuccess;
+
+            /* Check if we have notification for the next pending job in the queue from the
+             * NextJobExecutionChanged API of the AWS IoT Jobs service. */
+            xMqttStatus = MQTT_ProcessLoop( &xMqttContext, 300U );
+
+            if( xMqttStatus != MQTTSuccess )
+            {
+                xDemoStatus = pdFAIL;
+                LogError( ( "Failed to receive notification about next pending job: "
+                            "MQTT_ProcessLoop failed" ) );
+            }
+        }
+
+        /* Increment the demo run count. */
+        ulDemoRunCount++;
+
+        /* Retry demo loop only if there is a failure before completing
+         * the processing of any pending jobs. Any failure in MQTT unsubscribe
+         * or disconnect are considered a failure in demo execution and retry
+         * will not be attempted since a retry without any pending jobs will
+         * make this demo indefinitely wait. */
+        if( ( xDemoStatus == pdFAIL ) || ( xDemoEncounteredError == pdTRUE ) )
+        {
+            if( ulDemoRunCount < JOBS_MAX_DEMO_COUNT )
+            {
+                LogWarn( ( "Demo iteration %lu failed. Retrying...", ulDemoRunCount ) );
+                retryDemoLoop = pdTRUE;
+            }
+            else
+            {
+                LogError( ( "All %d demo iterations failed.", JOBS_MAX_DEMO_COUNT ) );
+                retryDemoLoop = pdFALSE;
+            }
+        }
+        else
+        {
+            /* Reset the flag for demo retry. */
+            retryDemoLoop = pdFALSE;
+        }
+
+        /* Unsubscribe from the NextJobExecutionChanged API topic. */
+        if( UnsubscribeFromTopic( &xMqttContext,
+                                  NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ),
+                                  sizeof( NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) - 1 ) != pdPASS )
         {
             xDemoStatus = pdFAIL;
-            LogError( ( "Failed to subscribe to NextJobExecutionChanged API of AWS IoT Jobs service: Topic=%s",
-                        NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) );
+            LogError( ( "Failed to unsubscribe from the NextJobExecutionChanged API of AWS IoT Jobs service: "
+                        "Topic=%s", NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) );
         }
-    }
 
-    if( xDemoStatus == pdPASS )
-    {
-        /* Publish to AWS IoT Jobs on the StartNextPendingJobExecution API to request the next pending job.
-         *
-         * Note: It is not required to make MQTT subscriptions to the response topics of the
-         * StartNextPendingJobExecution API because the AWS IoT Jobs service sends responses for
-         * the PUBLISH commands on the same MQTT connection irrespective of whether the client has subscribed
-         * to the response topics or not.
-         * This demo processes incoming messages from the response topics of the API in the prvEventCallback()
-         * handler that is supplied to the coreMQTT library. */
-        if( PublishToTopic( &xMqttContext,
-                            START_NEXT_JOB_TOPIC( democonfigTHING_NAME ),
-                            sizeof( START_NEXT_JOB_TOPIC( democonfigTHING_NAME ) ) - 1,
-                            NULL,
-                            0 ) != pdPASS )
+        /* Disconnect the MQTT and network connections with AWS IoT. */
+        if( DisconnectMqttSession( &xMqttContext, &xNetworkContext ) != pdPASS )
         {
             xDemoStatus = pdFAIL;
-            LogError( ( "Failed to publish to StartNextPendingJobExecution API of AWS IoT Jobs service: "
-                        "Topic=%s", START_NEXT_JOB_TOPIC( democonfigTHING_NAME ) ) );
+            LogError( ( "Disconnection from AWS Iot failed..." ) );
         }
-    }
 
-    /* Keep on running the demo until we receive a job for the "exit" action to exit the demo. */
-    while( ( xExitActionJobReceived == pdFALSE ) &&
-           ( xDemoEncounteredError == pdFALSE ) &&
-           ( xDemoStatus == pdPASS ) )
-    {
-        MQTTStatus_t xMqttStatus = MQTTSuccess;
-
-        /* Check if we have notification for the next pending job in the queue from the
-         * NextJobExecutionChanged API of the AWS IoT Jobs service. */
-        xMqttStatus = MQTT_ProcessLoop( &xMqttContext, 300U );
-
-        if( xMqttStatus != MQTTSuccess )
+        /* Add a delay if a retry is required. */
+        if( retryDemoLoop == pdTRUE )
         {
-            xDemoStatus = pdFAIL;
-            LogError( ( "Failed to receive notification about next pending job: "
-                        "MQTT_ProcessLoop failed" ) );
+            /* Clear the flag that indicates that indicates the demo error
+             * before attempting a retry. */
+            xDemoEncounteredError = pdFALSE;
+
+            LogInfo( ( "A short delay before the next demo iteration." ) );
+            vTaskDelay( DELAY_BETWEEN_DEMO_ITERATIONS_TICKS );
         }
-    }
-
-    /* Unsubscribe from the NextJobExecutionChanged API topic. */
-    if( UnsubscribeFromTopic( &xMqttContext,
-                              NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ),
-                              sizeof( NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) - 1 ) != pdPASS )
-    {
-        xDemoStatus = pdFAIL;
-        LogError( ( "Failed to subscribe unsubscribe from the NextJobExecutionChanged API of AWS IoT Jobs service: "
-                    "Topic=%s", NEXT_JOB_EXECUTION_CHANGED_TOPIC( democonfigTHING_NAME ) ) );
-    }
-
-    /* Disconnect the MQTT and network connections with AWS IoT. */
-    if( DisconnectMqttSession( &xMqttContext, &xNetworkContext ) != pdPASS )
-    {
-        xDemoStatus = pdFAIL;
-        LogError( ( "Disconnection from AWS Iot failed..." ) );
-    }
+    } while( retryDemoLoop == pdTRUE );
 
     return( ( ( xDemoStatus == pdPASS ) && ( xDemoEncounteredError == pdFALSE ) ) ?
             EXIT_SUCCESS : EXIT_FAILURE );

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -222,7 +222,7 @@
 #endif
 
 /**
- * @brief Time in ticks to wait between each iteration of the demo execution, 
+ * @brief Time in ticks to wait between each iteration of the demo execution,
  * in case a retry is required from demo execution failure.
  */
 #define DELAY_BETWEEN_DEMO_ITERATIONS_TICKS    ( pdMS_TO_TICKS( 5000U ) )
@@ -830,7 +830,7 @@ int RunJobsDemo( bool awsIotMqttMode,
         }
 
         /* Increment the demo run count. */
-        ulDemoRunCount++;
+        uxDemoRunCount++;
 
         /* Retry demo loop only if there is a failure before completing
          * the processing of any pending jobs. Any failure in MQTT unsubscribe
@@ -839,9 +839,9 @@ int RunJobsDemo( bool awsIotMqttMode,
          * make this demo indefinitely wait. */
         if( ( xDemoStatus == pdFAIL ) || ( xDemoEncounteredError == pdTRUE ) )
         {
-            if( ulDemoRunCount < JOBS_MAX_DEMO_COUNT )
+            if( uxDemoRunCount < JOBS_MAX_DEMO_COUNT )
             {
-                LogWarn( ( "Demo iteration %lu failed. Retrying...", ulDemoRunCount ) );
+                LogWarn( ( "Demo iteration %lu failed. Retrying...", uxDemoRunCount ) );
                 retryDemoLoop = pdTRUE;
             }
             else

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -222,8 +222,8 @@
 #endif
 
 /**
- * @brief Time in ticks to wait between each cycle of the demo implemented
- * by RunJobsDemo(), in case a retry is required.
+ * @brief Time in ticks to wait between each iteration of the demo execution, 
+ * in case a retry is required from demo execution failure.
  */
 #define DELAY_BETWEEN_DEMO_ITERATIONS_TICKS    ( pdMS_TO_TICKS( 5000U ) )
 
@@ -717,7 +717,7 @@ int RunJobsDemo( bool awsIotMqttMode,
                  const void * pNetworkInterface )
 {
     BaseType_t xDemoStatus = pdPASS;
-    uint32_t ulDemoRunCount = 0UL;
+    UBaseType_t uxDemoRunCount = 0UL;
     BaseType_t retryDemoLoop = pdFALSE;
 
     /* Remove compiler warnings about unused parameters. */
@@ -834,7 +834,7 @@ int RunJobsDemo( bool awsIotMqttMode,
 
         /* Retry demo loop only if there is a failure before completing
          * the processing of any pending jobs. Any failure in MQTT unsubscribe
-         * or disconnect are considered a failure in demo execution and retry
+         * or disconnect is considered a failure in demo execution and retry
          * will not be attempted since a retry without any pending jobs will
          * make this demo indefinitely wait. */
         if( ( xDemoStatus == pdFAIL ) || ( xDemoEncounteredError == pdTRUE ) )


### PR DESCRIPTION
Add retries to Jobs demo if a failure occurs.

Description
-----------
Add retries to Jobs demo if a failure occurs in a demo loop. Retry will be attempted only if a failure happens in a demo run. Retry will be attempted up to JOBS_MAX_DEMO_COUNT times.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.