### PR TITLE
Add PKCS log defines for secure element boards.

### DIFF
--- a/demos/common/pkcs11_helpers/pkcs11_helpers.c
+++ b/demos/common/pkcs11_helpers/pkcs11_helpers.c
@@ -54,26 +54,26 @@ BaseType_t xPkcs11GenerateRandomNumber( uint8_t * pusRandomNumBuffer,
 
     if( xStatus == pdPASS )
     {
-        /* Get list of functions supported by the PKCS11 port. */
+        /* Get list of functions supported by the PKCS #11 port. */
         xResult = C_GetFunctionList( &pxFunctionList );
 
         if( ( xResult != CKR_OK ) || ( pxFunctionList == NULL ) )
         {
             LogError( ( "Failed to generate random number. "
-                        "PCKS11 API, C_GetFunctionList, failed." ) );
+                        "PKCS #11 API, C_GetFunctionList, failed." ) );
             xStatus = pdFAIL;
         }
     }
 
     if( xStatus == pdPASS )
     {
-        /* Initialize PKCS11 module and create a new session. */
+        /* Initialize PKCS #11 module and create a new session. */
         xResult = xInitializePkcs11Session( &xSession );
 
         if( ( xResult != CKR_OK ) || ( xSession == CK_INVALID_HANDLE ) )
         {
             LogError( ( "Failed to generate random number. "
-                        "Failed to initialize PKCS11 session." ) );
+                        "Failed to initialize PKCS #11 session." ) );
             xStatus = pdFAIL;
         }
     }
@@ -86,7 +86,7 @@ BaseType_t xPkcs11GenerateRandomNumber( uint8_t * pusRandomNumBuffer,
         {
             xStatus = pdFAIL;
             LogError( ( "Failed to generate random number. "
-                        "PKCS11 API, C_GenerateRandom, failed to generate random number." ) );
+                        "PKCS #11 API, C_GenerateRandom, failed to generate random number." ) );
         }
     }
 
@@ -95,7 +95,7 @@ BaseType_t xPkcs11GenerateRandomNumber( uint8_t * pusRandomNumBuffer,
         if( pxFunctionList->C_CloseSession( xSession ) != CKR_OK )
         {
             xStatus = pdFAIL;
-            LogError( ( " Failed to close PKCS11 session after generating random number." ) );
+            LogError( ( " Failed to close PKCS #11 session after generating random number." ) );
         }
     }
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -39,6 +39,29 @@
 
 #include "FreeRTOS.h"
 
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for PKCS #11.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for PKCS #11.
+ */
+#include "logging_levels.h"
+
+/* Logging configuration for the PKCS #11 library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "PKCS11"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#include "logging_stack.h"
+
 extern const char * pcPkcs11GetThingName(void);
 
 /**

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -34,6 +34,29 @@
 
 #include "FreeRTOS.h"
 
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for PKCS #11.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for PKCS #11.
+ */
+#include "logging_levels.h"
+
+/* Logging configuration for the PKCS #11 library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "PKCS11"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#include "logging_stack.h"
+
 /**
  * @brief Malloc API used by core_pkcs11.h
  */

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_pkcs11_config.h
@@ -33,6 +33,29 @@
 
 #include "FreeRTOS.h"
 
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for PKCS #11.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for PKCS #11.
+ */
+#include "logging_levels.h"
+
+/* Logging configuration for the PKCS #11 library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "PKCS11"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#include "logging_stack.h"
+
 /**
  * @brief Malloc API used by core_pkcs11.h
  */


### PR DESCRIPTION
Add Log macros to secure element boards

Description
-----------
The PKCS demo helper modules depend on the PKCS config for log macro definitions, so 
now it makes to add them to the secure element boards.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
