### PR TITLE
Update FreeRTOS console text for Jobs and Device Shadow libraries

### DIFF
--- a/libraries/device_shadow_demo_dependencies.cmake
+++ b/libraries/device_shadow_demo_dependencies.cmake
@@ -59,8 +59,7 @@ afr_module_cmake_files(${AFR_CURRENT_MODULE}
 )
 
 afr_set_lib_metadata(ID "device_shadow_demo_dependencies")
-afr_set_lib_metadata(DESCRIPTION "This library enables you to store and retrieve the \
-current state (the \"shadow\") of every registered device on AWS IoT.")
+afr_set_lib_metadata(DESCRIPTION "This library enables a registered device to update and retrieve its current state (the \"shadow\") on AWS IoT.")
 afr_set_lib_metadata(DISPLAY_NAME "Device Shadow")
 afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")

--- a/libraries/jobs_demo_dependencies.cmake
+++ b/libraries/jobs_demo_dependencies.cmake
@@ -47,7 +47,7 @@ afr_module_include_dirs(
 afr_module(NAME jobs_demo_dependencies )
 
 afr_set_lib_metadata(ID "jobs_demo_dependencies")
-afr_set_lib_metadata(DESCRIPTION "This library enables device metrics reporting with AWS IoT Jobs.")
+afr_set_lib_metadata(DESCRIPTION "This library enables you to receive pending "jobs" from and send job execution updates to the AWS IoT Jobs service for a device registered on AWS IoT.")
 afr_set_lib_metadata(DISPLAY_NAME "Jobs")
 afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")

--- a/libraries/jobs_demo_dependencies.cmake
+++ b/libraries/jobs_demo_dependencies.cmake
@@ -47,7 +47,7 @@ afr_module_include_dirs(
 afr_module(NAME jobs_demo_dependencies )
 
 afr_set_lib_metadata(ID "jobs_demo_dependencies")
-afr_set_lib_metadata(DESCRIPTION "This library enables you to receive pending "jobs" from and send job execution updates to the AWS IoT Jobs service for a device registered on AWS IoT.")
+afr_set_lib_metadata(DESCRIPTION "This library enables a device registered on AWS IoT to receive pending job requests and post job updates to the AWS IoT Jobs service.")
 afr_set_lib_metadata(DISPLAY_NAME "Jobs")
 afr_set_lib_metadata(CATEGORY "Amazon Services")
 afr_set_lib_metadata(VERSION "1.0.0")


### PR DESCRIPTION
Fix the text to be displayed for the **Jobs** and **Device Shadow** libraries on FreeRTOS console on AWS IoT