### PR TITLE
Updating Cypress files for coreHTTP_Integration

### DIFF
--- a/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
+++ b/projects/cypress/CY8CKIT_064S0S2_4343W/mtb/aws_tests/afr.mk
@@ -330,6 +330,7 @@ SOURCES+=\
 	$(wildcard $(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/system/*.c)\
 	$(CY_AFR_ROOT)/libraries/c_sdk/standard/mqtt/test/iot_test_mqtt_agent.c\
 	$(CY_AFR_ROOT)/tests/integration_test/core_mqtt_system_test.c\
+	$(CY_AFR_ROOT)/tests/integration_test/core_http_system_test.c\
 	$(CY_AFR_ROOT)/tests/integration_test/shadow_system_test.c
 	
 

--- a/tests/integration_test/core_http_system_test.c
+++ b/tests/integration_test/core_http_system_test.c
@@ -389,7 +389,7 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
         }
     } while( ( transportStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( BackoffAlgStatus == BackoffAlgorithmSuccess ) );
 
-    TEST_ASSERT_EQUAL( transportStatus, TRANSPORT_SOCKET_STATUS_SUCCESS );
+    TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_SUCCESS, transportStatus );
 }
 
 /*-----------------------------------------------------------*/

--- a/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
+++ b/vendors/cypress/WICED_SDK/apps/test/aws_test/aws_test.mk
@@ -154,6 +154,7 @@ $(NAME)_SOURCES    := $(AMAZON_FREERTOS_PATH)vendors/cypress/boards/$(PLATFORM)/
                       $(AFR_C_SDK_STANDARD_PATH)mqtt/test/unit/iot_tests_mqtt_validate.c \
                       $(AFR_C_SDK_STANDARD_PATH)mqtt/test/unit/iot_tests_mqtt_metrics.c \
                       $(AMAZON_FREERTOS_PATH)tests/integration_test/core_mqtt_system_test.c \
+                      $(AMAZON_FREERTOS_PATH)tests/integration_test/core_http_system_test.c \
                       $(AFR_C_SDK_AWS_PATH)shadow/test/aws_test_shadow.c \
                       $(AFR_C_SDK_AWS_PATH)shadow/test/unit/aws_iot_tests_shadow_api.c \
                       $(AFR_C_SDK_AWS_PATH)shadow/test/unit/aws_iot_tests_shadow_parser.c \


### PR DESCRIPTION
This PR adds missing coreHTTP integration test sources in `aws_test.mk` and `afr.mk`, which were leading to build failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.