### PR TITLE
Update HTTP Shim default stack size to resolve overflow

### DIFF
--- a/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
+++ b/libraries/c_sdk/standard/https/src/private/iot_https_internal.h
@@ -191,13 +191,13 @@
     #define IOT_HTTPS_QUEUE_SEND_TICKS              ( 0U ) /* The ticks to wait for a #xQueueSendToBack to complete. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_QUEUE_SIZE
-    #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           ( 6U ) /* The size of the queue containing requests ready to send to the server. */
+    #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           ( 4U ) /* The size of the queue containing requests ready to send to the server. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_COUNT
-    #define IOT_HTTPS_DISPATCH_TASK_COUNT           ( 3U ) /* The number of tasks that send requests from the queue. */
+    #define IOT_HTTPS_DISPATCH_TASK_COUNT           ( 2U ) /* The number of tasks that send requests from the queue. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_STACK_SIZE
-    #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE ) /* The stack size of each dispatch task. */
+    #define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 2 ) /* The stack size of each dispatch task. */
 #endif
 #ifndef IOT_HTTPS_DISPATCH_TASK_PRIORITY
     #define IOT_HTTPS_DISPATCH_TASK_PRIORITY        ( IOT_THREAD_DEFAULT_PRIORITY ) /* Priority is deliberately chosen to match the original taskpool's priority. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
This resolves stack overflow issues from having the default stack size of the dispatch task too small.

The size of the dispatch task is doubled because `uxTaskGetStackHighWaterMark` tells us that all boards except renesas and pc will need at least double of `configMINIMAL_STACK_SIZE`. Therefore, it would be a good default so that customers will not need to configure that parameter themselves.

The number of dispatch tasks are also reduced to 2 because all the demos and tests only ever make one connection at a time.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.