### PR TITLE
Update demos and tests for backoffAlgorithm API change

### DIFF
--- a/demos/common/http_demo_helpers/http_demo_utils.c
+++ b/demos/common/http_demo_helpers/http_demo_utils.c
@@ -54,40 +54,76 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The random number generator to use for exponential backoff with
- * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the backoff algorithm library API.
+ * @brief Calculate and perform an exponential backoff with jitter delay for
+ * the next retry attempt of a failed network operation with the server.
  *
- * The PKCS11 module is used to generate the random number as it allows access
+ * The function generates a random number, calculates the next backoff period
+ * with the generated random number, and performs the backoff delay operation if the
+ * number of retries have not exhausted.
+ *
+ * @note The PKCS11 module is used to generate the random number as it allows access
  * to a True Random Number Generator (TRNG) if the vendor platform supports it.
- * It is recommended to use a device-specific unique random number generator so
- * that probability of collisions from devices in connection retries is mitigated.
+ * It is recommended to seed the random number generator with a device-specific entropy
+ * source so that probability of collisions from devices in connection retries is mitigated.
  *
- * @return A positive value if generating the random number was successful; otherwise
- * -1 to indicate failure.
+ * @note The backoff period is calculated using the backoffAlgorithm library.
+ *
+ * @param[in, out] pxRetryAttempts The context to use for backoff period calculation
+ * with the backoffAlgorithm library.
+ *
+ * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
+ * if there was failure in randon number generation OR all retry attempts had exhausted.
  */
-static int32_t prvGenerateRandomNumber();
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 
 /*-----------------------------------------------------------*/
 
-static int32_t prvGenerateRandomNumber()
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams )
 {
-    uint32_t ulRandomNum;
+    BaseType_t xReturnStatus = pdFAIL;
+    uint16_t usNextRetryBackOff = 0U;
+    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
 
-    /* Use the PKCS11 module to generate a random number. */
+    /**
+     * To calculate the backoff period for the next retry attempt, we will
+     * generate a random number to provide to the backoffAlgorithm library.
+     *
+     * Note: The PKCS11 module is used to generate the random number as it allows access
+     * to a True Random Number Generator (TRNG) if the vendor platform supports it.
+     * It is recommended to use a random number generator seeded with a device-specific
+     * entropy source so that probability of collisions from devices in connection retries
+     * is mitigated.
+     */
+    uint32_t ulRandomNum = 0;
+
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
                                      ( sizeof( ulRandomNum ) == pdPASS ) ) )
     {
-        ulRandomNum = ( ulRandomNum & INT32_MAX );
+        /* Get back-off value (in milliseconds) for the next retry attempt. */
+        xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );
+
+        if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+        {
+            LogError( ( "All retry attempts have exhausted. Operation will not be retried" ) );
+        }
+        else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
+        {
+            /* Perform the backoff delay. */
+            vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+
+            xReturnStatus = pdPASS;
+
+            LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
+                       ( pxRetryParams->attemptsDone + 1 ),
+                       pxRetryParams->maxRetryAttempts ) );
+        }
     }
     else
     {
-        /* Set the return value as negative to indicate failure. */
-        ulRandomNum = -1;
+        LogError( ( "Unable to retry operation with broker: Random number generation failed" ) );
     }
 
-    return ( int32_t ) ulRandomNum;
+    return xReturnStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -96,11 +132,9 @@ BaseType_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction
                                               NetworkContext_t * pxNetworkContext )
 {
     BaseType_t xReturn = pdFAIL;
-    /* Status returned by the retry utilities. */
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
     /* Struct containing the next backoff time. */
     BackoffAlgorithmContext_t xReconnectParams;
-    uint16_t usNextRetryBackOff = 0U;
+    BaseType_t xBackoffStatus = 0U;
 
     configASSERT( connectFunction != NULL );
     configASSERT( pxNetworkContext != NULL );
@@ -109,8 +143,7 @@ BaseType_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction
     BackoffAlgorithm_InitializeParams( &xReconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       prvGenerateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to the HTTP server. If connection fails, retry after a
      * timeout. The timeout value will exponentially increase until either the
@@ -122,25 +155,16 @@ BaseType_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction
 
         if( xReturn != pdPASS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, &usNextRetryBackOff );
-            configASSERT( xBackoffAlgStatus != BackoffAlgorithmRngFailure );
+            LogWarn( ( "Connection to the HTTP server failed. "
+                       "Retrying connection with backoff and jitter." ) );
 
-            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-            {
-                LogError( ( "Connection to the server failed, all attempts exhausted." ) );
-            }
-            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-            {
-                LogWarn( ( "Connection to the HTTP server failed. "
-                           "Retrying connection with backoff and jitter." ) );
-                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
-                LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
-                           ( xReconnectParams.attemptsDone + 1 ),
-                           MAX_RETRY_ATTEMPTS ) );
-            }
+            /* As the connection attempt failed, we will retry the connection after an
+             * exponential backoff with jitter delay. */
+
+            /* Calculate the backoff period for the next retry attempt and perform the wait operation. */
+            xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
-    } while( ( xReturn == pdFAIL ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+    } while( ( xReturn == pdFAIL ) && ( xBackoffStatus == pdPASS ) );
 
     return xReturn;
 }

--- a/demos/common/http_demo_helpers/http_demo_utils.c
+++ b/demos/common/http_demo_helpers/http_demo_utils.c
@@ -72,7 +72,7 @@
  * with the backoffAlgorithm library.
  *
  * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
- * if there was failure in randon number generation OR all retry attempts had exhausted.
+ * if there was failure in random number generation OR all retry attempts had exhausted.
  */
 static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 

--- a/demos/common/http_demo_helpers/http_demo_utils.c
+++ b/demos/common/http_demo_helpers/http_demo_utils.c
@@ -97,7 +97,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
     uint32_t ulRandomNum = 0;
 
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
-                                     ( sizeof( ulRandomNum ) == pdPASS ) ) )
+                                     sizeof( ulRandomNum ) ) == pdPASS )
     {
         /* Get back-off value (in milliseconds) for the next retry attempt. */
         xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );

--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -205,7 +205,7 @@ static bool mqttSessionEstablished = false;
  * with the backoffAlgorithm library.
  *
  * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
- * if there was failure in randon number generation OR all retry attempts had exhausted.
+ * if there was failure in random number generation OR all retry attempts had exhausted.
  */
 static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 

--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -293,7 +293,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
     uint32_t ulRandomNum = 0;
 
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
-                                     ( sizeof( ulRandomNum ) == pdPASS ) ) )
+                                     sizeof( ulRandomNum ) ) == pdPASS )
     {
         /* Get back-off value (in milliseconds) for the next retry attempt. */
         xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );

--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -187,20 +187,27 @@ static bool mqttSessionEstablished = false;
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The random number generator to use for exponential backoff with
- * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the backoff algorithm library API.
+ * @brief Calculate and perform an exponential backoff with jitter delay for
+ * the next retry attempt of a failed network operation with the server.
  *
- * The PKCS11 module is used to generate the random number as it allows access
+ * The function generates a random number, calculates the next backoff period
+ * with the generated random number, and performs the backoff delay operation if the
+ * number of retries have not exhausted.
+ *
+ * @note The PKCS11 module is used to generate the random number as it allows access
  * to a True Random Number Generator (TRNG) if the vendor platform supports it.
- * It is recommended to use a device-specific unique random number generator so
- * that probability of collisions from devices in connection retries is mitigated.
+ * It is recommended to seed the random number generator with a device-specific entropy
+ * source so that probability of collisions from devices in connection retries is mitigated.
  *
- * @return A positive value if generating the random number was successful; otherwise
- * -1 to indicate failure.
+ * @note The backoff period is calculated using the backoffAlgorithm library.
+ *
+ * @param[in, out] pxRetryAttempts The context to use for backoff period calculation
+ * with the backoffAlgorithm library.
+ *
+ * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
+ * if there was failure in randon number generation OR all retry attempts had exhausted.
  */
-static int32_t prvGenerateRandomNumber();
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -267,33 +274,61 @@ static uint32_t prvGetTimeMs( void );
 
 /*-----------------------------------------------------------*/
 
-static int32_t prvGenerateRandomNumber()
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams )
 {
-    uint32_t ulRandomNum;
+    BaseType_t xReturnStatus = pdFAIL;
+    uint16_t usNextRetryBackOff = 0U;
+    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
 
-    /* Use the PKCS11 module to generate a random number. */
+    /**
+     * To calculate the backoff period for the next retry attempt, we will
+     * generate a random number to provide to the backoffAlgorithm library.
+     *
+     * Note: The PKCS11 module is used to generate the random number as it allows access
+     * to a True Random Number Generator (TRNG) if the vendor platform supports it.
+     * It is recommended to use a random number generator seeded with a device-specific
+     * entropy source so that probability of collisions from devices in connection retries
+     * is mitigated.
+     */
+    uint32_t ulRandomNum = 0;
+
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
                                      ( sizeof( ulRandomNum ) == pdPASS ) ) )
     {
-        ulRandomNum = ( ulRandomNum & INT32_MAX );
+        /* Get back-off value (in milliseconds) for the next retry attempt. */
+        xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );
+
+        if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+        {
+            LogError( ( "All retry attempts have exhausted. Operation will not be retried" ) );
+        }
+        else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
+        {
+            /* Perform the backoff delay. */
+            vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+
+            xReturnStatus = pdPASS;
+
+            LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
+                       ( pxRetryParams->attemptsDone + 1 ),
+                       pxRetryParams->maxRetryAttempts ) );
+        }
     }
     else
     {
-        /* Set the return value as negative to indicate failure. */
-        ulRandomNum = -1;
+        LogError( ( "Unable to retry operation with broker: Random number generation failed" ) );
     }
 
-    return ( int32_t ) ulRandomNum;
+    return xReturnStatus;
 }
 
 static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNetworkContext )
 {
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t xReconnectParams = { 0 };
+    BaseType_t xBackoffStatus = pdPASS;
     ServerInfo_t xServerInfo = { 0 };
     SocketsConfig_t xSocketConfig = { 0 };
-    uint16_t usNextRetryBackOff = 0U;
 
     /* Initialize information to connect to the MQTT broker. */
     xServerInfo.pHostName = democonfigMQTT_BROKER_ENDPOINT;
@@ -312,8 +347,7 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
     BackoffAlgorithm_InitializeParams( &xReconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       prvGenerateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -333,21 +367,15 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
 
         if( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, &usNextRetryBackOff );
-            configASSERT( xBackoffAlgStatus != BackoffAlgorithmRngFailure );
+            LogWarn( ( "Connection to the broker failed. Attempting connection retry after backoff delay." ) );
 
-            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-            {
-                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-            }
-            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-            {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff delay." ) );
-                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
-            }
+            /* As the connection attempt failed, we will retry the connection after an
+             * exponential backoff with jitter delay. */
+
+            /* Calculate the backoff period for the next retry attempt and perform the wait operation. */
+            xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
-    } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+    } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
 
     return xNetworkStatus;
 }

--- a/demos/coreHTTP/http_demo_mutual_auth.c
+++ b/demos/coreHTTP/http_demo_mutual_auth.c
@@ -44,6 +44,14 @@
 /**
  * @file http_demo_mutual_auth.c
  * @brief Demonstrates usage of the HTTP library.
+ *
+ * @note This demo uses retry logic to connect to the server if connection attempts fail.
+ * The FreeRTOS/backoffAlgorithm library is used to calculate the retry interval with an exponential
+ * backoff and jitter algorithm. For generating random number required by the algorithm, the PKCS11
+ * module is used as it allows access to a True Random Number Generator (TRNG) if the vendor platform
+ * supports it.
+ * It is RECOMMENDED to seed the random number generator with a device-specific entropy source so that
+ * probability of collisions from devices in connection retries is mitigated.
  */
 /* Standard includes. */
 #include <stdio.h>

--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -34,6 +34,14 @@
  * client library API is used to download the S3 file (by sending multiple GET
  * requests, filling up the response buffer each time until all parts are
  * downloaded). If any request fails, an error code is returned.
+ *
+ * @note This demo uses retry logic to connect to the server if connection attempts fail.
+ * The FreeRTOS/backoffAlgorithm library is used to calculate the retry interval with an exponential
+ * backoff and jitter algorithm. For generating random number required by the algorithm, the PKCS11
+ * module is used as it allows access to a True Random Number Generator (TRNG) if the vendor platform
+ * supports it.
+ * It is RECOMMENDED to seed the random number generator with a device-specific entropy source so that
+ * probability of collisions from devices in connection retries is mitigated.
  */
 
 /**

--- a/demos/coreHTTP/http_demo_s3_upload.c
+++ b/demos/coreHTTP/http_demo_s3_upload.c
@@ -34,6 +34,14 @@
  * Client library API is used to upload a file to a S3 bucket by sending a PUT
  * request, and verify the file was uploaded using a GET request. If any request
  * fails, an error code is returned.
+ *
+ * @note This demo uses retry logic to connect to the server if connection attempts fail.
+ * The FreeRTOS/backoffAlgorithm library is used to calculate the retry interval with an exponential
+ * backoff and jitter algorithm. For generating random number required by the algorithm, the PKCS11
+ * module is used as it allows access to a True Random Number Generator (TRNG) if the vendor platform
+ * supports it.
+ * It is RECOMMENDED to seed the random number generator with a device-specific entropy source so that
+ * probability of collisions from devices in connection retries is mitigated.
  */
 
 /**

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -457,7 +457,7 @@ static MQTTStatus_t prvResumeSession( bool xSessionPresent );
  * with the backoffAlgorithm library.
  *
  * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
- * if there was failure in randon number generation OR all retry attempts had exhausted.
+ * if there was failure in random number generation OR all retry attempts had exhausted.
  */
 static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -404,22 +404,6 @@ typedef struct publishElement
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The random number generator to use for exponential backoff with
- * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the backoff algorithm library API.
- *
- * The PKCS11 module is used to generate the random number as it allows access
- * to a True Random Number Generator (TRNG) if the vendor platform supports it.
- * It is recommended to use a device-specific unique random number generator so
- * that probability of collisions from devices in connection retries is mitigated.
- *
- * @return A positive value if generating the random number was successful; otherwise
- * -1 to indicate failure.
- */
-static int32_t prvGenerateRandomNumber();
-
-/**
  * @brief Initializes an MQTT context, including transport interface and
  * network buffer.
  *
@@ -453,6 +437,29 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
  * appropriate error code from `MQTT_Publish()`
  */
 static MQTTStatus_t prvResumeSession( bool xSessionPresent );
+
+/**
+ * @brief Calculate and perform an exponential backoff with jitter delay for
+ * the next retry attempt of a failed network operation with the server.
+ *
+ * The function generates a random number, calculates the next backoff period
+ * with the generated random number, and performs the backoff delay operation if the
+ * number of retries have not exhausted.
+ *
+ * @note The PKCS11 module is used to generate the random number as it allows access
+ * to a True Random Number Generator (TRNG) if the vendor platform supports it.
+ * It is recommended to seed the random number generator with a device-specific entropy
+ * source so that probability of collisions from devices in connection retries is mitigated.
+ *
+ * @note The backoff period is calculated using the backoffAlgorithm library.
+ *
+ * @param[in, out] pxRetryAttempts The context to use for backoff period calculation
+ * with the backoffAlgorithm library.
+ *
+ * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
+ * if there was failure in randon number generation OR all retry attempts had exhausted.
+ */
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 
 /**
  * @brief Form a TCP connection to a server.
@@ -978,12 +985,11 @@ static int32_t prvGenerateRandomNumber()
 static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
 {
     BaseType_t xConnected = pdFAIL;
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t xReconnectParams;
+    BaseType_t xBackoffStatus = pdFAIL;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     ServerInfo_t xServerInfo = { 0 };
     SocketsConfig_t xSocketConfig = { 0 };
-    uint16_t usNextRetryBackOff = 0U;
 
     /* Initialize the MQTT broker information. */
     xServerInfo.pHostName = democonfigMQTT_BROKER_ENDPOINT;
@@ -1002,8 +1008,7 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
     BackoffAlgorithm_InitializeParams( &xReconnectParams,
                                        RETRY_BACKOFF_BASE_MS,
                                        RETRY_MAX_BACKOFF_DELAY_MS,
-                                       RETRY_MAX_ATTEMPTS,
-                                       prvGenerateRandomNumber );
+                                       RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after a
      * timeout. Timeout value will exponentially increase until the maximum
@@ -1024,25 +1029,15 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
 
         if( !xConnected )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, &usNextRetryBackOff );
-            configASSERT( xBackoffAlgStatus != BackoffAlgorithmRngFailure );
+            LogWarn( ( "Connection to the broker failed. Attempting connection retry after backoff delay." ) );
 
-            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-            {
-                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-            }
-            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-            {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff delay." ) );
-                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+            /* As the connection attempt failed, we will retry the connection after an
+             * exponential backoff with jitter delay. */
 
-                LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
-                           ( xReconnectParams.attemptsDone + 1 ),
-                           xReconnectParams.maxRetryAttempts ) );
-            }
+            /* Calculate the backoff period for the next retry attempt and perform the wait operation. */
+            xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
-    } while( ( xConnected != pdPASS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+    } while( ( xConnected != pdPASS ) && ( xBackoffStatus == pdPASS ) );
 
     return xConnected;
 }

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -980,7 +980,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
     uint32_t ulRandomNum = 0;
 
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
-                                     ( sizeof( ulRandomNum ) == pdPASS ) ) )
+                                     sizeof( ulRandomNum ) ) == pdPASS )
     {
         /* Get back-off value (in milliseconds) for the next retry attempt. */
         xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -247,7 +247,7 @@
  * with the backoffAlgorithm library.
  *
  * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
- * if there was failure in randon number generation OR all retry attempts had exhausted.
+ * if there was failure in random number generation OR all retry attempts had exhausted.
  */
 static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -668,7 +668,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
     uint32_t ulRandomNum = 0;
 
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
-                                     ( sizeof( ulRandomNum ) == pdPASS ) ) )
+                                     sizeof( ulRandomNum ) ) == pdPASS )
     {
         /* Get back-off value (in milliseconds) for the next retry attempt. */
         xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -229,20 +229,27 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The random number generator to use for exponential backoff with
- * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the backoff algorithm library API.
+ * @brief Calculate and perform an exponential backoff with jitter delay for
+ * the next retry attempt of a failed network operation with the server.
  *
- * The PKCS11 module is used to generate the random number as it allows access
+ * The function generates a random number, calculates the next backoff period
+ * with the generated random number, and performs the backoff delay operation if the
+ * number of retries have not exhausted.
+ *
+ * @note The PKCS11 module is used to generate the random number as it allows access
  * to a True Random Number Generator (TRNG) if the vendor platform supports it.
- * It is recommended to use a device-specific unique random number generator so
- * that probability of collisions from devices in connection retries is mitigated.
+ * It is recommended to seed the random number generator with a device-specific entropy
+ * source so that probability of collisions from devices in connection retries is mitigated.
  *
- * @return A positive value if generating the random number was successful; otherwise
- * -1 to indicate failure.
+ * @note The backoff period is calculated using the backoffAlgorithm library.
+ *
+ * @param[in, out] pxRetryAttempts The context to use for backoff period calculation
+ * with the backoffAlgorithm library.
+ *
+ * @return pdPASS if calculating the backoff period was successful; otherwise pdFAIL
+ * if there was failure in randon number generation OR all retry attempts had exhausted.
  */
-static int32_t prvGenerateRandomNumber();
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams );
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -642,23 +649,52 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
 }
 /*-----------------------------------------------------------*/
 
-static int32_t prvGenerateRandomNumber()
+static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams )
 {
-    uint32_t ulRandomNum;
+    BaseType_t xReturnStatus = pdFAIL;
+    uint16_t usNextRetryBackOff = 0U;
+    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
 
-    /* Use the PKCS11 module to generate a random number. */
+    /**
+     * To calculate the backoff period for the next retry attempt, we will
+     * generate a random number to provide to the backoffAlgorithm library.
+     *
+     * Note: The PKCS11 module is used to generate the random number as it allows access
+     * to a True Random Number Generator (TRNG) if the vendor platform supports it.
+     * It is recommended to use a random number generator seeded with a device-specific
+     * entropy source so that probability of collisions from devices in connection retries
+     * is mitigated.
+     */
+    uint32_t ulRandomNum = 0;
+
     if( xPkcs11GenerateRandomNumber( ( uint8_t * ) &ulRandomNum,
                                      ( sizeof( ulRandomNum ) == pdPASS ) ) )
     {
-        ulRandomNum = ( ulRandomNum & INT32_MAX );
+        /* Get back-off value (in milliseconds) for the next retry attempt. */
+        xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( pxRetryParams, ulRandomNum, &usNextRetryBackOff );
+
+        if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+        {
+            LogError( ( "All retry attempts have exhausted. Operation will not be retried" ) );
+        }
+        else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
+        {
+            /* Perform the backoff delay. */
+            vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+
+            xReturnStatus = pdPASS;
+
+            LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
+                       ( pxRetryParams->attemptsDone + 1 ),
+                       pxRetryParams->maxRetryAttempts ) );
+        }
     }
     else
     {
-        /* Set the return value as negative to indicate failure. */
-        ulRandomNum = -1;
+        LogError( ( "Unable to retry operation with broker: Random number generation failed" ) );
     }
 
-    return ( int32_t ) ulRandomNum;
+    return xReturnStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -666,12 +702,12 @@ static int32_t prvGenerateRandomNumber()
 static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNetworkContext )
 {
     ServerInfo_t xServerInfo = { 0 };
+
     SocketsConfig_t xSocketsConfig = { 0 };
     BaseType_t xStatus = pdPASS;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t xReconnectParams;
-    uint16_t usNextRetryBackOff = 0U;
+    BaseType_t xBackoffStatus = pdFALSE;
 
     /* Set the credentials for establishing a TLS connection. */
     /* Initializer server information. */
@@ -693,8 +729,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     BackoffAlgorithm_InitializeParams( &xReconnectParams,
                                        RETRY_BACKOFF_BASE_MS,
                                        RETRY_MAX_BACKOFF_DELAY_MS,
-                                       RETRY_MAX_ATTEMPTS,
-                                       prvGenerateRandomNumber );
+                                       RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -715,26 +750,15 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
 
         if( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, &usNextRetryBackOff );
-            configASSERT( xBackoffAlgStatus != BackoffAlgorithmRngFailure );
+            LogWarn( ( "Connection to the broker failed. Attempting connection retry after backoff delay." ) );
 
-            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-            {
-                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-                xStatus = pdFAIL;
-            }
-            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-            {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff delay." ) );
-                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+            /* As the connection attempt failed, we will retry the connection after an
+             * exponential backoff with jitter delay. */
 
-                LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
-                           ( xReconnectParams.attemptsDone + 1 ),
-                           xReconnectParams.maxRetryAttempts ) );
-            }
+            /* Calculate the backoff period for the next retry attempt and perform the wait operation. */
+            xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
-    } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+    } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
 
     return xStatus;
 }
@@ -824,10 +848,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult = MQTTSuccess;
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t xRetryParams;
+    BaseType_t xBackoffStatus = pdFAIL;
     MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
-    bool xFailedSubscribeToTopic = false;
+    BaseType_t xFailedSubscribeToTopic = pdFALSE;
     uint32_t ulTopicCount = 0U;
     BaseType_t xStatus = pdFAIL;
 
@@ -847,8 +871,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
     BackoffAlgorithm_InitializeParams( &xRetryParams,
                                        RETRY_BACKOFF_BASE_MS,
                                        RETRY_MAX_BACKOFF_DELAY_MS,
-                                       RETRY_MAX_ATTEMPTS,
-                                       prvGenerateRandomNumber );
+                                       RETRY_MAX_ATTEMPTS );
 
     do
     {
@@ -893,7 +916,7 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
         if( xStatus == pdPASS )
         {
             /* Reset flag before checking suback responses. */
-            xFailedSubscribeToTopic = false;
+            xFailedSubscribeToTopic = pdFALSE;
 
             /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
              * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
@@ -903,30 +926,21 @@ static BaseType_t prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTCont
             {
                 if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus == MQTTSubAckFailure )
                 {
-                    uint16_t usNextRetryBackOff = 0U;
-                    xFailedSubscribeToTopic = true;
+                    xFailedSubscribeToTopic = pdTRUE;
 
-                    /* Calculate back-off period for next retry of subscribe request. */
-                    xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xRetryParams, &usNextRetryBackOff );
-                    configASSERT( xBackoffAlgStatus != BackoffAlgorithmRngFailure );
+                    /* As the subscribe attempt failed, we will retry the connection after an
+                     * exponential backoff with jitter delay. */
 
-                    if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-                    {
-                        /* Retry subscribe after exponential back-off. */
-                        LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
-                                   xTopicFilterContext[ ulTopicCount ].pcTopicFilter ) );
-                        vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
-                    }
-                    else
-                    {
-                        LogError( ( "SUBSCRIBE request re-tries exhausted." ) );
-                    }
+                    /* Retry subscribe after exponential back-off. */
+                    LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
+                               xTopicFilterContext[ ulTopicCount ].pcTopicFilter ) );
 
+                    xBackoffStatus = prvBackoffForRetry( &xRetryParams );
                     break;
                 }
             }
         }
-    } while( ( xFailedSubscribeToTopic == true ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+    } while( ( xFailedSubscribeToTopic == pdTRUE ) && ( xBackoffStatus == pdPASS ) );
 
     return xStatus;
 }

--- a/demos/device_shadow_for_aws/shadow_demo_main.c
+++ b/demos/device_shadow_for_aws/shadow_demo_main.c
@@ -43,6 +43,15 @@
  * a second message to update the reported state of powerOn.
  * 6. Handle incoming message again in prvEventCallback. If the message is from update/accepted, verify that it
  * has the same clientToken as previously published in the update message. That will mark the end of the demo.
+ *
+ * @note This demo uses retry logic to connect to AWS IoT broker if connection attempts fail.
+ * The FreeRTOS/backoffAlgorithm library is used to calculate the retry interval with an exponential
+ * backoff and jitter algorithm. For generating random number required by the algorithm, the PKCS11
+ * module is used as it allows access to a True Random Number Generator (TRNG) if the vendor platform
+ * supports it.
+ * It is RECOMMENDED to seed the random number generator with a device-specific entropy source so that
+ * probability of collisions from devices in connection retries is mitigated.
+ *
  */
 
 /* Standard includes. */

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -50,6 +50,15 @@
  * contain a "message" and "topic" to publish to, e.g.
  * { "action": "publish", "topic": "demo/jobs", "message": "Hello World!" }.
  * An "exit" job exits the demo. Sending { "action": "exit" } will end the demo program.
+ *
+ * @note This demo uses retry logic to connect to AWS IoT broker if connection attempts fail.
+ * The FreeRTOS/backoffAlgorithm library is used to calculate the retry interval with an exponential
+ * backoff and jitter algorithm. For generating random number required by the algorithm, the PKCS11
+ * module is used as it allows access to a True Random Number Generator (TRNG) if the vendor platform
+ * supports it.
+ * It is RECOMMENDED to seed the random number generator with a device-specific entropy source so that
+ * probability of collisions from devices in connection retries is mitigated.
+ *
  */
 
 /* Standard includes. */

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -568,7 +568,7 @@ static int32_t failedRecv( NetworkContext_t * pNetworkContext,
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to the MQTT broker with reconnection retries.
@@ -974,7 +974,7 @@ static int32_t failedRecv( NetworkContext_t * pNetworkContext,
     return -1;
 }
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
     UBaseType_t uxRandNum = 0;
 
@@ -1002,7 +1002,7 @@ static int32_t generateRandomNumber()
     /* Close PKCS11 session. */
     TEST_ASSERT_EQUAL( CKR_OK, pFunctionList->C_CloseSession( session ) );
 
-    return( uxRandNum & INT32_MAX );
+    return uxRandNum;
 }
 
 static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext )
@@ -1032,8 +1032,7 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        RETRY_BACKOFF_BASE_MS,
                                        RETRY_MAX_BACKOFF_DELAY_MS,
-                                       RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -1049,9 +1048,10 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
         if( transportStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
         {
-            /* Get back-off value for the next connection retry. */
-            BackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            configASSERT( BackoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate random number and get back-off value for the next connection retry. */
+            BackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams,
+                                                                generateRandomNumber(),
+                                                                &nextRetryBackOff );
 
             if( BackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -880,9 +880,6 @@ TEST_GROUP( deviceShadow_Integration );
 
 TEST_SETUP( deviceShadow_Integration )
 {
-    /* Seed the pseudo random number generator. */
-    seedRandomNumberGenerator();
-
     /* Reset file-scoped global variables. */
     receivedSubAck = false;
     receivedUnsubAck = false;

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -342,20 +342,13 @@ static uint32_t getTimeMs();
  * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
  * of the backoff algorithm library API.
  *
+ * The PKCS11 module is used to generate the random random number as it allows
+ * access to a True Random Number Generator (TRNG) if the vendor platform supports it.
+ *
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
-
-/**
- * @brief Seed the random number generator used for exponential backoff
- * used in connection retry attempts.
- *
- * The PKCS11 module is used to seed the random number generator
- * as it allows access to a True Random Number Generator (TRNG) if the
- * vendor platform supports it.
- */
-static void seedRandomNumberGenerator();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -775,45 +768,35 @@ static MQTTStatus_t publishToTopic( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    const uint32_t multiplier = 0x015a4e35UL, increment = 1UL;
+    UBaseType_t uxRandNum = 0;
 
-    nextRand = ( multiplier * nextRand ) + increment;
-    return( ( int32_t ) ( nextRand >> 16UL ) & 0x7fffUL );
-}
+    CK_FUNCTION_LIST_PTR pFunctionList = NULL;
+    CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
 
-/*-----------------------------------------------------------*/
+    /* Get list of functions supported by the PKCS11 port. */
+    TEST_ASSERT_EQUAL( CKR_OK, C_GetFunctionList( &pFunctionList ) );
+    TEST_ASSERT_TRUE( pFunctionList != NULL );
 
-static void seedRandomNumberGenerator()
-{
-    /* Seed the global variable ONLY if it wasn't already seeded. */
-    if( nextRand == 0 )
-    {
-        CK_FUNCTION_LIST_PTR pFunctionList = NULL;
-        CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
+    /* Initialize PKCS11 module and create a new session. */
+    TEST_ASSERT_EQUAL( CKR_OK, xInitializePkcs11Session( &session ) );
+    TEST_ASSERT_TRUE( session != CK_INVALID_HANDLE );
 
-        /* Get list of functions supported by the PKCS11 port. */
-        TEST_ASSERT_EQUAL( CKR_OK, C_GetFunctionList( &pFunctionList ) );
-        TEST_ASSERT_TRUE( pFunctionList != NULL );
-
-        /* Initialize PKCS11 module and create a new session. */
-        TEST_ASSERT_EQUAL( CKR_OK, xInitializePkcs11Session( &session ) );
-        TEST_ASSERT_TRUE( session != CK_INVALID_HANDLE );
-
-        /*
-         * Seed random number generator with PKCS11.
-         * Use of PKCS11 can allow use of True Random Number Generator (TRNG)
-         * if the platform supports it.
-         */
-        TEST_ASSERT_EQUAL( CKR_OK, pFunctionList->C_GenerateRandom( session,
-                                                                    ( unsigned char * ) &nextRand,
-                                                                    sizeof( nextRand ) ) );
+    /*
+     * Seed random number generator with PKCS11.
+     * Use of PKCS11 can allow use of True Random Number Generator (TRNG)
+     * if the platform supports it.
+     */
+    TEST_ASSERT_EQUAL( CKR_OK, pFunctionList->C_GenerateRandom( session,
+                                                                ( unsigned char * ) &uxRandNum,
+                                                                sizeof( uxRandNum ) ) );
 
 
-        /* Close PKCS11 session. */
-        TEST_ASSERT_EQUAL( CKR_OK, pFunctionList->C_CloseSession( session ) );
-    }
+    /* Close PKCS11 session. */
+    TEST_ASSERT_EQUAL( CKR_OK, pFunctionList->C_CloseSession( session ) );
+
+    return uxRandNum;
 }
 
 /*-----------------------------------------------------------*/
@@ -845,8 +828,7 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        RETRY_BACKOFF_BASE_MS,
                                        RETRY_MAX_BACKOFF_DELAY_MS,
-                                       RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -862,9 +844,10 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
         if( transportStatus != TRANSPORT_SOCKET_STATUS_SUCCESS )
         {
-            /* Get back-off value for the next connection retry. */
-            BackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            configASSERT( BackoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate random number and get back-off value for the next connection retry. */
+            BackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams,
+                                                                generateRandomNumber(),
+                                                                &nextRetryBackOff );
 
             if( BackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {


### PR DESCRIPTION
The API of `FreeRTOS/backoffAlgorithm` library has changed to remove dependency on random number generator; instead require the caller to generate the random number and pass it to the `BackoffAlgorithm_GetNextBackoff` API for backoff period calculation. This PR updates the submodule pointer commit, and updates the demos and tests to use the simplied library API