### PR TITLE
Fix metadata issue of coreMQTT demo not getting enabled

### DIFF
--- a/libraries/core_http_demo_dependencies.cmake
+++ b/libraries/core_http_demo_dependencies.cmake
@@ -80,6 +80,8 @@ afr_module_dependencies(
     PUBLIC
         AFR::core_http
         AFR::http_demo_helpers
+        AFR::backoff_algorithm
+        AFR::pkcs11_helpers
 )
 
 # Add more dependencies for Secure Sockets based HTTP demo 
@@ -89,7 +91,6 @@ if(TARGET AFR::secure_sockets::mcu_port)
     afr_module_dependencies(
         ${AFR_CURRENT_MODULE}
         PUBLIC
-            AFR::backoff_algorithm
             AFR::transport_interface_secure_sockets
             AFR::secure_sockets
     )

--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -83,6 +83,17 @@ afr_module_dependencies(
         AFR::pkcs11_helpers
 )
 
+# Add dependency on PKCS11 Helpers module, that is required
+# by the Secure Sockets based coreMQTT demo, ONLY if the board
+# supports the PKCS11 module.
+if(TARGET AFR::pkcs11_implementation::mcu_port)
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        PUBLIC
+            AFR::pkcs11_helpers
+    )
+endif()
+
 # Add more dependencies for Secure Sockets based MQTT demo 
 # (at demos/coreMQTT folder) ONLY if the board supports 
 # the Secure Sockets library.

--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -79,6 +79,8 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PUBLIC
         AFR::core_mqtt
+        AFR::backoff_algorithm
+        AFR::pkcs11_helpers
 )
 
 # Add more dependencies for Secure Sockets based MQTT demo 
@@ -88,7 +90,6 @@ if(TARGET AFR::secure_sockets::mcu_port)
     afr_module_dependencies(
         ${AFR_CURRENT_MODULE}
         PUBLIC
-            AFR::backoff_algorithm
             AFR::transport_interface_secure_sockets
             AFR::secure_sockets
     )

--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -80,7 +80,6 @@ afr_module_dependencies(
     PUBLIC
         AFR::core_mqtt
         AFR::backoff_algorithm
-        AFR::pkcs11_helpers
 )
 
 # Add dependency on PKCS11 Helpers module, that is required


### PR DESCRIPTION
With PR#2767, the introduction of the internal `AFR::pkcs11_helpers` module,that is added as a dependency on coreMQTT (and other demos), the coreMQTT demos were not getting enabled by CMake build when enabling the `AFR::core_mqtt_demo_dependencies` module. This PR fixes the issue by adding the `AFR::pkcs11_helpers` module as a dependency for `AFR::core_mqtt_demo_dependencies` module so that the INTERNAL module can be enabled and thereby, allow the coreMQTT demo (and other demos) to be enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.