### PR TITLE
Update HTTP shim stack sizes for TI & ST

### DIFF
--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1978,6 +1978,7 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     IotHttpsReturnCode_t scheduleStatus = IOT_HTTPS_OK;
     IotLink_t * pQItem = NULL;
     _httpsRequest_t * pNextHttpsRequest = NULL;
+    UBaseType_t uxHighWaterMark;
 
     IotLogDebug( "Task with request ID: %p started.", pHttpsRequest );
 
@@ -2158,6 +2159,12 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     /* Now that the current request is finished, we dequeue the current request from the queue. */
     IotDeQueue_DequeueHead( &( pHttpsConnection->reqQ ) );
     IotMutex_Unlock( &( pHttpsConnection->connectionMutex ) );
+
+    uxHighWaterMark = uxTaskGetStackHighWaterMark( NULL );
+    IotLogError( "Stack unused: %lu, total: %lu, used: %lu.\r\n",
+                 ( unsigned long ) uxHighWaterMark,
+                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE,
+                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE - ( unsigned long ) uxHighWaterMark );
 
     /* This routine returns a void so there is no HTTPS_FUNCTION_CLEANUP_END();. */
 }

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1978,7 +1978,6 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     IotHttpsReturnCode_t scheduleStatus = IOT_HTTPS_OK;
     IotLink_t * pQItem = NULL;
     _httpsRequest_t * pNextHttpsRequest = NULL;
-    UBaseType_t uxHighWaterMark;
 
     IotLogDebug( "Task with request ID: %p started.", pHttpsRequest );
 
@@ -2159,12 +2158,6 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     /* Now that the current request is finished, we dequeue the current request from the queue. */
     IotDeQueue_DequeueHead( &( pHttpsConnection->reqQ ) );
     IotMutex_Unlock( &( pHttpsConnection->connectionMutex ) );
-
-    uxHighWaterMark = uxTaskGetStackHighWaterMark( NULL );
-    IotLogError( "Stack unused: %lu, total: %lu, used: %lu.\r\n",
-                 ( unsigned long ) uxHighWaterMark,
-                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE,
-                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE - ( unsigned long ) uxHighWaterMark );
 
     /* This routine returns a void so there is no HTTPS_FUNCTION_CLEANUP_END();. */
 }

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
@@ -53,7 +53,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
@@ -50,6 +50,9 @@
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
@@ -53,7 +53,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_PRIORITY        tskIDLE_PRIORITY
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
@@ -51,9 +51,9 @@
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
-#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/iot_config.h
@@ -53,6 +53,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_PRIORITY        tskIDLE_PRIORITY
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -33,7 +33,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -33,6 +33,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_PRIORITY        tskIDLE_PRIORITY
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -31,9 +31,9 @@
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
-#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -28,8 +28,11 @@
 #include <stdbool.h>
 
 /* Platform thread stack size and priority. */
-#define IOT_THREAD_DEFAULT_STACK_SIZE    2048
-#define IOT_THREAD_DEFAULT_PRIORITY      5
+#define IOT_THREAD_DEFAULT_STACK_SIZE           2048
+#define IOT_THREAD_DEFAULT_PRIORITY             5
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -33,7 +33,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           1
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_PRIORITY        tskIDLE_PRIORITY
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_config.h
@@ -53,6 +53,10 @@
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/iot_config.h
@@ -56,7 +56,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -25,8 +25,8 @@
 #define IOT_CONFIG_H_
 
 /* Platform thread stack size and priority. */
-#define IOT_THREAD_DEFAULT_STACK_SIZE    2048
-#define IOT_THREAD_DEFAULT_PRIORITY      5
+#define IOT_THREAD_DEFAULT_STACK_SIZE           2048
+#define IOT_THREAD_DEFAULT_PRIORITY             5
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -30,7 +30,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /* Set the number loop iterations in the task pool tests. This value is smaller than
  * the default. */

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -27,6 +27,10 @@
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE    2048
 #define IOT_THREAD_DEFAULT_PRIORITY      5
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 3 )
 
 /* Set the number loop iterations in the task pool tests. This value is smaller than
  * the default. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Originally, default stack size of `configMINIMAL_STACK_SIZE * 2` for HTTP shim dispatch task was insufficient for TI & ST, causing original HTTP demos to freeze. Therefore, we multiply by 4 instead, resulting in the following unused stack space:
For ST: Stack unused: 89, total: 360, used: 271
For TI: Stack unused: 131, total: 360, used: 229

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.