### PR TITLE
Fix build failures in Pic32

### DIFF
--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_demos/nbproject/configurations.xml
@@ -1118,7 +1118,7 @@
 				<property key="place-data-into-section" value="false"/>
 				<property key="post-instruction-scheduling" value="default"/>
 				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
+				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\\\&quot;aws_mbedtls_config.h\\\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;__free_rtos__"/>
 				<property key="strict-ansi" value="false"/>
 				<property key="support-ansi" value="false"/>
 				<property key="toplevel-reordering" value=""/>

--- a/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
+++ b/projects/microchip/curiosity_pic32mzef/mplab/aws_tests/nbproject/configurations.xml
@@ -1197,7 +1197,7 @@
 				<property key="place-data-into-section" value="false"/>
 				<property key="post-instruction-scheduling" value="default"/>
 				<property key="pre-instruction-scheduling" value="default"/>
-				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\&quot;aws_mbedtls_config.h\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
+				<property key="preprocessor-macros" value="MBEDTLS_CONFIG_FILE=\\\&quot;aws_mbedtls_config.h\\\&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;UNITY_INCLUDE_CONFIG_H;FREERTOS_ENABLE_UNIT_TESTS;__free_rtos__"/>
 				<property key="strict-ansi" value="false"/>
 				<property key="support-ansi" value="false"/>
 				<property key="toplevel-reordering" value=""/>


### PR DESCRIPTION
Fix build failures in Pic32

Description
-----------
Fix build failures in Pic32.
Root Cause: The builds were failing as the quotes in preprocessor macro for mbedtls config file was trimmed and resulting in includes like #include aws_mbedtls_config.h missing the quotes.
Fix: Add an escape character to the preprocessor macro definition.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.