### PR TITLE
Remove Device Defender library visibility for Nordic on FreeRTOS console

### DIFF
--- a/libraries/device_defender_demo_dependencies.cmake
+++ b/libraries/device_defender_demo_dependencies.cmake
@@ -79,6 +79,7 @@ afr_module_dependencies(
     PUBLIC
         AFR::device_defender
         AFR::core_json
+        AFR::mqtt_demo_helpers
         # Add dependency on core_mqtt_demo_dependencies module 
         # so that coreMQTT library is auto-included when selecting
         # Device Defender library on the FreeRTOS console.


### PR DESCRIPTION
As there exists no demo for the new Device Defender library using MQTT over BLE stack, the library should not be visible in the list of supported libraries on FreeRTOS console for the Nordic board (which support only BLE).

By adding a dependency on `AFR::mqtt_demo_helpers` module (that depends on Secure Sockets), the Device Defender library module is not enabled for the Nordic board (as the Nordic board does not support Secure Sockets). 