### PR TITLE
Fix build failure for connection sharing demo on nuvoton ethernet.

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
@@ -1766,6 +1766,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../demos/coreMQTT/mqtt_demo_mutual_auth.c</FilePath>
 						</File>
+						<File>
+							<FileName>mqtt_demo_connection_sharing.c</FileName>
+							<FileType>1</FileType>
+							<FilePath>../../../../../demos/coreMQTT/mqtt_demo_connection_sharing.c</FilePath>
+						</File>
 					</Files>
 				</Group>
 				<Group>


### PR DESCRIPTION
Fix build failure for connection sharing demo on Nuvoton ethernet.

Description
-----------
Nuvoton ethernet project file is missing file for coreMQTT connection sharing demo. Adding that to fix the build issue.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.