### PR TITLE
Update HTTP shim stack sizes for Cypress64

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
@@ -60,6 +60,12 @@
 /* Platform thread priority. */
 #define IOT_THREAD_DEFAULT_PRIORITY             ( 5 )
 
+/* Platform stack size for HTTPS library. */
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"
 

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/iot_config.h
@@ -60,7 +60,7 @@
 /* Platform thread priority. */
 #define IOT_THREAD_DEFAULT_PRIORITY             ( 5 )
 
-/* Platform stack size for HTTPS library. */
+/* Dispatch task and queue configurations for HTTPS library. */
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/iot_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/iot_config.h
@@ -52,7 +52,7 @@
 /* Platform thread priority. */
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 
-/* Platform stack size for HTTPS library. */
+/* Dispatch task and queue configurations for HTTPS library. */
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/iot_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/iot_config.h
@@ -27,8 +27,8 @@
 #include <stdbool.h>
 
 /* MQTT demo configuration. */
-#define IOT_DEMO_MQTT_PUBLISH_BURST_COUNT    ( 10 )
-#define IOT_DEMO_MQTT_PUBLISH_BURST_SIZE     ( 2 )
+#define IOT_DEMO_MQTT_PUBLISH_BURST_COUNT       ( 10 )
+#define IOT_DEMO_MQTT_PUBLISH_BURST_SIZE        ( 2 )
 
 /* Shadow demo configuration. The demo publishes periodic Shadow updates and responds
  * to changing Shadows. */
@@ -50,19 +50,25 @@
 
 
 /* Platform thread priority. */
-#define IOT_THREAD_DEFAULT_PRIORITY      5
+#define IOT_THREAD_DEFAULT_PRIORITY             5
 
-#define BLE_SUPPORTED      ( 1 )
-#define WIFI_SUPPORTED     ( 1 )
+/* Platform stack size for HTTPS library. */
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+
+#define BLE_SUPPORTED                           ( 1 )
+#define WIFI_SUPPORTED                          ( 1 )
 
 /* Network type configuration for this board. */
 #ifndef DEFAULT_NETWORK
-#define DEFAULT_NETWORK    AWSIOT_NETWORK_TYPE_WIFI
+    #define DEFAULT_NETWORK    AWSIOT_NETWORK_TYPE_WIFI
 #endif
 
 /* Increasing MQTT and shadow timeout for the board, as there is a delay in sending large payload over BLE for the board. */
-#define IOT_TEST_MQTT_TIMEOUT_MS   ( 30000 )
-#define AWS_IOT_TEST_SHADOW_TIMEOUT ( 30000 )
+#define IOT_TEST_MQTT_TIMEOUT_MS       ( 30000 )
+#define AWS_IOT_TEST_SHADOW_TIMEOUT    ( 30000 )
 
 
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Originally, default stack size of configMINIMAL_STACK_SIZE * 2 for HTTP shim dispatch task was insufficient for Cypress64, causing original HTTP demos to freeze. Therefore, we multiply by 4 instead, resulting in the following unused stack space:
Stack unused: 232, total: 520, used: 288.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.