### PR TITLE
Update HTTP Shim configs for Nuvoton & ST

### DIFF
--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1978,6 +1978,7 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     IotHttpsReturnCode_t scheduleStatus = IOT_HTTPS_OK;
     IotLink_t * pQItem = NULL;
     _httpsRequest_t * pNextHttpsRequest = NULL;
+    UBaseType_t uxHighWaterMark;
 
     IotLogDebug( "Task with request ID: %p started.", pHttpsRequest );
 
@@ -2158,6 +2159,12 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     /* Now that the current request is finished, we dequeue the current request from the queue. */
     IotDeQueue_DequeueHead( &( pHttpsConnection->reqQ ) );
     IotMutex_Unlock( &( pHttpsConnection->connectionMutex ) );
+
+    uxHighWaterMark = uxTaskGetStackHighWaterMark( NULL );
+    IotLogError( "Stack unused: %lu, total: %lu, used: %lu.\r\n",
+                 ( unsigned long ) uxHighWaterMark,
+                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE,
+                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE - ( unsigned long ) uxHighWaterMark );
 
     /* This routine returns a void so there is no HTTPS_FUNCTION_CLEANUP_END();. */
 }

--- a/libraries/c_sdk/standard/https/src/iot_https_client.c
+++ b/libraries/c_sdk/standard/https/src/iot_https_client.c
@@ -1978,7 +1978,6 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     IotHttpsReturnCode_t scheduleStatus = IOT_HTTPS_OK;
     IotLink_t * pQItem = NULL;
     _httpsRequest_t * pNextHttpsRequest = NULL;
-    UBaseType_t uxHighWaterMark;
 
     IotLogDebug( "Task with request ID: %p started.", pHttpsRequest );
 
@@ -2159,12 +2158,6 @@ static void _sendHttpsRequest( _httpsRequest_t * pHttpsRequest )
     /* Now that the current request is finished, we dequeue the current request from the queue. */
     IotDeQueue_DequeueHead( &( pHttpsConnection->reqQ ) );
     IotMutex_Unlock( &( pHttpsConnection->connectionMutex ) );
-
-    uxHighWaterMark = uxTaskGetStackHighWaterMark( NULL );
-    IotLogError( "Stack unused: %lu, total: %lu, used: %lu.\r\n",
-                 ( unsigned long ) uxHighWaterMark,
-                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE,
-                 ( unsigned long ) IOT_HTTPS_DISPATCH_TASK_STACK_SIZE - ( unsigned long ) uxHighWaterMark );
 
     /* This routine returns a void so there is no HTTPS_FUNCTION_CLEANUP_END();. */
 }

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/iot_config.h
@@ -54,6 +54,12 @@
 #define IOT_THREAD_DEFAULT_PRIORITY             5
 #define IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES    ( 0 )
 
+/* Dispatch task and queue configurations for HTTPS library. */
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
@@ -47,6 +47,8 @@
 /* Set the task pool stack size and priority */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           1024
 #define IOT_THREAD_DEFAULT_PRIORITY             5
+
+/* Dispatch task and queue configurations for HTTPS library. */
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/iot_config.h
@@ -45,13 +45,17 @@
 /* #define IOT_LOG_LEVEL_DEMO                   IOT_LOG_INFO */
 
 /* Set the task pool stack size and priority */
-#define IOT_THREAD_DEFAULT_STACK_SIZE    1024
-#define IOT_THREAD_DEFAULT_PRIORITY      5
+#define IOT_THREAD_DEFAULT_STACK_SIZE           1024
+#define IOT_THREAD_DEFAULT_PRIORITY             5
+#define IOT_HTTPS_DISPATCH_TASK_COUNT           1
+#define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
+#define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
 
 /**
  * Static network buffer size provided to coreMQTT library.
  */
-#define NETWORK_BUFFER_SIZE              512
+#define NETWORK_BUFFER_SIZE                     512
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -35,7 +35,6 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 2 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -30,6 +30,8 @@
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5
+
+/* Dispatch task and queue configurations for HTTPS library. */
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/iot_config.h
@@ -33,7 +33,7 @@
 #define IOT_HTTPS_DISPATCH_TASK_COUNT           1
 #define IOT_HTTPS_DISPATCH_QUEUE_SIZE           2
 #define IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY    1
-#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 4 )
+#define IOT_HTTPS_DISPATCH_TASK_STACK_SIZE      ( configMINIMAL_STACK_SIZE * 2 )
 
 /* Include the common configuration file for FreeRTOS. */
 #include "iot_config_common.h"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Originally, default stack size of configMINIMAL_STACK_SIZE * 2 for HTTP shim dispatch task was insufficient for Nuvoton, causing original HTTP demos to freeze. Therefore, we multiply by 4 instead, resulting in the following unused stack space:
Stack unused: 171, total: 400, used: 229

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.