### PR TITLE
Add memory estimates for HTTPS V1 compatibility layer

### DIFF
--- a/libraries/c_sdk/standard/https/CODESIZE.md
+++ b/libraries/c_sdk/standard/https/CODESIZE.md
@@ -1,0 +1,24 @@
+# Code size of HTTPS Compatibility Layer
+
+Code size for the HTTPS Compatibility Layer is calculated using GCC for ARM Cortex-M4 on [FreeRTOS 202011.00 release](https://github.com/aws/amazon-freertos/releases/tag/202011.00). Build for calculating code size is done using build configuration for [Cypress CY8CKIT-064S0S2-4343W](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_psoc64.html) by using the Release configuration. All logs were disabled in this build. Refer to the table below for calculated code sizes.
+
+| File | With -O1 Optimization | With -Os Optimization |
+| :-: | :-: | :-: |
+| iot_https_client.c | 21.0K | 19.6K |
+| iot_https_utils.c | 0.5K | 0.5K |
+| **Total estimate** | **21.5K** | **21.1K** |
+
+The HTTPS Compatibility Layer is implemented using the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md). In addition, the HTTPS Compatibility Layer maintains all dependencies of HTTP V1.x.x library. To account for the total code size of the HTTPS Compatibility Layer, code sizes for all dependencies have been considered (see below).
+
+1. **The coreHTTP library** : The HTTPS Compatibility Layer is implemented using [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md). Memory estimates for [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md) can be found in the documentation [here](https://freertos.org/mqtt/index.html).
+
+2. **Platform Abstraction** :  This HTTPS Compatibility Layer depends on the platform-specific implementation of network abstraction. The code size is calculated for the [FreeRTOS implementation of Abstraction Layer](../../../abstractions/platform/freertos) and is added in the table below.
+
+| File | With -O1 Optimization | With -Os Optimization |
+| :-: | :-: | :-: |
+| iot_network_freertos.c | 1.2K | 1.1K |
+| **Total estimate** | **1.2K** | **1.1K** |
+
+Note that the implementation for network abstraction may not be exclusively used by the HTTPS Compatibility Layer, but may be shared by other libraries. However, this network abstraction is not used by any of the [redesigned libraries for LTS](https://www.freertos.org/ltsroadmap.html).
+
+3. **Linear Containers** : This HTTPS Compatibility Layer depends on [Linear Containers](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/v4.0_beta_deprecated/lib-ref/c-sdk/linear_containers/index.html). However, this implementation can be found in a [c header file](../common/include/iot_linear_containers.h), and its code sizes are already accounted for in the calculated sizes of this HTTPS Compatibility Layer.

--- a/libraries/c_sdk/standard/https/CODESIZE.md
+++ b/libraries/c_sdk/standard/https/CODESIZE.md
@@ -1,6 +1,6 @@
 # Code size of HTTPS Compatibility Layer
 
-Code size for the HTTPS Compatibility Layer is calculated using GCC for ARM Cortex-M4 on [FreeRTOS 202011.00 release](https://github.com/aws/amazon-freertos/releases/tag/202011.00). Build for calculating code size is done using build configuration for [Cypress CY8CKIT-064S0S2-4343W](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_psoc64.html) by using the Release configuration. All logs were disabled in this build. Refer to the table below for calculated code sizes.
+Code size for the HTTPS Compatibility Layer is calculated using GCC for ARM Cortex-M4 on [FreeRTOS 202012.00 release](https://github.com/aws/amazon-freertos/releases/tag/202012.00). Build for calculating code size is done using build configuration for [Cypress CY8CKIT-064S0S2-4343W](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_cypress_psoc64.html) by using the Release configuration. All logs were disabled in this build. Refer to the table below for calculated code sizes.
 
 | File | With -O1 Optimization | With -Os Optimization |
 | :-: | :-: | :-: |
@@ -8,7 +8,7 @@ Code size for the HTTPS Compatibility Layer is calculated using GCC for ARM Cort
 | iot_https_utils.c | 0.5K | 0.5K |
 | **Total estimate** | **21.5K** | **21.1K** |
 
-The HTTPS Compatibility Layer is implemented using the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md). In addition, the HTTPS Compatibility Layer maintains all dependencies of HTTP V1.x.x library. To account for the total code size of the HTTPS Compatibility Layer, code sizes for all dependencies have been considered (see below).
+The HTTPS Compatibility Layer is implemented using the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md). In addition, the HTTPS Compatibility Layer maintains the dependency of the network abstraction and linear containers from the HTTP V1.x.x library. The task pool dependency is removed in order to allow statically-allocated tasks. To account for the total code size of the HTTPS Compatibility Layer, code sizes for all dependencies have been considered (see below).
 
 1. **The coreHTTP library** : The HTTPS Compatibility Layer is implemented using [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md). Memory estimates for [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md) can be found in the documentation [here](https://freertos.org/mqtt/index.html).
 

--- a/libraries/c_sdk/standard/https/README.md
+++ b/libraries/c_sdk/standard/https/README.md
@@ -12,7 +12,8 @@ Configuration settings are C pre-processor constants. They can be set with a #de
 1. `IOT_HTTPS_DISPATCH_QUEUE_SIZE` - The number of requests in the queue that are ready to be sent to the HTTP server.
 2. `IOT_HTTPS_DISPATCH_TASK_COUNT` - The number of tasks that are responsible for sending requests from the dispatch queue.
 3. `IOT_HTTPS_DISPATCH_TASK_STACK_SIZE` - The stack size of each dispatch task, sized appropriately for each board.
-4. `IOT_HTTPS_DISPATCH_TASK_PRIORITY` - The priority of each dispatch task. This priority is deliberately chosen to match the original taskpool's priority. Doing so prevents starvation of the network-receive task and tasks potentially used by other libraries.
+4. `IOT_HTTPS_DISPATCH_USE_STATIC_MEMORY` - If set to 1, the memory used by the dispatch task will be allocated statically by the library. Otherwise, memory will be allocated on the heap.
+5. `IOT_HTTPS_DISPATCH_TASK_PRIORITY` - The priority of each dispatch task. This priority is deliberately chosen to match the original taskpool's priority. Doing so prevents starvation of the network-receive task and tasks potentially used by other libraries.
 
 
 ## Code size of HTTPS Compatibility Layer
@@ -26,3 +27,4 @@ Please be aware that, this code size is about 14KB higher than the [code size](h
 ## Tasks required for HTTPS Compatibility Layer
 
 The HTTPS Compatibility Layer has a run time dependency on tasks created by each dispatch task and Network Abstraction implementation, in addition to the system tasks. The Network Abstraction implementation creates a task to receive from the network.
+

--- a/libraries/c_sdk/standard/https/README.md
+++ b/libraries/c_sdk/standard/https/README.md
@@ -1,0 +1,28 @@
+# HTTPS Compatibility Layer
+
+HTTPS Compatibility Layer provides backward compatibility from [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md) to [HTTP V1.x.x APIs](include/iot_https_client.h). **We recommend that you use the coreHTTP library for optimized memory usage and modularity, but you can use the HTTPS Compatibility Layer when you do not have the flexibility.**
+
+
+## Configs for HTTPS Compatibility Layer
+
+Configuration settings for the HTTPS Compatibility Layer, are available in addition to the [configurations of HTTPS V1.x.x library](https://docs.aws.amazon.com/freertos/latest/lib-ref/html2/https/https_config.html).
+
+Configuration settings are C pre-processor constants. They can be set with a #define in the config file (iot_config.h) or by using a compiler option such as -D in gcc. If a configuration setting is not defined, the HTTPS Compatibility Layer will use a "sensible" default value (unless otherwise noted). Because they are compile-time constants, this HTTPS Compatibility Layer must be rebuilt if a configuration setting is changed.
+
+1. `IOT_HTTPS_DISPATCH_QUEUE_SIZE` - The number of requests in the queue that are ready to be sent to the HTTP server.
+2. `IOT_HTTPS_DISPATCH_TASK_COUNT` - The number of tasks that are responsible for sending requests from the dispatch queue.
+3. `IOT_HTTPS_DISPATCH_TASK_STACK_SIZE` - The stack size of each dispatch task, sized appropriately for each board.
+4. `IOT_HTTPS_DISPATCH_TASK_PRIORITY` - The priority of each dispatch task. This priority is deliberately chosen to match the original taskpool's priority. Doing so prevents starvation of the network-receive task and tasks potentially used by other libraries.
+
+
+## Code size of HTTPS Compatibility Layer
+
+Code sizes are calculated for the HTTPS Compatibility Layer on [FreeRTOS 202011.00 release](https://github.com/aws/amazon-freertos/releases/tag/202011.00). In order to calculate the total cost to memory of the HTTPS Compatibility Layer, the code sizes of its dependencies are also included. HTTPS Compatibility Layer and its dependencies have a code size of **22.2KB** with `-Os` compiler optimization.
+Please be aware that, this code size is about 14KB higher than the [code size](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/standard/coreHTTP/docs/doxygen/output/html/index.html) required by the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md).
+
+**Note** Refer to the [CODESIZE.md](CODESIZE.md) for more details about the calculation of code sizes for the HTTPS Compatibility Layer and the [coreHTTP FreeRTOS documentation](https://freertos.org/http/index.html) for coreHTTP library.
+
+
+## Tasks required for HTTPS Compatibility Layer
+
+The HTTPS Compatibility Layer has a run time dependency on tasks created by each dispatch task and Network Abstraction implementation, in addition to the system tasks. The Network Abstraction implementation creates a task to receive from the network.

--- a/libraries/c_sdk/standard/https/README.md
+++ b/libraries/c_sdk/standard/https/README.md
@@ -18,8 +18,8 @@ Configuration settings are C pre-processor constants. They can be set with a #de
 
 ## Code size of HTTPS Compatibility Layer
 
-Code sizes are calculated for the HTTPS Compatibility Layer on [FreeRTOS 202011.00 release](https://github.com/aws/amazon-freertos/releases/tag/202011.00). In order to calculate the total cost to memory of the HTTPS Compatibility Layer, the code sizes of its dependencies are also included. HTTPS Compatibility Layer and its dependencies have a code size of **22.2KB** with `-Os` compiler optimization.
-Please be aware that, this code size is about 14KB higher than the [code size](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/standard/coreHTTP/docs/doxygen/output/html/index.html) required by the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md).
+Code sizes are calculated for the HTTPS Compatibility Layer on [FreeRTOS 202011.00 release](https://github.com/aws/amazon-freertos/releases/tag/202011.00). In order to calculate the total cost to memory of the HTTPS Compatibility Layer, the code sizes of its dependencies are also included. HTTPS Compatibility Layer and its dependencies have a code size of **30.4KB** with `-Os` compiler optimization.
+Please be aware that, this code size is about **22.2KB** higher than the [code size](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/standard/coreHTTP/docs/doxygen/output/html/index.html) required by the [coreHTTP library](https://github.com/FreeRTOS/coreHTTP/blob/master/README.md).
 
 **Note** Refer to the [CODESIZE.md](CODESIZE.md) for more details about the calculation of code sizes for the HTTPS Compatibility Layer and the [coreHTTP FreeRTOS documentation](https://freertos.org/http/index.html) for coreHTTP library.
 


### PR DESCRIPTION
Description
-----------
<!--- Describe your changes in detail -->
Provides code sizes for the HTTPS V1 compatibility layer in comparison to coreHTTP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.