### PR TITLE
FreeRTOS+TCP: Update Submodule Pointer (#2826)

### DIFF
--- a/demos/device_defender_for_aws/metrics_collector/freertos_plus_tcp/metrics_collector.c
+++ b/demos/device_defender_for_aws/metrics_collector/freertos_plus_tcp/metrics_collector.c
@@ -74,13 +74,13 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
                     "bytes sent: %u, packets sent: %u.",
                     ( unsigned int ) metrics.xInput.uxByteCount,
                     ( unsigned int ) metrics.xInput.uxPacketCount,
-                    ( unsigned int ) metrics.XOutput.uxByteCount,
-                    ( unsigned int ) metrics.XOutput.uxPacketCount ) );
+                    ( unsigned int ) metrics.xOutput.uxByteCount,
+                    ( unsigned int ) metrics.xOutput.uxPacketCount ) );
 
         pOutNetworkStats->bytesReceived = metrics.xInput.uxByteCount;
         pOutNetworkStats->packetsReceived = metrics.xInput.uxPacketCount;
-        pOutNetworkStats->bytesSent = metrics.XOutput.uxByteCount;
-        pOutNetworkStats->packetsSent = metrics.XOutput.uxPacketCount;
+        pOutNetworkStats->bytesSent = metrics.xOutput.uxByteCount;
+        pOutNetworkStats->packetsSent = metrics.xOutput.uxPacketCount;
 
         status = MetricsCollectorSuccess;
     }

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -56,7 +56,8 @@ void prvCreateDHCPSocket();
  * The signature of the function under test.
  ****************************************************************/
 
-void vDHCPProcess( BaseType_t xReset );
+void vDHCPProcess( BaseType_t xReset,
+                   eDHCPState_t eExpectedState );
 
 /****************************************************************
  * Abstract prvProcessDHCPReplies proved memory safe in ProcessDHCPReplies.
@@ -74,6 +75,7 @@ BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
 void harness()
 {
     BaseType_t xReset;
+    eDHCPState_t eExpectedState;
 
     /****************************************************************
      * Initialize the counter used to bound the number of times
@@ -91,12 +93,12 @@ void harness()
      * xReset==True resets the state to eWaitingSendFirstDiscover.
      ****************************************************************/
 
-    if( !( ( xDHCPData.eDHCPState == eWaitingSendFirstDiscover ) ||
+    if( !( ( xDHCPData.eDHCPState == eInitialWait ) ||
            ( xReset != pdFALSE ) ) )
     {
         prvCreateDHCPSocket();
         __CPROVER_assume( xDHCPSocket != NULL );
     }
 
-    vDHCPProcess( xReset );
+    vDHCPProcess( xReset, eExpectedState );
 }


### PR DESCRIPTION
* Update TCP submodule pointer

* Update the submodule pointer of TCP to V2.3.2

* Update defender demos

* Update Harness for vDHCPProcess

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.