### PR TITLE
Cypress Psoc64 metadata fix

### DIFF
--- a/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
@@ -543,8 +543,8 @@ function(cy_create_exe_target)
     if (OTA_SUPPORT)
         cy_config_ota_exe_target(EXE_APP_NAME ${ARG_EXE_APP_NAME})
     endif()
-
-    cy_sign_boot_image(EXE_APP_NAME ${ARG_EXE_APP_NAME})
+    if(NOT AFR_METADATA_MODE)
+        cy_sign_boot_image(EXE_APP_NAME ${ARG_EXE_APP_NAME})
+    endif()
 
 endfunction()
-

--- a/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
@@ -230,7 +230,7 @@ function(cy_sign_boot_image)
 
         # We can use objcopy for .hex to .bin for all toolchains
         find_program(GCC_OBJCOPY arm-none-eabi-objcopy HINT "${AFR_TOOLCHAIN_PATH}")
-        if(NOT GCC_OBJCOPY AND (NOT AFR_METADATA_MODE))
+        if((NOT GCC_OBJCOPY) AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
         endif()
 
@@ -302,7 +302,7 @@ function(cy_sign_boot_image)
 
         # We can use objcopy for .hex to .bin for all toolchains
         find_program(GCC_OBJCOPY arm-none-eabi-objcopy HINT "${AFR_TOOLCHAIN_PATH}")
-        if(NOT GCC_OBJCOPY AND (NOT AFR_METADATA_MODE))
+        if((NOT GCC_OBJCOPY) AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
         endif()
 
@@ -345,7 +345,7 @@ function(cy_sign_boot_image)
 
         # Sign both TFM and AFR images
         find_program(CY_SIGN_SCRIPT cysecuretools)
-        if(NOT CY_SIGN_SCRIPT AND (NOT AFR_METADATA_MODE))
+        if((NOT CY_SIGN_SCRIPT) AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find cysecuretools.")
         endif()
 

--- a/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
@@ -230,7 +230,7 @@ function(cy_sign_boot_image)
 
         # We can use objcopy for .hex to .bin for all toolchains
         find_program(GCC_OBJCOPY arm-none-eabi-objcopy HINT "${AFR_TOOLCHAIN_PATH}")
-        if(NOT GCC_OBJCOPY )
+        if(NOT GCC_OBJCOPY AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
         endif()
 
@@ -302,7 +302,7 @@ function(cy_sign_boot_image)
 
         # We can use objcopy for .hex to .bin for all toolchains
         find_program(GCC_OBJCOPY arm-none-eabi-objcopy HINT "${AFR_TOOLCHAIN_PATH}")
-        if(NOT GCC_OBJCOPY )
+        if(NOT GCC_OBJCOPY AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find arm-none-eabi-objcopy.")
         endif()
 

--- a/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
@@ -544,6 +544,6 @@ function(cy_create_exe_target)
         cy_config_ota_exe_target(EXE_APP_NAME ${ARG_EXE_APP_NAME})
     endif()
 
-        cy_sign_boot_image(EXE_APP_NAME ${ARG_EXE_APP_NAME})
+    cy_sign_boot_image(EXE_APP_NAME ${ARG_EXE_APP_NAME})
 
 endfunction()

--- a/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
+++ b/vendors/cypress/MTB/psoc6/cmake/cy_create_exe_target.cmake
@@ -345,7 +345,7 @@ function(cy_sign_boot_image)
 
         # Sign both TFM and AFR images
         find_program(CY_SIGN_SCRIPT cysecuretools)
-        if(NOT CY_SIGN_SCRIPT )
+        if(NOT CY_SIGN_SCRIPT AND (NOT AFR_METADATA_MODE))
             message(FATAL_ERROR "Cannot find cysecuretools.")
         endif()
 
@@ -543,8 +543,7 @@ function(cy_create_exe_target)
     if (OTA_SUPPORT)
         cy_config_ota_exe_target(EXE_APP_NAME ${ARG_EXE_APP_NAME})
     endif()
-    if(NOT AFR_METADATA_MODE)
+
         cy_sign_boot_image(EXE_APP_NAME ${ARG_EXE_APP_NAME})
-    endif()
 
 endfunction()

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/CMakeLists.txt
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/CMakeLists.txt
@@ -128,17 +128,31 @@ afr_set_board_metadata(VENDOR_NAME "Cypress")
 afr_set_board_metadata(FAMILY_NAME "PSoC 6")
 afr_set_board_metadata(DATA_RAM_MEMORY "1024KB")
 afr_set_board_metadata(PROGRAM_MEMORY "2MB")
-afr_set_board_metadata(CODE_SIGNER "")
-afr_set_board_metadata(SUPPORTED_IDE "ModusToolbox")
-afr_set_board_metadata(RECOMMENDED_IDE "ModusToolbox")
-afr_set_board_metadata(IDE_ModusToolbox_NAME "ModusToolbox")
+afr_set_board_metadata(CODE_SIGNER "null")
+afr_set_board_metadata(SUPPORTED_IDE "CMakeBuildSystem;ModusToolbox")
+afr_set_board_metadata(RECOMMENDED_IDE "CMakeBuildSystem")
+afr_set_board_metadata(KEY_IMPORT_PROVISIONING "TRUE")
+# settings for CmakeBuildSystem as IDE
+afr_set_board_metadata(IDE_CMakeBuildSystem_NAME "CMakeBuildSystem")
+afr_set_board_metadata(IDE_CMakeBuildSystem_COMPILER "GCC")
+if("${AFR_TOOLCHAIN}" STREQUAL "arm-armclang")
+    afr_set_board_metadata(IDE_CMakeBuildSystem_COMPILER "ARM")
+elseif("${AFR_TOOLCHAIN}" STREQUAL "arm-iar")
+    afr_set_board_metadata(IDE_CMakeBuildSystem_COMPILER "IAR")
+endif()
+afr_set_board_metadata(IDE_CMakeBuildSystem_PROJECT_LOCATION "null")
+# settings for ModusToolbox as IDE
+afr_set_board_metadata(IDE_ModusToolbox_NAME "Eclipse IDE for ModusToolbox")
 afr_set_board_metadata(IDE_ModusToolbox_COMPILER "GCC")
 if("${AFR_TOOLCHAIN}" STREQUAL "arm-armclang")
     afr_set_board_metadata(IDE_ModusToolbox_COMPILER "ARM")
 elseif("${AFR_TOOLCHAIN}" STREQUAL "arm-iar")
     afr_set_board_metadata(IDE_ModusToolbox_COMPILER "IAR")
 endif()
-afr_set_board_metadata(IDE_ModusToolbox_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/cypress/${AFR_BOARD_NAME}/ModusToolbox/aws_demos")
+# demo project directory location
+afr_set_board_metadata(IDE_ModusToolbox_PROJECT_LOCATION "${AFR_ROOT_DIR}/projects/cypress/${AFR_BOARD_NAME}/mtb/aws_demos")
+# demo project configuration file location
+afr_set_board_metadata(AWS_DEMOS_CONFIG_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}/aws_demos/config_files")
 
 cy_add_link_libraries(
     DEVICE "CYB0644ABZI-S2D44"


### PR DESCRIPTION
Description
-----------
This PR will fix the borken build combination on psco64 board.

The problem was caused by:
1. The the error of objcopy and cysecuretools not found
2. Incorrect metadata info

It fixs it by:
1. Omitt the error of objcopy and cysecuretools not found in METADATA_MODE, since this two tools is only used for generating the binary image.
2. Update the metadata.



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.