### PR TITLE
Reducing Nuvoton buffer sizes for multi-threaded demo

### DIFF
--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -123,7 +123,7 @@
  * be less than democonfigUSER_BUFFER_LENGTH. We don't expect S3 to send more
  * than 1024 bytes of headers.
  */
-#define democonfigUSER_BUFFER_LENGTH                ( 2048 )
+#define democonfigUSER_BUFFER_LENGTH                ( 1536 )
 
 /**
  * @brief The size of the range of the file to download, with each request.
@@ -132,12 +132,12 @@
  * in the user buffer. We don't expect S3 to send more than 1024 bytes of
  * headers.
  */
-#define democonfigRANGE_REQUEST_LENGTH              ( 1024 )
+#define democonfigRANGE_REQUEST_LENGTH              ( 512 )
 
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 5 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */


### PR DESCRIPTION
Reducing the memory size requirement for the buffers of each thread in the multi-threaded download demo, for Nuvoton boards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.