### PR TITLE
Fix BLE test case failure

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_serialize.h
@@ -233,6 +233,11 @@ typedef struct MQTTBLEPublishInfo
      * @brief Pending flag for continuation of publish packet.
      */
     bool pending;
+
+    /**
+     * @brief Packet Identifier for QoS1, QoS2 publish packet.
+     */
+    uint16_t packetIdentifier;
 } MQTTBLEPublishInfo_t;
 /** @} */
 

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
@@ -685,7 +685,6 @@ static MQTTBLEStatus_t handleOutgoingPublish( MQTTBLEPublishInfo_t * pPublishInf
                                               size_t * pSerializedBufLength )
 {
     MQTTBLEStatus_t status = MQTTBLESuccess;
-    uint16_t packetIdentifier = 0;
 
     LogDebug( ( "Processing outgoing PUBLISH." ) );
 
@@ -700,7 +699,7 @@ static MQTTBLEStatus_t handleOutgoingPublish( MQTTBLEPublishInfo_t * pPublishInf
         pPublishInfo->pending = parsePublish( buf,
                                               bytesToSend,
                                               pPublishInfo,
-                                              &packetIdentifier );
+                                              &pPublishInfo->packetIdentifier );
     }
 
     LogDebug( ( "IotBleMqtt_SerializePublish before if" ) );
@@ -710,7 +709,7 @@ static MQTTBLEStatus_t handleOutgoingPublish( MQTTBLEPublishInfo_t * pPublishInf
         status = IotBleMqtt_SerializePublish( pPublishInfo,
                                               pSerializedBuf,
                                               pSerializedBufLength,
-                                              packetIdentifier );
+                                              pPublishInfo->packetIdentifier );
 
         if( pPublishInfo->pTopicName != NULL )
         {

--- a/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
+++ b/libraries/c_sdk/standard/ble/test/iot_mqtt_ble_system_test.c
@@ -315,6 +315,11 @@ static SemaphoreHandle_t bleChannelSem;
 static uint32_t getTimeMs();
 
 /**
+ * @brief Global variable to keep track of BLE status and enable only once.
+ */
+static BaseType_t bleEnabled = pdFALSE;
+
+/**
  * @brief Sends an MQTT CONNECT packet over connected BLE Channel.
  *
  * @param[in] pContext MQTT context pointer.
@@ -809,6 +814,12 @@ static void testSetUp()
     packetTypeForDisconnection = MQTT_PACKET_TYPE_INVALID;
     memset( &incomingInfo, 0u, sizeof( MQTTPublishInfo_t ) );
 
+    if( bleEnabled == pdFALSE )
+    {
+        bleEnable();
+        bleEnabled = pdTRUE;
+    }
+
     /* setup BLE transport interface. */
     setupBleTransportInterface( &networkContext );
 
@@ -852,15 +863,15 @@ TEST_TEAR_DOWN( coreMQTT_Integration_BLE )
  */
 TEST_GROUP_RUNNER( coreMQTT_Integration_BLE )
 {
-    /* Enable BLE middleware and GATT services only once for all tests in the group. */
-    bleEnable();
-
     RUN_TEST_CASE( coreMQTT_Integration_BLE, Subscribe_Publish_With_Qos_0 );
     RUN_TEST_CASE( coreMQTT_Integration_BLE, Subscribe_Publish_With_Qos_1 );
     RUN_TEST_CASE( coreMQTT_Integration_BLE, ProcessLoop_KeepAlive );
 
     /* Disconnect and turn off BLE after all tests in the group. */
-    bleDisable();
+    if( bleEnabled == pdTRUE )
+    {
+        bleDisable();
+    }
 }
 
 /* ========================== Test Cases ============================ */


### PR DESCRIPTION
Fix BLE test case failure

Description
-----------
Modified the test case to not cause a reboot if test assert fails.
Fixed a case where packet identifier was not set correctly for transport interface.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.