### PR TITLE
Add support for collecting metrics in demos connecting to AWS IoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For detailed documentation on FreeRTOS, refer to the [FreeRTOS User Guide](https
 
 ### AWS Collection of Metrics
 
-AWS collects usage metrics indicating the operating system, hardware platform and MQTT client information of use to AWS IoT from the MQTT mutual auth demo by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and can be disabled by updating the `OS_NAME`, `OS_VERSION`, `HARDWARE_PLATFORM_NAME` and `MQTT_LIB` configuration macros in the `demos/mqtt/mqtt_demo_mutual_auth/demo_config.h` file of the MQTT mutual auth demo.
+AWS collects usage metrics indicating the operating system, and MQTT client information of use to AWS IoT from the MQTT mutual auth demo by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and can be disabled by updating the `OS_NAME`, `OS_VERSION` and `MQTT_LIB` configuration macros in the `demos/include/aws_iot_metrics.h` file.
 
 #### Format
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ For detailed documentation on FreeRTOS, refer to the [FreeRTOS User Guide](https
 
 ### AWS Collection of Metrics
 
-AWS collects usage metrics indicating the operating system, and MQTT client information of use to AWS IoT from the MQTT mutual auth demo by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and can be disabled by updating the `OS_NAME`, `OS_VERSION` and `MQTT_LIB` configuration macros in the `demos/include/aws_iot_metrics.h` file.
+The demos that connect to AWS IoT report metrics to AWS about the operating system, and the MQTT client library used by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and these can be disabled by updating the following configuration macros in the `demos/include/aws_iot_metrics.h` file:
+````
+#define AWS_IOT_METRICS_STRING                   NULL
+#define AWS_IOT_METRICS_STRING_LENGTH    0U
+```
 
 #### Format
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ To directly access the **Getting Started Guide** for supported hardware platform
 
 For detailed documentation on FreeRTOS, refer to the [FreeRTOS User Guide](https://aws.amazon.com/documentation/freertos).
 
+### AWS Collection of Metrics
+
+AWS collects usage metrics indicating the operating system, hardware platform and MQTT client information of use to AWS IoT from the MQTT mutual auth demo by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and can be disabled by updating the `OS_NAME`, `OS_VERSION`, `HARDWARE_PLATFORM_NAME` and `MQTT_LIB` configuration macros in the `demos/mqtt/mqtt_demo_mutual_auth/demo_config.h` file of the MQTT mutual auth demo.
+
+#### Format
+
+The format of the username string with metrics is:
+
+```
+<Actual_Username>?SDK=<OS_Name>&Version=<OS_Version>MQTTLib=<MQTT_Library_name>@<MQTT_Library_version>
+```
+
+where
+
+* **Actual_Username** is the actual username used for authentication (if a username/password is used for authentication).
+* **OS_Name** is the Operating System the application is running on.
+* **OS_Version** is the version number of the Operating System.
+* **MQTT_Library_name** is the MQTT Client library being used.
+* **MQTT_Library_version** is the version of the MQTT Client library being used.
+
 ## Supported Hardware
 
 For additional boards that are supported for FreeRTOS, please visit the [AWS Device Catalog](https://devices.amazonaws.com/search?kw=freertos)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ For detailed documentation on FreeRTOS, refer to the [FreeRTOS User Guide](https
 ### AWS Collection of Metrics
 
 The demos that connect to AWS IoT report metrics to AWS about the operating system, and the MQTT client library used by sending a specially formatted string in the username field of the MQTT CONNECT packet. These metrics help AWS IoT improve security and provide better technical support. Providing these metrics is optional for users, and these can be disabled by updating the following configuration macros in the `demos/include/aws_iot_metrics.h` file:
-````
-#define AWS_IOT_METRICS_STRING                   NULL
+
+```
+#define AWS_IOT_METRICS_STRING           NULL
 #define AWS_IOT_METRICS_STRING_LENGTH    0U
 ```
 

--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -44,6 +44,9 @@
 /* Shadow includes */
 #include "mqtt_demo_helpers.h"
 
+/* Include AWS IoT metrics macros header. */
+#include "aws_iot_metrics.h"
+
 /* Retry utilities include. */
 #include "backoff_algorithm.h"
 
@@ -605,6 +608,14 @@ BaseType_t EstablishMqttSession( MQTTContext_t * pxMqttContext,
              * unique, such as a device serial number. */
             xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
             xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+            /* User metrics string as username to report OS and MQTT client version metrics to
+             * AWS IoT. */
+            xConnectInfo.pUserName = AWS_IOT_METRICS_STRING;
+            xConnectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
+            /* Password for authentication is not used. */
+            xConnectInfo.pPassword = NULL;
+            xConnectInfo.passwordLength = 0U;
 
             /* The maximum time interval in seconds which is allowed to elapse
              * between two Control Packets.

--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -609,8 +609,8 @@ BaseType_t EstablishMqttSession( MQTTContext_t * pxMqttContext,
             xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
             xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
 
-            /* User metrics string as username to report OS and MQTT client version metrics to
-             * AWS IoT. */
+            /* Use the metrics string as username to report the OS and MQTT client version
+             * metrics to AWS IoT. */
             xConnectInfo.pUserName = AWS_IOT_METRICS_STRING;
             xConnectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
             /* Password for authentication is not used. */

--- a/demos/coreMQTT/mqtt_demo_connection_sharing.c
+++ b/demos/coreMQTT/mqtt_demo_connection_sharing.c
@@ -82,6 +82,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include AWS IoT metrics macros header. */
+#include "aws_iot_metrics.h"
+
 /**
  * These configuration settings are required to run the demo.
  */
@@ -828,6 +831,11 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
      * unique, such as a device serial number. */
     xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
     xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+    /* Use the metrics string as username to report the OS and MQTT client version
+     * metrics to AWS IoT. */
+    xConnectInfo.pUserName = AWS_IOT_METRICS_STRING;
+    xConnectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
 
     /* Set MQTT keep-alive period. It is the responsibility of the application
      * to ensure that the interval between Control Packets being sent does not

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -81,6 +81,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include AWS IoT metrics macros header. */
+#include "aws_iot_metrics.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /** Note: The device client certificate and private key credentials are
@@ -796,6 +799,11 @@ static BaseType_t prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTConte
      * unique, such as a device serial number. */
     xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
     xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+    /* Use the metrics string as username to report the OS and MQTT client version
+     * metrics to AWS IoT. */
+    xConnectInfo.pUserName = AWS_IOT_METRICS_STRING;
+    xConnectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
 
     /* Set MQTT keep-alive period. If the application does not send packets at an interval less than
      * the keep-alive period, the MQTT library will send PINGREQ packets. */

--- a/demos/include/aws_iot_metrics.h
+++ b/demos/include/aws_iot_metrics.h
@@ -1,0 +1,65 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @brief Macros for reporting metrics about customer platform and MQTT client used
+ * when running applications against AWS IoT.
+ * These metrics help AWS IoT offer faster technical support to customers.
+ */
+
+/* Include MQTT header for MQTT_LIBRARY_VERSION macro. */
+#include "core_mqtt.h"
+
+/**
+ * @brief The name of the operating system that the application is running on.
+ * The current value is given as an example. Please update for your specific
+ * operating system.
+ */
+#define democonfigOS_NAME       "FreeRTOS"
+
+/**
+ * @brief The version of the operating system that the application is running
+ * on. The current value is given as an example. Please update for your specific
+ * operating system version.
+ */
+#define democonfigOS_VERSION    "V10.4.3"
+
+/**
+ * @brief The name of the MQTT library used and its version, following an "@"
+ * symbol.
+ */
+#define democonfigMQTT_LIB      "core-mqtt@" MQTT_LIBRARY_VERSION
+
+/**
+ * @brief The MQTT metrics string expected by AWS IoT.
+ */
+#define AWS_IOT_METRICS_STRING                                 \
+    "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
+    "&MQTTLib=" democonfigMQTT_LIB
+
+/**
+ * @brief The length of the MQTT metrics string expected by AWS IoT.
+ */
+#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )


### PR DESCRIPTION
Add support for collecting metrics of **OS**, **Kernel version** and **MQTT client version** through demos that connect to AWS IoT. These metrics are OPTIONAL for users. These metrics help AWS IoT improve security and provide better technical support.