### PR TITLE
Fix S3 multi threading demo failure on NXP.

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -123,7 +123,7 @@
  * be less than democonfigUSER_BUFFER_LENGTH. We don't expect S3 to send more
  * than 1024 bytes of headers.
  */
-#define democonfigUSER_BUFFER_LENGTH                ( 2048 )
+#define democonfigUSER_BUFFER_LENGTH                ( 1536 )
 
 /**
  * @brief The size of the range of the file to download, with each request.
@@ -132,12 +132,12 @@
  * in the user buffer. We don't expect S3 to send more than 1024 bytes of
  * headers.
  */
-#define democonfigRANGE_REQUEST_LENGTH              ( 1024 )
+#define democonfigRANGE_REQUEST_LENGTH              ( 512 )
 
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 5 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */


### PR DESCRIPTION
Fix S3 multi threading demo failure on NXP.

Description
-----------
Root cause: The S3 multi threaded demo allocates memory for the queues needed in the demo. With the default size for the Queue elements, the demo fails to allocate memory.
Fix: Optimize the size of the Queue elements for http demo for NXP.

This is the same change as #2857, which got merged to release-candidate.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.