### PR TITLE
Add comment about handling S3 request limits to S3 download demos

### DIFF
--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -40,6 +40,13 @@
  * "presigned_urls_gen.py" (located in http_demo_helpers) to generate these
  * URLs. For detailed instructions, see the accompanied README.md.
  *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
+ *
  * @note This demo uses retry logic to connect to the server if connection
  * attempts fail. The FreeRTOS/backoffAlgorithm library is used to calculate the
  * retry interval with an exponential backoff and jitter algorithm. For

--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -47,6 +47,13 @@
  * "presigned_urls_gen.py" (located in http_demo_helpers) to generate these
  * URLs. For detailed instructions, see the accompanied README.md.
  *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
+ *
  * @note This demo uses retry logic to connect to the server if connection
  * attempts fail. The FreeRTOS/backoffAlgorithm library is used to calculate the
  * retry interval with an exponential backoff and jitter algorithm. For


### PR DESCRIPTION
Adding a comment to the top of S3 download and multi-threaded download demo source code files, to explain how to handle S3 request limits. This is done to prevent users from treating this case as a bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.