### PR TITLE
Fix timeout in mqtt_ble demo

### DIFF
--- a/demos/ble/mqtt_ble/mqtt_demo_ble_transport.c
+++ b/demos/ble/mqtt_ble/mqtt_demo_ble_transport.c
@@ -313,7 +313,7 @@ static MQTTStatus_t getNewData( const MQTTFixedBuffer_t * buf,
 
     /* Waits until there is data available from the channel to receive it.
      * A "No data was received from the transport." may appear from each unsuccessful attempt.
-     * This program will stop after 20 attempts, with 250 seconds in between by default.
+     * This program will stop after 20 attempts, with 250 milliseconds in between by default.
      * If you have high latency, you can adjust MQTT_MAX_RECV_ATTEMPTS above. */
     do
     {
@@ -788,16 +788,13 @@ MQTTStatus_t RunMQTTBLETransportDemo( void )
 
             mqttSubscribeToTopics( &fixedBuffer );
 
-            /* Process incoming packets from the broker. There will be one SUBACK packet
-             * for each topic subscribed to.  There remains the possiblity that another
+            /* Process incoming packets from the broker. Having just sent a single SUBSCRIBE
+             * for both topics, we should receive a single SUBACK. There remains the possiblity that another
              * person will publish to the topic before the SUBACK is received, but since
              * we are the only ones using this topic filter name, here that chance is zero.
              * However, one should use a generic incoming packet function for higher use
              * topic filters in case a PUBLISH arrives before the SUBACK. */
-            for( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
-            {
-                mqttProcessIncomingPacket( &fixedBuffer );
-            }
+            mqttProcessIncomingPacket( &fixedBuffer );
 
             /********************* Publish and Keep Alive Loop. ********************/
             /* Publish messages with QOS0, send and process Keep alive messages. */
@@ -853,12 +850,7 @@ MQTTStatus_t RunMQTTBLETransportDemo( void )
             }
 
             mqttUnsubscribeFromTopic( &fixedBuffer );
-
-            /* Process Incoming unsubscribe acks from the broker. */
-            for( size_t subscriptionNumber = 0; subscriptionNumber < NUM_SUBS_AT_ONCE; ++subscriptionNumber )
-            {
-                mqttProcessIncomingPacket( &fixedBuffer );
-            }
+            mqttProcessIncomingPacket( &fixedBuffer );
 
             /* Send an MQTT Disconnect packet over the already connected BLE channel.
              * There is no corresponding response for the disconnect packet. After sending


### PR DESCRIPTION
Description
-----------
Related Issues:
- https://github.com/aws/amazon-freertos/issues/2838
- [amazon-freertos-ble-android-sdk#38](https://github.com/aws/amazon-freertos-ble-android-sdk/issues/38)

For _before_ behavior see the above Git Issue. Replicated locally for debugging.

The timeout occurs because the MCU serializes/sends a single SUBSCRIBE packet that queries both topics, but then incorrectly expects a one SUBACK _per_ topic subscribed (2 total). This is inaccurate as it's possible to query subscription to multiple topics in a _single_ SUBSCRIBE packet, and it's 1-to-1 for SUBSRIBE-to-SUBACK.
The same occurs for UNSUBSCRIBE/UNSUBACK.
See:
- `mqtt_demo_ble_transport.c::mqttSubscribeToTopics`
- `mqtt_demo_ble_transport.c::mqttUnsubscribeToTopics`
- [MQTT::SUBSCRIBE](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063)

Verified fix for nrf52840dk and esp32_devkitc.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.