### PR TITLE
TEST PR: DO NOT MERGE

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
@@ -564,6 +564,11 @@
 							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/fmc.c</FilePath>
 						</File>
 						<File>
+							<FileName>gpio.c</FileName>
+							<FileType>1</FileType>
+							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/gpio.c</FilePath>
+						</File>
+						<File>
 							<FileName>sys.c</FileName>
 							<FileType>1</FileType>
 							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/sys.c</FilePath>

--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_tests/aws_tests.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_tests/aws_tests.uvproj
@@ -578,6 +578,11 @@
 							<FileType>1</FileType>
 							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/retarget.c</FilePath>
 						</File>
+						<File>
+							<FileName>gpio.c</FileName>
+							<FileType>1</FileType>
+							<FilePath>../../../../../vendors/nuvoton/sdk/StdDriver/src/gpio.c</FilePath>
+						</File>
 					</Files>
 				</Group>
 				<Group>

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -117,6 +117,7 @@ target_sources(
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/sys.c"
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/uart.c"
         "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/retarget.c"
+        "${AFR_VENDORS_DIR}/nuvoton/sdk/StdDriver/src/gpio.c"
         "${AFR_KERNEL_DIR}/portable/MemMang/heap_4.c"
         "${AFR_KERNEL_DIR}/portable/RVDS/ARM_CM4F/port.c"
         "${board_dir}/application_code/nuvoton_code/entropy_hardware_poll.c"

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
@@ -71,6 +71,7 @@ extern uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ];
  * 1 but a DHCP server could not be contacted.  See the online documentation for
  * more information.  In both cases the node can be discovered using
  * "ping RTOSDemo". */
+#if ( configENABLED_NETWORKS & AWSIOT_NETWORK_TYPE_ETH )
 static const uint8_t ucIPAddress[ 4 ] =
 {
     configIP_ADDR0,
@@ -99,7 +100,7 @@ static const uint8_t ucDNSServerAddress[ 4 ] =
     configDNS_SERVER_ADDR2,
     configDNS_SERVER_ADDR3
 };
-
+#endif
 
 /**
  * @brief Application task startup hook.
@@ -484,7 +485,7 @@ void vAssertCalled( const char * pcFile,
 
 void vApplicationIdleHook( void )
 {
-    const uint32_t ulMSToSleep = 1;
+//    const uint32_t ulMSToSleep = 1;
     const TickType_t xIdleCheckPeriod = pdMS_TO_TICKS( 1000UL );
     static TickType_t xTimeNow, xLastTimeCheck = 0;
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/main.c
@@ -485,7 +485,6 @@ void vAssertCalled( const char * pcFile,
 
 void vApplicationIdleHook( void )
 {
-//    const uint32_t ulMSToSleep = 1;
     const TickType_t xIdleCheckPeriod = pdMS_TO_TICKS( 1000UL );
     static TickType_t xTimeNow, xLastTimeCheck = 0;
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
@@ -34,7 +34,7 @@
 /**
  * @brief Maximum number of sockets that can be created simultaneously.
  */
-#define wificonfigMAX_SOCKETS                 ( 1 )
+#define wificonfigMAX_SOCKETS                 ( 5 )
 
 /**
  * @brief Maximum number of connection retries.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
@@ -114,4 +114,27 @@
  */
 #define wificonfigMAX_RECV_BUF_SIZE           ( 1024 * 12 )
 
+/**
+ * @brief Enable WiFi H/W reset
+ */
+#define wificonfigHW_RESET                    ( 1 )
+
+/**
+ * @brief Receive WiFi TCP packet using Passive mode
+ */
+#define wificonfigTCP_PASSIVE_MODE            ( 1 )
+
+/**
+ * @brief Enable UART H/W flow control
+ */
+#define wificonfigSERIAL_FC                   ( 1 )
+
+/**
+ * @brief Set UART baud rate
+ *
+ * Could be select 115200/230400/460800/921600/1152000/2304000
+ * Must enable wificonfigSERIAL_FC to support this feature, or it always runs as default 115200
+ */
+#define wificonfigBAUD_RATE                   ( 115200 )
+
 #endif /* _AWS_WIFI_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
@@ -132,7 +132,7 @@
 /**
  * @brief Set UART baud rate
  *
- * Could be select 115200/230400/460800/921600/1152000/2304000
+ * Could be select 115200/230400/460800
  * Must enable wificonfigSERIAL_FC to support this feature, or it always runs as default 115200
  */
 #define wificonfigBAUD_RATE                   ( 115200 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_wifi_config.h
@@ -132,7 +132,7 @@
 /**
  * @brief Set UART baud rate
  *
- * Could be select 115200/230400/460800
+ * Could be select 115200/230400/460800/921600/1152000/2304000
  * Must enable wificonfigSERIAL_FC to support this feature, or it always runs as default 115200
  */
 #define wificonfigBAUD_RATE                   ( 115200 )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_wifi_config.h
@@ -34,7 +34,7 @@
 /**
  * @brief Maximum number of sockets that can be created simultaneously.
  */
-#define wificonfigMAX_SOCKETS                 ( 2 )
+#define wificonfigMAX_SOCKETS                 ( 5 )
 
 /**
  * @brief Maximum number of connection retries.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_wifi_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_wifi_config.h
@@ -119,4 +119,27 @@
  */
 #define wificonfigMAX_RECV_BUF_SIZE           ( 1024 * 3 )
 
+/**
+ * @brief Enable WiFi H/W reset
+ */
+#define wificonfigHW_RESET                    ( 1 )
+
+/**
+ * @brief Receive WiFi TCP packet using Passive mode
+ */
+#define wificonfigTCP_PASSIVE_MODE            ( 0 )
+
+/**
+ * @brief Enable UART H/W flow control
+ */
+#define wificonfigSERIAL_FC                   ( 0 )
+
+/**
+ * @brief Set UART baud rate
+ *
+ * Could be select 115200/230400/460800/921600/1152000/2304000
+ * Must enable wificonfigSERIAL_FC to support this feature, or it always runs as default 115200
+ */
+#define wificonfigBAUD_RATE                   ( 115200 )
+
 #endif /* _AWS_WIFI_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -217,9 +217,6 @@ static BaseType_t prvFLASH_SaveFile( char * pcFileName,
     CK_RV xResult = pdFALSE;
     uint32_t certFlashAddr = 0;
     CK_RV xBytesWritten = 0;
-//    CK_ULONG ulFlashMark = pkcs11OBJECT_FLASH_CERT_PRESENT;
-//    const P11CertData_t * pCertFlash;
-//    P11CertData_t * pCertSave = 0;
     
     /* enough room to store the certificate */
     if( ulDataSize > pkcs11OBJECT_CERTIFICATE_MAX_SIZE )
@@ -439,7 +436,6 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 
     CK_RV ulReturn = CKR_OK;
     char        *pcFileName     = NULL;
-//    uint8_t     *pucData;
 
     if( xHandle == eAwsDeviceCertificate )
     {

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -217,9 +217,9 @@ static BaseType_t prvFLASH_SaveFile( char * pcFileName,
     CK_RV xResult = pdFALSE;
     uint32_t certFlashAddr = 0;
     CK_RV xBytesWritten = 0;
-    CK_ULONG ulFlashMark = pkcs11OBJECT_FLASH_CERT_PRESENT;
-    const P11CertData_t * pCertFlash;
-    P11CertData_t * pCertSave = 0;
+//    CK_ULONG ulFlashMark = pkcs11OBJECT_FLASH_CERT_PRESENT;
+//    const P11CertData_t * pCertFlash;
+//    P11CertData_t * pCertSave = 0;
     
     /* enough room to store the certificate */
     if( ulDataSize > pkcs11OBJECT_CERTIFICATE_MAX_SIZE )
@@ -439,7 +439,7 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
 
     CK_RV ulReturn = CKR_OK;
     char        *pcFileName     = NULL;
-    uint8_t     *pucData;
+//    uint8_t     *pucData;
 
     if( xHandle == eAwsDeviceCertificate )
     {

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -47,11 +47,16 @@
 /* flash driver includes. */
 #include "NuMicro.h"
 
+#ifndef pkcs11configLABEL_DEVICE_RESERVE_KEY
+#define pkcs11configLABEL_DEVICE_RESERVE_KEY "Device Reserve key"
+#endif
+
 //#define pkcs11FILE_NAME_PUBLISHER_CERTIFICATE    "FreeRTOS_Publisher_Certificate.dat"
 //#define pkcs11FILE_NAME_PUBLISHER_KEY            "FreeRTOS_Publisher_Key.dat"
 #define pkcs11palFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"
 #define pkcs11palFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"
 #define pkcs11palFILE_CODE_SIGN_PUBLIC_KEY       "FreeRTOS_P11_CodeSignKey.dat"
+#define pkcs11palFILE_NAME_RESERVE_KEY                "FreeRTOS_P11_ReserveKey.dat"
 
 #define pkcs11OBJECT_CERTIFICATE_MAX_SIZE    2048
 #define pkcs11OBJECT_FLASH_CERT_PRESENT      ( 0x1A2B3C4DUL )
@@ -62,7 +67,8 @@ enum eObjectHandles
     eAwsDevicePrivateKey = 1,
     eAwsDevicePublicKey,
     eAwsDeviceCertificate,
-    eAwsCodeSigningKey
+    eAwsCodeSigningKey,
+    eAwsDeviceReserveKey,
 };
 
 /**
@@ -176,6 +182,13 @@ static void prvLabelToFilenameHandle( uint8_t * pcLabel,
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
             *pHandle = eAwsCodeSigningKey;
         }
+        else if( 0 == memcmp( pcLabel,
+                              &pkcs11configLABEL_DEVICE_RESERVE_KEY,
+                              sizeof( pkcs11configLABEL_DEVICE_RESERVE_KEY ) ) )
+        {
+            *pcFileName = pkcs11palFILE_NAME_RESERVE_KEY;
+            *pHandle = eAwsDeviceReserveKey;
+        }        
         else
         {
             *pcFileName = NULL;
@@ -233,6 +246,10 @@ static BaseType_t prvFLASH_SaveFile( char * pcFileName,
     {
         certFlashAddr = P11KeyConfig.CodeSignKey;
     }
+    else if( strcmp( pcFileName, pkcs11palFILE_NAME_RESERVE_KEY ) == 0 )
+    {
+        certFlashAddr = P11KeyConfig.ReserveKey;
+    }    
     else
     {
         certFlashAddr = NULL;
@@ -289,7 +306,11 @@ static BaseType_t prvFLASH_ReadFile( char * pcFileName,
     {
         pCertFlash = (P11CertData_t *)P11KeyConfig.CodeSignKey;        
     }
-
+    else if( strcmp( pcFileName, pkcs11palFILE_NAME_RESERVE_KEY ) == 0 )
+    {
+        pCertFlash = (P11CertData_t *)P11KeyConfig.ReserveKey;        
+    }
+    
     if( ( pCertFlash !=0 ) && ( pCertFlash->ulDeviceCertificateMark == pkcs11OBJECT_FLASH_CERT_PRESENT ) )
     {
         pCertData = ( uint8_t * ) pCertFlash->cCertificateData;
@@ -439,6 +460,11 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
     else if( xHandle == eAwsCodeSigningKey )
     {
         pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
+        *pIsPrivate = CK_FALSE;
+    }
+    else if( xHandle == eAwsDeviceReserveKey )
+    {
+        pcFileName = pkcs11palFILE_NAME_RESERVE_KEY;
         *pIsPrivate = CK_FALSE;
     }
     else

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/secure_sockets/iot_secure_sockets.c
@@ -188,7 +188,7 @@ static BaseType_t prvNetworkSend( void * pvContext,
     }
 
     //taskYIELD();
-    if (ESP_WIFI_Get_Ipd_Size(&(pxSecureSocket->xWiFiConn)) > ESP_WIFI_IPD_HIGH_LEVEL) {
+    if (ESP_WIFI_Get_Ipd_Size(&xNuWiFi.xWifiObject) > ESP_WIFI_IPD_HIGH_LEVEL) {
         /* Allow other tasks can process the received data */
         vTaskDelay(100);
     }
@@ -324,6 +324,8 @@ int32_t SOCKETS_Connect( Socket_t xSocket,
                     /* Mark that the socket is connected. */
                     pxSecureSocket->ulFlags |= securesocketsSOCKET_IS_CONNECTED_FLAG;
                 }
+                /* Clear the socket Ipd buffer */
+                ESP_WIFI_Clear_Ipd(&xNuWiFi.xWifiObject, ulSocketNum);
                 xSemaphoreGive(xNuWiFi.xWifiSem);
             }
         }
@@ -526,8 +528,8 @@ int32_t SOCKETS_Close( Socket_t xSocket )
                 }
                 lSocketRet = SOCKETS_ERROR_NONE;
             }
-            /* Reset the socket Ipd buffer */
-            ESP_WIFI_Reset_Ipd(&pxSecureSocket->xWiFiConn);
+            /* Clear the socket Ipd buffer */
+            ESP_WIFI_Clear_Ipd(&xNuWiFi.xWifiObject, ulSocketNum);
             xSemaphoreGive(xNuWiFi.xWifiSem);
         }
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/wifi/iot_wifi.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/wifi/iot_wifi.c
@@ -116,7 +116,9 @@ WIFIReturnCode_t WIFI_On( void )
         xNuWiFi.xWifiObject.UartBaudRate = ESP_UART_BAUDRATE;
         xNuWiFi.xWifiObject.Timeout = ESP_TIMEOUT_IN_MS;
         xNuWiFi.xWifiObject.IsMultiConn = pdFALSE;
-        xNuWiFi.xWifiObject.ActiveCmd = CMD_NONE;
+        xNuWiFi.xWifiObject.HeapUsage = 0;
+        xNuWiFi.xWifiObject.IsPassiveMode = pdFALSE;
+        xNuWiFi.xWifiObject.ActiveSocket = 0;
 
         xWIFI_IsInitialized = pdTRUE;
     }

--- a/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
+++ b/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
@@ -1253,7 +1253,7 @@ ESP_WIFI_Status_t ESP_WIFI_Recv( ESP_WIFI_Object_t * pxObj, ESP_WIFI_Conn_t * px
             }
 
             if ((*usRecvLen) == 0) {
-                do {
+                while (1) {
                     xTickCurrent = xTaskGetTickCount();
                     if (xTickCurrent < xTickEnd) {
                         xTickTimeout = xTickEnd - xTickCurrent;
@@ -1264,7 +1264,13 @@ ESP_WIFI_Status_t ESP_WIFI_Recv( ESP_WIFI_Object_t * pxObj, ESP_WIFI_Conn_t * px
                     }
 
                     xRet = ESP_IO_Recv(pxObj, pxObj->CmdData, sizeof(pxObj->CmdData), pxConn->LinkID, xTickTimeout);
-                } while (xRet != ESP_WIFI_STATUS_RECV);
+                    if (xRet == ESP_WIFI_STATUS_RECV) {
+                        break;
+                    } else {
+                        /* Release the CPU resource */
+                        vTaskDelay(1);
+                    }
+                }
             } else {
                 ucDoFlag = 0;
             }

--- a/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
+++ b/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
@@ -743,7 +743,7 @@ ESP_WIFI_Status_t ESP_WIFI_GetNetStatus( ESP_WIFI_Object_t * pxObj )
 {
     ESP_WIFI_Status_t xRet;
 
-    xRet = ESP_AT_Command(pxObj, (uint8_t *)"AT+CIFSR\r\n", 0);
+    xRet = ESP_AT_Command(pxObj, (uint8_t *)"AT+CIFSR\r\n", 30);
 
     if (xRet == ESP_WIFI_STATUS_OK) {
         AT_ParseAddress(pxObj);

--- a/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
+++ b/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.c
@@ -550,7 +550,6 @@ ESP_WIFI_Status_t ESP_IO_Recv( ESP_WIFI_Object_t * pxObj, uint8_t pucRxBuf[], ui
 static ESP_WIFI_Status_t ESP_AT_Command( ESP_WIFI_Object_t * pxObj, uint8_t * pucCmd, uint32_t ulTimeWaitMs )
 {
     ESP_WIFI_Status_t xRet = ESP_WIFI_STATUS_TIMEOUT;
-    uint16_t usCount;
 
     /* Wait for last AT command is done */
     while (xTaskGetTickCount() < pxObj->AvailableTick) {
@@ -1071,7 +1070,6 @@ ESP_WIFI_Status_t ESP_WIFI_Send( ESP_WIFI_Object_t * pxObj, ESP_WIFI_Conn_t * px
     ESP_WIFI_Status_t xRet = ESP_WIFI_STATUS_ERROR;
     TickType_t xTickCurrent, xTickEnd, xTickTimeout;
     uint16_t usAskSend, usRealSend;
-    uint8_t ucExit = 0;
     uint8_t ucCount;
 
     xTickEnd = xTaskGetTickCount() + xTimeout;
@@ -1154,8 +1152,7 @@ ESP_WIFI_Status_t ESP_WIFI_Recv_TCP_PASSIVE( ESP_WIFI_Object_t * pxObj, uint8_t 
                                  uint16_t usReqLen, uint16_t * usRecvLen, TickType_t xTickEnd )
 {
     ESP_WIFI_Status_t xRet = ESP_WIFI_STATUS_TIMEOUT;
-    TickType_t xTickCurrent, xTickTimeout;
-    uint8_t ucDoFlag = 1;
+   
 
     if (xWifiIpd[ucLinkID].DataAvailable != 0) {
         xWifiIpd[ucLinkID].TcpData = (char *)pcBuf;

--- a/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.h
+++ b/vendors/nuvoton/sdk/middleware/wifi_esp8266/esp8266_wifi.h
@@ -80,7 +80,11 @@
 #define AT_SEND_STRING              ">"
 #define AT_RECV_STRING              "+IPD,"
 #define AT_PASSIVE_STRING           "+CIPRECVDATA,"
-#define AT_CLOSE_STRING             ",CLOSED"
+#define AT_CLOSE0_STRING            "0,CLOSED"
+#define AT_CLOSE1_STRING            "1,CLOSED"
+#define AT_CLOSE2_STRING            "2,CLOSED"
+#define AT_CLOSE3_STRING            "3,CLOSED"
+#define AT_CLOSE4_STRING            "4,CLOSED"
 
 /* List of commands */
 #define CMD_NONE                    0x00
@@ -127,7 +131,7 @@ typedef struct {
     BaseType_t IsConnected;
     BaseType_t IsMultiConn;
     BaseType_t IsPassiveMode;
-    uint8_t ActiveSocket;
+    int8_t ActiveSocket;
 
     uint8_t StaIpAddr[4];
     uint8_t StaMacAddr[6];
@@ -136,10 +140,11 @@ typedef struct {
 } ESP_WIFI_Object_t;
 
 typedef struct {
+    BaseType_t IsOpen;
+    BaseType_t IsPassiveMode;
     char *TcpData;
     uint16_t DataAvailable;
     uint16_t DataReceive;
-    BaseType_t IsPassiveMode;
 } ESP_WIFI_IPD_t;
 
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
- Support M487 PKCS one reserve key
-     M487 WiFi driver modifications.     1. Use dynamic allocate buffer instead of static array     2. Support TCP passive mode     3. Support Serial RTS/CTS     4. Support H/W reset
- M487 demos and tests support new WiFi driver, project files are merged based on the commit e9cbe09 on Jun 11, 2020
- Fix wifi ESP8266 unstable on some board
- Fix wifi ESP8266 DNS resolve fail issue at baudrate 921600
- M487 WiFi driver add socket ID checking
- Modify M487 CMakeList for cmake support on new WiFi driver
- Adjust M487 wifi max sockets as 5
- Remove esp8266_wifi.c unused variables
- Fix unsued variable in M487 demo main.c & pkcs11_pal.c
- Removed the commented out code of M487 demo main.c & pkcs11_pal.c
- Release CPU resource for other tasks in WiFi long time blocking


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
