### PR TITLE
Fix build failure of NXP MCUExpresso test project

### DIFF
--- a/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.cproject
+++ b/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.cproject
@@ -171,7 +171,6 @@
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/freertos_plus/standard/freertos_plus_posix/include"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/coreJSON/source/include"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/device_shadow_for_aws/source/include"/>
-									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../demos/common/mqtt_demo_helpers"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/device_defender_for_aws/source/include"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/jobs_for_aws/source/include"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/pkcs11"/>

--- a/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.project
+++ b/projects/nxp/lpc54018iotmodule/mcuxpresso/aws_tests/.project
@@ -1678,11 +1678,6 @@
 			<locationURI>BASE_DIR/libraries/device_shadow_for_aws/source/include/shadow_config_defaults.h</locationURI>
 		</link>
 		<link>
-			<name>demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c</name>
-			<type>1</type>
-			<locationURI>BASE_DIR/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c</locationURI>
-		</link>
-		<link>
 			<name>libraries/device_defender_for_aws/source/defender.c</name>
 			<type>1</type>
 			<locationURI>BASE_DIR/libraries/device_defender_for_aws/source/defender.c</locationURI>


### PR DESCRIPTION
Remove demo-specific file from the `aws_tests` project file of the NXP MCUExpresso to fix build failure