### PR TITLE
Update nordic cmake to use latest segger compiler version

### DIFF
--- a/tools/cmake/toolchains/arm-segger.cmake
+++ b/tools/cmake/toolchains/arm-segger.cmake
@@ -30,17 +30,21 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 # Default flags and include paths.
 include_directories(${CMAKE_FIND_ROOT_PATH}/../../include)
 
-# Overwrite the command to compile c files
+
+# Override the command to compile c files
 set(CMAKE_C_COMPILE_OBJECT
 	"<CMAKE_C_COMPILER> <DEFINES> <INCLUDES> <FLAGS> <SOURCE> -o <OBJECT>.asm"
 	"<CMAKE_ASM_COMPILER> --traditional-format -mcpu=cortex-m4 -mlittle-endian -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb <OBJECT>.asm -o <OBJECT>"
 )
 
-# Overwrite the command to compile asm files
+message("${CMAKE_C_COMPILE_OBJECT}")
+string(REPLACE "-MD" "-MD <OBJECT>.d" CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}")
+
+# Override the command to compile asm files
 set(CMAKE_ASM_COMPILE_OBJECT
 	"<CMAKE_C_COMPILER> <DEFINES> <INCLUDES> <FLAGS> <SOURCE> -o <OBJECT>.asm"
 	"<CMAKE_ASM_COMPILER> --traditional-format -mcpu=cortex-m4 -mlittle-endian -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb <OBJECT>.asm -o <OBJECT>"
 )
 
-# Overwrite the linker command.
+# Override the linker command.
 set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_LINKER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")

--- a/tools/cmake/toolchains/arm-segger.cmake
+++ b/tools/cmake/toolchains/arm-segger.cmake
@@ -30,15 +30,11 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 # Default flags and include paths.
 include_directories(${CMAKE_FIND_ROOT_PATH}/../../include)
 
-
 # Override the command to compile c files
 set(CMAKE_C_COMPILE_OBJECT
 	"<CMAKE_C_COMPILER> <DEFINES> <INCLUDES> <FLAGS> <SOURCE> -o <OBJECT>.asm"
 	"<CMAKE_ASM_COMPILER> --traditional-format -mcpu=cortex-m4 -mlittle-endian -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb <OBJECT>.asm -o <OBJECT>"
 )
-
-message("${CMAKE_C_COMPILE_OBJECT}")
-string(REPLACE "-MD" "-MD <OBJECT>.d" CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}")
 
 # Override the command to compile asm files
 set(CMAKE_ASM_COMPILE_OBJECT

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -99,6 +99,7 @@ set(c_flags
     "-mtp=soft"
     "-munaligned-access"
     "-nostdinc"
+    "-w"
     "-quiet"
     "-gdwarf-4"
     "-g3"
@@ -483,14 +484,14 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
        ${exe_target}
        PRIVATE
        "${nrf5_sdk}/external/nrf_cc310/lib/libnrf_cc310_0.9.10.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       "${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
-       "${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+       #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       #"${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+       #"${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
     )
 
     if(AFR_METADATA_MODE)
@@ -524,6 +525,7 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
     function(nrf52840_build)
         set( build_target ${ARGV0} )
         set( build_mkld_flags ${${ARGV1}} )
+
         add_custom_command(
             TARGET ${build_target}
             PRE_LINK

--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -484,14 +484,9 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
        ${exe_target}
        PRIVATE
        "${nrf5_sdk}/external/nrf_cc310/lib/libnrf_cc310_0.9.10.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-       #"${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
-       #"${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+       "${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+       "${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
     )
 
     if(AFR_METADATA_MODE)

--- a/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
+++ b/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
@@ -105,20 +105,14 @@ target_link_options(
     PRIVATE
     ${linker_flags}
 )
-set_target_properties(bootloader PROPERTIES FLAGS "-MD abc.d" )
 
 target_link_libraries(
   bootloader
   PRIVATE
   "${nrf5_sdk}/external/nrf_cc310_bl/lib/libnrf_cc310_bl_0.9.10.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  #"${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
-  #"${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+  "${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  "${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
 )
 
 # bootloader src

--- a/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
+++ b/vendors/nordic/boards/nrf52840-dk/bootloader.cmake
@@ -105,19 +105,20 @@ target_link_options(
     PRIVATE
     ${linker_flags}
 )
+set_target_properties(bootloader PROPERTIES FLAGS "-MD abc.d" )
 
 target_link_libraries(
   bootloader
   PRIVATE
   "${nrf5_sdk}/external/nrf_cc310_bl/lib/libnrf_cc310_bl_0.9.10.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
-  "${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
-  "${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+  #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv5_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_mempoll_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libm_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libc_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libcpp_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libdebugio_v7em_fpv4_sp_d16_hard_t_le_eabi.a"
+  #"${AFR_COMPILER_DIR}/../../../lib/libvfprintf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
+  #"${AFR_COMPILER_DIR}/../../../lib/libvfscanf_v7em_fpv4_sp_d16_hard_t_le_eabi.o"
 )
 
 # bootloader src


### PR DESCRIPTION
Update nordic cmake to use latest segger compiler version 5.32a

Description
-----------
Modify the libc files to the new files from the compiler version.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.