### PR TITLE
Fix WiFi network deletion for ESP32

### DIFF
--- a/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c
@@ -1108,11 +1108,11 @@ WIFIReturnCode_t WIFI_NetworkDelete( uint16_t usIndex )
 			{
 				xRet = nvs_commit( xNvsHandle );
 			}
-		}
 
-		if( xRet == ESP_OK )
-		{
-			xWiFiRet = eWiFiSuccess;
+			if( xRet == ESP_OK )
+			{
+				xWiFiRet = eWiFiSuccess;
+			}
 		}
 
 		// Close


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
#2906 raises the following issue: in https://github.com/aws/amazon-freertos/blob/d92499008954c68a28c5ba58f9d7798a8f787ec4/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c#L1550, `_deleteNetworkTask` calls [`_popNetwork`](https://github.com/aws/amazon-freertos/blob/master/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c#L1192) with a `NULL` network profile, so [`WIFI_NetworkGet`](https://github.com/aws/amazon-freertos/blob/master/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c#L1020) is not called, and `ret` remains `eWiFiSuccess`. When [`WIFI_NetworkDelete`](https://github.com/aws/amazon-freertos/blob/master/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c#L1071) is called, it is then possible, if no networks are saved, for `usIndex < xRegistry.usNumNetworks`, so [`WIFI_NetworkDelete`](https://github.com/aws/amazon-freertos/blob/master/vendors/espressif/boards/esp32/ports/wifi/iot_wifi.c#L1071) returns success without deleting anything. `_popNetwork` will then decrement `wifiProvisioning.numNetworks`, causing it to underflow to UINT_MAX.

This fixes the issue by always returning `eWiFiFailure` when `usIndex >= xRegistry.usNumNetworks`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
