### PR TITLE
Secure sockets test group simplify

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -127,8 +127,8 @@ static volatile EventGroupHandle_t xSyncEventGroup = NULL;
 /* Bit definitions used with the xSyncEventGroup event group to allow the
  * prvEchoClientTxTask() and prvEchoClientRxTask() tasks to synchronize before
  * commencing a new cycle with a different socket. */
-#define tcptestTX_TASK_BIT    ( 0x01 << 1 )
-#define tcptestRX_TASK_BIT    ( 0x01 << 2 )
+#define tcptestTX_TASK_BIT                                  ( 0x01 << 1 )
+#define tcptestRX_TASK_BIT                                  ( 0x01 << 2 )
 
 #ifndef Threadsafe_SameSocketDifferentTasksFrameSize
     #define Threadsafe_SameSocketDifferentTasksFrameSize    ( 2 * 1500 )
@@ -1543,6 +1543,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                  */
                 xNumBytesReceived += lNumBytes;
             }
+
             if( lNumBytes < 0 )
             {
                 break;
@@ -1551,6 +1552,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
             xEndTime = xTaskGetTickCount();
         }
         while( xMessageLength > xNumBytesReceived );
+
         xResult = prvCheckTimeout( xStartTime, xEndTime, xTimeout );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Receive timeout was outside of acceptable range" );
 
@@ -1940,7 +1942,6 @@ static void prvSOCKETS_SendRecv_VaryLength( Server_t xConn )
         /* Send each message length ulMaxLoopCount times. */
         for( ulI = 0; ulI < ulMaxLoopCount; ulI++ )
         {
-
             memset( pucTxBuffer, tcptestTX_BUFFER_FILLER, tcptestBUFFER_SIZE );
 
             prvCreateTxData( ( char * ) pucTxBuffer,

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -130,8 +130,8 @@ static volatile EventGroupHandle_t xSyncEventGroup = NULL;
 #define tcptestTX_TASK_BIT                                  ( 0x01 << 1 )
 #define tcptestRX_TASK_BIT                                  ( 0x01 << 2 )
 
-#ifndef Threadsafe_SameSocketDifferentTasksFrameSize
-    #define Threadsafe_SameSocketDifferentTasksFrameSize    ( 2 * 1500 )
+#ifndef tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE
+    #define tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE    tcptestTWICE_MAX_FRAME_SIZE
 #endif
 
 /* Array setup for 2x an Ethernet II data section */
@@ -2727,7 +2727,7 @@ static void prvSOCKETS_Threadsafe_SameSocketDifferentTasks( Server_t xConn )
                 xRecvLen = 1;
             }
 
-            while( xTotalReceived < Threadsafe_SameSocketDifferentTasksFrameSize )
+            while( xTotalReceived < tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE )
             {
                 xReturned = SOCKETS_Recv( ( Socket_t ) xSocket, ( char * ) pcReceivedString, xRecvLen, 0 );
 
@@ -2822,7 +2822,7 @@ static void prvEchoClientTxTask( void * pvParameters )
                                                                                        /* Using % to avoid bug in case a new state is unknowingly added. */
 
         vTaskPrioritySet( NULL, tcptestECHO_TEST_HIGH_PRIORITY );
-        xMaxBufferSize = Threadsafe_SameSocketDifferentTasksFrameSize;
+        xMaxBufferSize = tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE;
 
         /* Set low priority if requested . */
         if( ( xMode == LARGE_BUFFER_LOW_PRIORITY ) || ( xMode == SMALL_BUFFER_LOW_PRIORITY ) )
@@ -2849,12 +2849,12 @@ static void prvEchoClientTxTask( void * pvParameters )
         xStatus = pdTRUE;
 
         /* Keep sending until the entire buffer has been sent. */
-        while( xTransmitted < Threadsafe_SameSocketDifferentTasksFrameSize )
+        while( xTransmitted < tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE )
         {
             /* How many bytes are left to send?  Attempt to send them
              * all at once (so the length is potentially greater than the
              * MSS). */
-            xLenToSend = Threadsafe_SameSocketDifferentTasksFrameSize - xTransmitted;
+            xLenToSend = tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE - xTransmitted;
 
             /* Every loop switch the size of the packet from maximum to smallest. */
             if( xLenToSend > xMaxBufferSize )

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1484,7 +1484,6 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
     TickType_t xStartTime;
     TickType_t xEndTime;
     TickType_t xTimeout = 0;
-    TickType_t xWaitTime = 1000;
     uint8_t * pucTxBuffer = ( uint8_t * ) pcTxBuffer;
     uint8_t * pucRxBuffer = ( uint8_t * ) pcRxBuffer;
     size_t xMessageLength = 1200;
@@ -1552,7 +1551,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
             xEndTime = xTaskGetTickCount();
         }
         while( xMessageLength > xNumBytesReceived );
-        xResult = prvCheckTimeout( xStartTime, xEndTime, xWaitTime );
+        xResult = prvCheckTimeout( xStartTime, xEndTime, xTimeout );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Receive timeout was outside of acceptable range" );
 
         xResult = prvCheckRxTxBuffers( pucTxBuffer, pucRxBuffer, xMessageLength );

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1555,7 +1555,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
 
         xResult = prvCheckTimeout( xStartTime, xEndTime, xTimeout );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Receive timeout was outside of acceptable range" );
-
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( xMessageLength, xNumBytesReceived, "Data was not received \r\n" );
         xResult = prvCheckRxTxBuffers( pucTxBuffer, pucRxBuffer, xMessageLength );
 
         xResult = prvShutdownHelper( xSocket );

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -130,6 +130,9 @@ static volatile EventGroupHandle_t xSyncEventGroup = NULL;
 #define tcptestTX_TASK_BIT    ( 0x01 << 1 )
 #define tcptestRX_TASK_BIT    ( 0x01 << 2 )
 
+#ifndef Threadsafe_SameSocketDifferentTasksFrameSize
+    #define Threadsafe_SameSocketDifferentTasksFrameSize    ( 2 * 1500 )
+#endif
 
 /* Array setup for 2x an Ethernet II data section */
 #define tcptestTWICE_MAX_FRAME_SIZE    ( 2 * 1500 )
@@ -423,7 +426,7 @@ typedef struct
 #define tcptestMAX_LOOPS_ECHO_TEST            tcptestMAX_ECHO_TEST_MODES
 
 #define tcptestECHO_TEST_LOW_PRIORITY         tskIDLE_PRIORITY
-#define tcptestECHO_TEST_HIGH_PRIORITY        ( configMAX_PRIORITIES - 1 )
+#define tcptestECHO_TEST_HIGH_PRIORITY        ( configMAX_PRIORITIES - 2 )
 
 #ifndef ipconfigTCP_MSS
     #define ipconfigTCP_MSS                   ( 256 )
@@ -898,9 +901,7 @@ static BaseType_t prvRecvHelper( Socket_t xSocket,
 
         if( xNumBytes == 0 )
         {
-            tcptestFAILUREPRINTF( ( "Timed out receiving from echo server \r\n" ) );
-            xResult = pdFAIL;
-            break;
+            tcptestFAILUREPRINTF( ( "Warning Timed out receiving from echo server \r\n" ) );
         }
         else if( xNumBytes < 0 )
         {
@@ -1543,12 +1544,16 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                  */
                 xNumBytesReceived += lNumBytes;
             }
+            if( lNumBytes < 0 )
+            {
+                break;
+            }
 
             xEndTime = xTaskGetTickCount();
         }
-        while( ( ( xEndTime - xStartTime ) < xWaitTime ) && ( xMessageLength > xNumBytesReceived ) );
-
-        TEST_ASSERT_EQUAL_INT32_MESSAGE( xMessageLength, xNumBytesReceived, "Data was not received \r\n" );
+        while( xMessageLength > xNumBytesReceived );
+        xResult = prvCheckTimeout( xStartTime, xEndTime, xWaitTime );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Receive timeout was outside of acceptable range" );
 
         xResult = prvCheckRxTxBuffers( pucTxBuffer, pucRxBuffer, xMessageLength );
 
@@ -1936,6 +1941,7 @@ static void prvSOCKETS_SendRecv_VaryLength( Server_t xConn )
         /* Send each message length ulMaxLoopCount times. */
         for( ulI = 0; ulI < ulMaxLoopCount; ulI++ )
         {
+
             memset( pucTxBuffer, tcptestTX_BUFFER_FILLER, tcptestBUFFER_SIZE );
 
             prvCreateTxData( ( char * ) pucTxBuffer,
@@ -1949,6 +1955,7 @@ static void prvSOCKETS_SendRecv_VaryLength( Server_t xConn )
 
             TEST_ASSERT_EQUAL_INT32_MESSAGE( pdPASS, xResult, "Data failed to send\r\n" );
             memset( pucRxBuffer, tcptestRX_BUFFER_FILLER, tcptestBUFFER_SIZE );
+
             xResult = prvRecvHelper( xSocket,
                                      pucRxBuffer,
                                      xMessageLengths[ ulIndex ] );
@@ -2720,7 +2727,7 @@ static void prvSOCKETS_Threadsafe_SameSocketDifferentTasks( Server_t xConn )
                 xRecvLen = 1;
             }
 
-            while( xTotalReceived < tcptestTWICE_MAX_FRAME_SIZE )
+            while( xTotalReceived < Threadsafe_SameSocketDifferentTasksFrameSize )
             {
                 xReturned = SOCKETS_Recv( ( Socket_t ) xSocket, ( char * ) pcReceivedString, xRecvLen, 0 );
 
@@ -2816,7 +2823,7 @@ static void prvEchoClientTxTask( void * pvParameters )
                                                                                        /* Using % to avoid bug in case a new state is unknowingly added. */
 
         vTaskPrioritySet( NULL, tcptestECHO_TEST_HIGH_PRIORITY );
-        xMaxBufferSize = tcptestTWICE_MAX_FRAME_SIZE;
+        xMaxBufferSize = Threadsafe_SameSocketDifferentTasksFrameSize;
 
         /* Set low priority if requested . */
         if( ( xMode == LARGE_BUFFER_LOW_PRIORITY ) || ( xMode == SMALL_BUFFER_LOW_PRIORITY ) )
@@ -2843,12 +2850,12 @@ static void prvEchoClientTxTask( void * pvParameters )
         xStatus = pdTRUE;
 
         /* Keep sending until the entire buffer has been sent. */
-        while( xTransmitted < tcptestTWICE_MAX_FRAME_SIZE )
+        while( xTransmitted < Threadsafe_SameSocketDifferentTasksFrameSize )
         {
             /* How many bytes are left to send?  Attempt to send them
              * all at once (so the length is potentially greater than the
              * MSS). */
-            xLenToSend = tcptestTWICE_MAX_FRAME_SIZE - xTransmitted;
+            xLenToSend = Threadsafe_SameSocketDifferentTasksFrameSize - xTransmitted;
 
             /* Every loop switch the size of the packet from maximum to smallest. */
             if( xLenToSend > xMaxBufferSize )
@@ -3053,7 +3060,7 @@ static void prvThreadSafeDifferentSocketsDifferentTasks( void * pvParameters )
                                           ipconfigTCP_MSS - xReceivedBytes,        /* The size of the buffer provided to receive the data. */
                                           0 );                                     /* No flags. */
 
-                if( xReturned <= 0 )
+                if( xReturned < 0 )
                 {
                     break;
                 }

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -2730,7 +2730,6 @@ static void prvSOCKETS_Threadsafe_SameSocketDifferentTasks( Server_t xConn )
             {
                 xReturned = SOCKETS_Recv( ( Socket_t ) xSocket, ( char * ) pcReceivedString, xRecvLen, 0 );
 
-                TEST_ASSERT_NOT_EQUAL_MESSAGE( 0, xReturned, "Timeout occurred" );
                 TEST_ASSERT_GREATER_THAN_MESSAGE( 0, xReturned, "Error occurred receiving large message" );
 
                 /* Data was received. */

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -127,8 +127,8 @@ static volatile EventGroupHandle_t xSyncEventGroup = NULL;
 /* Bit definitions used with the xSyncEventGroup event group to allow the
  * prvEchoClientTxTask() and prvEchoClientRxTask() tasks to synchronize before
  * commencing a new cycle with a different socket. */
-#define tcptestTX_TASK_BIT                                  ( 0x01 << 1 )
-#define tcptestRX_TASK_BIT                                  ( 0x01 << 2 )
+#define tcptestTX_TASK_BIT                                               ( 0x01 << 1 )
+#define tcptestRX_TASK_BIT                                               ( 0x01 << 2 )
 
 #ifndef tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE
     #define tcptestTHREAD_SAFE_SAME_SOCKET_DIFFERENT_TASKS_FRAME_SIZE    tcptestTWICE_MAX_FRAME_SIZE

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1074,7 +1074,7 @@ static BaseType_t prvCheckTimeout( TickType_t xStartTime,
     if( ( int32_t ) ( xEndTime - xStartTime ) < ( int32_t ) ( xTimeout - integrationtestportableTIMEOUT_UNDER_TOLERANCE ) )
     {
         xResult = pdFAIL;
-        tcptestFAILUREPRINTF( ( "Start Time: %d, End Time: %d, Timeout: %d \n", xStartTime, xEndTime, xTimeout ) );
+        tcptestFAILUREPRINTF( ( "UNDER TOLERANCE failure Start Time: %d, End Time: %d, Timeout: %d \n", xStartTime, xEndTime, xTimeout ) );
     }
 
     /* Did the function exit after a reasonable amount of time?
@@ -1082,7 +1082,7 @@ static BaseType_t prvCheckTimeout( TickType_t xStartTime,
     if( ( xEndTime - xStartTime ) > ( xTimeout + integrationtestportableTIMEOUT_OVER_TOLERANCE ) )
     {
         xResult = pdFAIL;
-        tcptestFAILUREPRINTF( ( "Start Time: %d, End Time: %d, Timeout: %d \n", xStartTime, xEndTime, xTimeout ) );
+        tcptestFAILUREPRINTF( ( "OVER TOLERANCE failure Start Time: %d, End Time: %d, Timeout: %d \n", xStartTime, xEndTime, xTimeout ) );
     }
 
     return xResult;

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_test_tcp_config.h
@@ -45,7 +45,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20    /* FIX ME. */
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200    /* FIX ME. */
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_tcp_config.h
@@ -38,7 +38,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      1
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      1
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      250
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      450
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      1
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      250
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      450
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_test_tcp_config.h
@@ -45,7 +45,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20    /* FIX ME. */
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200    /* FIX ME. */
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for


### PR DESCRIPTION
## Description
1. [FreeRTOS adds cellular LTE-M interface library to support cellular IoT based applications](https://aws.amazon.com/about-aws/whats-new/2020/12/freertos-adds-cellular-lte-m-library-support-cellular-iot-based-applications/), using Cellular, the echo server is no longer in local network like using wi-Fi or Eth, this PR made some suggested changes for Secure Socket Test group making it more realistic for scenarios that echo servers are in a remote network.( https://quip-amazon.com/KNMVAxus311S/Secure-Sockets-Test-Plan-Changes-proposal)
2. These changes improves the coverage for some boards in existing CI, see below test results


## Testing
1. [IDT log ](https://s3.console.aws.amazon.com/s3/buckets/dhs-share/object/edit_public_read_access?region=us-east-1&showversions=false)testing Cellular module B96 + Nuvoton M487.
2. CI testing logs:
a. All passed for pc*,numaker_iot_m487_wifi*,esp*,infineon* boards
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/2100/
b. Improving coverage for ti*,st*,xilinx* boards (the coverage can improve more if we adjust the default values for ST baords)
(with changes)
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/2107/
(without changes)
https://amazon-freertos-ci.corp.amazon.com/job/im_v2_master/job/nightly_custom_job/2106/

