### PR TITLE
Remove redundant func declaration

### DIFF
--- a/libraries/abstractions/wifi/include/iot_wifi.h
+++ b/libraries/abstractions/wifi/include/iot_wifi.h
@@ -732,25 +732,6 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
 /* @[declare_wifi_wifi_ping] */
 
 /**
- * @brief Get IP configuration (IP address, NetworkMask, Gateway and
- *        DNS server addresses).
- *
- * @param[out] pxIPInfo - Current IP configuration.
- *
- * @return @ref eWiFiSuccess if successful and IP Address buffer has the interface's IP address,
- * failure code otherwise.
- *
- * **Example**
- * @code
- * WIFIIPConfiguration_t xIPInfo;
- * WIFI_GetIPInfo( &xIPInfo );
- * @endcode
- */
-/* @[declare_wifi_wifi_getip] */
-WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPInfo );
-/* @[declare_wifi_wifi_getip] */
-
-/**
  * @brief Retrieves the Wi-Fi interface's MAC address.
  *
  * @param[out] pucMac MAC Address buffer sized 6 bytes.


### PR DESCRIPTION
There were duplicate _declarations_ of 
```c
WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPInfo )
```
This PR removes the duplicate. The other declaration of course remains at line#979.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.