### PR TITLE
Fix async UART read issue on esp32 and esp32-s2

### DIFF
--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -375,16 +375,17 @@ int32_t iot_uart_read_async(IotUARTHandle_t const pxUartPeripheral, uint8_t * co
     }
 
     uart_ctx_t *uart_ctx = (uart_ctx_t *) pxUartPeripheral;
-    uart_ctx->read_buf = (char *) pvBuffer;
-    uart_ctx->bytes_to_read = xBytes;
-    uart_ctx->async_bytes_read = 0;
-
     //Read from another task to make async
     if (!xSemaphoreTake(uart_ctx->uart_rd_cb_wait, SEM_WAIT_TIME)) {
         ESP_LOGE(TAG, "%s: failed to acquire read sem", __func__);
         return IOT_UART_READ_FAILED;
     }
-    uart_enable_rx_intr(uart_ctx->uart_port_num);
+
+    uart_ctx->read_buf = (char *) pvBuffer;
+    uart_ctx->bytes_to_read = xBytes;
+    uart_ctx->async_bytes_read = 0;
+
+    esp_timer_start_once(uart_ctx->uart_timer_rd_hdl, 0);
     uart_ctx->rd_op_in_progress = true;
     return IOT_UART_SUCCESS;
 }


### PR DESCRIPTION
Description
-----------
**Issue:** iot_uart_read_async() fails with timeout when
       1. uart write async is called in a loop.
       2. In another thread read a single byte via uart read sync and remaining bytes
	   via uart read async with timeout.

**Fix:** The number of bytes to read is overwritten by multiple calls to iot_uart_read_async.
     Semaphore was taken after updating these values, now take Semaphore i.e. blocking before updating these values
     If uart write is called first and then uart read async is called after some time, the read async doesn't work
     due to interupt values not checked until call to ueart read async.
     This was fixed by calling async read once from the function itself.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.