### PR TITLE
espressif iot_wifi.c: Fix log print for SYSTEM_EVENT_AP_STOP event

### DIFF
--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -178,7 +178,7 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
                 xEventGroupSetBits(wifi_event_group, AP_STARTED_BIT);
                 break;
             case SYSTEM_EVENT_AP_STOP:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_START");
+                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_STOP");
                 wifi_ap_state = false;
                 xEventGroupClearBits(wifi_event_group, AP_STARTED_BIT);
                 xEventGroupSetBits(wifi_event_group, AP_STOPPED_BIT);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fixes issue reported in https://github.com/aws/amazon-freertos/issues/2925

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.