### PR TITLE
Fix ESP32 WiFi Deletion test

### DIFF
--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -1204,7 +1204,7 @@ WIFIReturnCode_t _popNetwork( uint16_t index,
         ret = WIFI_NetworkDelete( STORAGE_INDEX( index ) );
     }
 
-    if( ret == eWiFiSuccess )
+    if( ( ret == eWiFiSuccess ) && ( wifiProvisioning.numNetworks > 0 ) )
     {
         wifiProvisioning.numNetworks--;
 

--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -1127,11 +1127,11 @@ WIFIReturnCode_t WIFI_NetworkDelete( uint16_t usIndex )
 			{
 				xRet = nvs_commit( xNvsHandle );
 			}
+		}
 
-			if( xRet == ESP_OK )
-			{
-				xWiFiRet = eWiFiSuccess;
-			}
+		if( xRet == ESP_OK )
+		{
+			xWiFiRet = eWiFiSuccess;
 		}
 
 		// Close


### PR DESCRIPTION
- Revert "Fix WiFi network deletion for ESP32 (#2909)"
- Fix WiFi Network Deletion

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
#2909 attempted to fix a potential overflow issue in [iot_ble_wifi_provisioning.c](https://github.com/aws/amazon-freertos/blob/master/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c#L1204)'s `_popNetwork`, where calling delete on a non-existent network would decrement the number of networks to UINT_MAX. That commit fixed the issue by changing the return value of `WiFi_NetworkDelete` for ESP32 for the non-existent case, but it caused a [test to fail](https://github.com/aws/amazon-freertos/blob/master/libraries/abstractions/wifi/test/iot_test_wifi.c#L1296). This PR reverts that commit and instead alters the checks of `iot_ble_wifi_provisioning.c`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
