### PR TITLE
Fix build combo error when only BLE is selected.

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h
@@ -32,9 +32,6 @@
 #include "FreeRTOS.h"
 #include "stream_buffer.h"
 
-/* Transport interface include. */
-#include "transport_interface.h"
-
 #include "iot_ble_mqtt_transport_config.h"
 #include "iot_ble_mqtt_serialize.h"
 #include "iot_ble_data_transfer.h"
@@ -50,6 +47,14 @@ typedef struct BleTransportParams
     StaticStreamBuffer_t xStreamBufferStruct;
     MQTTBLEPublishInfo_t publishInfo;
 } BleTransportParams_t;
+
+/**
+ * Forward declaration of NetworkContext.
+ * Note: Do not directly include transport_interface.h header file, since in OCW console user may
+ * chooes BLE without coreMQTT and coreHTTP. This can avoid the build error.
+ */
+struct NetworkContext;
+typedef struct NetworkContext NetworkContext_t;
 
 /**
  * @brief Initiailzes the Circular buffer to store the received data


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In OCW, when only BLE is selected (without coreMQTT and coreHTTP), the build combo will report an error that "transport_interface.h: No such file or directory". As show in the log: https://amazon-freertos-ci.corp.amazon.com/job/Build_Combinations/job/espressif/job/esp32_devkitc/4104/artifact/afr-test-infra-manager/artifacts/log/ble_BLE_GATT_SERVER_DEMO_cmake.txt

and see:
https://github.com/DanielYEHsieh/amazon-freertos/blob/a57b63649e75ba9ac5f669386be58e6382e65962/libraries/c_sdk/standard/ble/include/iot_ble_mqtt_transport.h#L36

According to libraries/abstractions/transport/transport_interface.cmake, the single source of truth for the transport_interface.h is in the coreMQTT repository, and also possible from coreHTTP. So change the header include to forward declaration so that it won't report an error when only BLE is used. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.