### PR TITLE
Cbor/handle Indefinite Lengthed Containers

### DIFF
--- a/libraries/c_sdk/standard/serializer/include/iot_serializer.h
+++ b/libraries/c_sdk/standard/serializer/include/iot_serializer.h
@@ -429,7 +429,53 @@ typedef struct IotSerializerDecodeInterface
      */
     bool ( * isEndOfContainer )( IotSerializerDecoderIterator_t iterator );
 
+    /**
+     * @brief Function to obtain the starting buffer address of the raw encoded data (scalar or container type)
+     * represented by the passed decoder object.
+     * Container SHOULD be of type array or map.
+     *
+     * @param[in] pDecoderObject The decoder object whose underlying data's starting location in the buffer
+     * is to be returned.
+     * @param[out] pEncodedDataStartAddr This will be populated with the starting location of the encoded object
+     * in the data buffer.
+     *
+     * @return #IOT_SERIALIZER_SUCCESS if successful; otherwise #IOT_SERIALIZER_NOT_SUPPORTED
+     * for a non-container type iterator.
+     */
+    IotSerializerError_t ( * getBufferAddress )( const IotSerializerDecoderObject_t *
+                                                 pDecoderObject,
+                                                 const uint8_t **
+                                                 pEncodedDataStartAddr );
 
+
+    /**
+     * @brief Function to get the size of the raw encoded data in the buffer (ONLY of container type object)
+     * that is represented by the passed decoder object.
+     * Container SHOULD be of type array or map.
+     *
+     * @param[in] pDecoderObject The decoder objects whose underlying buffer data's length needs to be
+     * calculated.
+     * @param[out] The length of the underlying data in the buffer represented by the decoder object.
+     *
+     * @return #IOT_SERIALIZER_SUCCESS if successful; otherwise #IOT_SERIALIZER_NOT_SUPPORTED
+     * for a non-container type decoder object.
+     */
+    IotSerializerError_t ( * getSizeOfEncodedData )( const IotSerializerDecoderObject_t * pDecoderObject,
+                                                     size_t * pEncodedDataLength );
+
+    /**
+     * @brief Function to calculate the size of a container.
+     * It returns in constant time, O(1), for fixed-length containers, and incurs O(N) time for indefinite-length
+     * containers.
+     *
+     * @param[in] pDecoderObject The decoder object representing a container whose size will be calculated.
+     * @param[out] pLength The calculated length of the container will be stored here, if successful.
+     *
+     * @return #IOT_SERIALIZER_SUCCESS if successful, #IOT_SERIALIZER_NOT_SUPPORTED for a non-container type object
+     * or the appropriate error code.
+     */
+    IotSerializerError_t ( * getSizeOf )( const IotSerializerDecoderObject_t * pDecoderObject,
+                                          size_t * pLength );
 
     /**
      * @brief Steps out of the container by updating the decoder object to next byte position

--- a/libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
+++ b/libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
@@ -60,24 +60,83 @@ static bool _isEndOfContainer( IotSerializerDecoderIterator_t iterator );
 
 static void _destroy( IotSerializerDecoderObject_t * pDecoderObject );
 
+static IotSerializerError_t _getBufferAddress( const IotSerializerDecoderObject_t * pDecoderObject,
+                                               const uint8_t ** pEncodedDataStartAddr );
+
+
+
+static IotSerializerError_t _getSizeOfEncodedData( const IotSerializerDecoderObject_t * pDecoderObject,
+                                                   size_t * pEncodedDataLength );
+
+static IotSerializerError_t _getSizeOf( const IotSerializerDecoderObject_t * pDecoderObject,
+                                        size_t * pLength );
+/*-----------------------------------------------------------*/
+/**
+ * @brief Utility to calculates the length of the raw encoded data represented by the
+ * passed `pValue` object.
+ */
+static size_t _calculateSizeOfCborObject( CborValue * pValue );
+/**
+ * @brief Calculates the number of elements in an indefinite-length container
+ * in O(N) time by iterating through the container.
+ * @note For array type containers, it returns the number of elements in the array.
+ * For map type containers, it returns the 2 * number of entry pairs in the map.
+ * This is meant ONLY for indefinite-length containers (though it supports fixed-length containers).
+ * Fixed-length containers should use tinycbor provided APIs, `cbor_value_get_map_length`,
+ * and `cbor_value_get_array_length()`
+ *
+ * @param pCborValue[in]  The `CborValue` representing the indefinite-length container.
+ * @param pContainerSize[in,out] This will be populated with the calculated size of the container.
+ * @return `CborNoError` if successful, otherwise returns the appropriate `CborError` error.
+ */
+static CborError _calculateSizeOfIndefiniteLengthContainer( CborValue * pCborValue,
+                                                            size_t * pContainerSize );
+
+/*-----------------------------------------------------------*/
+
+
 IotSerializerDecodeInterface_t _IotSerializerCborDecoder =
 {
-    .init             = _init,
-    .get              = _get,
-    .find             = _find,
-    .stepIn           = _stepIn,
-    .stepOut          = _stepOut,
-    .next             = _next,
-    .isEndOfContainer = _isEndOfContainer,
-    .destroy          = _destroy
+    .init                 = _init,
+    .get                  = _get,
+    .find                 = _find,
+    .stepIn               = _stepIn,
+    .stepOut              = _stepOut,
+    .next                 = _next,
+    .isEndOfContainer     = _isEndOfContainer,
+    .getBufferAddress     = _getBufferAddress,
+    .getSizeOfEncodedData = _getSizeOfEncodedData,
+    .getSizeOf            = _getSizeOf,
+    .destroy              = _destroy
 };
 
 /* Wrapper CborValue with additional fields. */
 typedef struct _cborValueWrapper
 {
     CborValue cborValue;
-    bool isOutermost;
+    struct _cborValueWrapper * pParent;
 } _cborValueWrapper_t;
+
+/*-----------------------------------------------------------*/
+static size_t _calculateSizeOfCborObject( CborValue * pValue )
+{
+    IotSerializer_Assert( pValue != NULL );
+    CborValue nextValue;
+    CborError status = CborNoError;
+
+    /* Copy the contents of the current CBOR object so that we can advance to the next object. */
+    /* memcpy( &nextValue, &pValue->cborValue, sizeof( CborValue ) ); */
+    nextValue = *pValue;
+
+    /* Advance to the next element in the container. */
+    status = cbor_value_advance( &nextValue );
+    IotSerializer_Assert( status == CborNoError );
+
+    /* Suppress compiler warning of "unused" variable. */
+    ( void ) status;
+
+    return( ( size_t ) ( nextValue.ptr - pValue->ptr ) );
+}
 
 /*-----------------------------------------------------------*/
 
@@ -245,10 +304,23 @@ static IotSerializerError_t _createDecoderObject( _cborValueWrapper_t * pCborVal
 
                     {
                         /*
-                         * If its a finite length text/byte string, and user have passed a null length buffer,
-                         * we avoid copying the string by storing pointer to the start of the string.
-                         */
-                        pDecoderObject->u.value.u.string.pString = ( uint8_t * ) ( cbor_value_get_next_byte( &next ) - ( pDecoderObject->u.value.u.string.length ) );
+                         * If its a finite length text/byte string, and user have passed a
+                         * null length buffer, we avoid copying the string by storing
+                         * pointer to the start of the string. */
+                        pDecoderObject->u.value.u.string.pString =
+                            ( uint8_t * ) ( cbor_value_get_next_byte( &next ) - ( pDecoderObject->u.value.u.string.length ) );
+
+                        /* Edge case: current value is the last one in map/array and the
+                         * map/array has indefinite length. In this case, a special break
+                         * character 0xFF is written so the u.value.u.string.pString is
+                         * offset by 1. Therefore, we should deduct 1 to account for the
+                         * break character. */
+                        if( ( pCborValueWrapper->pParent != NULL ) &&
+                            ( cbor_value_is_length_known( &( pCborValueWrapper->pParent->cborValue ) ) == false ) &&
+                            cbor_value_at_end( &next ) )
+                        {
+                            pDecoderObject->u.value.u.string.pString--;
+                        }
                     }
                     else
                     {
@@ -274,7 +346,7 @@ static IotSerializerError_t _init( IotSerializerDecoderObject_t * pDecoderObject
                                    size_t maxSize )
 {
     CborParser * pCborParser = IotSerializer_MallocCborParser( sizeof( CborParser ) );
-    _cborValueWrapper_t cborValueWrapper = { .isOutermost = 0 };
+    _cborValueWrapper_t cborValueWrapper = { .pParent = NULL };
 
     if( pCborParser == NULL )
     {
@@ -294,8 +366,6 @@ static IotSerializerError_t _init( IotSerializerDecoderObject_t * pDecoderObject
     /* If init succeeds, create the decoder object. */
     if( cborError == CborNoError )
     {
-        cborValueWrapper.isOutermost = true;
-
         returnedError = _createDecoderObject( &cborValueWrapper, pDecoderObject );
     }
 
@@ -330,8 +400,8 @@ static void _destroy( IotSerializerDecoderObject_t * pDecoderObject )
 
     _cborValueWrapper_t * pCborValueWrapper = _castDecoderObjectToCborValue( pDecoderObject );
 
-    /* If this is outmost object, the parser's memory needs to be freed. */
-    if( pCborValueWrapper->isOutermost )
+    /* If this is outermost object, the parser's memory needs to be freed. */
+    if( pCborValueWrapper->pParent == NULL )
     {
         IotSerializer_FreeCborParser( ( void * ) ( pCborValueWrapper->cborValue.parser ) );
     }
@@ -371,7 +441,7 @@ static IotSerializerError_t _find( IotSerializerDecoderObject_t * pDecoderObject
     _cborValueWrapper_t * pCborValueWrapper = _castDecoderObjectToCborValue( pDecoderObject );
 
     /* Set this object not to be outermost one. */
-    newCborValueWrapper.isOutermost = false;
+    newCborValueWrapper.pParent = pCborValueWrapper;
 
     cborError = cbor_value_map_find_value(
         &pCborValueWrapper->cborValue,
@@ -420,7 +490,7 @@ static IotSerializerError_t _stepIn( IotSerializerDecoderObject_t * pDecoderObje
 
         pNewObject->type = pDecoderObject->type;
 
-        pNewCborValueWrapper->isOutermost = false;
+        pNewCborValueWrapper->pParent = pCborValueWrapper;
         pNewObject->u.pHandle = ( void * ) pNewCborValueWrapper;
 
         *pIterator = ( IotSerializerDecoderIterator_t ) pNewObject;
@@ -444,8 +514,17 @@ static IotSerializerError_t _stepOut( IotSerializerDecoderIterator_t iterator,
     _cborValueWrapper_t * pOuterCborValueWrapper = _castDecoderObjectToCborValue( pDecoderObject );
     _cborValueWrapper_t * pInnerCborValueWrapper = _castDecoderIteratorToCborValue( iterator );
 
+    CborValue outerCborValueCopy;
+
+    /* Clone the underlying CborValue object of the parent container, so that the original CborValue object's state/data
+     * is unaffected with this function's operation. This allows the container's decoder object re-usable for accessor
+     * and iteration operations.
+     *
+     * Note: By performing a cbor_value_leave_container() operation on the cloned copy, only the state/data of the copy
+     * is changed.*/
+    memcpy( &outerCborValueCopy, &pOuterCborValueWrapper->cborValue, sizeof( CborValue ) );
     cborError = cbor_value_leave_container(
-        &pOuterCborValueWrapper->cborValue,
+        &outerCborValueCopy,
         &pInnerCborValueWrapper->cborValue );
 
     if( cborError == CborNoError )
@@ -482,4 +561,139 @@ static bool _isEndOfContainer( IotSerializerDecoderIterator_t iterator )
     _cborValueWrapper_t * pCborValueWrapper = _castDecoderIteratorToCborValue( iterator );
 
     return cbor_value_at_end( &pCborValueWrapper->cborValue );
+}
+/*-----------------------------------------------------------*/
+
+static IotSerializerError_t _getBufferAddress( const IotSerializerDecoderObject_t * pDecoderObject,
+                                               const uint8_t ** pEncodedDataStartAddr )
+{
+    IotSerializer_Assert( pDecoderObject != NULL );
+
+    IotSerializerError_t status = IOT_SERIALIZER_SUCCESS;
+
+    if( IotSerializer_IsContainer( pDecoderObject ) )
+    {
+        *pEncodedDataStartAddr =
+            ( ( _cborValueWrapper_t * ) ( pDecoderObject->u.pHandle ) )->cborValue.ptr;
+    }
+    else
+    {
+        status = IOT_SERIALIZER_NOT_SUPPORTED;
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+IotSerializerError_t _getSizeOfEncodedData( const IotSerializerDecoderObject_t * pDecoderObject,
+                                            size_t * pEncodedDataLength )
+{
+    IotSerializer_Assert( pDecoderObject != NULL );
+    IotSerializerError_t status = IOT_SERIALIZER_SUCCESS;
+
+    if( IotSerializer_IsContainer( pDecoderObject ) )
+    {
+        *pEncodedDataLength = _calculateSizeOfCborObject(
+            &( ( ( _cborValueWrapper_t * ) pDecoderObject->u.pHandle )->cborValue ) );
+    }
+    else
+    {
+        status = IOT_SERIALIZER_NOT_SUPPORTED;
+    }
+
+    return status;
+}
+/*-----------------------------------------------------------*/
+
+static CborError _calculateSizeOfIndefiniteLengthContainer( CborValue * pCborValue,
+                                                            size_t * pContainerSize )
+{
+    IotSerializer_Assert( pCborValue != NULL );
+    IotSerializer_Assert( cbor_value_is_container( pCborValue ) );
+    IotSerializer_Assert( pContainerSize != NULL );
+
+    CborError status = CborNoError;
+    CborValue iterator;
+    CborValue cborCopy;
+
+    /* Clone the provide CborValue object to keep its state/data unaffected. */
+    memcpy( &cborCopy, pCborValue, sizeof( CborValue ) );
+
+    /* Reset the value to count the number of elements in the container. */
+    *pContainerSize = 0;
+    status = cbor_value_enter_container( &cborCopy, &iterator );
+
+    while( ( status == CborNoError ) && ( cbor_value_at_end( &iterator ) == false ) )
+    {
+        *pContainerSize = ( *pContainerSize + 1 );
+        status = cbor_value_advance( &iterator );
+    }
+
+    status = cbor_value_leave_container( &cborCopy, &iterator );
+
+    return status;
+}
+/*-----------------------------------------------------------*/
+
+IotSerializerError_t _getSizeOf( const IotSerializerDecoderObject_t * pDecoderObject,
+                                 size_t * pLength )
+{
+    IotSerializer_Assert( pDecoderObject != NULL );
+    IotSerializer_Assert( pLength != NULL );
+
+    IotSerializerError_t status = IOT_SERIALIZER_SUCCESS;
+    _cborValueWrapper_t * pCborValueWrapper = _castDecoderObjectToCborValue( pDecoderObject );
+    CborError cborError = CborNoError;
+
+    if( IotSerializer_IsContainer( pDecoderObject ) )
+    {
+        switch( pDecoderObject->type )
+        {
+            case IOT_SERIALIZER_CONTAINER_MAP:
+
+                if( cbor_value_get_map_length(
+                        &( ( _cborValueWrapper_t * ) ( pDecoderObject->u.pHandle ) )->cborValue,
+                        pLength ) == CborErrorUnknownLength )
+                {
+                    /* This is an indefinite length map. Calculate its length by
+                     * traversing it. */
+                    cborError = _calculateSizeOfIndefiniteLengthContainer(
+                                             &pCborValueWrapper->cborValue, pLength );
+
+                    _translateErrorCode( cborError, &status );
+
+                    /* Modify the calculated size of elements for the map to
+                     * represent number of "entry pairs". */
+                    *pLength = *pLength / 2;
+                }
+
+                break;
+
+            case IOT_SERIALIZER_CONTAINER_ARRAY:
+
+                if( cbor_value_get_array_length(
+                        &( ( _cborValueWrapper_t * ) ( pDecoderObject->u.pHandle ) )->cborValue,
+                        pLength ) == CborErrorUnknownLength )
+                {
+                    /* This is an indefinite length array. Calculate its length
+                     * by traversing it. */
+                    cborError = _calculateSizeOfIndefiniteLengthContainer(
+                                             &pCborValueWrapper->cborValue, pLength );
+
+                    _translateErrorCode( cborError, &status );
+                }
+
+                break;
+
+            default:
+                status = IOT_SERIALIZER_NOT_SUPPORTED;
+        }
+    }
+    else
+    {
+        status = IOT_SERIALIZER_NOT_SUPPORTED;
+    }
+
+    return status;
 }

--- a/libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
+++ b/libraries/c_sdk/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
@@ -71,11 +71,13 @@ static IotSerializerError_t _getSizeOfEncodedData( const IotSerializerDecoderObj
 static IotSerializerError_t _getSizeOf( const IotSerializerDecoderObject_t * pDecoderObject,
                                         size_t * pLength );
 /*-----------------------------------------------------------*/
+
 /**
  * @brief Utility to calculates the length of the raw encoded data represented by the
  * passed `pValue` object.
  */
 static size_t _calculateSizeOfCborObject( CborValue * pValue );
+
 /**
  * @brief Calculates the number of elements in an indefinite-length container
  * in O(N) time by iterating through the container.
@@ -659,7 +661,7 @@ IotSerializerError_t _getSizeOf( const IotSerializerDecoderObject_t * pDecoderOb
                     /* This is an indefinite length map. Calculate its length by
                      * traversing it. */
                     cborError = _calculateSizeOfIndefiniteLengthContainer(
-                                             &pCborValueWrapper->cborValue, pLength );
+                        &pCborValueWrapper->cborValue, pLength );
 
                     _translateErrorCode( cborError, &status );
 
@@ -679,7 +681,7 @@ IotSerializerError_t _getSizeOf( const IotSerializerDecoderObject_t * pDecoderOb
                     /* This is an indefinite length array. Calculate its length
                      * by traversing it. */
                     cborError = _calculateSizeOfIndefiniteLengthContainer(
-                                             &pCborValueWrapper->cborValue, pLength );
+                        &pCborValueWrapper->cborValue, pLength );
 
                     _translateErrorCode( cborError, &status );
                 }

--- a/libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c
+++ b/libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c
@@ -421,20 +421,20 @@ static const uint8_t _testEncodedNestedMap[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthNestedArray[] =
 {
-    0x9F,                           /*# array(*)        <---- Indefinite length array */
-        0x63,                       /*# text(3) */
-        0x45, 0x6C, 0x31,           /*# "El1" */
+    0x9F,                   /*# array(*)        <---- Indefinite length array */
+    0x63,                   /*# text(3) */
+    0x45, 0x6C, 0x31,       /*# "El1" */
 
-        0x01,                       /*# unsigned(1) */
+    0x01,                   /*# unsigned(1) */
 
-        0x63,                       /*# text(3) */
-        0x45, 0x6C, 0x33,           /*# "El3" */
+    0x63,                   /*# text(3) */
+    0x45, 0x6C, 0x33,       /*# "El3" */
 
-        0x9F,                       /*# array(*)        <---- Indefinite length nested array */
-            0x64,                   /*# text(4) */
-            0x4C, 0x61, 0x73, 0x74, /*# "Last" */
-        0xFF,                       /*# primitive(*)    <---- "break" */
-    0xFF,                           /*# primitive(*)    <---- "break" */
+    0x9F,                   /*# array(*)        <---- Indefinite length nested array */
+    0x64,                   /*# text(4) */
+    0x4C, 0x61, 0x73, 0x74, /*# "Last" */
+    0xFF,                   /*# primitive(*)    <---- "break" */
+    0xFF,                   /*# primitive(*)    <---- "break" */
 };
 
 /* CBOR Diagnostic notation:
@@ -446,25 +446,25 @@ static const uint8_t _testEncodedIndefiniteLengthNestedArray[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthMap[] =
 {
-    0xBF,                                                                       /* # map(*) */
+    0xBF,                                                       /* # map(*) */
 
-        0x6A,                                                                   /* # text(10) */
-        0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,             /* # "statusCode" */
-        0x19, 0x01, 0x90,                                                       /* # unsigned(400) */
+    0x6A,                                                       /* # text(10) */
+    0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65, /* # "statusCode" */
+    0x19, 0x01, 0x90,                                           /* # unsigned(400) */
 
-        0x69,                                                                   /* # text(9) */
-        0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,                   /* # "errorCode" */
-        0x6E,                                                                   /* # text(14) */
-        0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79,             /* # "InvalidPayload" */
-        0x6C, 0x6F, 0x61, 0x64,
+    0x69,                                                       /* # text(9) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,       /* # "errorCode" */
+    0x6E,                                                       /* # text(14) */
+    0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, /* # "InvalidPayload" */
+    0x6C, 0x6F, 0x61, 0x64,
 
-        0x6C,                                                                   /* # text(12) */
-        0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
-        0x78, 0x18,                                                             /* # text(24) */
-        0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
-        0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
+    0x6C,                                                                   /* # text(12) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
+    0x78, 0x18,                                                             /* # text(24) */
+    0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
+    0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
 
-    0xFF,                                                                       /* # primitive(*) */
+    0xFF, /* # primitive(*) */
 };
 
 /* CBOR Diagnostic notation:
@@ -476,23 +476,23 @@ static const uint8_t _testEncodedIndefiniteLengthMap[] =
  */
 static const uint8_t _testEncodedDefiniteLengthMap[] =
 {
-    0xA3,                                                                       /* # map(3) */
+    0xA3,                                                                   /* # map(3) */
 
-        0x6A,                                                                   /* # text(10) */
-        0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,             /* # "statusCode" */
-        0x19, 0x01, 0x90,                                                       /* # unsigned(400) */
+    0x6A,                                                                   /* # text(10) */
+    0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,             /* # "statusCode" */
+    0x19, 0x01, 0x90,                                                       /* # unsigned(400) */
 
-        0x69,                                                                   /* # text(9) */
-        0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,                   /* # "errorCode" */
-        0x6E,                                                                   /* # text(14) */
-        0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C, 0x6F, /* # "InvalidPayload" */
-        0x61, 0x64,
+    0x69,                                                                   /* # text(9) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,                   /* # "errorCode" */
+    0x6E,                                                                   /* # text(14) */
+    0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C, 0x6F, /* # "InvalidPayload" */
+    0x61, 0x64,
 
-        0x6C,                                                                   /* # text(12) */
-        0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
-        0x78, 0x18,                                                             /* # text(24) */
-        0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
-        0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
+    0x6C,                                                                   /* # text(12) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
+    0x78, 0x18,                                                             /* # text(24) */
+    0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
+    0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
 };
 
 /* CBOR Diagnostic notation:
@@ -507,36 +507,36 @@ static const uint8_t _testEncodedDefiniteLengthMap[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthNestedMap[] =
 {
-    0xBF,                                                                       /* # map(*) */
-        0x66,                                                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                                     /* # "result" */
-        0xBF,                                                                   /* # map(*) */
-            0x6A,                                                               /* # text(10) */
-            0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,         /* # "statusCode" */
-            0x19, 0x01, 0x90,                                                   /* # unsigned(400) */
+    0xBF,                                                             /* # map(*) */
+    0x66,                                                             /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                               /* # "result" */
+    0xBF,                                                             /* # map(*) */
+    0x6A,                                                             /* # text(10) */
+    0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,       /* # "statusCode" */
+    0x19, 0x01, 0x90,                                                 /* # unsigned(400) */
 
-            0x69,                                                               /* # text(9) */
-            0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,               /* # "errorCode" */
-            0x6E,                                                               /* # text(14) */
-            0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C,   /* # "InvalidPayload" */
-            0x6F, 0x61, 0x64,
+    0x69,                                                             /* # text(9) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,             /* # "errorCode" */
+    0x6E,                                                             /* # text(14) */
+    0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C, /* # "InvalidPayload" */
+    0x6F, 0x61, 0x64,
 
-            0x6C,                                                               /* # text(12) */
-            0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67,   /* # "errorMessage" */
-            0x65,
+    0x6C,                                                             /* # text(12) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, /* # "errorMessage" */
+    0x65,
 
-            0x78, 0x18,                                                         /* # text(24) */
-            0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E,   /* # "Message cannot be parsed" */
-            0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
-            0x65, 0x64,
-        0xFF,                                                                   /* # primitive(*) */
+    0x78, 0x18,                                                       /* # text(24) */
+    0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, /* # "Message cannot be parsed" */
+    0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
+    0x65, 0x64,
+    0xFF,                                                                   /* # primitive(*) */
 
-        0x67,                                                                   /* # text(7) */
-        0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73,                               /* # "success" */
-        0x6E,                                                                   /* # text(14) */
-        0x4E, 0x6F, 0x74, 0x20, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73, 0x66, /* # "Not successful" */
-        0x75, 0x6C,
-    0xFF,                                                                       /* # primitive(*) */
+    0x67,                                                                   /* # text(7) */
+    0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73,                               /* # "success" */
+    0x6E,                                                                   /* # text(14) */
+    0x4E, 0x6F, 0x74, 0x20, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73, 0x66, /* # "Not successful" */
+    0x75, 0x6C,
+    0xFF,                                                                   /* # primitive(*) */
 };
 
 /* CBOR Diagnostic notation:
@@ -550,29 +550,29 @@ static const uint8_t _testEncodedIndefiniteLengthNestedMap[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthNestedMapWith2BreakChars[] =
 {
-    0xBF,                                                                       /* # map(*) */
-        0x66,                                                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                                     /* # "result" */
-        0xBF,                                                                   /* # map(*) */
-            0x6A,                                                               /* # text(10) */
-            0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,         /* # "statusCode" */
-            0x19, 0x01, 0x90,                                                   /* # unsigned(400) */
+    0xBF,                                                             /* # map(*) */
+    0x66,                                                             /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                               /* # "result" */
+    0xBF,                                                             /* # map(*) */
+    0x6A,                                                             /* # text(10) */
+    0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,       /* # "statusCode" */
+    0x19, 0x01, 0x90,                                                 /* # unsigned(400) */
 
-            0x69,                                                               /* # text(9) */
-            0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,               /* # "errorCode" */
-            0x6E,                                                               /* # text(14) */
-            0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C,   /* # "InvalidPayload" */
-            0x6F, 0x61, 0x64,
+    0x69,                                                             /* # text(9) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,             /* # "errorCode" */
+    0x6E,                                                             /* # text(14) */
+    0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C, /* # "InvalidPayload" */
+    0x6F, 0x61, 0x64,
 
-            0x6C,                                                               /* # text(12) */
-            0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67,   /* # "errorMessage"*/
-            0x65,
-            0x78, 0x18,                                                         /* # text(24) */
-            0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E,   /* # "Message cannot be parsed" */
-            0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
-            0x65, 0x64,
-        0xFF,                                                                   /* # primitive(*) */
-    0xFF,                                                                       /* # primitive(*) */
+    0x6C,                                                             /* # text(12) */
+    0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, /* # "errorMessage"*/
+    0x65,
+    0x78, 0x18,                                                       /* # text(24) */
+    0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, /* # "Message cannot be parsed" */
+    0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
+    0x65, 0x64,
+    0xFF, /* # primitive(*) */
+    0xFF, /* # primitive(*) */
 };
 
 /* CBOR Diagnostic notation:
@@ -582,13 +582,13 @@ static const uint8_t _testEncodedIndefiniteLengthNestedMapWith2BreakChars[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthMapWithFFatTheEnd[] =
 {
-    0xBF,                                       /* # map(*) */
-        0x66,                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+    0xBF,                               /* # map(*) */
+    0x66,                               /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74, /* # "result" */
 
-        0x44,                                   /* # bytes(4) */
-        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
-    0xFF,                                       /* # primitive(*) */
+    0x44,                               /* # bytes(4) */
+    0xAA, 0xBB, 0xCC, 0xFF,             /* # "\xAA\xBB\xCC\xFF" */
+    0xFF,                               /* # primitive(*) */
 };
 
 /* CBOR Diagnostic notation:
@@ -598,12 +598,12 @@ static const uint8_t _testEncodedIndefiniteLengthMapWithFFatTheEnd[] =
  */
 static const uint8_t _testEncodedDefiniteLengthMapWithFFatTheEnd[] =
 {
-    0xA1,                                       /* # map(1) */
-        0x66,                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+    0xA1,                               /* # map(1) */
+    0x66,                               /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74, /* # "result" */
 
-        0x44,                                   /* # bytes(4) */
-        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+    0x44,                               /* # bytes(4) */
+    0xAA, 0xBB, 0xCC, 0xFF,             /* # "\xAA\xBB\xCC\xFF" */
 };
 
 /* CBOR Diagnostic notation:
@@ -614,13 +614,13 @@ static const uint8_t _testEncodedDefiniteLengthMapWithFFatTheEnd[] =
  */
 static const uint8_t _testEncodedIndefiniteLengthArrayWithFFatTheEnd[] =
 {
-    0x9F,                                       /* # array(*) */
-        0x66,                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+    0x9F,                               /* # array(*) */
+    0x66,                               /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74, /* # "result" */
 
-        0x44,                                   /* # bytes(4) */
-        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
-    0xFF,                                       /* # primitive(*) */
+    0x44,                               /* # bytes(4) */
+    0xAA, 0xBB, 0xCC, 0xFF,             /* # "\xAA\xBB\xCC\xFF" */
+    0xFF,                               /* # primitive(*) */
 };
 
 /* CBOR Diagnostic notation:
@@ -631,26 +631,25 @@ static const uint8_t _testEncodedIndefiniteLengthArrayWithFFatTheEnd[] =
  */
 static const uint8_t _testEncodedDefiniteLengthArrayWithFFatTheEnd[] =
 {
-    0x82,                                       /* # array(2) */
-        0x66,                                   /* # text(6) */
-        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+    0x82,                               /* # array(2) */
+    0x66,                               /* # text(6) */
+    0x72, 0x65, 0x73, 0x75, 0x6C, 0x74, /* # "result" */
 
-        0x44,                                   /* # bytes(4) */
-        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+    0x44,                               /* # bytes(4) */
+    0xAA, 0xBB, 0xCC, 0xFF,             /* # "\xAA\xBB\xCC\xFF" */
 };
 
 /*----------------------------------------------------------------------------------------------*/
 TEST_GROUP( Serializer_Unit_CBOR_Decoder );
 
 TEST_SETUP( Serializer_Unit_CBOR_Decoder )
-{    
+{
     /* Reset buffer to zero. */
     memset( _buffer, 0, _BUFFER_SIZE );
 
     /* Init decoder object with buffer. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &_decoderObject, _buffer, _BUFFER_SIZE ) );
-
 }
 
 TEST_TEAR_DOWN( Serializer_Unit_CBOR_Decoder )
@@ -695,8 +694,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
     size_t unsupportedTypeDecoderObjectLength = 0;
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outermostDecoder,
-                                                                    _testEncodedNestedMap,
-                                                                    sizeof( _testEncodedNestedMap ) ) );
+                                                              _testEncodedNestedMap,
+                                                              sizeof( _testEncodedNestedMap ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostDecoder.type );
 
 
@@ -708,7 +707,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
      * outermost decoder object.*/
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.getBufferAddress( &outermostDecoder,
-                                                        &pDecoderObjectStartAddr ) );
+                                                  &pDecoderObjectStartAddr ) );
     TEST_ASSERT_EQUAL_PTR( &_testEncodedNestedMap[ 0 ], pDecoderObjectStartAddr );
 
     /* Verify that the getSizeOfEncodedData() correctly calculates the length of the outermost decoder
@@ -718,7 +717,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
     TEST_ASSERT_EQUAL( sizeof( _testEncodedNestedMap ), decoderDataLength );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outermostDecoder, "1",
-                                                                    &outerMapDecoder1 ) );
+                                                              &outerMapDecoder1 ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outerMapDecoder1.type );
 
     /* Verify the functionality of getSizeOf() API on the inner map. */
@@ -729,7 +728,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
      * for the entry keyed by "1".*/
     TEST_ASSERT_EQUAL_PTR( IOT_SERIALIZER_SUCCESS,
                            _decoder.getBufferAddress( &outerMapDecoder1,
-                                                            &pDecoderObjectStartAddr ) );
+                                                      &pDecoderObjectStartAddr ) );
     TEST_ASSERT_EQUAL_PTR( &_testEncodedNestedMap[ 3 ], pDecoderObjectStartAddr );
 
     /* Verify that the getSizeOfEncodedData() correctly calculates the length of the container type
@@ -739,14 +738,14 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
     TEST_ASSERT_EQUAL( 4u, decoderDataLength );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outerMapDecoder1, "A",
-                                                                    &innerMapDecoder ) );
+                                                              &innerMapDecoder ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, innerMapDecoder.type );
 
     /* Make sure that the getBufferAddress() API does not support getting buffer address of value in the
      * the nested entry keyed by "A".*/
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
                        _decoder.getBufferAddress( &innerMapDecoder,
-                                                        &pDecoderObjectStartAddr ) );
+                                                  &pDecoderObjectStartAddr ) );
 
     /* Verify that the getSizeOfEncodedData() does not support calculation of non-container type data.*/
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
@@ -754,14 +753,14 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
                            &innerMapDecoder, &unsupportedTypeDecoderObjectLength ) );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outermostDecoder, "3",
-                                                                    &outerMapDecoder2 ) );
+                                                              &outerMapDecoder2 ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BOOL, outerMapDecoder2.type );
 
     /* Make sure that the getBufferAddress() API does not give the buffer address of the value data
      * in the entry keyed by "3".*/
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
                        _decoder.getBufferAddress( &outerMapDecoder2,
-                                                        &pDecoderObjectStartAddr ) );
+                                                  &pDecoderObjectStartAddr ) );
 
     /* Verify that the getSizeOfEncodedData() does not support calculation of non-container type data.*/
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
@@ -786,14 +785,14 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
     IotSerializerDecoderIterator_t nestedMapIter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outerDecoder1,
-                                                                    _testEncodedNestedMap,
-                                                                    sizeof( _testEncodedNestedMap ) ) );
+                                                              _testEncodedNestedMap,
+                                                              sizeof( _testEncodedNestedMap ) ) );
 
     /* Obtain an iterator to the contents of the map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &outerDecoder1,
-                                                                      &outerIter ) );
+                                                                &outerIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
-                                                                   &iterToDecoderObject ) );
+                                                             &iterToDecoderObject ) );
     /* Validate that we can obtain the key data of the first entry in the outer map. */
     TEST_ASSERT_EQUAL_STRING_LEN( "1", iterToDecoderObject.u.value.u.string.pString,
                                   iterToDecoderObject.u.value.u.string.length );
@@ -801,7 +800,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
-                                                                   &iterToDecoderObject ) );
+                                                             &iterToDecoderObject ) );
     /* Validate that we can obtain the value data (i.e. nested map) of the first entry in the parent/outer map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getBufferAddress(
                            &iterToDecoderObject, &pDecoderObjectStartAddr ) );
@@ -811,7 +810,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
-                                                                   &iterToDecoderObject2 ) );
+                                                             &iterToDecoderObject2 ) );
     /* Validate that we can obtain the key data of the second entry in the outer map. */
     TEST_ASSERT_EQUAL_STRING_LEN( "3", iterToDecoderObject2.u.value.u.string.pString,
                                   iterToDecoderObject2.u.value.u.string.length );
@@ -819,7 +818,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
-                                                                   &iterToDecoderObject2 ) );
+                                                             &iterToDecoderObject2 ) );
     /* Validate that we can obtain the boolean value data of the second entry in the outer map. */
     TEST_ASSERT_EQUAL( false, iterToDecoderObject2.u.value.u.booleanValue );
     _decoder.destroy( &iterToDecoderObject2 );
@@ -827,25 +826,25 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
     /* Iterate to the end of the outer map container. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( outerIter,
-                                                                       &outerDecoder1 ) );
+                                                                 &outerDecoder1 ) );
     _decoder.destroy( &outerDecoder1 );
 
 
     /* Test with iterating in the nested map in the entry keyed by "1" */
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outerDecoder2,
-                                                                    _testEncodedNestedMap,
-                                                                    sizeof( _testEncodedNestedMap ) ) );
+                                                              _testEncodedNestedMap,
+                                                              sizeof( _testEncodedNestedMap ) ) );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outerDecoder2, "1",
-                                                                    &nestedMapDecoder ) );
+                                                              &nestedMapDecoder ) );
 
     /* Obtain an iterator to the contents of the nested map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &nestedMapDecoder,
-                                                                      &nestedMapIter ) );
+                                                                &nestedMapIter ) );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( nestedMapIter,
-                                                                   &iterToDecoderObject3 ) );
+                                                             &iterToDecoderObject3 ) );
     /* Validate that we can obtain the key data of the only entry in the nested map. */
     TEST_ASSERT_EQUAL_STRING_LEN( "A", iterToDecoderObject3.u.value.u.string.pString,
                                   iterToDecoderObject3.u.value.u.string.length );
@@ -853,7 +852,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( nestedMapIter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( nestedMapIter,
-                                                                   &iterToDecoderObject3 ) );
+                                                             &iterToDecoderObject3 ) );
     /* Validate that we can obtain the integer value of the only entry in the nested map. */
     TEST_ASSERT_EQUAL_INT( 10, iterToDecoderObject3.u.value.u.signedInt );
 
@@ -861,7 +860,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( nestedMapIter ) );
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( nestedMapIter,
-                                                                       &nestedMapDecoder ) );
+                                                                 &nestedMapDecoder ) );
     _decoder.destroy( &nestedMapDecoder );
     _decoder.destroy( &outerDecoder2 );
 }
@@ -877,8 +876,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthMap )
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &mapDecoder,
-                                            _testEncodedIndefiniteLengthMap,
-                                            sizeof( _testEncodedIndefiniteLengthMap ) ) );
+                                      _testEncodedIndefiniteLengthMap,
+                                      sizeof( _testEncodedIndefiniteLengthMap ) ) );
 
     /* Test that size of an indefinite length map can be calculated. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &mapDecoder, &mapSize ) );
@@ -912,8 +911,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthMap )
     /* Make sure that we can obtain the same value entry from the "find()" API */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &mapDecoder,
-                                            "errorMessage",
-                                            &valueObject2 ) );
+                                      "errorMessage",
+                                      &valueObject2 ) );
     TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
                                   valueObject2.u.value.u.string.pString,
                                   valueObject2.u.value.u.string.length );
@@ -939,8 +938,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthNestedArray 
 
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &arrayDecoder,
-                                                                    _testEncodedIndefiniteLengthNestedArray,
-                                                                    sizeof( _testEncodedIndefiniteLengthNestedArray ) ) );
+                                                              _testEncodedIndefiniteLengthNestedArray,
+                                                              sizeof( _testEncodedIndefiniteLengthNestedArray ) ) );
 
     /* Test that size of an indefinite length map can be calculated. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &arrayDecoder, &arraySize ) );
@@ -991,12 +990,12 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectReuseAfterIteration )
     IotSerializerDecoderIterator_t iterator2 = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
 
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &mapDecoder,
-                                                                    _testEncodedNestedMap,
-                                                                    sizeof( _testEncodedNestedMap ) ) );
+                                                              _testEncodedNestedMap,
+                                                              sizeof( _testEncodedNestedMap ) ) );
 
     /* Obtain an iterator to the contents of the map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &mapDecoder,
-                                                                      &iterator1 ) );
+                                                                &iterator1 ) );
 
 
     /* Undergo one round of iteration through the map */
@@ -1015,7 +1014,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectReuseAfterIteration )
 
     /* Sanity check with another round of iteration! */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &mapDecoder,
-                                                                      &iterator2 ) );
+                                                                &iterator2 ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
@@ -1038,23 +1037,23 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMap )
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedIndefiniteLengthMap,
-                                            sizeof( _testEncodedIndefiniteLengthMap ) ) );
+                                      _testEncodedIndefiniteLengthMap,
+                                      sizeof( _testEncodedIndefiniteLengthMap ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the status code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "statusCode",
-                                            &statusCode ) );
+                                      "statusCode",
+                                      &statusCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
     TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
 
     /* Find the error code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "errorCode",
-                                            &errorCode ) );
+                                      "errorCode",
+                                      &errorCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
                                   errorCode.u.value.u.string.pString,
@@ -1063,8 +1062,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMap )
     /* Find the error message. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "errorMessage",
-                                            &errorMessage ) );
+                                      "errorMessage",
+                                      &errorMessage ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
                                   errorMessage.u.value.u.string.pString,
@@ -1086,23 +1085,23 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMap )
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedDefiniteLengthMap,
-                                            sizeof( _testEncodedDefiniteLengthMap ) ) );
+                                      _testEncodedDefiniteLengthMap,
+                                      sizeof( _testEncodedDefiniteLengthMap ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the status code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "statusCode",
-                                            &statusCode ) );
+                                      "statusCode",
+                                      &statusCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
     TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
 
     /* Find the error code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "errorCode",
-                                            &errorCode ) );
+                                      "errorCode",
+                                      &errorCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
                                   errorCode.u.value.u.string.pString,
@@ -1111,8 +1110,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMap )
     /* Find the error message. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "errorMessage",
-                                            &errorMessage ) );
+                                      "errorMessage",
+                                      &errorMessage ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
                                   errorMessage.u.value.u.string.pString,
@@ -1136,30 +1135,30 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedM
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedIndefiniteLengthNestedMap,
-                                            sizeof( _testEncodedIndefiniteLengthNestedMap ) ) );
+                                      _testEncodedIndefiniteLengthNestedMap,
+                                      sizeof( _testEncodedIndefiniteLengthNestedMap ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the result map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "result",
-                                            &resultMap ) );
+                                      "result",
+                                      &resultMap ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, resultMap.type );
 
     /* Find the status code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "statusCode",
-                                            &statusCode ) );
+                                      "statusCode",
+                                      &statusCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
     TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
 
     /* Find the error code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "errorCode",
-                                            &errorCode ) );
+                                      "errorCode",
+                                      &errorCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
                                   errorCode.u.value.u.string.pString,
@@ -1168,8 +1167,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedM
     /* Find the error message. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "errorMessage",
-                                            &errorMessage ) );
+                                      "errorMessage",
+                                      &errorMessage ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
                                   errorMessage.u.value.u.string.pString,
@@ -1178,8 +1177,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedM
     /* Find the success message. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "success",
-                                            &success ) );
+                                      "success",
+                                      &success ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, success.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "Not successful",
                                   success.u.value.u.string.pString,
@@ -1204,30 +1203,30 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedM
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedIndefiniteLengthNestedMapWith2BreakChars,
-                                            sizeof( _testEncodedIndefiniteLengthNestedMapWith2BreakChars ) ) );
+                                      _testEncodedIndefiniteLengthNestedMapWith2BreakChars,
+                                      sizeof( _testEncodedIndefiniteLengthNestedMapWith2BreakChars ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the result map. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "result",
-                                            &resultMap ) );
+                                      "result",
+                                      &resultMap ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, resultMap.type );
 
     /* Find the status code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "statusCode",
-                                            &statusCode ) );
+                                      "statusCode",
+                                      &statusCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
     TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
 
     /* Find the error code. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "errorCode",
-                                            &errorCode ) );
+                                      "errorCode",
+                                      &errorCode ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
                                   errorCode.u.value.u.string.pString,
@@ -1236,8 +1235,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedM
     /* Find the error message. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &resultMap,
-                                            "errorMessage",
-                                            &errorMessage ) );
+                                      "errorMessage",
+                                      &errorMessage ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
     TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
                                   errorMessage.u.value.u.string.pString,
@@ -1259,15 +1258,15 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMapWith
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedIndefiniteLengthMapWithFFatTheEnd,
-                                            sizeof( _testEncodedIndefiniteLengthMapWithFFatTheEnd ) ) );
+                                      _testEncodedIndefiniteLengthMapWithFFatTheEnd,
+                                      sizeof( _testEncodedIndefiniteLengthMapWithFFatTheEnd ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the result. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "result",
-                                            &result ) );
+                                      "result",
+                                      &result ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BYTE_STRING, result.type );
     TEST_ASSERT_EQUAL( sizeof( expectedResult ), result.u.value.u.string.length );
     TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedResult,
@@ -1287,15 +1286,15 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMapWithFF
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostMap,
-                                            _testEncodedDefiniteLengthMapWithFFatTheEnd,
-                                            sizeof( _testEncodedDefiniteLengthMapWithFFatTheEnd ) ) );
+                                      _testEncodedDefiniteLengthMapWithFFatTheEnd,
+                                      sizeof( _testEncodedDefiniteLengthMapWithFFatTheEnd ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
 
     /* Find the result. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.find( &outermostMap,
-                                            "result",
-                                            &result ) );
+                                      "result",
+                                      &result ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BYTE_STRING, result.type );
     TEST_ASSERT_EQUAL( sizeof( expectedResult ), result.u.value.u.string.length );
     TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedResult,
@@ -1317,8 +1316,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthArrayWi
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostArray,
-                                            _testEncodedIndefiniteLengthArrayWithFFatTheEnd,
-                                            sizeof( _testEncodedIndefiniteLengthArrayWithFFatTheEnd ) ) );
+                                      _testEncodedIndefiniteLengthArrayWithFFatTheEnd,
+                                      sizeof( _testEncodedIndefiniteLengthArrayWithFFatTheEnd ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_ARRAY, outermostArray.type );
 
     /* Start iterating the array. */
@@ -1343,7 +1342,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthArrayWi
     /* Stop iterating the array and destroy the iterator. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter,
-                                                                       &outermostArray ) );
+                                                                 &outermostArray ) );
 
     _decoder.destroy( &byteString );
     _decoder.destroy( &result );
@@ -1361,8 +1360,8 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthArrayWith
     /* Initialize the decoder. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
                        _decoder.init( &outermostArray,
-                                            _testEncodedDefiniteLengthArrayWithFFatTheEnd,
-                                            sizeof( _testEncodedDefiniteLengthArrayWithFFatTheEnd ) ) );
+                                      _testEncodedDefiniteLengthArrayWithFFatTheEnd,
+                                      sizeof( _testEncodedDefiniteLengthArrayWithFFatTheEnd ) ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_ARRAY, outermostArray.type );
 
     /* Start iterating the array. */
@@ -1387,7 +1386,7 @@ TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthArrayWith
     /* Stop iterating the array and destroy the iterator. */
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
     TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter,
-                                                                       &outermostArray ) );
+                                                                 &outermostArray ) );
 
     _decoder.destroy( &byteString );
     _decoder.destroy( &result );

--- a/libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c
+++ b/libraries/c_sdk/standard/serializer/test/iot_tests_serializer_cbor.c
@@ -44,6 +44,7 @@
 #define _BUFFER_SIZE    100
 
 static IotSerializerEncoderObject_t _encoderObject;
+static IotSerializerDecoderObject_t _decoderObject;
 
 uint8_t _buffer[ _BUFFER_SIZE ];
 
@@ -380,4 +381,1015 @@ TEST( Serializer_Unit_CBOR, Encoder_map_nest_array )
     }
 
     TEST_ASSERT_TRUE( cbor_value_at_end( &arrayElement ) );
+}
+
+/*----------------------------------------------------------------------------------------------
+ *      DECODER
+ *----------------------------------------------------------------------------------------------*/
+
+/* CBOR Diagnostic notation:
+ * {
+ *      "1": {
+ *          "A": 10
+ *      },
+ *      "3": false
+ * }
+ */
+static const uint8_t _testEncodedNestedMap[] =
+{
+    0xA2, /* # map(2) */
+    0x61, /* # text(1) */
+    0x31, /* # "1" */
+    0xA1, /* # map(1) */
+    0x61, /* # text(1) */
+    0x41, /* # "A" */
+    0x0A, /* # unsigned(10) */
+    0x61, /* # text(1) */
+    0x33, /* # "3" */
+    0xF4, /* # false */
+};
+
+/* CBOR Diagnostic notation:
+ * [
+ *    "El1",
+ *    1,
+ *    "El3",
+ *    [
+ *       "Last"
+ *    ]
+ * ]
+ */
+static const uint8_t _testEncodedIndefiniteLengthNestedArray[] =
+{
+    0x9F,                           /*# array(*)        <---- Indefinite length array */
+        0x63,                       /*# text(3) */
+        0x45, 0x6C, 0x31,           /*# "El1" */
+
+        0x01,                       /*# unsigned(1) */
+
+        0x63,                       /*# text(3) */
+        0x45, 0x6C, 0x33,           /*# "El3" */
+
+        0x9F,                       /*# array(*)        <---- Indefinite length nested array */
+            0x64,                   /*# text(4) */
+            0x4C, 0x61, 0x73, 0x74, /*# "Last" */
+        0xFF,                       /*# primitive(*)    <---- "break" */
+    0xFF,                           /*# primitive(*)    <---- "break" */
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *   "statusCode": 400,
+ *   "errorCode": "InvalidPayload",
+ *   "errorMessage": "Message cannot be parsed"
+ * }
+ */
+static const uint8_t _testEncodedIndefiniteLengthMap[] =
+{
+    0xBF,                                                                       /* # map(*) */
+
+        0x6A,                                                                   /* # text(10) */
+        0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,             /* # "statusCode" */
+        0x19, 0x01, 0x90,                                                       /* # unsigned(400) */
+
+        0x69,                                                                   /* # text(9) */
+        0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,                   /* # "errorCode" */
+        0x6E,                                                                   /* # text(14) */
+        0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79,             /* # "InvalidPayload" */
+        0x6C, 0x6F, 0x61, 0x64,
+
+        0x6C,                                                                   /* # text(12) */
+        0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
+        0x78, 0x18,                                                             /* # text(24) */
+        0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
+        0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
+
+    0xFF,                                                                       /* # primitive(*) */
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *   "statusCode": 400,
+ *   "errorCode": "InvalidPayload",
+ *   "errorMessage": "Message cannot be parsed"
+ * }
+ */
+static const uint8_t _testEncodedDefiniteLengthMap[] =
+{
+    0xA3,                                                                       /* # map(3) */
+
+        0x6A,                                                                   /* # text(10) */
+        0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,             /* # "statusCode" */
+        0x19, 0x01, 0x90,                                                       /* # unsigned(400) */
+
+        0x69,                                                                   /* # text(9) */
+        0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,                   /* # "errorCode" */
+        0x6E,                                                                   /* # text(14) */
+        0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C, 0x6F, /* # "InvalidPayload" */
+        0x61, 0x64,
+
+        0x6C,                                                                   /* # text(12) */
+        0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, /* # "errorMessage" */
+        0x78, 0x18,                                                             /* # text(24) */
+        0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E, 0x6E, /* # "Message cannot be parsed" */
+        0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73, 0x65, 0x64,
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *    "result": {
+ *                 "statusCode": 400,
+ *                 "errorCode": "InvalidPayload",
+ *                 "errorMessage": "Message cannot be parsed"
+ *              },
+ *    "success": "Not successful"
+ * }
+ */
+static const uint8_t _testEncodedIndefiniteLengthNestedMap[] =
+{
+    0xBF,                                                                       /* # map(*) */
+        0x66,                                                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                                     /* # "result" */
+        0xBF,                                                                   /* # map(*) */
+            0x6A,                                                               /* # text(10) */
+            0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,         /* # "statusCode" */
+            0x19, 0x01, 0x90,                                                   /* # unsigned(400) */
+
+            0x69,                                                               /* # text(9) */
+            0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,               /* # "errorCode" */
+            0x6E,                                                               /* # text(14) */
+            0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C,   /* # "InvalidPayload" */
+            0x6F, 0x61, 0x64,
+
+            0x6C,                                                               /* # text(12) */
+            0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67,   /* # "errorMessage" */
+            0x65,
+
+            0x78, 0x18,                                                         /* # text(24) */
+            0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E,   /* # "Message cannot be parsed" */
+            0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
+            0x65, 0x64,
+        0xFF,                                                                   /* # primitive(*) */
+
+        0x67,                                                                   /* # text(7) */
+        0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73,                               /* # "success" */
+        0x6E,                                                                   /* # text(14) */
+        0x4E, 0x6F, 0x74, 0x20, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73, 0x66, /* # "Not successful" */
+        0x75, 0x6C,
+    0xFF,                                                                       /* # primitive(*) */
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *    "result": {
+ *                 "statusCode": 400,
+ *                 "errorCode": "InvalidPayload",
+ *                 "errorMessage": "Message cannot be parsed"
+ *              }
+ * }
+ */
+static const uint8_t _testEncodedIndefiniteLengthNestedMapWith2BreakChars[] =
+{
+    0xBF,                                                                       /* # map(*) */
+        0x66,                                                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,                                     /* # "result" */
+        0xBF,                                                                   /* # map(*) */
+            0x6A,                                                               /* # text(10) */
+            0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6F, 0x64, 0x65,         /* # "statusCode" */
+            0x19, 0x01, 0x90,                                                   /* # unsigned(400) */
+
+            0x69,                                                               /* # text(9) */
+            0x65, 0x72, 0x72, 0x6F, 0x72, 0x43, 0x6F, 0x64, 0x65,               /* # "errorCode" */
+            0x6E,                                                               /* # text(14) */
+            0x49, 0x6E, 0x76, 0x61, 0x6C, 0x69, 0x64, 0x50, 0x61, 0x79, 0x6C,   /* # "InvalidPayload" */
+            0x6F, 0x61, 0x64,
+
+            0x6C,                                                               /* # text(12) */
+            0x65, 0x72, 0x72, 0x6F, 0x72, 0x4D, 0x65, 0x73, 0x73, 0x61, 0x67,   /* # "errorMessage"*/
+            0x65,
+            0x78, 0x18,                                                         /* # text(24) */
+            0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x20, 0x63, 0x61, 0x6E,   /* # "Message cannot be parsed" */
+            0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x70, 0x61, 0x72, 0x73,
+            0x65, 0x64,
+        0xFF,                                                                   /* # primitive(*) */
+    0xFF,                                                                       /* # primitive(*) */
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *     "result": h'AABBCCFF'
+ * }
+ */
+static const uint8_t _testEncodedIndefiniteLengthMapWithFFatTheEnd[] =
+{
+    0xBF,                                       /* # map(*) */
+        0x66,                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+
+        0x44,                                   /* # bytes(4) */
+        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+    0xFF,                                       /* # primitive(*) */
+};
+
+/* CBOR Diagnostic notation:
+ * {
+ *     "result": h'AABBCCFF'
+ * }
+ */
+static const uint8_t _testEncodedDefiniteLengthMapWithFFatTheEnd[] =
+{
+    0xA1,                                       /* # map(1) */
+        0x66,                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+
+        0x44,                                   /* # bytes(4) */
+        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+};
+
+/* CBOR Diagnostic notation:
+ * [
+ *     "result",
+ *      h'AABBCCFF'
+ * ]
+ */
+static const uint8_t _testEncodedIndefiniteLengthArrayWithFFatTheEnd[] =
+{
+    0x9F,                                       /* # array(*) */
+        0x66,                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+
+        0x44,                                   /* # bytes(4) */
+        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+    0xFF,                                       /* # primitive(*) */
+};
+
+/* CBOR Diagnostic notation:
+ * [
+ *     "result",
+ *      h'AABBCCFF'
+ * ]
+ */
+static const uint8_t _testEncodedDefiniteLengthArrayWithFFatTheEnd[] =
+{
+    0x82,                                       /* # array(2) */
+        0x66,                                   /* # text(6) */
+        0x72, 0x65, 0x73, 0x75, 0x6C, 0x74,     /* # "result" */
+
+        0x44,                                   /* # bytes(4) */
+        0xAA, 0xBB, 0xCC, 0xFF,                 /* # "\xAA\xBB\xCC\xFF" */
+};
+
+/*----------------------------------------------------------------------------------------------*/
+TEST_GROUP( Serializer_Unit_CBOR_Decoder );
+
+TEST_SETUP( Serializer_Unit_CBOR_Decoder )
+{    
+    /* Reset buffer to zero. */
+    memset( _buffer, 0, _BUFFER_SIZE );
+
+    /* Init decoder object with buffer. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &_decoderObject, _buffer, _BUFFER_SIZE ) );
+
+}
+
+TEST_TEAR_DOWN( Serializer_Unit_CBOR_Decoder )
+{
+    /* Destroy decoder object. */
+    _decoder.destroy( &_decoderObject );
+
+    TEST_ASSERT( _decoderObject.u.pHandle == NULL );
+}
+
+/*----------------------------------------------------------------------------------------------*/
+TEST_GROUP_RUNNER( Serializer_Unit_CBOR_Decoder )
+{
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthNestedArray );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectReuseAfterIteration );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedMap );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedMapWith2BreakChars );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMapWithFFatTheEnd );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMapWithFFatTheEnd );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthArrayWithFFatTheEnd );
+    RUN_TEST_CASE( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthArrayWithFFatTheEnd );
+}
+
+/*----------------------------------------------------------------------------------------------*/
+
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithNestedMap )
+{
+    IotSerializerDecoderObject_t outermostDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    size_t numOfEntriesInOuterMap;
+    const uint8_t * pDecoderObjectStartAddr = NULL;
+    size_t decoderDataLength = 0;
+    IotSerializerDecoderObject_t outerMapDecoder1 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t innerMapDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    size_t numOfEntriesInInnerMap;
+    IotSerializerDecoderObject_t outerMapDecoder2 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    size_t unsupportedTypeDecoderObjectLength = 0;
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outermostDecoder,
+                                                                    _testEncodedNestedMap,
+                                                                    sizeof( _testEncodedNestedMap ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostDecoder.type );
+
+
+    /* Verify the functionality of getSizeOf() API on the outer map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &outermostDecoder, &numOfEntriesInOuterMap ) );
+    TEST_ASSERT_EQUAL( 2, numOfEntriesInOuterMap );
+
+    /* Make sure that the getBufferAddress() API returns the first location of the buffer for the
+     * outermost decoder object.*/
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.getBufferAddress( &outermostDecoder,
+                                                        &pDecoderObjectStartAddr ) );
+    TEST_ASSERT_EQUAL_PTR( &_testEncodedNestedMap[ 0 ], pDecoderObjectStartAddr );
+
+    /* Verify that the getSizeOfEncodedData() correctly calculates the length of the outermost decoder
+     * data. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOfEncodedData(
+                           &outermostDecoder, &decoderDataLength ) );
+    TEST_ASSERT_EQUAL( sizeof( _testEncodedNestedMap ), decoderDataLength );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outermostDecoder, "1",
+                                                                    &outerMapDecoder1 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outerMapDecoder1.type );
+
+    /* Verify the functionality of getSizeOf() API on the inner map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &outerMapDecoder1, &numOfEntriesInInnerMap ) );
+    TEST_ASSERT_EQUAL( 1, numOfEntriesInInnerMap );
+
+    /* Make sure that the getBufferAddress() API returns the first location in the buffer to the value
+     * for the entry keyed by "1".*/
+    TEST_ASSERT_EQUAL_PTR( IOT_SERIALIZER_SUCCESS,
+                           _decoder.getBufferAddress( &outerMapDecoder1,
+                                                            &pDecoderObjectStartAddr ) );
+    TEST_ASSERT_EQUAL_PTR( &_testEncodedNestedMap[ 3 ], pDecoderObjectStartAddr );
+
+    /* Verify that the getSizeOfEncodedData() correctly calculates the length of the container type
+     * value of the entry keyed by "1" */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOfEncodedData(
+                           &outerMapDecoder1, &decoderDataLength ) );
+    TEST_ASSERT_EQUAL( 4u, decoderDataLength );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outerMapDecoder1, "A",
+                                                                    &innerMapDecoder ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, innerMapDecoder.type );
+
+    /* Make sure that the getBufferAddress() API does not support getting buffer address of value in the
+     * the nested entry keyed by "A".*/
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
+                       _decoder.getBufferAddress( &innerMapDecoder,
+                                                        &pDecoderObjectStartAddr ) );
+
+    /* Verify that the getSizeOfEncodedData() does not support calculation of non-container type data.*/
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
+                       _decoder.getSizeOfEncodedData(
+                           &innerMapDecoder, &unsupportedTypeDecoderObjectLength ) );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outermostDecoder, "3",
+                                                                    &outerMapDecoder2 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BOOL, outerMapDecoder2.type );
+
+    /* Make sure that the getBufferAddress() API does not give the buffer address of the value data
+     * in the entry keyed by "3".*/
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
+                       _decoder.getBufferAddress( &outerMapDecoder2,
+                                                        &pDecoderObjectStartAddr ) );
+
+    /* Verify that the getSizeOfEncodedData() does not support calculation of non-container type data.*/
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_NOT_SUPPORTED,
+                       _decoder.getSizeOfEncodedData(
+                           &outerMapDecoder2, &unsupportedTypeDecoderObjectLength ) );
+
+    _decoder.destroy( &outerMapDecoder1 );
+    _decoder.destroy( &outerMapDecoder2 );
+    _decoder.destroy( &outermostDecoder );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderIteratorWithNestedMap )
+{
+    IotSerializerDecoderObject_t outerDecoder1 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t outerIter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    const uint8_t * pDecoderObjectStartAddr = NULL;
+    IotSerializerDecoderObject_t iterToDecoderObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t iterToDecoderObject2 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t iterToDecoderObject3 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t outerDecoder2 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t nestedMapDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t nestedMapIter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outerDecoder1,
+                                                                    _testEncodedNestedMap,
+                                                                    sizeof( _testEncodedNestedMap ) ) );
+
+    /* Obtain an iterator to the contents of the map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &outerDecoder1,
+                                                                      &outerIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
+                                                                   &iterToDecoderObject ) );
+    /* Validate that we can obtain the key data of the first entry in the outer map. */
+    TEST_ASSERT_EQUAL_STRING_LEN( "1", iterToDecoderObject.u.value.u.string.pString,
+                                  iterToDecoderObject.u.value.u.string.length );
+
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
+                                                                   &iterToDecoderObject ) );
+    /* Validate that we can obtain the value data (i.e. nested map) of the first entry in the parent/outer map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getBufferAddress(
+                           &iterToDecoderObject, &pDecoderObjectStartAddr ) );
+    TEST_ASSERT_EQUAL_PTR( &_testEncodedNestedMap[ 3 ], pDecoderObjectStartAddr );
+    _decoder.destroy( &iterToDecoderObject );
+
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
+                                                                   &iterToDecoderObject2 ) );
+    /* Validate that we can obtain the key data of the second entry in the outer map. */
+    TEST_ASSERT_EQUAL_STRING_LEN( "3", iterToDecoderObject2.u.value.u.string.pString,
+                                  iterToDecoderObject2.u.value.u.string.length );
+    _decoder.destroy( &iterToDecoderObject2 );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( outerIter,
+                                                                   &iterToDecoderObject2 ) );
+    /* Validate that we can obtain the boolean value data of the second entry in the outer map. */
+    TEST_ASSERT_EQUAL( false, iterToDecoderObject2.u.value.u.booleanValue );
+    _decoder.destroy( &iterToDecoderObject2 );
+
+    /* Iterate to the end of the outer map container. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( outerIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( outerIter,
+                                                                       &outerDecoder1 ) );
+    _decoder.destroy( &outerDecoder1 );
+
+
+    /* Test with iterating in the nested map in the entry keyed by "1" */
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &outerDecoder2,
+                                                                    _testEncodedNestedMap,
+                                                                    sizeof( _testEncodedNestedMap ) ) );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &outerDecoder2, "1",
+                                                                    &nestedMapDecoder ) );
+
+    /* Obtain an iterator to the contents of the nested map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &nestedMapDecoder,
+                                                                      &nestedMapIter ) );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( nestedMapIter,
+                                                                   &iterToDecoderObject3 ) );
+    /* Validate that we can obtain the key data of the only entry in the nested map. */
+    TEST_ASSERT_EQUAL_STRING_LEN( "A", iterToDecoderObject3.u.value.u.string.pString,
+                                  iterToDecoderObject3.u.value.u.string.length );
+
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( nestedMapIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( nestedMapIter,
+                                                                   &iterToDecoderObject3 ) );
+    /* Validate that we can obtain the integer value of the only entry in the nested map. */
+    TEST_ASSERT_EQUAL_INT( 10, iterToDecoderObject3.u.value.u.signedInt );
+
+    /* Iterate to the end of the nested map container. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( nestedMapIter ) );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( nestedMapIter,
+                                                                       &nestedMapDecoder ) );
+    _decoder.destroy( &nestedMapDecoder );
+    _decoder.destroy( &outerDecoder2 );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthMap )
+{
+    IotSerializerDecoderObject_t mapDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    size_t mapSize = 0;
+    IotSerializerDecoderIterator_t iter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderObject_t keyObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t valueObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t valueObject2 = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &mapDecoder,
+                                            _testEncodedIndefiniteLengthMap,
+                                            sizeof( _testEncodedIndefiniteLengthMap ) ) );
+
+    /* Test that size of an indefinite length map can be calculated. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &mapDecoder, &mapSize ) );
+    TEST_ASSERT_EQUAL( 3, mapSize );
+
+    /* Test iterating through the map and extracting the first and last elements. */
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &mapDecoder, &iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &keyObject ) );
+
+    /* Validate that we can obtain the first key value in the indefinite length map. */
+    TEST_ASSERT_EQUAL_STRING_LEN( "statusCode",
+                                  keyObject.u.value.u.string.pString,
+                                  keyObject.u.value.u.string.length );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) ); /* Move to statusCode value. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) ); /* Move to errorCode key. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) ); /* Move to errorCode value. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) ); /* Move to errorMessage key. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) ); /* Move to errorMessage value. */
+
+
+    /* The last element is a special case for byte/text string extraction due to
+     * the succeeding byte being the "break" byte. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &valueObject ) );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  valueObject.u.value.u.string.pString,
+                                  valueObject.u.value.u.string.length );
+
+
+    /* Make sure that we can obtain the same value entry from the "find()" API */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &mapDecoder,
+                                            "errorMessage",
+                                            &valueObject2 ) );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  valueObject2.u.value.u.string.pString,
+                                  valueObject2.u.value.u.string.length );
+
+    /* Destroy the iterator. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter, &mapDecoder ) );
+
+    _decoder.destroy( &keyObject );
+    _decoder.destroy( &valueObject );
+    _decoder.destroy( &mapDecoder );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestGetSizeOfForIndefiniteLengthNestedArray )
+{
+    IotSerializerDecoderObject_t arrayDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    size_t arraySize = 0;
+    IotSerializerDecoderIterator_t iter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderIterator_t nestedIter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderObject_t elementObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t nestedArrayObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t nestedObject = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &arrayDecoder,
+                                                                    _testEncodedIndefiniteLengthNestedArray,
+                                                                    sizeof( _testEncodedIndefiniteLengthNestedArray ) ) );
+
+    /* Test that size of an indefinite length map can be calculated. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.getSizeOf( &arrayDecoder, &arraySize ) );
+    TEST_ASSERT_EQUAL( 4, arraySize );
+
+    /* Test iterating through the array and extracting the first and last elements. */
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &arrayDecoder, &iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &elementObject ) );
+
+    /* Validate that we can obtain the first element value in the indefinite length array. */
+    TEST_ASSERT_EQUAL_STRING_LEN( "El1", elementObject.u.value.u.string.pString,
+                                  elementObject.u.value.u.string.length );
+
+    /* Go to the last element in the list. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+
+    /* The last element is a special case for byte/text string extraction as it is an indefinite-length nested array
+     * within the outer indefinite-length array. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &nestedArrayObject ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &nestedArrayObject, &nestedIter ) );
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( nestedIter, &nestedObject ) );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Last", nestedObject.u.value.u.string.pString,
+                                  nestedObject.u.value.u.string.length );
+
+    /* Destroy the iterators. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( nestedIter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( nestedIter, &nestedArrayObject ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter, &arrayDecoder ) );
+
+    _decoder.destroy( &nestedObject );
+    _decoder.destroy( &nestedArrayObject );
+    _decoder.destroy( &elementObject );
+    _decoder.destroy( &arrayDecoder );
+}
+
+/* Verifies that a container decoder object remains valid for re-use after a complete round of iterating
+ * through its contents */
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectReuseAfterIteration )
+{
+    IotSerializerDecoderObject_t mapDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t iterator1 = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderObject_t valueDecoder = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t iterator2 = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.init( &mapDecoder,
+                                                                    _testEncodedNestedMap,
+                                                                    sizeof( _testEncodedNestedMap ) ) );
+
+    /* Obtain an iterator to the contents of the map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &mapDecoder,
+                                                                      &iterator1 ) );
+
+
+    /* Undergo one round of iteration through the map */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator1 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator1 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator1 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator1 ) );
+
+    /* End the iteration by invalidating the iterator */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iterator1, &mapDecoder ) );
+
+    /* NOW check that the decoder object of the map is still valid! */
+    /* Sanity check with "find()" function". */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.find( &mapDecoder, "3", &valueDecoder ) );
+    TEST_ASSERT_EQUAL( false, valueDecoder.u.value.u.booleanValue );
+
+    /* Sanity check with another round of iteration! */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &mapDecoder,
+                                                                      &iterator2 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iterator2 ) );
+
+    /* End the second round of iteration */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iterator2, &mapDecoder ) );
+
+    _decoder.destroy( &valueDecoder );
+    _decoder.destroy( &mapDecoder );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMap )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t statusCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorMessage = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedIndefiniteLengthMap,
+                                            sizeof( _testEncodedIndefiniteLengthMap ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the status code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "statusCode",
+                                            &statusCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
+    TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
+
+    /* Find the error code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "errorCode",
+                                            &errorCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
+                                  errorCode.u.value.u.string.pString,
+                                  errorCode.u.value.u.string.length );
+
+    /* Find the error message. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "errorMessage",
+                                            &errorMessage ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  errorMessage.u.value.u.string.pString,
+                                  errorMessage.u.value.u.string.length );
+
+    _decoder.destroy( &errorMessage );
+    _decoder.destroy( &errorCode );
+    _decoder.destroy( &statusCode );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMap )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t statusCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorMessage = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedDefiniteLengthMap,
+                                            sizeof( _testEncodedDefiniteLengthMap ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the status code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "statusCode",
+                                            &statusCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
+    TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
+
+    /* Find the error code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "errorCode",
+                                            &errorCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
+                                  errorCode.u.value.u.string.pString,
+                                  errorCode.u.value.u.string.length );
+
+    /* Find the error message. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "errorMessage",
+                                            &errorMessage ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  errorMessage.u.value.u.string.pString,
+                                  errorMessage.u.value.u.string.length );
+
+    _decoder.destroy( &errorMessage );
+    _decoder.destroy( &errorCode );
+    _decoder.destroy( &statusCode );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedMap )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t resultMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t statusCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorMessage = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t success = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedIndefiniteLengthNestedMap,
+                                            sizeof( _testEncodedIndefiniteLengthNestedMap ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the result map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "result",
+                                            &resultMap ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, resultMap.type );
+
+    /* Find the status code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "statusCode",
+                                            &statusCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
+    TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
+
+    /* Find the error code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "errorCode",
+                                            &errorCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
+                                  errorCode.u.value.u.string.pString,
+                                  errorCode.u.value.u.string.length );
+
+    /* Find the error message. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "errorMessage",
+                                            &errorMessage ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  errorMessage.u.value.u.string.pString,
+                                  errorMessage.u.value.u.string.length );
+
+    /* Find the success message. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "success",
+                                            &success ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, success.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Not successful",
+                                  success.u.value.u.string.pString,
+                                  success.u.value.u.string.length );
+
+    _decoder.destroy( &errorMessage );
+    _decoder.destroy( &errorCode );
+    _decoder.destroy( &statusCode );
+    _decoder.destroy( &success );
+    _decoder.destroy( &resultMap );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthNestedMapWith2BreakChars )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t resultMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t statusCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorCode = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t errorMessage = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedIndefiniteLengthNestedMapWith2BreakChars,
+                                            sizeof( _testEncodedIndefiniteLengthNestedMapWith2BreakChars ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the result map. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "result",
+                                            &resultMap ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, resultMap.type );
+
+    /* Find the status code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "statusCode",
+                                            &statusCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_SIGNED_INT, statusCode.type );
+    TEST_ASSERT_EQUAL( 400, statusCode.u.value.u.signedInt );
+
+    /* Find the error code. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "errorCode",
+                                            &errorCode ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorCode.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "InvalidPayload",
+                                  errorCode.u.value.u.string.pString,
+                                  errorCode.u.value.u.string.length );
+
+    /* Find the error message. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &resultMap,
+                                            "errorMessage",
+                                            &errorMessage ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, errorMessage.type );
+    TEST_ASSERT_EQUAL_STRING_LEN( "Message cannot be parsed",
+                                  errorMessage.u.value.u.string.pString,
+                                  errorMessage.u.value.u.string.length );
+
+    _decoder.destroy( &errorMessage );
+    _decoder.destroy( &errorCode );
+    _decoder.destroy( &statusCode );
+    _decoder.destroy( &resultMap );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthMapWithFFatTheEnd )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t result = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    uint8_t expectedResult[] = { 0xAA, 0xBB, 0xCC, 0xFF };
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedIndefiniteLengthMapWithFFatTheEnd,
+                                            sizeof( _testEncodedIndefiniteLengthMapWithFFatTheEnd ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the result. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "result",
+                                            &result ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BYTE_STRING, result.type );
+    TEST_ASSERT_EQUAL( sizeof( expectedResult ), result.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedResult,
+                                   result.u.value.u.string.pString,
+                                   result.u.value.u.string.length );
+
+    _decoder.destroy( &result );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthMapWithFFatTheEnd )
+{
+    IotSerializerDecoderObject_t outermostMap = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t result = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    uint8_t expectedResult[] = { 0xAA, 0xBB, 0xCC, 0xFF };
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostMap,
+                                            _testEncodedDefiniteLengthMapWithFFatTheEnd,
+                                            sizeof( _testEncodedDefiniteLengthMapWithFFatTheEnd ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_MAP, outermostMap.type );
+
+    /* Find the result. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.find( &outermostMap,
+                                            "result",
+                                            &result ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_BYTE_STRING, result.type );
+    TEST_ASSERT_EQUAL( sizeof( expectedResult ), result.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedResult,
+                                   result.u.value.u.string.pString,
+                                   result.u.value.u.string.length );
+
+    _decoder.destroy( &result );
+    _decoder.destroy( &outermostMap );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithIndefiniteLengthArrayWithFFatTheEnd )
+{
+    IotSerializerDecoderObject_t outermostArray = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t iter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderObject_t result = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t byteString = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    uint8_t expectedByteString[] = { 0xAA, 0xBB, 0xCC, 0xFF };
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostArray,
+                                            _testEncodedIndefiniteLengthArrayWithFFatTheEnd,
+                                            sizeof( _testEncodedIndefiniteLengthArrayWithFFatTheEnd ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_ARRAY, outermostArray.type );
+
+    /* Start iterating the array. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &outermostArray, &iter ) );
+
+    /* Find the result. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &result ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, result.type );
+    TEST_ASSERT_EQUAL( 6, result.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_STRING_LEN( "result",
+                                  result.u.value.u.string.pString,
+                                  result.u.value.u.string.length );
+
+    /* Find the byte array last element of which is 0xFF. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &byteString ) );
+    TEST_ASSERT_EQUAL( sizeof( expectedByteString ), byteString.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedByteString,
+                                   byteString.u.value.u.string.pString,
+                                   byteString.u.value.u.string.length );
+
+    /* Stop iterating the array and destroy the iterator. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter,
+                                                                       &outermostArray ) );
+
+    _decoder.destroy( &byteString );
+    _decoder.destroy( &result );
+    _decoder.destroy( &outermostArray );
+}
+
+TEST( Serializer_Unit_CBOR_Decoder, TestDecoderObjectWithDefiniteLengthArrayWithFFatTheEnd )
+{
+    IotSerializerDecoderObject_t outermostArray = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderIterator_t iter = IOT_SERIALIZER_DECODER_ITERATOR_INITIALIZER;
+    IotSerializerDecoderObject_t result = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t byteString = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    uint8_t expectedByteString[] = { 0xAA, 0xBB, 0xCC, 0xFF };
+
+    /* Initialize the decoder. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS,
+                       _decoder.init( &outermostArray,
+                                            _testEncodedDefiniteLengthArrayWithFFatTheEnd,
+                                            sizeof( _testEncodedDefiniteLengthArrayWithFFatTheEnd ) ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_CONTAINER_ARRAY, outermostArray.type );
+
+    /* Start iterating the array. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepIn( &outermostArray, &iter ) );
+
+    /* Find the result. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &result ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SCALAR_TEXT_STRING, result.type );
+    TEST_ASSERT_EQUAL( 6, result.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_STRING_LEN( "result",
+                                  result.u.value.u.string.pString,
+                                  result.u.value.u.string.length );
+
+    /* Find the byte string last element of which is 0xFF. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.get( iter, &byteString ) );
+    TEST_ASSERT_EQUAL( sizeof( expectedByteString ), byteString.u.value.u.string.length );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedByteString,
+                                   byteString.u.value.u.string.pString,
+                                   byteString.u.value.u.string.length );
+
+    /* Stop iterating the array and destroy the iterator. */
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.next( iter ) );
+    TEST_ASSERT_EQUAL( IOT_SERIALIZER_SUCCESS, _decoder.stepOut( iter,
+                                                                       &outermostArray ) );
+
+    _decoder.destroy( &byteString );
+    _decoder.destroy( &result );
+    _decoder.destroy( &outermostArray );
 }

--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -216,6 +216,7 @@ static void RunTests( void )
 
     #if ( testrunnerFULL_SERIALIZER_ENABLED == 1 )
         RUN_TEST_GROUP( Serializer_Unit_CBOR );
+        RUN_TEST_GROUP( Serializer_Unit_CBOR_Decoder );
         RUN_TEST_GROUP( Serializer_Unit_JSON );
         RUN_TEST_GROUP( Serializer_Unit_JSON_deserialize );
     #endif

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -214,6 +214,21 @@ static void prvMiscInitialization( void )
 
     ESP_ERROR_CHECK( ret );
 }
+
+/*-----------------------------------------------------------*/
+extern void esp_vApplicationTickHook();
+void IRAM_ATTR vApplicationTickHook()
+{
+    esp_vApplicationTickHook();
+}
+
+/*-----------------------------------------------------------*/
+extern void esp_vApplicationIdleHook();
+void vApplicationIdleHook()
+{
+    esp_vApplicationIdleHook();
+}
+
 /*-----------------------------------------------------------*/
 
 void vApplicationDaemonTaskStartupHook( void )


### PR DESCRIPTION
Description
-----------
See bug fix [aws-iot-device-sdk-embedded-C#912](https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/912).
Said fix was not ported to `amazon-freertos`. This PR adds the same fix, and tests of that fix with necessary updates.
Now, enabling `testrunnerFULL_SERIALIZER_ENABLED` additionally runs the added test suite: `Serializer_Unit_CBOR_Decoder`


**Testing**:
1. Pull the changes.
2. Define `testrunnerFULL_SERIALIZER_ENABLED == 1` in your `aws_test_runner_config.h` to configure `aws_tests` for the added var-length cbor string tests.
3. Run `aws_tests` and verify that all `Serializer_Unit_CBOR_Decoder` tests pass.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.