### PR TITLE
Update README instruction for setting up UART CLI demo

### DIFF
--- a/demos/cli/README.md
+++ b/demos/cli/README.md
@@ -14,8 +14,9 @@ Please note that inorder to run `task_stats` command, `configUSE_TRACE_FACILITY`
 
 ### Enable the demo
 
-1. Enable the demo by defining `CONFIG_CLI_UART_DEMO_ENABLED` flag in `aws_demo_config.h`
-2. Set the network types `democonfigNETWORK_TYPES` to `AWSIOT_NETWORK_TYPE_NONE` in `aws_demo_config.h`
+1. Enable the demo by defining `CONFIG_CLI_UART_DEMO_ENABLED` flag in `aws_demo_config.h`.
+2. Set the network types `democonfigNETWORK_TYPES` to `AWSIOT_NETWORK_TYPE_NONE` in `aws_demo_config.h` for the board.
+3. Set the enabled network `configENABLED_NETWORKS` to `AWSIOT_NETWORK_TYPE_NONE` in `aws_iot_demo_network_config.h` for the board.
 3. Build and flash the application onto the board.
 
 ### Example


### PR DESCRIPTION
For running the UART CLI demo, no network type configuration is required. Thus, the network type configs in `aws_demo_config.h` and `aws_iot_network_config.h` need to be set to `AWSIOT_NETWORK_TYPE_NONE` to successfully initilize and run the CLI over UART demo. The `demos/cli/README.md` file was missing this instruction about the config change in `aws_iot_network_config.h` file. This PR updates the README accordingly.