### PR TITLE
Add a configurable delay in test runner before starting tests

### DIFF
--- a/tests/common/aws_test_runner.c
+++ b/tests/common/aws_test_runner.c
@@ -42,6 +42,13 @@
 /* Application version info. */
 #include "aws_application_version.h"
 
+/**
+ * Default value of delay period before the execution of tests on device.
+ */
+#ifndef AWS_TEST_RUNNER_DELAY_MS
+    #define AWS_TEST_RUNNER_DELAY_MS    5000
+#endif
+
 const AppVersion32_t xAppFirmwareVersion =
 {
     .u.x.ucMajor = APP_VERSION_MAJOR,
@@ -270,6 +277,12 @@ void TEST_RUNNER_RunTests_task( void * pvParameters )
     UnityFixture.GroupFilter = 0;
     UnityFixture.NameFilter = testrunnerTEST_FILTER;
     UnityFixture.RepeatCount = 1;
+
+    /* Add sufficient delay before starting tests on device to allow
+     * device to be available as serial port connection to the host machine
+     * OS.
+     * The serial console is used by host machine to view device logs. */
+    vTaskDelay( pdMS_TO_TICKS( AWS_TEST_RUNNER_DELAY_MS ) );
 
     UNITY_BEGIN();
 

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run AFQP tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED              0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_OTA_CBOR_ENABLED    testrunnerUNSUPPORTED

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/aws_test_runner_config.h
@@ -30,7 +30,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                         0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_BLE_ENABLED                    testrunnerUNSUPPORTED

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/aws_test_runner_config.h
@@ -30,7 +30,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                         0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_BLE_ENABLED                    testrunnerUNSUPPORTED

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                          0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests */
 #define testrunnerFULL_OTA_CBOR_ENABLED                testrunnerUNSUPPORTED

--- a/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_runner_config.h
@@ -29,41 +29,52 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                          0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests */
-#define testrunnerFULL_OTA_CBOR_ENABLED                testrunnerUNSUPPORTED
-#define testrunnerFULL_POSIX_ENABLED                   testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
+#define testrunnerFULL_POSIX_ENABLED                testrunnerUNSUPPORTED
 
 /* Enable tests by setting defines to 1 */
-#define testrunnerFULL_OTA_AGENT_ENABLED               0
-#define testrunnerFULL_OTA_PAL_ENABLED                 0
-#define testrunnerFULL_MQTT_ALPN_ENABLED               0
-#define testrunnerFULL_CORE_MQTT_ENABLED               0
-#define testrunnerFULL_CORE_HTTP_ENABLED               0
-#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED       0
-#define testrunnerFULL_CORE_MQTT_AWS_IOT_ENABLED       0
-#define testrunnerFULL_DEVICE_SHADOW_ENABLED           0
-#define testrunnerFULL_PKCS11_ENABLED                  0
-#define testrunnerFULL_DEFENDER_ENABLED                0
-#define testrunnerFULL_CRYPTO_ENABLED                  0
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED        0
-#define testrunnerFULL_MQTT_AGENT_ENABLED              0
-#define testrunnerFULL_TCP_ENABLED                     1
-#define testrunnerFULL_GGD_ENABLED                     0
-#define testrunnerFULL_GGD_HELPER_ENABLED              0
-#define testrunnerFULL_SHADOW_ENABLED                  0
-#define testrunnerFULL_SHADOWv4_ENABLED                0
-#define testrunnerFULL_MQTTv4_ENABLED                  0
-#define testrunnerFULL_WIFI_ENABLED                    0
-#define testrunnerFULL_MEMORYLEAK_ENABLED              0
-#define testrunnerFULL_TLS_ENABLED                     0
-#define testrunnerFULL_WIFI_PROVISIONING_ENABLED       0
-#define testrunnerUTIL_PLATFORM_CLOCK_ENABLED          0
-#define testrunnerFULL_LINEAR_CONTAINERS_ENABLED       0
-#define testrunnerUTIL_PLATFORM_THREADS_ENABLED        0
-#define testrunnerFULL_SERIALIZER_ENABLED              0
-#define testrunnerFULL_HTTPS_CLIENT_ENABLED            0
-#define testrunnerFULL_COMMON_IO_ENABLED               0
-#define testrunnerFULL_CLI_ENABLED                     0
+#define testrunnerFULL_OTA_AGENT_ENABLED            0
+#define testrunnerFULL_OTA_PAL_ENABLED              0
+#define testrunnerFULL_MQTT_ALPN_ENABLED            0
+#define testrunnerFULL_CORE_MQTT_ENABLED            0
+#define testrunnerFULL_CORE_HTTP_ENABLED            0
+#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED    0
+#define testrunnerFULL_CORE_MQTT_AWS_IOT_ENABLED    0
+#define testrunnerFULL_DEVICE_SHADOW_ENABLED        0
+#define testrunnerFULL_PKCS11_ENABLED               0
+#define testrunnerFULL_DEFENDER_ENABLED             0
+#define testrunnerFULL_CRYPTO_ENABLED               0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED     0
+#define testrunnerFULL_MQTT_AGENT_ENABLED           0
+#define testrunnerFULL_TCP_ENABLED                  1
+#define testrunnerFULL_GGD_ENABLED                  0
+#define testrunnerFULL_GGD_HELPER_ENABLED           0
+#define testrunnerFULL_SHADOW_ENABLED               0
+#define testrunnerFULL_SHADOWv4_ENABLED             0
+#define testrunnerFULL_MQTTv4_ENABLED               0
+#define testrunnerFULL_WIFI_ENABLED                 0
+#define testrunnerFULL_MEMORYLEAK_ENABLED           0
+#define testrunnerFULL_TLS_ENABLED                  0
+#define testrunnerFULL_WIFI_PROVISIONING_ENABLED    0
+#define testrunnerUTIL_PLATFORM_CLOCK_ENABLED       0
+#define testrunnerFULL_LINEAR_CONTAINERS_ENABLED    0
+#define testrunnerUTIL_PLATFORM_THREADS_ENABLED     0
+#define testrunnerFULL_SERIALIZER_ENABLED           0
+#define testrunnerFULL_HTTPS_CLIENT_ENABLED         0
+#define testrunnerFULL_COMMON_IO_ENABLED            0
+#define testrunnerFULL_CLI_ENABLED                  0
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 #define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
 #define testrunnerFULL_OTA_AGENT_ENABLED            testrunnerUNSUPPORTED

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 #define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
 #define testrunnerFULL_OTA_AGENT_ENABLED            testrunnerUNSUPPORTED

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /*#define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Enable tests by setting defines to 1 */
 #define testrunnerFULL_OTA_CBOR_ENABLED             0

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/aws_test_runner_config.h
@@ -26,7 +26,18 @@
 #ifndef AWS_TEST_RUNNER_CONFIG_H
 #define AWS_TEST_RUNNER_CONFIG_H
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 #define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
 #define testrunnerFULL_OTA_AGENT_ENABLED            testrunnerUNSUPPORTED

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/aws_test_runner_config.h
@@ -28,7 +28,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED              0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_OTA_CBOR_ENABLED    testrunnerUNSUPPORTED

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/aws_test_runner_config.h
@@ -30,7 +30,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                         0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_WIFI_ENABLED                   testrunnerUNSUPPORTED

--- a/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                          0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests */
 #define testrunnerFULL_OTA_CBOR_ENABLED                testrunnerUNSUPPORTED

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_runner_config.h
@@ -30,7 +30,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                         0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_BLE_ENABLED                    testrunnerUNSUPPORTED

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_runner_config.h
@@ -28,7 +28,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
@@ -30,7 +30,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                         0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
 #define testrunnerFULL_WIFI_ENABLED                   testrunnerUNSUPPORTED

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run AFQP tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED               0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests */
 #define testrunnerFULL_CBOR_ENABLED         testrunnerUNSUPPORTED

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/aws_test_runner_config.h
@@ -29,35 +29,46 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                      0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
-#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_AGENT_ENABLED           testrunnerUNSUPPORTED
-#define testrunnerFULL_OTA_PAL_ENABLED             testrunnerUNSUPPORTED
-#define testrunnerFULL_MQTT_ALPN_ENABLED           testrunnerUNSUPPORTED
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_AGENT_ENABLED            testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_PAL_ENABLED              testrunnerUNSUPPORTED
+#define testrunnerFULL_MQTT_ALPN_ENABLED            testrunnerUNSUPPORTED
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED     testrunnerUNSUPPORTED
 
 /* Supported tests. 0 = Disabled, 1 = Enabled */
-#define testrunnerFULL_TASKPOOL_ENABLED            0
-#define testrunnerFULL_MQTT_AGENT_ENABLED          0
-#define testrunnerFULL_TCP_ENABLED                 1
-#define testrunnerFULL_GGD_ENABLED                 0
-#define testrunnerFULL_GGD_HELPER_ENABLED          0
-#define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_SHADOWv4_ENABLED            0
-#define testrunnerFULL_CORE_HTTP_ENABLED           0
-#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED   0
-#define testrunnerFULL_MQTTv4_ENABLED              0
-#define testrunnerFULL_PKCS11_ENABLED              0
-#define testrunnerFULL_CRYPTO_ENABLED              0
-#define testrunnerFULL_WIFI_ENABLED                0
-#define testrunnerFULL_MEMORYLEAK_ENABLED          0
-#define testrunnerFULL_TLS_ENABLED                 0
-#define testrunnerFULL_POSIX_ENABLED               0
-#define testrunnerFULL_HTTPS_CLIENT_ENABLED        0
-#define testrunnerFULL_COMMON_IO_ENABLED           0
-#define testrunnerFULL_CLI_ENABLED                 0
-#define testrunnerFULL_DEVICE_SHADOW_ENABLED       0
+#define testrunnerFULL_TASKPOOL_ENABLED             0
+#define testrunnerFULL_MQTT_AGENT_ENABLED           0
+#define testrunnerFULL_TCP_ENABLED                  1
+#define testrunnerFULL_GGD_ENABLED                  0
+#define testrunnerFULL_GGD_HELPER_ENABLED           0
+#define testrunnerFULL_SHADOW_ENABLED               0
+#define testrunnerFULL_SHADOWv4_ENABLED             0
+#define testrunnerFULL_CORE_HTTP_ENABLED            0
+#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED    0
+#define testrunnerFULL_MQTTv4_ENABLED               0
+#define testrunnerFULL_PKCS11_ENABLED               0
+#define testrunnerFULL_CRYPTO_ENABLED               0
+#define testrunnerFULL_WIFI_ENABLED                 0
+#define testrunnerFULL_MEMORYLEAK_ENABLED           0
+#define testrunnerFULL_TLS_ENABLED                  0
+#define testrunnerFULL_POSIX_ENABLED                0
+#define testrunnerFULL_HTTPS_CLIENT_ENABLED         0
+#define testrunnerFULL_COMMON_IO_ENABLED            0
+#define testrunnerFULL_CLI_ENABLED                  0
+#define testrunnerFULL_DEVICE_SHADOW_ENABLED        0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/aws_test_runner_config.h
@@ -29,35 +29,46 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                      0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported tests. */
-#define testrunnerFULL_OTA_CBOR_ENABLED            testrunnerUNSUPPORTED
-#define testrunnerFULL_MQTT_ALPN_ENABLED           testrunnerUNSUPPORTED
-#define testrunnerFULL_PKCS11_ENABLED              testrunnerUNSUPPORTED
-#define testrunnerFULL_CRYPTO_ENABLED              testrunnerUNSUPPORTED
+#define testrunnerFULL_OTA_CBOR_ENABLED             testrunnerUNSUPPORTED
+#define testrunnerFULL_MQTT_ALPN_ENABLED            testrunnerUNSUPPORTED
+#define testrunnerFULL_PKCS11_ENABLED               testrunnerUNSUPPORTED
+#define testrunnerFULL_CRYPTO_ENABLED               testrunnerUNSUPPORTED
 
 /* Supported tests. 0 = Disabled, 1 = Enabled */
-#define testrunnerFULL_TASKPOOL_ENABLED            0
-#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED    0
-#define testrunnerFULL_MQTT_AGENT_ENABLED          0
-#define testrunnerFULL_MQTTv4_ENABLED              0
-#define testrunnerFULL_TCP_ENABLED                 1
-#define testrunnerFULL_GGD_ENABLED                 0
-#define testrunnerFULL_GGD_HELPER_ENABLED          0
-#define testrunnerFULL_SHADOW_ENABLED              0
-#define testrunnerFULL_SHADOWv4_ENABLED            0
-#define testrunnerFULL_WIFI_ENABLED                0
-#define testrunnerFULL_MEMORYLEAK_ENABLED          0
-#define testrunnerFULL_TLS_ENABLED                 0
-#define testrunnerFULL_OTA_AGENT_ENABLED           0
-#define testrunnerFULL_OTA_PAL_ENABLED             0
-#define testrunnerFULL_POSIX_ENABLED               0
-#define testrunnerFULL_HTTPS_CLIENT_ENABLED        0
-#define testrunnerFULL_DEVICE_SHADOW_ENABLED       0
-#define testrunnerFULL_CORE_MQTT_ENABLED           0
-#define testrunnerFULL_CORE_MQTT_AWS_IOT_ENABLED   0
-#define testrunnerFULL_CORE_HTTP_ENABLED           0
-#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED   0
+#define testrunnerFULL_TASKPOOL_ENABLED             0
+#define testrunnerFULL_MQTT_STRESS_TEST_ENABLED     0
+#define testrunnerFULL_MQTT_AGENT_ENABLED           0
+#define testrunnerFULL_MQTTv4_ENABLED               0
+#define testrunnerFULL_TCP_ENABLED                  1
+#define testrunnerFULL_GGD_ENABLED                  0
+#define testrunnerFULL_GGD_HELPER_ENABLED           0
+#define testrunnerFULL_SHADOW_ENABLED               0
+#define testrunnerFULL_SHADOWv4_ENABLED             0
+#define testrunnerFULL_WIFI_ENABLED                 0
+#define testrunnerFULL_MEMORYLEAK_ENABLED           0
+#define testrunnerFULL_TLS_ENABLED                  0
+#define testrunnerFULL_OTA_AGENT_ENABLED            0
+#define testrunnerFULL_OTA_PAL_ENABLED              0
+#define testrunnerFULL_POSIX_ENABLED                0
+#define testrunnerFULL_HTTPS_CLIENT_ENABLED         0
+#define testrunnerFULL_DEVICE_SHADOW_ENABLED        0
+#define testrunnerFULL_CORE_MQTT_ENABLED            0
+#define testrunnerFULL_CORE_MQTT_AWS_IOT_ENABLED    0
+#define testrunnerFULL_CORE_HTTP_ENABLED            0
+#define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED    0
 
 #endif /* AWS_TEST_RUNNER_CONFIG_H */

--- a/vendors/vendor/boards/board/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /* #define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Enable tests by setting defines to 1 */
 #define testrunnerFULL_OTA_CBOR_ENABLED             0

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/aws_test_runner_config.h
@@ -29,7 +29,18 @@
 /* Uncomment this line if you want to run DQP_FR tests only. */
 /*#define testrunnerAFQP_ENABLED */
 
-#define testrunnerUNSUPPORTED                       0
+#define testrunnerUNSUPPORTED    0
+
+/* Uncomment this line to specify the delay (in milliseconds) to add before
+ * starting the tests execution on device.
+ * This is useful if the device takes some time after flashing to appear
+ * on the serial port of the host machine OS. The serial console is used
+ * by IDT to detect state of test execution on device. Therefore, the delay
+ * value can be configured to ensure that the device (after flashing) is
+ * available on host machine before it starts executing tests so that IDT
+ * can detect when tests start execution on device through the serial console.
+ */
+/* #define AWS_TEST_RUNNER_DELAY_MS                       ( 1000 )*/
 
 /* Unsupported Tests */
 #define testrunnerFULL_CBOR_ENABLED                 testrunnerUNSUPPORTED


### PR DESCRIPTION
### Problem

The AWS IoT Device Tester team has encountered a problem of a race condition between the device starting execution of tests and the device being available on the host machine OS for IDT being able to gain serial access to the device. 

If the tests start executing on device before the device is available as serial connection on the host machine (running Device Tester), then the Device Tester state machine would not detect that tests had started on the device, and thus, treat it as failure.

### Solution
This PR adds a delay value before the `---------STARTING TESTS---------` string is printed in the test runner to allow the device to be serially available to the Device Tester before beginning of tests on the device.

The delay value is configurable with the `AWS_TEST_RUNNER_DELAY_MS` macro to allow changing the value specific to the delay requirements of the board. The macro carries a default value of 5 seconds.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.