### PR TITLE
esp32 - Fix SoftAP Provisioning (LWIP)

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -173,7 +173,6 @@ target_include_directories(
         "${esp_idf_dir}/components/esp_netif/include"
         "${esp_idf_dir}/components/esp_eth/include"
         "${esp_idf_dir}/components/soc/soc/include"
-        "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser"
 )
 endif()
 
@@ -181,12 +180,48 @@ target_sources(
     AFR::wifi::mcu_port
     INTERFACE 
         "${afr_ports_dir}/wifi/iot_wifi.c"
-        "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
-        # Due to nghttp's dependency on it, http_parser is added to generate metadata
-        # so that it is present in the code downloaded from the FreeRTOS console.
-        "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.c"
-        "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.h"
 )
+
+# SoftAP Provisioning - The add functionality is part of the wifi lib when usig LWIP
+if( NOT AFR_ESP_FREERTOS_TCP )
+    target_include_directories(
+        AFR::wifi::mcu_port
+        INTERFACE
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser"
+            "${AFR_ROOT_DIR}/libraries/3rdparty/mbedtls/include"
+            "${esp_idf_dir}/components/protocomm/proto-c"
+            "${esp_idf_dir}/components/protocomm/src/common"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c"
+            "${esp_idf_dir}/components/esp_http_server/include"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c"
+    )
+
+    target_sources(
+        AFR::wifi::mcu_port
+        INTERFACE
+            "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.c"
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.h"
+            "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
+            "${esp_idf_dir}/components/protocomm/src/common/protocomm.c"
+            "${esp_idf_dir}/components/protocomm/src/security/security1.c"
+            "${esp_idf_dir}/components/protocomm/src/transports/protocomm_httpd.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/session.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec1.pb-c.c"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c/protobuf-c/protobuf-c.c"
+            "${esp_idf_dir}/components/wifi_provisioning/src/wifi_config.c"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_config.pb-c.c"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_constants.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/constants.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec0.pb-c.c"
+    )
+
+    target_link_libraries(
+        AFR::wifi::mcu_port
+        INTERFACE
+            3rdparty::mbedtls
+    )
+endif()
 
 # BLE
 set(BLE_SUPPORTED 1 CACHE INTERNAL "BLE is supported on this platform.")

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -182,40 +182,37 @@ target_sources(
         "${afr_ports_dir}/wifi/iot_wifi.c"
 )
 
-# SoftAP Provisioning - The add functionality is part of the wifi lib when usig LWIP
+# SoftAP Provisioning - Available ONLY when using LWIP stack
 if( NOT AFR_ESP_FREERTOS_TCP )
     target_include_directories(
         AFR::wifi::mcu_port
         INTERFACE
             "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser"
             "${AFR_ROOT_DIR}/libraries/3rdparty/mbedtls/include"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c"
             "${esp_idf_dir}/components/protocomm/proto-c"
             "${esp_idf_dir}/components/protocomm/src/common"
-            "${esp_idf_dir}/components/protobuf-c/protobuf-c"
-            "${esp_idf_dir}/components/esp_http_server/include"
             "${esp_idf_dir}/components/wifi_provisioning/proto-c"
+            "${esp_idf_dir}/components/esp_http_server/include"
     )
-
     target_sources(
         AFR::wifi::mcu_port
         INTERFACE
             "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
             "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.c"
             "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.h"
-            "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c/protobuf-c/protobuf-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/session.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec0.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec1.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/constants.pb-c.c"
             "${esp_idf_dir}/components/protocomm/src/common/protocomm.c"
             "${esp_idf_dir}/components/protocomm/src/security/security1.c"
             "${esp_idf_dir}/components/protocomm/src/transports/protocomm_httpd.c"
-            "${esp_idf_dir}/components/protocomm/proto-c/session.pb-c.c"
-            "${esp_idf_dir}/components/protocomm/proto-c/sec1.pb-c.c"
-            "${esp_idf_dir}/components/protobuf-c/protobuf-c/protobuf-c/protobuf-c.c"
-            "${esp_idf_dir}/components/wifi_provisioning/src/wifi_config.c"
             "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_config.pb-c.c"
             "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_constants.pb-c.c"
-            "${esp_idf_dir}/components/protocomm/proto-c/constants.pb-c.c"
-            "${esp_idf_dir}/components/protocomm/proto-c/sec0.pb-c.c"
+            "${esp_idf_dir}/components/wifi_provisioning/src/wifi_config.c"
     )
-
     target_link_libraries(
         AFR::wifi::mcu_port
         INTERFACE

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -163,7 +163,6 @@ target_include_directories(
         "${esp_idf_dir}/components/esp_netif/include"
         "${esp_idf_dir}/components/esp_eth/include"
         "${esp_idf_dir}/components/soc/soc/include"
-        "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser"
 )
 endif()
 
@@ -171,12 +170,45 @@ target_sources(
     AFR::wifi::mcu_port
     INTERFACE
     "${afr_ports_dir}/wifi/iot_wifi.c"
-    "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
-    # Due to nghttp's dependency on it, http_parser is added to generate metadata
-    # so that it is present in the code downloaded from the FreeRTOS console.
-    "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.c"
-    "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.h"
 )
+
+ # SoftAP Provisioning - Available ONLY when using LWIP stack
+if( NOT AFR_ESP_FREERTOS_TCP )
+    target_include_directories(
+        AFR::wifi::mcu_port
+        INTERFACE
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser"
+            "${AFR_ROOT_DIR}/libraries/3rdparty/mbedtls/include"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c"
+            "${esp_idf_dir}/components/protocomm/proto-c"
+            "${esp_idf_dir}/components/protocomm/src/common"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c"
+            "${esp_idf_dir}/components/esp_http_server/include"
+    )
+    target_sources(
+        AFR::wifi::mcu_port
+        INTERFACE
+            "${afr_ports_dir}/wifi/iot_softap_wifi_provisioning.c"
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.c"
+            "${AFR_ROOT_DIR}/libraries/coreHTTP/source/dependency/3rdparty/http_parser/http_parser.h"
+            "${esp_idf_dir}/components/protobuf-c/protobuf-c/protobuf-c/protobuf-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/session.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec0.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/sec1.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/proto-c/constants.pb-c.c"
+            "${esp_idf_dir}/components/protocomm/src/common/protocomm.c"
+            "${esp_idf_dir}/components/protocomm/src/security/security1.c"
+            "${esp_idf_dir}/components/protocomm/src/transports/protocomm_httpd.c"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_config.pb-c.c"
+            "${esp_idf_dir}/components/wifi_provisioning/proto-c/wifi_constants.pb-c.c"
+            "${esp_idf_dir}/components/wifi_provisioning/src/wifi_config.c"
+    )
+    target_link_libraries(
+        AFR::wifi::mcu_port
+        INTERFACE
+            3rdparty::mbedtls
+    )
+endif()
 
 # PKCS11
 if(ECC608_IN_USE)

--- a/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
+++ b/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
@@ -175,13 +175,24 @@ static esp_err_t prvSetProvisionConfig( const wifi_prov_config_set_data_t * pxRe
 static esp_err_t prvApplyProvisionConfig( wifi_prov_ctx_t ** ppxUserContext )
 {
     esp_err_t xReturnCode = ESP_FAIL;
+    wifi_mode_t mode_wifi = WIFI_MODE_NULL;
+
+    /* Maintain AP for connection to mobile provisioning app, and verify the 
+     * credentials before storing to flash --> Use dual AP+STA mode */
+    esp_wifi_get_mode(&mode_wifi);
+    if( mode_wifi != WIFI_MODE_APSTA && esp_wifi_set_mode( WIFI_MODE_APSTA ) == ESP_OK)
+    {
+        esp_wifi_get_mode(&mode_wifi);
+    }
+    else 
+    {
+        ESP_LOGE( TAG, "Failed to switch to AP+STA mode" );
+    }
 
     /* Try to connect using provisioned SSID/password */
     WIFINetworkParams_t xAttemptParams;
-
     prvNetworkProfile2Params( &xProvisionedParams, &xAttemptParams );
-
-    if( eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) )
+    if( mode_wifi == WIFI_MODE_APSTA && eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) )
     {
         ESP_LOGI( TAG, "Successfully connected to %s", xAttemptParams.ucSSID );
 
@@ -241,11 +252,6 @@ uint32_t IotWifiSoftAPProv_Init( void )
     {
         ESP_LOGE( TAG, "Failed to configure AP" );
     }
-    else if( ESP_OK != esp_wifi_set_mode( WIFI_MODE_APSTA ) )
-    {
-        /* Currently WIFI_ConfigureAP configures as AP only. So we tweak to APSTA */
-        ESP_LOGE( TAG, "Failed to switch to APSTA" );
-    }
     else if( eWiFiSuccess != WIFI_StartAP() )
     {
         ESP_LOGE( TAG, "Failed to start AP" );
@@ -256,7 +262,7 @@ uint32_t IotWifiSoftAPProv_Init( void )
     }
     else
     {
-        ESP_LOGI( TAG, "SoftAP Provisioning started with SSID '%s', Password '%s'", xAPConfig.ucSSID, xAPConfig.xPassword.xWPA.cPassphrase );
+        ESP_LOGI( TAG, "SoftAP Provisioning started with SSID:'%s', Password:'%s'", xAPConfig.ucSSID, xAPConfig.xPassword.xWPA.cPassphrase );
         ulReturnCode = pdPASS;
     }
 
@@ -293,7 +299,10 @@ uint32_t IotWifiSoftAPProv_Connect( uint32_t ulNetworkIndex )
         if( eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) )
         {
             ulReturnCode = pdPASS;
-            ESP_LOGI( TAG, "Successfully connected to saved network profile[%d]", ulNetworkIndex );
+            ESP_LOGI( TAG, "Successfully connected to saved network profile[%d] SSID:%.*s", 
+                ulNetworkIndex, 
+                xSavedNetworkProfile.ucSSIDLength,
+                xSavedNetworkProfile.ucSSID);
         }
         else
         {

--- a/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
+++ b/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
@@ -175,16 +175,17 @@ static esp_err_t prvSetProvisionConfig( const wifi_prov_config_set_data_t * pxRe
 static esp_err_t prvApplyProvisionConfig( wifi_prov_ctx_t ** ppxUserContext )
 {
     esp_err_t xReturnCode = ESP_FAIL;
-    wifi_mode_t mode_wifi = WIFI_MODE_NULL;
+    wifi_mode_t xMode_Wifi = WIFI_MODE_NULL;
 
-    /* Maintain AP for connection to mobile provisioning app, and verify the 
+    /* Maintain AP for connection to mobile provisioning app, and verify the
      * credentials before storing to flash --> Use dual AP+STA mode */
-    esp_wifi_get_mode(&mode_wifi);
-    if( mode_wifi != WIFI_MODE_APSTA && esp_wifi_set_mode( WIFI_MODE_APSTA ) == ESP_OK)
+    esp_wifi_get_mode( &xMode_Wifi );
+
+    if( ( xMode_Wifi != WIFI_MODE_APSTA ) && ( esp_wifi_set_mode( WIFI_MODE_APSTA ) == ESP_OK ) )
     {
-        esp_wifi_get_mode(&mode_wifi);
+        esp_wifi_get_mode( &xMode_Wifi );
     }
-    else 
+    else
     {
         ESP_LOGE( TAG, "Failed to switch to AP+STA mode" );
     }
@@ -192,7 +193,8 @@ static esp_err_t prvApplyProvisionConfig( wifi_prov_ctx_t ** ppxUserContext )
     /* Try to connect using provisioned SSID/password */
     WIFINetworkParams_t xAttemptParams;
     prvNetworkProfile2Params( &xProvisionedParams, &xAttemptParams );
-    if( mode_wifi == WIFI_MODE_APSTA && eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) )
+
+    if( ( xMode_Wifi == WIFI_MODE_APSTA ) && ( eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) ) )
     {
         ESP_LOGI( TAG, "Successfully connected to %s", xAttemptParams.ucSSID );
 
@@ -299,10 +301,10 @@ uint32_t IotWifiSoftAPProv_Connect( uint32_t ulNetworkIndex )
         if( eWiFiSuccess == WIFI_ConnectAP( &xAttemptParams ) )
         {
             ulReturnCode = pdPASS;
-            ESP_LOGI( TAG, "Successfully connected to saved network profile[%d] SSID:%.*s", 
-                ulNetworkIndex, 
-                xSavedNetworkProfile.ucSSIDLength,
-                xSavedNetworkProfile.ucSSID);
+            ESP_LOGI( TAG, "Successfully connected to saved network profile[%d] SSID:%.*s",
+                      ulNetworkIndex,
+                      xSavedNetworkProfile.ucSSIDLength,
+                      xSavedNetworkProfile.ucSSID );
         }
         else
         {

--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -28,10 +28,6 @@
 
 #include "string.h"
 #include "esp_wifi.h"
-
-#define LOG_LOCAL_LEVEL    ESP_LOG_DEBUG
-
-
 #include "esp_log.h"
 #include "esp_event.h"
 #include "event_groups.h"

--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -28,6 +28,10 @@
 
 #include "string.h"
 #include "esp_wifi.h"
+
+#define LOG_LOCAL_LEVEL    ESP_LOG_DEBUG
+
+
 #include "esp_log.h"
 #include "esp_event.h"
 #include "event_groups.h"
@@ -58,6 +62,7 @@ static bool wifi_ap_state;
 static bool wifi_auth_failure;
 
 static esp_netif_t *esp_netif_info;
+static esp_netif_t *esp_softap_netif_info;
 
 #define WIFI_FLASH_NS     "WiFi"
 #define MAX_WIFI_KEY_WIDTH         ( 5 )
@@ -378,6 +383,7 @@ WIFIReturnCode_t WIFI_On( void )
     if (event_loop_inited == false) {
         ret = esp_event_loop_create_default();
         esp_netif_info = esp_netif_create_default_wifi_sta();
+        esp_softap_netif_info = esp_netif_create_default_wifi_ap();
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Failed to init event loop %d", __func__, ret);
             goto err;
@@ -1309,6 +1315,14 @@ WIFIReturnCode_t WIFI_StartAP( void )
             xSemaphoreGive( xWiFiSem );
             return wifi_ret;
         }
+
+        /* Enable DHCP server, if it's not already enabled */
+        if ( ESP_ERR_ESP_NETIF_INVALID_PARAMS == esp_netif_dhcps_start(esp_softap_netif_info))
+        {
+            ESP_LOGE(TAG, "%s: Failed to start DHCP server", __func__);
+            return eWiFiFailure;
+        }
+
         // Wait for wifi started event
         xEventGroupWaitBits(wifi_event_group, AP_STARTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
         wifi_ret = eWiFiSuccess;


### PR DESCRIPTION
Description
-----------
These were recently broken from upgrade to IDF v4.2. 
- Fixes build when `IOT_WIFI_ENABLE_SOFTAP_PROVISIONING == 1`. Also revised build so its fully captured by _our_ CMake and does not rely on additional downstream IDF component builds (e.g. esp_http_server, etc.)
- Fixes broken adapter for AP Net-IF. As a result of recent changes, the usual callback after `AP_START` was not installed so DHCPS, DNS, etc. was not starting when AP was started
- Misc improvements to `iot_softap_wifi_provisioning.c`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.