### PR TITLE
Remove repetition of metadata in log messages

### DIFF
--- a/libraries/logging/README.md
+++ b/libraries/logging/README.md
@@ -1,0 +1,105 @@
+## Sample Implementation of Logging Interface
+
+This library provides reference implementations of the [logging interface](#the-logging-interface) that is used by FreeRTOS libraries and demos to generate log messages. This library provides
+implementations for both ISO C90 standard and ISO C99 standard (with GNU extension) of the logging interface.
+
+**Note**: Users can provide their own implementations of the logging interface to enable logging, if they choose to not use this implementation.
+
+### Logging Task 
+Logging messages from multiple tasks are serialized with a FreeRTOS queue that is serviced by a daemon logging task. The daemon task reads log message strings from the queue and forwards them to the vendor-specific function through the `configPRINT` macro.
+
+Each of the implementations (C90 and C99 with GNU extension) route the logging interface macros to a logging function (defined in [`iot_logging_task.h`](./include/iot_logging_task.h)) that pushes the message to the FreeRTOS queue, thereby serializing messages logged through the logging interfaces.
+
+### Setting the Verbosity Level
+To configure the verbosity level of log messages from a FreeRTOS library, define the `LIBRARY_LOG_LEVEL` macro to one of the following values in the library-specific configuration file (like `core_mqtt_config.h` for the coreMQTT library). Valid values for LIBRARY_LOG_LEVEL are:
+
+`LOG_NONE (turns logging off)`  
+`LOG_ERROR`  
+`LOG_WARN`  
+`LOG_INFO` 
+`LOG_DEBUG`
+
+For example:
+```
+#define LIBRARY_LOG_LEVEL  LOG_NONE
+```
+
+### Log Message Output
+
+The sample implementation adds some metadata information for debugging aid as prefix to the log message strings passed by FreeRTOS libraries and demos. Both the C90 and C99 implementations
+add the **task name**, **FreeRTOS timer tick count** and **incrementing counter value** to each log message. 
+
+#### ISO C90 Implementation
+
+This is the default enabled implementation of the logging interface in the library.
+
+If your compiler only supports the ISO C90 standard, the C90 implementation can be used by setting the `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION` configuration to `0`. (This is default implementation enabled in the library.)
+With the ISO C90 implementation, here is an example output of log messages for the MQTT Connection Sharing Demo:
+
+```
+83 2128 [SyncPublisher] [INFO] Publish operation complete. Sleeping for 100 ms.
+84 2140 [SyncPublisher] [INFO] Adding publish operation for message Hello World! Sync: 3
+on topic filter/sync/3
+85 2142 [SyncPublisher] [INFO] Waiting for publish 3 to complete.
+86 2168 [iot_thread] [INFO] Packet received. ReceivedBytes=2.
+87 2168 [iot_thread] [INFO] Ack packet deserialized with result: MQTTSuccess.
+88 2168 [iot_thread] [INFO] State record updated. New state=MQTTPublishDone.
+89 2170 [SyncPublisher] [INFO] Publish operation complete. Sleeping for 100 ms.
+90 2182 [SyncPublisher] [INFO] Adding publish operation for message Hello World! Sync: 4
+on topic filter/sync/4
+91 2184 [SyncPublisher] [INFO] Waiting for publish 4 to complete.
+92 2209 [iot_thread] [INFO] Packet received. ReceivedBytes=2.
+93 2209 [iot_thread] [INFO] Ack packet deserialized with result: MQTTSuccess.
+94 2209 [iot_thread] [INFO] State record updated. New state=MQTTPublishDone.
+95 2210 [SyncPublisher] [INFO] Publish operation complete. Sleeping for 100 ms.
+```
+
+
+#### ISO C99 Implementation (with GNU extension)
+
+This implementation uses variadic macros specified by the ISO C99 standard macros and [the GNU extension feature of comma elision](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/cpp/Variadic-Macros.html) with the `##` operator.
+If your toolchain supports both ISO C99 and GNU extension, you can enabled this implementation by setting the `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION` configuration.
+
+With the use of variadic macro feature of ISO C99, this implementation adds extra metadata information of the source library and file location of the log messages.
+**Note**: If you want to add/remove/change the metadata added, you can directly make changes in the [`logging_stack.h`](./include/logging_stack.h) file.
+
+#### Setting the Text Name
+To set the text name define the LIBRARY_LOG_NAME macro to a string within the same configuration file used to define SdkLog(). Each log message prints the name, so it is normal to set the name to the name of the library. For example:
+```
+#define LIBRARY_LOG_NAME “MQTT”
+```
+Setting the name to an empty string will save program space.
+
+Using this implementation. here is an example output of log messages for the MQTT Connection Sharing Demo:
+
+```
+78 1950 [iot_thread] [INFO] [MQTT] [core_mqtt.c:886] Packet received. ReceivedBytes=2.
+79 1950 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1162] Ack packet deserialized with result: MQTTSuccess.
+80 1951 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1175] State record updated. New state=MQTTPublishDone.
+81 1953 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1846] Publish operation complete. Sleeping for 100 ms.
+
+82 1953 [AsyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1970] Deleting Async Publisher task.
+83 1965 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1820] Adding publish operation for message Hello World! Sync: 3
+on topic filter/sync/3
+84 1967 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1832] Waiting for publish 3 to complete.
+85 1981 [iot_thread] [INFO] [MQTT] [core_mqtt.c:886] Packet received. ReceivedBytes=2.
+86 1981 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1162] Ack packet deserialized with result: MQTTSuccess.
+87 1982 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1175] State record updated. New state=MQTTPublishDone.
+88 1983 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1846] Publish operation complete. Sleeping for 100 ms.
+
+89 1995 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1820] Adding publish operation for message Hello World! Sync: 4
+```
+
+
+### The Logging Interface
+The FreeRTOS libraries use the following 4 logging macros, listed in increasing order of verbosity. For example, LogError() is only called when there is an error so is the least verbose, whereas LogDebug() is called more frequently to provide debug level information and is therefore the most verbose.
+
+LogError
+LogWarn
+LogInfo
+LogDebug
+Logging macros are used with a variable number of arguments, just like printf() (with the exception that they use double parenthesis). For example, the libraries call the logging macros in the following way:
+
+```
+LogInfo( ( “This prints an integer %d”, 100 ) );
+```

--- a/libraries/logging/README.md
+++ b/libraries/logging/README.md
@@ -1,9 +1,9 @@
 ## Sample Implementation of Logging Interface
 
-This library provides reference implementations of the [logging interface](#using-your-custom-implementation-of-logging-interface) that is used by FreeRTOS libraries and demos to generate log messages. This sample provides
+This sample provides reference implementations of the [logging interface](#using-your-custom-implementation-of-logging-interface) that is used by FreeRTOS libraries and demos to generate log messages. This sample provides
 implementations of the logging interface for both the ISO C90 and ISO C99 (with GNU extension) standards.
 
-The sample implementations add add metadata information of **task name**, **FreeRTOS timer tick count** and **incrementing counter value** as prefixes to each log message. Additionally, the ISO C99 implementation adds metadata information of the **library name** and **source file location** to each log message.
+The sample implementations add metadata information of **task name**, **FreeRTOS timer tick count** and **incrementing counter value** as prefixes to each log message. Additionally, the ISO C99 implementation adds metadata information of the **library name** and **source file location** to each log message.
 
 **Note**: Users can provide their own implementations of the logging interface to enable logging, if they choose to not use this implementation. Please refer [here](#using-your-custom-implementation-of-logging-interface) for more information.
 
@@ -78,7 +78,7 @@ LogInfo( ( “This prints an integer %d”, 100 ) );
 ```
 
 Your custom implementation of the logging interface needs to define these macros to
-map them to their logging implementation, depending on the logging levels you want to enable.  
+map them to your logging implementation, depending on the logging levels you want to enable.  
 Logging macros use format specifier and variable number of arguments, just like standard function, `printf`, but they use double parenthesis to support ISO C90 standard which should be taken care while defining them.
 
 If you have a thread safe printf function, LogInfo should be defined like

--- a/libraries/logging/README.md
+++ b/libraries/logging/README.md
@@ -5,13 +5,17 @@ implementations for both ISO C90 standard and ISO C99 standard (with GNU extensi
 
 **Note**: Users can provide their own implementations of the logging interface to enable logging, if they choose to not use this implementation.
 
+To enable logging using the sample implementation for a FreeRTOS library and/or demo, 
+* The logging level can be configured with the [`LIBRARY_LOG_LEVEL`](#setting-the-verbosity-level) configuration. Additionally, if using the ISO C99 (with GNU extension) implementation, the [`LIBRARY_LOG_NAME`](#setting-the-library-text-name) macro can also be defined to configure the library name.
+* The [`logging_stack.h`](./include/logging_stack.h) file must be included _after_ the above macro configurations in the FreeRTOS library-specific config file (like `core_mqtt_config.h` for coreMQTT library).
+
 ### Logging Task 
 Logging messages from multiple tasks are serialized with a FreeRTOS queue that is serviced by a daemon logging task. The daemon task reads log message strings from the queue and forwards them to the vendor-specific function through the `configPRINT` macro.
 
 Each of the implementations (C90 and C99 with GNU extension) route the logging interface macros to a logging function (defined in [`iot_logging_task.h`](./include/iot_logging_task.h)) that pushes the message to the FreeRTOS queue, thereby serializing messages logged through the logging interfaces.
 
 ### Setting the Verbosity Level
-To configure the verbosity level of log messages from a FreeRTOS library, define the `LIBRARY_LOG_LEVEL` macro to one of the following values in the library-specific configuration file (like `core_mqtt_config.h` for the coreMQTT library). Valid values for LIBRARY_LOG_LEVEL are:
+To configure the verbosity level of log messages from a FreeRTOS library, define the `LIBRARY_LOG_LEVEL` macro to one of the following values in the library-specific configuration file (like `core_mqtt_config.h` for the coreMQTT library). Valid values for `LIBRARY_LOG_LEVEL` are:
 
 `LOG_NONE (turns logging off)`  
 `LOG_ERROR`  
@@ -58,19 +62,19 @@ on topic filter/sync/4
 #### ISO C99 Implementation (with GNU extension)
 
 This implementation uses variadic macros specified by the ISO C99 standard macros and [the GNU extension feature of comma elision](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/cpp/Variadic-Macros.html) with the `##` operator.
-If your toolchain supports both ISO C99 and GNU extension, you can enabled this implementation by setting the `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION` configuration.
+If your toolchain supports both ISO C99 standard and GNU extension, you can enabled this implementation by setting the `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION` configuration to `1`.
 
 With the use of variadic macro feature of ISO C99, this implementation adds extra metadata information of the source library and file location of the log messages.
 **Note**: If you want to add/remove/change the metadata added, you can directly make changes in the [`logging_stack.h`](./include/logging_stack.h) file.
 
-#### Setting the Text Name
+#### Setting the Library Text Name
 To set the text name define the LIBRARY_LOG_NAME macro to a string within the same configuration file used to define SdkLog(). Each log message prints the name, so it is normal to set the name to the name of the library. For example:
 ```
 #define LIBRARY_LOG_NAME “MQTT”
 ```
 Setting the name to an empty string will save program space.
 
-Using this implementation. here is an example output of log messages for the MQTT Connection Sharing Demo:
+Using this implementation, following is an example output of log messages for the MQTT Connection Sharing Demo. Note that this additionally adds the library name (`[MQTT]`) and source file location (like `[core_mqtt.c:1175]`) in each log message.
 
 ```
 78 1950 [iot_thread] [INFO] [MQTT] [core_mqtt.c:886] Packet received. ReceivedBytes=2.

--- a/libraries/logging/include/iot_logging_task.h
+++ b/libraries/logging/include/iot_logging_task.h
@@ -45,19 +45,41 @@ BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
                                    UBaseType_t uxPriority,
                                    UBaseType_t uxQueueLength );
 
-typedef struct LoggingBufferData
-{
-    char * logBuffer;
-    size_t maxBufferLen;
-    size_t bufferLen;
-} LoggingBufferData_t;
+/**
+ * @brief Interface for logging message at Error level.
+ *
+ * This function adds a "[ERROR]" prefix to the
+ * log message to label it as an error.
+ */
+void vLoggingPrintfError( const char * pcFormat,
+                          ... );
 
-void acquireMutexForLogBuffer();
+/**
+ * @brief Interface for logging message at Warn level.
+ *
+ * This function adds a "[WARN]" prefix to the
+ * log message to label it as a warning.
+ */
+void vLoggingPrintfWarn( const char * pcFormat,
+                         ... );
 
-void releaseMutexOfLogBuffer();
+/**
+ * @brief Interface for logging message at Info level.
+ *
+ * This function adds a "[INFO]" prefix to the
+ * log message to label it as an informational message.
+ */
+void vLoggingPrintfInfo( const char * pcFormat,
+                         ... );
 
-void createLogMessage( const char * pcFormat,
-                       ... );
+/**
+ * @brief Interface for logging message at Debug level.
+ *
+ * This function adds a "[DEBUG]" prefix to the
+ * log message to label it as a debug level message.
+ */
+void vLoggingPrintfDebug( const char * pcFormat,
+                          ... );
 
 /**
  * @brief Interface to print via the logging interface.

--- a/libraries/logging/include/iot_logging_task.h
+++ b/libraries/logging/include/iot_logging_task.h
@@ -46,6 +46,18 @@ BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
                                    UBaseType_t uxQueueLength );
 
 /**
+ * @brief Interface to print via the logging interface.
+ *
+ * Uses the same semantics as printf().  How the print is performed depends on
+ * which files are being built.  Some vLoggingPrintf() implementations will
+ * output directly, others will use a logging task to allow log message to be
+ * output in the background should the output device be too slow for output to
+ * be performed inline.
+ */
+void vLoggingPrintf( const char * pcFormat,
+                     ... );
+
+/**
  * @brief Interface for logging message at Error level.
  *
  * This function adds a "[ERROR]" prefix to the
@@ -80,17 +92,5 @@ void vLoggingPrintfInfo( const char * pcFormat,
  */
 void vLoggingPrintfDebug( const char * pcFormat,
                           ... );
-
-/**
- * @brief Interface to print via the logging interface.
- *
- * Uses the same semantics as printf().  How the print is performed depends on
- * which files are being built.  Some vLoggingPrintf() implementations will
- * output directly, others will use a logging task to allow log message to be
- * output in the background should the output device be too slow for output to
- * be performed inline.
- */
-void vLoggingPrintf( const char * pcFormat,
-                     ... );
 
 #endif /* AWS_LOGGING_TASK_H */

--- a/libraries/logging/include/iot_logging_task.h
+++ b/libraries/logging/include/iot_logging_task.h
@@ -35,8 +35,6 @@
     #error "include FreeRTOS.h must appear in source files before include iot_logging_task.h"
 #endif
 
-#include "semphr.h"
-
 /**
  * @brief Initialization function for logging task.
  *
@@ -54,7 +52,9 @@ typedef struct LoggingBufferData
     size_t bufferLen;
 } LoggingBufferData_t;
 
-extern SemaphoreHandle_t xLogBufferMutex;
+void acquireMutexForLogBuffer();
+
+void releaseMutexOfLogBuffer();
 
 void createLogMessage( const char * pcFormat,
                        ... );

--- a/libraries/logging/include/iot_logging_task.h
+++ b/libraries/logging/include/iot_logging_task.h
@@ -35,6 +35,8 @@
     #error "include FreeRTOS.h must appear in source files before include iot_logging_task.h"
 #endif
 
+#include "semphr.h"
+
 /**
  * @brief Initialization function for logging task.
  *
@@ -44,6 +46,18 @@
 BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
                                    UBaseType_t uxPriority,
                                    UBaseType_t uxQueueLength );
+
+typedef struct LoggingBufferData
+{
+    char * logBuffer;
+    size_t maxBufferLen;
+    size_t bufferLen;
+} LoggingBufferData_t;
+
+extern SemaphoreHandle_t xLogBufferMutex;
+
+void createLogMessage( const char * pcFormat,
+                       ... );
 
 /**
  * @brief Interface to print via the logging interface.

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -77,7 +77,6 @@
     #define SdkLogWarn( message )            vLoggingPrintfWarn message
     #define SdkLogInfo( message )            vLoggingPrintfInfo message
     #define SdkLogDebug( message )           vLoggingPrintfDebug message
-    *
 #endif /* if defined( LOGGING_METADATA_WITH_C99_SUPPORT ) && ( LOGGING_METADATA_WITH_C99_SUPPORT == 1 ) */
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -43,7 +43,7 @@
 
 /* Macro to extract only the file name from file path to use for metadata in
  * log messages. */
-#ifdef _MSC_VER
+#if defined( _MSC_VER_ ) || defined( __ARMCC_VERSION )
     #define FILENAME           ( strrchr( __FILE__, '\\' ) ? strrchr( __FILE__, '\\' ) + 1 : __FILE__ )
 #else
     #define FILENAME           ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
@@ -62,8 +62,8 @@
 /* @cond DOXYGEN_IGNORE */
 #define SdkAssembledAndLog( metadata, message )                 \
     do { acquireMutexForLogBuffer(); createLogMessage metadata; \
-        createLogMessage message;  createLogMessage( "\r\n" );  \
-        releaseMutexOfLogBuffer(); } while( 0 )                 \
+         createLogMessage message;  createLogMessage( "\r\n" ); \
+         releaseMutexOfLogBuffer(); } while( 0 )                \
 /** @endcond */
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -30,6 +30,7 @@
 
 /* Include header for logging level macros. */
 #include "logging_levels.h"
+#include "iot_logging_task.h"
 
 /* FreeRTOS Include. */
 #include "FreeRTOS.h"
@@ -58,6 +59,15 @@
     #define SdkLog( string )
 #endif
 
+#define SdkAssembledAndLog( metadata, message )           \
+    do {                                                  \
+        xSemaphoreTake( xLogBufferMutex, portMAX_DELAY ); \
+        createLogMessage metadata;                        \
+        createLogMessage message;                         \
+        createLogMessage( "\r\n" );                       \
+        xSemaphoreGive( xLogBufferMutex );                \
+    } while( 0 )
+
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
 #if !defined( LIBRARY_LOG_LEVEL ) ||       \
     ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && \
@@ -71,28 +81,28 @@
 #else
     #if LIBRARY_LOG_LEVEL == LOG_DEBUG
         /* All log level messages will logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogInfo( message )     SdkLog( ( "[INFO] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogDebug( message )    SdkLog( ( "[DEBUG] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkAssembledAndLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogWarn( message )     SdkAssembledAndLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogInfo( message )     SdkAssembledAndLog( ( "[INFO] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogDebug( message )    SdkAssembledAndLog( ( "[DEBUG] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
 
     #elif LIBRARY_LOG_LEVEL == LOG_INFO
         /* Only INFO, WARNING and ERROR messages will be logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogInfo( message )     SdkLog( ( "[INFO] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkAssembledAndLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogWarn( message )     SdkAssembledAndLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogInfo( message )     SdkAssembledAndLog( ( "[INFO] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
         #define LogDebug( message )
 
     #elif LIBRARY_LOG_LEVEL == LOG_WARN
         /* Only WARNING and ERROR messages will be logged.*/
-        #define LogError( message )    SdkLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkAssembledAndLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
+        #define LogWarn( message )     SdkAssembledAndLog( ( "[WARN] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
         #define LogInfo( message )
         #define LogDebug( message )
 
     #elif LIBRARY_LOG_LEVEL == LOG_ERROR
         /* Only ERROR messages will be logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkAssembledAndLog( ( "[ERROR] [%s] "LOG_METADATA_FORMAT, LIBRARY_LOG_NAME, LOG_METADATA_ARGS ), message )
         #define LogWarn( message )
         #define LogInfo( message )
         #define LogDebug( message )

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -59,14 +59,12 @@
     #define SdkLog( string )
 #endif
 
-#define SdkAssembledAndLog( metadata, message ) \
-    do {                                        \
-        acquireMutexForLogBuffer();             \
-        createLogMessage metadata;              \
-        createLogMessage message;               \
-        createLogMessage( "\r\n" );             \
-        releaseMutexOfLogBuffer();              \
-    } while( 0 )
+/* @cond DOXYGEN_IGNORE */
+#define SdkAssembledAndLog( metadata, message )                 \
+    do { acquireMutexForLogBuffer(); createLogMessage metadata; \
+        createLogMessage message;  createLogMessage( "\r\n" );  \
+        releaseMutexOfLogBuffer(); } while( 0 )                 \
+/** @endcond */
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
 #if !defined( LIBRARY_LOG_LEVEL ) ||       \

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -30,10 +30,10 @@
 
 /* Include header for logging level macros. */
 #include "logging_levels.h"
-#include "iot_logging_task.h"
 
 /* FreeRTOS Include. */
 #include "FreeRTOS.h"
+#include "iot_logging_task.h"
 
 /* Standard Include. */
 #include <stdint.h>
@@ -59,13 +59,13 @@
     #define SdkLog( string )
 #endif
 
-#define SdkAssembledAndLog( metadata, message )           \
-    do {                                                  \
-        xSemaphoreTake( xLogBufferMutex, portMAX_DELAY ); \
-        createLogMessage metadata;                        \
-        createLogMessage message;                         \
-        createLogMessage( "\r\n" );                       \
-        xSemaphoreGive( xLogBufferMutex );                \
+#define SdkAssembledAndLog( metadata, message ) \
+    do {                                        \
+        acquireMutexForLogBuffer();             \
+        createLogMessage metadata;              \
+        createLogMessage message;               \
+        createLogMessage( "\r\n" );             \
+        releaseMutexOfLogBuffer();              \
     } while( 0 )
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -63,15 +63,14 @@
         #define FILENAME    ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
     #endif
 
-
     #define SdkLogError( message )           SdkLogErrorC99 message
-    #define SdkLogErrorC99( format, ... )    SdkLog( ( "[ERROR] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ ) )
+    #define SdkLogErrorC99( format, ... )    vLoggingPrintf( "[ERROR] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
     #define SdkLogWarn( message )            SdkLogWarnC99 message
-    #define SdkLogWarnC99( format, ... )     SdkLog( ( "[WARN] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ ) )
+    #define SdkLogWarnC99( format, ... )     vLoggingPrintf( "[WARN] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
     #define SdkLogInfo( message )            SdkLogInfoC99 message
-    #define SdkLogInfoC99( format, ... )     SdkLog( ( "[INFO] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ ) )
+    #define SdkLogInfoC99( format, ... )     vLoggingPrintf( "[INFO] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
     #define SdkLogDebug( message )           SdkLogDebugC99 message
-    #define SdkLogDebugC99( format, ... )    SdkLog( ( "[DEBUG] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ ) )
+    #define SdkLogDebugC99( format, ... )    vLoggingPrintf( "[DEBUG] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
 #else /* if LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION == 1 */
     #define SdkLogError( message )           vLoggingPrintfError message
     #define SdkLogWarn( message )            vLoggingPrintfWarn message

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -230,7 +230,7 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
         /* Add newline characters if the message does not end with them.*/
         ulFormatLen = strlen( pcFormat );
 
-        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, 2, "\r\n" ) != 0 ) )
+        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
         {
             xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "%s", "\r\n" );
         }

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -285,6 +285,8 @@ void vLoggingPrintfInfo( const char * pcFormat,
 
     va_start( args, pcFormat );
     prvLoggingPrintfCommon( LOG_INFO, pcFormat, args );
+
+    va_end( args );
 }
 
 void vLoggingPrintfDebug( const char * pcFormat,

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -152,13 +152,23 @@ void createLogMessage( const char * pcFormat,
     va_list args;
 
     configASSERT( pcFormat != NULL );
-    configASSERT( logBufferIndex < sizeof( logMessageBuffer ) );
 
-    /* There are a variable number of parameters. */
-    va_start( args, pcFormat );
+    /* If the buffer is completely filled with log message, we will just add new line
+     * endings to the buffer. */
+    if( logBufferIndex >= sizeof( logMessageBuffer ) )
+    {
+        logBufferIndex = sizeof( logMessageBuffer ) - 1;
+        logMessageBuffer[ logBufferIndex ] = '\r';
+        logMessageBuffer[ logBufferIndex ] = '\n';
+    }
+    else
+    {
+        /* There are a variable number of parameters. */
+        va_start( args, pcFormat );
 
-    /* Populate string into the log buffer. */
-    logBufferIndex += vsnprintf( logMessageBuffer + logBufferIndex, configLOGGING_MAX_MESSAGE_LENGTH - logBufferIndex, pcFormat, args );
+        /* Populate string into the log buffer. */
+        logBufferIndex += vsnprintf( logMessageBuffer + logBufferIndex, configLOGGING_MAX_MESSAGE_LENGTH - logBufferIndex, pcFormat, args );
+    }
 
     /* If input is line ending, then we are at the end of the log message. */
     if( ( strlen( pcFormat ) >= 2UL ) && ( strcmp( pcFormat + strlen( pcFormat ) - 2, "\r\n" ) == 0U ) )

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -141,6 +141,7 @@ static void prvLoggingPrintfCommon( uint8_t usLoggingLevel,
 
     configASSERT( usLoggingLevel <= LOG_DEBUG );
     configASSERT( pcFormat != NULL );
+    configASSERT( configLOGGING_MAX_MESSAGE_LENGTH > 0 );
 
     /* The queue is created by xLoggingTaskInitialize().  Check
      * xLoggingTaskInitialize() has been called. */
@@ -206,6 +207,7 @@ static void prvLoggingPrintfCommon( uint8_t usLoggingLevel,
         if( pcLevelString != NULL )
         {
             xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s] ", pcLevelString );
+            configASSERT( xLength > 0 );
         }
 
         xLength2 = vsnprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, pcFormat, args );
@@ -232,6 +234,7 @@ static void prvLoggingPrintfCommon( uint8_t usLoggingLevel,
         if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
         {
             xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "%s", "\r\n" );
+            configASSERT( xLength > 0 );
         }
 
         /* Only send the buffer to the logging task if it is
@@ -267,6 +270,8 @@ void vLoggingPrintfError( const char * pcFormat,
     va_end( args );
 }
 
+/*-----------------------------------------------------------*/
+
 void vLoggingPrintfWarn( const char * pcFormat,
                          ... )
 {
@@ -278,6 +283,8 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_end( args );
 }
 
+/*-----------------------------------------------------------*/
+
 void vLoggingPrintfInfo( const char * pcFormat,
                          ... )
 {
@@ -288,6 +295,8 @@ void vLoggingPrintfInfo( const char * pcFormat,
 
     va_end( args );
 }
+
+/*-----------------------------------------------------------*/
 
 void vLoggingPrintfDebug( const char * pcFormat,
                           ... )

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -131,9 +131,9 @@ static void prvLoggingTask( void * pvParameters )
 
 /*-----------------------------------------------------------*/
 
-static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
-                                  const char * pcFormat,
-                                  va_list args )
+static void prvLoggingPrintfCommon( uint8_t usLoggingLevel,
+                                    const char * pcFormat,
+                                    va_list args )
 {
     size_t xLength = 0;
     int32_t xLength2 = 0;
@@ -188,7 +188,7 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
         switch( usLoggingLevel )
         {
             case LOG_ERROR:
-                pcLevelString = "ERROR ";
+                pcLevelString = "ERROR";
                 break;
 
             case LOG_WARN:
@@ -263,7 +263,7 @@ void vLoggingPrintfError( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    vLoggingPrintfCommon( LOG_ERROR, pcFormat, args );
+    prvLoggingPrintfCommon( LOG_ERROR, pcFormat, args );
 
     va_end( args );
 }
@@ -274,7 +274,7 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    vLoggingPrintfCommon( LOG_WARN, pcFormat, args );
+    prvLoggingPrintfCommon( LOG_WARN, pcFormat, args );
 
     va_end( args );
 }
@@ -285,7 +285,7 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    vLoggingPrintfCommon( LOG_INFO, pcFormat, args );
+    prvLoggingPrintfCommon( LOG_INFO, pcFormat, args );
 }
 
 void vLoggingPrintfDebug( const char * pcFormat,
@@ -294,7 +294,7 @@ void vLoggingPrintfDebug( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    vLoggingPrintfCommon( LOG_DEBUG, pcFormat, args );
+    prvLoggingPrintfCommon( LOG_DEBUG, pcFormat, args );
 
     va_end( args );
 }
@@ -316,7 +316,7 @@ void vLoggingPrintf( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    vLoggingPrintfCommon( LOG_NONE, pcFormat, args );
+    prvLoggingPrintfCommon( LOG_NONE, pcFormat, args );
 
     va_end( args );
 }

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -152,8 +152,8 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
     if( pcPrintString != NULL )
     {
         static BaseType_t xEndOfMessage = pdTRUE;
-        size_t ulFormatStrLen = 0UL;
         const char * pcLevelString = NULL;
+        size_t ulFormatLen = 0UL;
 
         /* Add metadata of task name and tick time for a new log message. */
         if( strcmp( pcFormat, "\n" ) != 0 )
@@ -184,6 +184,7 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
             #endif /* if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 ) */
         }
 
+        /* Choose the string for the log level metadata for the log message. */
         switch( usLoggingLevel )
         {
             case LOG_ERROR:
@@ -202,6 +203,7 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
                 pcLevelString = "DEBUG";
         }
 
+        /* Add the chosen log level information as prefix for the message. */
         if( pcLevelString != NULL )
         {
             xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s] ", pcLevelString );
@@ -224,6 +226,14 @@ static void vLoggingPrintfCommon( uint8_t usLoggingLevel,
         }
 
         xLength += ( size_t ) xLength2;
+
+        /* Add newline characters if the message does not end with them.*/
+        ulFormatLen = strlen( pcFormat );
+
+        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, 2, "\r\n" ) != 0 ) )
+        {
+            xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "%s", "\r\n" );
+        }
 
         /* Only send the buffer to the logging task if it is
          * not empty. */

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -130,7 +130,7 @@ static void prvLoggingTask( void * pvParameters )
         if( xQueueReceive( xQueue, &pcReceivedString, portMAX_DELAY ) == pdPASS )
         {
             configPRINT_STRING( pcReceivedString );
-            
+
             vPortFree( ( void * ) pcReceivedString );
         }
     }
@@ -168,7 +168,7 @@ void createLogMessage( const char * pcFormat,
         /* Populate string into the log buffer. */
         logBufferIndex += vsnprintf( logMessageBuffer + logBufferIndex, configLOGGING_MAX_MESSAGE_LENGTH - logBufferIndex, pcFormat, args );
 
-        va_end(args);
+        va_end( args );
     }
 
     /* If input is line ending, the log message string has been completely generated. */
@@ -215,32 +215,32 @@ void vLoggingPrintf( const char * pcFormat,
         va_start( args, pcFormat );
 
         /* Add metadata of task name and tick time for a new log message. */
-        if ( strcmp( pcFormat, "\n" ) != 0 ) 
+        if( strcmp( pcFormat, "\n" ) != 0 )
         {
             /* Add metadata of task name and tick count if config is enabled. */
             #if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 )
-            {
-                const char * pcTaskName;
-                const char * pcNoTask = "None";
-                static BaseType_t xMessageNumber = 0;
-
-                /* Add a time stamp and the name of the calling task to the
-                * start of the log. */
-                if( xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED )
                 {
-                    pcTaskName = pcTaskGetName( NULL );
-                }
-                else
-                {
-                    pcTaskName = pcNoTask;
-                }
+                    const char * pcTaskName;
+                    const char * pcNoTask = "None";
+                    static BaseType_t xMessageNumber = 0;
 
-                xLength += snprintf( pcPrintString, configLOGGING_MAX_MESSAGE_LENGTH, "%lu %lu [%s] ",
-                                ( unsigned long ) xMessageNumber++,
-                                ( unsigned long ) xTaskGetTickCount(),
-                                pcTaskName );
-            }
-            #endif
+                    /* Add a time stamp and the name of the calling task to the
+                     * start of the log. */
+                    if( xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED )
+                    {
+                        pcTaskName = pcTaskGetName( NULL );
+                    }
+                    else
+                    {
+                        pcTaskName = pcNoTask;
+                    }
+
+                    xLength += snprintf( pcPrintString, configLOGGING_MAX_MESSAGE_LENGTH, "%lu %lu [%s] ",
+                                         ( unsigned long ) xMessageNumber++,
+                                         ( unsigned long ) xTaskGetTickCount(),
+                                         pcTaskName );
+                }
+            #endif /* if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 ) */
         }
 
         xLength2 = vsnprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, pcFormat, args );

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -153,12 +153,16 @@ void vLoggingPrintf( const char * pcFormat,
 
     if( pcPrintString != NULL )
     {
-        static BaseType_t xEndOfMessage = pdFALSE;
+        /* Variable to track when a stream of log message is completed. */
+        /* Note: A log message may be sent over multiple calls to vLoggingPrintf, thus, */
+        /* this variable tracks when the log message ends. */
+        static BaseType_t xEndOfMessage = pdTRUE;
         size_t ulFormatStrLen = 0UL;
 
         /* There are a variable number of parameters. */
         va_start( args, pcFormat );
 
+        /* Add metadata of task name and tick time for a new log message. */
         if( ( strcmp( pcFormat, "\n" ) != 0 ) && ( xEndOfMessage == pdTRUE ) )
         {
             #if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 )
@@ -192,7 +196,8 @@ void vLoggingPrintf( const char * pcFormat,
 
         ulFormatStrLen = strlen( pcFormat );
 
-        /* Look for new line character in message to detect if the log message has ended. */
+        /* Look for new line character in message to detect if the log message has ended.
+        * This is done to ensure that the metadata is added only once per log message. */
         if( ( ulFormatStrLen >= 2UL ) && ( strcmp( pcFormat + ulFormatStrLen - 2, "\r\n" ) == 0U ) )
         {
             xEndOfMessage = pdTRUE;

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -153,10 +153,13 @@ void vLoggingPrintf( const char * pcFormat,
 
     if( pcPrintString != NULL )
     {
+        static BaseType_t xEndOfMessage = pdFALSE;
+        size_t ulFormatStrLen = 0UL;
+
         /* There are a variable number of parameters. */
         va_start( args, pcFormat );
 
-        if( strcmp( pcFormat, "\n" ) != 0 )
+        if( ( strcmp( pcFormat, "\n" ) != 0 ) && ( xEndOfMessage == pdTRUE ) )
         {
             #if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 )
                 {
@@ -185,6 +188,18 @@ void vLoggingPrintf( const char * pcFormat,
                     xLength = 0;
                 }
             #endif /* if ( configLOGGING_INCLUDE_TIME_AND_TASK_NAME == 1 ) */
+        }
+
+        ulFormatStrLen = strlen( pcFormat );
+
+        /* Look for new line character in message to detect if the log message has ended. */
+        if( ( ulFormatStrLen >= 2UL ) && ( strcmp( pcFormat + ulFormatStrLen - 2, "\r\n" ) ) )
+        {
+            xEndOfMessage = pdTRUE;
+        }
+        else
+        {
+            xEndOfMessage = pfFALSE;
         }
 
         xLength2 = vsnprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, pcFormat, args );

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -199,7 +199,7 @@ void vLoggingPrintf( const char * pcFormat,
         }
         else
         {
-            xEndOfMessage = pfFALSE;
+            xEndOfMessage = pdFALSE;
         }
 
         xLength2 = vsnprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, pcFormat, args );

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -151,7 +151,6 @@ static void prvLoggingPrintfCommon( uint8_t usLoggingLevel,
 
     if( pcPrintString != NULL )
     {
-        static BaseType_t xEndOfMessage = pdTRUE;
         const char * pcLevelString = NULL;
         size_t ulFormatLen = 0UL;
 

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -195,7 +195,7 @@ void createLogMessage( const char * pcFormat,
                                                                    sizeof( logMessageBuffer ) );
             #endif
 
-            newLogMessage == pdFALSE;
+            newLogMessage = pdFALSE;
         }
 
         /* There are a variable number of parameters. */

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -193,7 +193,7 @@ void vLoggingPrintf( const char * pcFormat,
         ulFormatStrLen = strlen( pcFormat );
 
         /* Look for new line character in message to detect if the log message has ended. */
-        if( ( ulFormatStrLen >= 2UL ) && ( strcmp( pcFormat + ulFormatStrLen - 2, "\r\n" ) ) )
+        if( ( ulFormatStrLen >= 2UL ) && ( strcmp( pcFormat + ulFormatStrLen - 2, "\r\n" ) == 0U ) )
         {
             xEndOfMessage = pdTRUE;
         }

--- a/libraries/logging/iot_logging_task_dynamic_buffers.c
+++ b/libraries/logging/iot_logging_task_dynamic_buffers.c
@@ -157,9 +157,9 @@ void createLogMessage( const char * pcFormat,
      * endings to the buffer. */
     if( logBufferIndex >= sizeof( logMessageBuffer ) )
     {
+        logMessageBuffer[ sizeof( logMessageBuffer ) - 2 ] = '\r';
+        logMessageBuffer[ sizeof( logMessageBuffer ) - 1 ] = '\n';
         logBufferIndex = sizeof( logMessageBuffer ) - 1;
-        logMessageBuffer[ logBufferIndex ] = '\r';
-        logMessageBuffer[ logBufferIndex ] = '\n';
     }
     else
     {

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSConfig.h
@@ -422,4 +422,12 @@
     #define UNTESTED_FUNCTION()
 #endif
 
+/* This config enables extra verbosity in log messages with metadata information
+ * about the source library and location of the log message.
+ * This requires that the toolchain support C99 (for variadic macros) and the GNU
+ * extension for comma elision in variadic macros (with ##__VA_ARGS__).
+ * If this flag is enabled, you can change the metadata information from the logging_stack.h
+ * file.*/
+#define LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION    ( 1 )
+
 #endif /* #define FREERTOS_CONFIG_H */

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -52,6 +52,7 @@
 
 /* Demo includes. */
 #include "aws_demo_logging.h"
+#include "logging_levels.h"
 
 /*-----------------------------------------------------------*/
 
@@ -284,18 +285,60 @@ void vLoggingPrintf( const char * pcFormat,
     va_list xArgs;
 
     va_start( xArgs, pcFormat );
-    prvLoggingPrintf( pdTRUE, pcFormat, xArgs );
+    prvLoggingPrintf( LOG_NONE, pdTRUE, pcFormat, xArgs );
     va_end( xArgs );
 }
 /*-----------------------------------------------------------*/
 
 void vLoggingPrint( const char * pcFormat )
 {
-    prvLoggingPrintf( pdFALSE, pcFormat, NULL );
+    prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
+}
+void vLoggingPrintfError( const char * pcFormat,
+                          ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_ERROR, pcFormat, args );
+
+    va_end( args );
+}
+
+void vLoggingPrintfWarn( const char * pcFormat,
+                         ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_WARN, pcFormat, args );
+
+    va_end( args );
+}
+
+void vLoggingPrintfInfo( const char * pcFormat,
+                         ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_INFO, pcFormat, args );
+}
+
+void vLoggingPrintfDebug( const char * pcFormat,
+                          ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_DEBUG, pcFormat, args );
+
+    va_end( args );
 }
 /*-----------------------------------------------------------*/
 
-static void prvLoggingPrintf( BaseType_t xFormatted,
+static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs )
 {
@@ -310,6 +353,8 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
     const char * pcNoTask = "None";
     int iOriginalPriority;
     HANDLE xCurrentTask;
+    const char * pcLevelString = NULL;
+    size_t ulFormatLen = 0UL;
 
     if( ( xStdoutLoggingUsed != pdFALSE ) ||
         ( xDiskFileLoggingUsed != pdFALSE ) ||
@@ -325,8 +370,7 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
             pcTaskName = pcNoTask;
         }
 
-        if( ( xAfterLineBreak == pdTRUE ) &&
-            ( strcmp( pcFormat, "\r\n" ) != 0 ) &&
+        if( ( strcmp( pcFormat, "\r\n" ) != 0 ) &&
             ( xFormatted != pdFALSE ) )
         {
             xLength = snprintf( cPrintString,
@@ -335,13 +379,36 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
                                 xMessageNumber++,
                                 ( unsigned long ) xTaskGetTickCount(),
                                 pcTaskName );
-            xAfterLineBreak = pdFALSE;
         }
         else
         {
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
-            xAfterLineBreak = pdTRUE;
+        }
+
+        /* Choose the string for the log level metadata for the log message. */
+        switch( usLoggingLevel )
+        {
+            case LOG_ERROR:
+                pcLevelString = "ERROR";
+                break;
+
+            case LOG_WARN:
+                pcLevelString = "WARN";
+                break;
+
+            case LOG_INFO:
+                pcLevelString = "INFO";
+                break;
+
+            case LOG_DEBUG:
+                pcLevelString = "DEBUG";
+        }
+
+        /* Add the chosen log level information as prefix for the message. */
+        if( pcLevelString != NULL )
+        {
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s] ", pcLevelString );
         }
 
         if( xArgs != NULL )
@@ -351,22 +418,23 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
                                   pcFormat,
                                   xArgs );
         }
-        else
-        {
-            xLength2 = snprintf( cPrintString + xLength,
-                                 dlMAX_PRINT_STRING_LENGTH - xLength,
-                                 "%s",
-                                 pcFormat );
-        }
 
         if( xLength2 < 0 )
         {
             /* Clean up. */
-            xLength2 = sizeof( cPrintString ) - 1 - xLength;
-            cPrintString[ sizeof( cPrintString ) - 1 ] = '\0';
+            xLength2 = 0;
+            cPrintString[ xLength ] = '\0';
         }
 
         xLength += xLength2;
+
+        /* Add newline characters if the message does not end with them.*/
+        ulFormatLen = strlen( pcFormat );
+
+        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
+        {
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "%s", "\r\n" );
+        }
 
         /* For ease of viewing, copy the string into another buffer, converting
          * IP addresses to dot notation on the way. */

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -118,7 +118,8 @@ static void prvCreatePrintSocket( void * pvParameter1,
  * Write a messages to stdout, either with or without a time-stamp.
  * A Windows thread will finally call printf() and fflush().
  */
-static void prvLoggingPrintf( BaseType_t xFormatted,
+static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs );
 
@@ -294,13 +295,15 @@ void vLoggingPrint( const char * pcFormat )
 {
     prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
 }
+
+/*-----------------------------------------------------------*/
 void vLoggingPrintfError( const char * pcFormat,
                           ... )
 {
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_ERROR, pcFormat, args );
+    prvLoggingPrintf( LOG_ERROR, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -311,7 +314,7 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_WARN, pcFormat, args );
+    prvLoggingPrintf( LOG_WARN, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -322,7 +325,7 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_INFO, pcFormat, args );
+    prvLoggingPrintf( LOG_INFO, pdTRUE, pcFormat, args );
 }
 
 void vLoggingPrintfDebug( const char * pcFormat,
@@ -331,7 +334,7 @@ void vLoggingPrintfDebug( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_DEBUG, pcFormat, args );
+    prvLoggingPrintf( LOG_DEBUG, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -347,7 +350,6 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, xLength2, rc;
     static BaseType_t xMessageNumber = 0;
-    static BaseType_t xAfterLineBreak = pdTRUE;
     uint32_t ulIPAddress;
     const char * pcTaskName;
     const char * pcNoTask = "None";

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -289,6 +289,7 @@ void vLoggingPrintf( const char * pcFormat,
     prvLoggingPrintf( LOG_NONE, pdTRUE, pcFormat, xArgs );
     va_end( xArgs );
 }
+
 /*-----------------------------------------------------------*/
 
 void vLoggingPrint( const char * pcFormat )
@@ -297,6 +298,7 @@ void vLoggingPrint( const char * pcFormat )
 }
 
 /*-----------------------------------------------------------*/
+
 void vLoggingPrintfError( const char * pcFormat,
                           ... )
 {
@@ -307,6 +309,8 @@ void vLoggingPrintfError( const char * pcFormat,
 
     va_end( args );
 }
+
+/*-----------------------------------------------------------*/
 
 void vLoggingPrintfWarn( const char * pcFormat,
                          ... )
@@ -319,6 +323,8 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_end( args );
 }
 
+/*-----------------------------------------------------------*/
+
 void vLoggingPrintfInfo( const char * pcFormat,
                          ... )
 {
@@ -327,6 +333,8 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_start( args, pcFormat );
     prvLoggingPrintf( LOG_INFO, pdTRUE, pcFormat, args );
 }
+
+/*-----------------------------------------------------------*/
 
 void vLoggingPrintfDebug( const char * pcFormat,
                           ... )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.h
@@ -30,7 +30,7 @@
  * threads.  Do not call printf() directly while the scheduler is running.
  *
  * Set xLogToStdout, xLogToFile and xLogToUDP to either pdTRUE or pdFALSE to
- * lot to stdout, a disk file and a UDP port respectively.
+ * log to stdout, a disk file and a UDP port respectively.
  *
  * If xLogToUDP is pdTRUE then ulRemoteIPAddress and usRemotePort must be set
  * to the IP address and port number to which UDP log messages will be sent.
@@ -40,5 +40,67 @@ void vLoggingInit( BaseType_t xLogToStdout,
                    BaseType_t xLogToUDP,
                    uint32_t ulRemoteIPAddress,
                    uint16_t usRemotePort );
+
+/**
+ * @brief Printf like logging interface for logging in
+ * from FreeRTOS tasks in the Windows platform.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrint( const char * pcFormat );
+
+/**
+ * @brief Interface for logging message at Error level.
+ *
+ * This function adds a "[ERROR]" prefix to the
+ * log message to label it as an error.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfError( const char * pcFormat,
+                          ... );
+
+/**
+ * @brief Interface for logging message at Warn level.
+ *
+ * This function adds a "[WARN]" prefix to the
+ * log message to label it as a warning.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfWarn( const char * pcFormat,
+                         ... );
+
+/**
+ * @brief Interface for logging message at Info level.
+ *
+ * This function adds a "[INFO]" prefix to the
+ * log message to label it as an informational message.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfInfo( const char * pcFormat,
+                         ... );
+
+/**
+ * @brief Interface for logging message at Debug level.
+ *
+ * This function adds a "[DEBUG]" prefix to the
+ * log message to label it as a debug level message.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfDebug( const char * pcFormat,
+                          ... );
 
 #endif /* AWS_DEMO_LOGGING_H */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
@@ -213,4 +213,12 @@
  * take up unnecessary RAM. */
 #define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
 
+/* This config enables extra verbosity in log messages with metadata information
+ * about the source library and location of the log message.
+ * This requires that the toolchain support C99 (for variadic macros) and the GNU
+ * extension for comma elision in variadic macros (with ##__VA_ARGS__).
+ * If this flag is enabled, you can change the metadata information from the logging_stack.h
+ * file.*/
+#define LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION    ( 1 ) 
+
 #endif /* FREERTOS_CONFIG_H */

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -52,6 +52,7 @@
 
 /* Demo includes. */
 #include "aws_demo_logging.h"
+#include "logging_levels.h"
 
 /*-----------------------------------------------------------*/
 
@@ -284,18 +285,62 @@ void vLoggingPrintf( const char * pcFormat,
     va_list xArgs;
 
     va_start( xArgs, pcFormat );
-    prvLoggingPrintf( pdTRUE, pcFormat, xArgs );
+    prvLoggingPrintf( LOG_NONE, pdTRUE, pcFormat, xArgs );
     va_end( xArgs );
 }
 /*-----------------------------------------------------------*/
 
 void vLoggingPrint( const char * pcFormat )
 {
-    prvLoggingPrintf( pdFALSE, pcFormat, NULL );
+    prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
 }
+
+void vLoggingPrintfError( const char * pcFormat,
+                          ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_ERROR, pcFormat, args );
+
+    va_end( args );
+}
+
+void vLoggingPrintfWarn( const char * pcFormat,
+                         ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_WARN, pcFormat, args );
+
+    va_end( args );
+}
+
+void vLoggingPrintfInfo( const char * pcFormat,
+                         ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_INFO, pcFormat, args );
+}
+
+void vLoggingPrintfDebug( const char * pcFormat,
+                          ... )
+{
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_DEBUG, pcFormat, args );
+
+    va_end( args );
+}
+
 /*-----------------------------------------------------------*/
 
-static void prvLoggingPrintf( BaseType_t xFormatted,
+static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs )
 {
@@ -304,12 +349,13 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, xLength2, rc;
     static BaseType_t xMessageNumber = 0;
-    static BaseType_t xAfterLineBreak = pdTRUE;
     uint32_t ulIPAddress;
     const char * pcTaskName;
     const char * pcNoTask = "None";
     int iOriginalPriority;
     HANDLE xCurrentTask;
+    const char * pcLevelString = NULL;
+    size_t ulFormatLen = 0UL;
 
     if( ( xStdoutLoggingUsed != pdFALSE ) ||
         ( xDiskFileLoggingUsed != pdFALSE ) ||
@@ -325,8 +371,7 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
             pcTaskName = pcNoTask;
         }
 
-        if( ( xAfterLineBreak == pdTRUE ) &&
-            ( strcmp( pcFormat, "\r\n" ) != 0 ) &&
+        if( ( strcmp( pcFormat, "\r\n" ) != 0 ) &&
             ( xFormatted != pdFALSE ) )
         {
             xLength = snprintf( cPrintString,
@@ -335,13 +380,36 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
                                 xMessageNumber++,
                                 ( unsigned long ) xTaskGetTickCount(),
                                 pcTaskName );
-            xAfterLineBreak = pdFALSE;
         }
         else
         {
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
-            xAfterLineBreak = pdTRUE;
+        }
+
+        /* Choose the string for the log level metadata for the log message. */
+        switch( usLoggingLevel )
+        {
+            case LOG_ERROR:
+                pcLevelString = "ERROR";
+                break;
+
+            case LOG_WARN:
+                pcLevelString = "WARN";
+                break;
+
+            case LOG_INFO:
+                pcLevelString = "INFO";
+                break;
+
+            case LOG_DEBUG:
+                pcLevelString = "DEBUG";
+        }
+
+        /* Add the chosen log level information as prefix for the message. */
+        if( pcLevelString != NULL )
+        {
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s] ", pcLevelString );
         }
 
         if( xArgs != NULL )
@@ -351,22 +419,23 @@ static void prvLoggingPrintf( BaseType_t xFormatted,
                                   pcFormat,
                                   xArgs );
         }
-        else
-        {
-            xLength2 = snprintf( cPrintString + xLength,
-                                 dlMAX_PRINT_STRING_LENGTH - xLength,
-                                 "%s",
-                                 pcFormat );
-        }
 
         if( xLength2 < 0 )
         {
             /* Clean up. */
-            xLength2 = sizeof( cPrintString ) - 1 - xLength;
-            cPrintString[ sizeof( cPrintString ) - 1 ] = '\0';
+            xLength2 = 0;
+            cPrintString[ xLength ] = '\0';
         }
 
         xLength += xLength2;
+
+        /* Add newline characters if the message does not end with them.*/
+        ulFormatLen = strlen( pcFormat );
+
+        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
+        {
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "%s", "\r\n" );
+        }
 
         /* For ease of viewing, copy the string into another buffer, converting
          * IP addresses to dot notation on the way. */

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -118,7 +118,8 @@ static void prvCreatePrintSocket( void * pvParameter1,
  * Write a messages to stdout, either with or without a time-stamp.
  * A Windows thread will finally call printf() and fflush().
  */
-static void prvLoggingPrintf( BaseType_t xFormatted,
+static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs );
 
@@ -301,7 +302,7 @@ void vLoggingPrintfError( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_ERROR, pcFormat, args );
+    prvLoggingPrintf( LOG_ERROR, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -312,7 +313,7 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_WARN, pcFormat, args );
+    prvLoggingPrintf( LOG_WARN, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -323,7 +324,9 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_INFO, pcFormat, args );
+    prvLoggingPrintf( LOG_INFO, pdTRUE, pcFormat, args );
+
+    va_end( args );
 }
 
 void vLoggingPrintfDebug( const char * pcFormat,
@@ -332,7 +335,7 @@ void vLoggingPrintfDebug( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_DEBUG, pcFormat, args );
+    prvLoggingPrintf( LOG_DEBUG, pdTRUE, pcFormat, args );
 
     va_end( args );
 }

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -296,6 +296,8 @@ void vLoggingPrint( const char * pcFormat )
     prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
 }
 
+/*-----------------------------------------------------------*/
+
 void vLoggingPrintfError( const char * pcFormat,
                           ... )
 {
@@ -306,6 +308,8 @@ void vLoggingPrintfError( const char * pcFormat,
 
     va_end( args );
 }
+
+/*-----------------------------------------------------------*/
 
 void vLoggingPrintfWarn( const char * pcFormat,
                          ... )
@@ -318,6 +322,8 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_end( args );
 }
 
+/*-----------------------------------------------------------*/
+
 void vLoggingPrintfInfo( const char * pcFormat,
                          ... )
 {
@@ -328,6 +334,8 @@ void vLoggingPrintfInfo( const char * pcFormat,
 
     va_end( args );
 }
+
+/*-----------------------------------------------------------*/
 
 void vLoggingPrintfDebug( const char * pcFormat,
                           ... )

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.h
@@ -41,4 +41,66 @@ void vLoggingInit( BaseType_t xLogToStdout,
                    uint32_t ulRemoteIPAddress,
                    uint16_t usRemotePort );
 
+/**
+ * @brief Printf like logging interface for logging in
+ * from FreeRTOS tasks in the Windows platform.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrint( const char * pcFormat );
+
+/**
+ * @brief Interface for logging message at Error level.
+ *
+ * This function adds a "[ERROR]" prefix to the
+ * log message to label it as an error.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfError( const char * pcFormat,
+                          ... );
+
+/**
+ * @brief Interface for logging message at Warn level.
+ *
+ * This function adds a "[WARN]" prefix to the
+ * log message to label it as a warning.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfWarn( const char * pcFormat,
+                         ... );
+
+/**
+ * @brief Interface for logging message at Info level.
+ *
+ * This function adds a "[INFO]" prefix to the
+ * log message to label it as an informational message.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfInfo( const char * pcFormat,
+                         ... );
+
+/**
+ * @brief Interface for logging message at Debug level.
+ *
+ * This function adds a "[DEBUG]" prefix to the
+ * log message to label it as a debug level message.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ */
+void vLoggingPrintfDebug( const char * pcFormat,
+                          ... );
+
 #endif /* AWS_DEMO_LOGGING_H */


### PR DESCRIPTION
### Problem

#### Problem 1: Metadata is duplicated in log messages
With the refactored libraries using the new logging macros (`LogError`, `LogInfo`, `LogWarn`, `LogDebug`), the log messages from the libraries contain duplication of task name and tick count metadata which makes the log messages non-readable. The cause of the metadata repetition is that each of the `LogXXXX` calls results in 3 calls to `vLoggingPrintf`, due to which the metadata is repeated in each call. 
Here is an example of logs from the `coreMQTT` library when running the `core_mqtt_mutual_auth` demo:
```
[INFO] [MQTT] [core_mqtt.c:886] 4 34300 [iot_thread] Packet received. ReceivedBytes=2.5 34302 [iot_thread] 
[INFO] [MQTT] [core_mqtt_serializer.c:970] 6 34308 [iot_thread] CONNACK session present bit not set.7 34310 [iot_thread] 
[INFO] [MQTT] [core_mqtt_serializer.c:912] 8 34314 [iot_thread] Connection accepted.9 34316 [iot_thread] 
[INFO] [MQTT] [core_mqtt.c:1563] 10 34322 [iot_thread] Received MQTT CONNACK successfully from broker.11 34324 [iot_thread] 
[INFO] [MQTT] [core_mqtt.c:1829] 12 34328 [iot_thread] MQTT connection established with the broker.13 34332 [iot_thread] 
```

#### Problem 2: Log messages are out-of-order when `LogXXXX` macros are called in multi-threaded environment
The implementation of `logging_stack.h` makes 3 calls to `vLoggingPrintf` which are vulnerable to context-switch before the completion of the 3 calls.
Here is an example of mangled logs from the MQTT connection sharing demo that contains log calls from multiple tasks:

```
125 21323 [Subscriber] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:2042] 126 21323 [Subscriber] Received publish on topic filter/sync/1
Message payload: Hello World! Sync: 1
168 21667 [SyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1832] 173 21768 [AsyncPublisher] [INFO] [MQTTDemo] [mqtt_demo_connection_sharing.c:1914] 174 21768 [AsyncPublisher] Adding publish operation for message Hello World! Async: 4 
on topic filter/async/4175 21768 [AsyncPublisher] 
176 21868 [iot_thread] [INFO] [MQTT] [core_mqtt.c:885] 177 21868 [iot_thread] Packet received. ReceivedBytes=39.178 21868 [iot_thread] 
```

### Solution
This PR fixes the problem by refactoring the macro layer implementation in `logging_stack.h` to call the logging function (exposed by `iot_logging_task.h`) only once instead of 3 times. 
This PR refactors simplifies the implementation by removing the metadata addition logic for the ISO C90 compliant code. In addition, it also adds support for ISO C99 (with GNU extension) standard to show how extra metadata of source library, file location can be added with simple variadic macro logic.
The library can be configured with either of the C90 or C99 implementations a new macro `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION`. 

After the fix, the above logs from `coreMQTT` library look like:

```
10 34340 [iot_thread] [INFO] [MQTT] [core_mqtt.c:886] Packet received. ReceivedBytes=2.
11 34344 [iot_thread] [INFO] [MQTT] [core_mqtt_serializer.c:970] CONNACK session present bit not set.
12 34350 [iot_thread] [INFO] [MQTT] [core_mqtt_serializer.c:912] Connection accepted.
13 34356 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1563] Received MQTT CONNACK successfully from broker.
14 34362 [iot_thread] [INFO] [MQTT] [core_mqtt.c:1829] MQTT connection established with the broker.
```
 