### PR TITLE
BLE HAL test fixes

### DIFF
--- a/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
+++ b/libraries/abstractions/ble_hal/test/include/iot_test_ble_hal_common.h
@@ -187,9 +187,6 @@ typedef struct
 #define bletestsDEVICE_NAME                   "TEST"
 #define bletestsMAX_PROPERTY_SIZE             30
 
-#define bletestsMTU_SIZE1                     200
-#define bletestsMTU_SIZE2                     220
-
 #define bletestsMIN_ADVERTISEMENT_INTERVAL    0x12C
 #define bletestsMAX_ADVERTISEMENT_INTERVAL    0x258
 
@@ -204,36 +201,38 @@ typedef struct
 
 #define BLE_TIME_LIMIT                        2500                  /* Set time limit to 2.5s */
 
-typedef enum
+enum
 {
-    eBLEHALEventServerRegisteredCb = 0,
-    eBLEHALEventEnableDisableCb = 1,
-    eBLEHALEventCharAddedCb = 2,
-    eBLEHALEventServiceAddedCb = 3,
-    eBLEHALEventServiceStartedCb = 4,
-    eBLEHALEventServiceStoppedCb = 5,
-    eBLEHALEventServiceDeletedCb = 6,
-    eBLEHALEventCharDescrAddedCb = 7,
-    eBLEHALEventIncludedServiceAdded = 8,
-    eBLEHALEventRegisterBleAdapterCb = 9,
-    eBLEHALEventAdapterPropertiesCb = 10,
-    eBLEHALEventRegisterUnregisterGattServerCb = 11,
-    eBLEHALEventPropertyCb = 12,
-    eBLEHALEventSetAdvCb = 13,
-    eBLEHALEventStartAdvCb = 14,
-    eBLEHALEventConnectionCb = 15,
-    eBLEHALEventConnectionUpdateCb = 16,
-    eBLEHALEventReadAttrCb = 17,
-    eBLEHALEventWriteAttrCb = 18,
-    eBLEHALEventIndicateCb = 19,
-    eBLEHALEventConfimCb = 20,
-    eBLEHALEventSSPrequestCb = 21,
-    eBLEHALEventSSPrequestConfirmationCb = 22,
-    eBLEHALEventPairingStateChangedCb = 23,
-    eBLEHALEventRequestExecWriteCb = 24,
-    eBLEHALEventMtuChangedCb = 25,
-    eBLENbHALEvents
-} BLEHALEventsTypes_t;
+    eBLEHALEventNone = 0x00U,
+    eBLEHALEventServerRegisteredCb = 0x01U,
+    eBLEHALEventEnableDisableCb = 0x02U,
+    eBLEHALEventCharAddedCb = 0x04U,
+    eBLEHALEventServiceAddedCb = 0x08U,
+    eBLEHALEventServiceStartedCb = 0x10U,
+    eBLEHALEventServiceStoppedCb = 0x20U,
+    eBLEHALEventServiceDeletedCb = 0x40U,
+    eBLEHALEventCharDescrAddedCb = 0x80U,
+    eBLEHALEventIncludedServiceAdded = 0x100U,
+    eBLEHALEventRegisterBleAdapterCb = 0x200U,
+    eBLEHALEventAdapterPropertiesCb = 0x400U,
+    eBLEHALEventRegisterUnregisterGattServerCb = 0x800U,
+    eBLEHALEventPropertyCb = 0x1000U,
+    eBLEHALEventSetAdvCb = 0x2000U,
+    eBLEHALEventStartAdvCb = 0x4000U,
+    eBLEHALEventConnectionCb = 0x8000U,
+    eBLEHALEventConnectionUpdateCb = 0x10000U,
+    eBLEHALEventReadAttrCb = 0x20000U,
+    eBLEHALEventWriteAttrCb = 0x40000U,
+    eBLEHALEventIndicateCb = 0x80000U,
+    eBLEHALEventConfimCb = 0x100000U,
+    eBLEHALEventSSPrequestCb = 0x200000U,
+    eBLEHALEventSSPrequestConfirmationCb = 0x400000U,
+    eBLEHALEventPairingStateChangedCb = 0x800000U,
+    eBLEHALEventRequestExecWriteCb = 0x1000000U,
+    eBLEHALEventMtuChangedCb = 0x2000000U
+};
+
+typedef uint32_t BLEHALEventsTypes_t;
 
 typedef struct
 {
@@ -521,6 +520,15 @@ BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
                                              void * pxMessage,
                                              size_t xMessageLength,
                                              uint32_t timeoutMs );
+BLEHALEventsTypes_t IotTestBleHal_WaitForEvents( BLEHALEventsTypes_t xEventsToWaitFor,
+                                                 uint32_t timeoutMs );
+
+BTStatus_t IotTestBleHal_GetEventFromQueueWithMatch( BLEHALEventsTypes_t xEventName,
+                                                     int32_t lhandle,
+                                                     void * pxMessage,
+                                                     size_t xMessageLength,
+                                                     bool ( * pxMatch )( void * pvEvent ) );
+
 BTStatus_t IotTestBleHal_WaitEventFromQueueWithMatch( BLEHALEventsTypes_t xEventName,
                                                       int32_t lhandle,
                                                       void * pxMessage,

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -27,6 +27,7 @@
  * @file aws_test_ble.c
  * @brief Tests for ble.
  */
+#include "iot_ble_config.h"
 #include "iot_test_ble_hal_afqp.h"
 
 extern BTGattServerInterface_t * _pxGattServerInterface;
@@ -259,31 +260,41 @@ TEST( Full_BLE, BLE_Connection_Mode1Level2 )
     BTStatus_t xStatus;
     BLETESTPairingStateChangedCallback_t xPairingStateChangedEvent;
     BLETESTsspRequestCallback_t xSSPrequestEvent;
+    BLEHALEventsTypes_t xEventsReceived;
 
     IotTestBleHal_ClearEventQueue();
 
     IotTestBleHal_StartAdvertisement();
     IotTestBleHal_WaitConnection( true );
 
-    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), BLE_TESTS_WAIT );
+    /* SSP Pairing request callback is optional for a board to support. Some boards handle the requeust directly in stack and will emit only Pairing state change callback. */
+    xEventsReceived = IotTestBleHal_WaitForEvents( ( eBLEHALEventSSPrequestCb | eBLEHALEventPairingStateChangedCb ), BLE_TESTS_WAIT );
+    TEST_ASSERT_NOT_EQUAL( eBLEHALEventNone, xEventsReceived );
 
-    if( xStatus == eBTStatusSuccess )
+    if( ( xEventsReceived & eBLEHALEventSSPrequestCb ) == eBLEHALEventSSPrequestCb )
     {
-        /*
-         * Pairing request user level callback is optional for Mode 1 level 2, as they dont need authentication and BLE stack can accept or reject mode 1 level 2 pairing requests without
-         * user intervention.
-         */
+        xStatus = IotTestBleHal_GetEventFromQueueWithMatch( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), NULL );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
         TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
         TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
+
         xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
-    }
 
-    xStatus = IotTestBleHal_WaitEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), bletestWAIT_MODE1_LEVEL2_QUERY, IotTestBleHal_CheckBondState );
-    TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );                        /* Pairing should never come since it is secure connection only */
-    TEST_ASSERT_EQUAL( eBTStatusFail, xPairingStateChangedEvent.xStatus ); /* Pairing should never come since it is secure connection only */
-    /* @TODO add correct flag */
-    /* TEST_ASSERT_EQUAL(eBTauthFailInsuffSecurity, xPairingStateChangedEvent.xReason); */ /* Pairing should never come since it is secure connection only */
+        xStatus = xStatus = IotTestBleHal_WaitEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), bletestWAIT_MODE1_LEVEL2_QUERY, IotTestBleHal_CheckBondState );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );                        /* Pairing should never come since it is secure connection only */
+        TEST_ASSERT_EQUAL( eBTStatusFail, xPairingStateChangedEvent.xStatus ); /* Pairing should never come since it is secure connection only */
+        /* @TODO add correct flag */
+        /* TEST_ASSERT_EQUAL(eBTauthFailInsuffSecurity, xPairingStateChangedEvent.xReason); */ /* Pairing should never come since it is secure connection only */
+    }
+    else
+    {
+        xStatus = IotTestBleHal_GetEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), IotTestBleHal_CheckBondState );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );                        /* Pairing should never come since it is secure connection only */
+        TEST_ASSERT_EQUAL( eBTStatusFail, xPairingStateChangedEvent.xStatus ); /* Pairing should never come since it is secure connection only */
+        /* @TODO add correct flag */
+        /* TEST_ASSERT_EQUAL(eBTauthFailInsuffSecurity, xPairingStateChangedEvent.xReason); */ /* Pairing should never come since it is secure connection only */
+    }
 }
 
 TEST( Full_BLE, BLE_Connection_RemoveBonding )
@@ -770,7 +781,7 @@ TEST( Full_BLE, BLE_Connection_SimpleConnection )
     xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventMtuChangedCb, NO_HANDLE, ( void * ) &xMtuChangedEvent, sizeof( BLETESTMtuChangedCallback_t ), BLE_TESTS_WAIT );
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
     TEST_ASSERT_EQUAL( _usBLEConnId, xMtuChangedEvent.usConnId );
-    TEST_ASSERT_EQUAL( bletestsMTU_SIZE1, xMtuChangedEvent.usMtu );
+    TEST_ASSERT_EQUAL( IOT_BLE_PREFERRED_MTU_SIZE, xMtuChangedEvent.usMtu );
 }
 
 

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_afqp.c
@@ -281,7 +281,7 @@ TEST( Full_BLE, BLE_Connection_Mode1Level2 )
         xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
-        xStatus = xStatus = IotTestBleHal_WaitEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), bletestWAIT_MODE1_LEVEL2_QUERY, IotTestBleHal_CheckBondState );
+        xStatus = IotTestBleHal_WaitEventFromQueueWithMatch( eBLEHALEventPairingStateChangedCb, NO_HANDLE, ( void * ) &xPairingStateChangedEvent, sizeof( BLETESTPairingStateChangedCallback_t ), bletestWAIT_MODE1_LEVEL2_QUERY, IotTestBleHal_CheckBondState );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );                        /* Pairing should never come since it is secure connection only */
         TEST_ASSERT_EQUAL( eBTStatusFail, xPairingStateChangedEvent.xStatus ); /* Pairing should never come since it is secure connection only */
         /* @TODO add correct flag */

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -27,6 +27,7 @@
  * @file iot_test_ble_hal_common.c
  * @brief Tests for ble.
  */
+#include "iot_ble_config.h"
 #include "iot_test_ble_hal_common.h"
 
 void pushToQueue( IotLink_t * pEventList );
@@ -51,7 +52,7 @@ uint16_t usHandlesBufferC[ bletestATTR_SRVCC_NUMBER ];
 
 uint8_t ucCbPropertyBuffer[ bletestsMAX_PROPERTY_SIZE ];
 uint32_t usCbConnInterval;
-uint16_t _bletestsMTU_SIZE = bletestsMTU_SIZE1;
+uint16_t _bletestsMTU_SIZE = IOT_BLE_PREFERRED_MTU_SIZE;
 
 const int ServiceB_CharNumber = 6;
 const int ServiceB_CharArray[] = { bletestATTR_SRVCB_CHAR_A, bletestATTR_SRVCB_CHAR_B, bletestATTR_SRVCB_CHAR_C, bletestATTR_SRVCB_CHAR_D, bletestATTR_SRVCB_CHAR_E, bletestATTR_SRVCB_CHAR_F };
@@ -1041,7 +1042,7 @@ void IotTestBleHal_StartStopAdvCheck( bool start )
 void IotTestBleHal_SetAdvProperty( void )
 {
     BTProperty_t pxProperty;
-    uint16_t usMTUsize = bletestsMTU_SIZE1;
+    uint16_t usMTUsize = IOT_BLE_PREFERRED_MTU_SIZE;
 
     pxProperty.xType = eBTpropertyBdname;
     pxProperty.xLen = strlen( bletestsDEVICE_NAME );
@@ -1113,21 +1114,28 @@ void IotTestBleHal_BTUnregister( void )
 void IotTestBleHal_CreateSecureConnection_Model1Level4( bool IsBondSucc )
 {
     BTStatus_t xStatus;
+    BLEHALEventsTypes_t xEventsReceived;
     BLETESTsspRequestCallback_t xSSPrequestEvent;
     BLETESTPairingStateChangedCallback_t xPairingStateChangedEvent;
 
-    /* Wait secure connection. Secure connection is triggered by writting to bletestsCHARB. */
-    xStatus = IotTestBleHal_WaitEventFromQueue( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), BLE_TESTS_WAIT );
+    /* Wait secure connection. Secure connection is triggered by writing to bletestsCHARB. */
 
-    if( xStatus == eBTStatusSuccess )
+    /* SSP Pairing request callback is optional for a board to support. Some boards handle this directly in stack and will invoke only a passkey confirmation. */
+    xEventsReceived = IotTestBleHal_WaitForEvents( ( eBLEHALEventSSPrequestCb | eBLEHALEventSSPrequestConfirmationCb ), BLE_TESTS_WAIT );
+    TEST_ASSERT_NOT_EQUAL( eBLEHALEventNone, xEventsReceived );
+
+    if( ( xEventsReceived & eBLEHALEventSSPrequestCb ) == eBLEHALEventSSPrequestCb )
     {
-        /*
-         * Initial Pairing request user level callback with consent is optional for Mode 1 level 4, as the user interaction is required in next step.
-         */
-        TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
-        TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
-        IotTestBleHal_ClearEventQueue();
+        xStatus = IotTestBleHal_GetEventFromQueueWithMatch( eBLEHALEventSSPrequestCb, NO_HANDLE, ( void * ) &xSSPrequestEvent, sizeof( BLETESTsspRequestCallback_t ), NULL );
+        TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
 
+        if( IsBondSucc == true )
+        {
+            TEST_ASSERT_EQUAL( 0, memcmp( &xSSPrequestEvent.xRemoteBdAddr, &_xAddressConnectedDevice, sizeof( BTBdaddr_t ) ) );
+            TEST_ASSERT_EQUAL( eBTsspVariantConsent, xSSPrequestEvent.xPairingVariant );
+        }
+
+        IotTestBleHal_ClearEventQueue();
         xStatus = _pxBTInterface->pxSspReply( &xSSPrequestEvent.xRemoteBdAddr, eBTsspVariantConsent, true, 0 );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
     }
@@ -1765,45 +1773,132 @@ void prvRequestWriteCb( uint16_t usConnId,
  */
 }
 
-
-void * checkQueueForEventWithMatch( BLEHALEventsTypes_t xEventName,
-                                    int32_t lhandle,
-                                    bool ( * pxMatch )( void * pvEvent ) )
+static BTStatus_t popEventFromQueueWithMatch( BLEHALEventsTypes_t xEventName,
+                                              int32_t lhandle,
+                                              void * pEventBuffer,
+                                              size_t bufferLength,
+                                              bool ( * pxMatch )( void * pvEvent ) )
 {
-    BLEHALEventsInternals_t * pEventIndex;
-    IotLink_t * pEventListIndex;
-    void * pvPtr = NULL;
+    BLEHALEventsInternals_t * pEvent;
+    IotLink_t * pEventLink;
+    BTStatus_t xStatus = eBTStatusFail;
+
+    IotBle_Assert( pEventBuffer != NULL );
+    IotBle_Assert( bufferLength >= sizeof( BLEHALEventsInternals_t ) );
 
     IotMutex_Lock( &threadSafetyMutex );
 
     /* Get the event associated to the callback */
-    IotContainers_ForEach( &eventQueueHead, pEventListIndex )
+    IotContainers_ForEach( &eventQueueHead, pEventLink )
     {
-        pEventIndex = IotLink_Container( BLEHALEventsInternals_t, pEventListIndex, eventList );
+        pEvent = IotLink_Container( BLEHALEventsInternals_t, pEventLink, eventList );
 
-        if( ( pEventIndex->xEventTypes == xEventName ) &&
-            ( pEventIndex->lHandle == lhandle ) )
+        if( ( pEvent->xEventTypes == xEventName ) &&
+            ( pEvent->lHandle == lhandle ) )
         {
-            pvPtr = pEventIndex;
-            IotListDouble_Remove( &pEventIndex->eventList );
-
-            if( ( pxMatch != NULL ) && ( pvPtr != NULL ) && !pxMatch( pvPtr ) )
+            if( ( pxMatch == NULL ) || ( pxMatch( pEvent ) == true ) )
             {
-                pvPtr = NULL;
+                IotListDouble_Remove( &pEvent->eventList );
+                memcpy( pEventBuffer, pEvent, bufferLength );
+                IotTest_Free( pEvent );
+                xStatus = eBTStatusSuccess;
+                break; /* If the right event is received, exit. */
             }
-
-            break; /* If the right event is received, exit. */
         }
     }
 
     IotMutex_Unlock( &threadSafetyMutex );
 
-    return pvPtr;
+    return xStatus;
+}
+
+static BLEHALEventsTypes_t checkQueueForEvents( BLEHALEventsTypes_t xEventsToCheck )
+{
+    BLEHALEventsTypes_t eventSet = eBLEHALEventNone;
+    BLEHALEventsInternals_t * pEvent;
+    IotLink_t * pEventLink;
+
+    IotMutex_Lock( &threadSafetyMutex );
+
+    /* Get the event associated to the callback */
+    IotContainers_ForEach( &eventQueueHead, pEventLink )
+    {
+        pEvent = IotLink_Container( BLEHALEventsInternals_t, pEventLink, eventList );
+
+        if( ( xEventsToCheck & pEvent->xEventTypes ) == pEvent->xEventTypes )
+        {
+            eventSet |= pEvent->xEventTypes;
+        }
+    }
+
+    IotMutex_Unlock( &threadSafetyMutex );
+
+    return eventSet;
+}
+
+/* This function first check if an event is waiting in the list. If not, it will go and wait on the queue.
+ * When an event is received on the queue, if it is not the expected event, it goes on the waiting list.
+ */
+BLEHALEventsTypes_t IotTestBleHal_WaitForEvents( BLEHALEventsTypes_t xEventsToWaitFor,
+                                                 uint32_t timeoutMs )
+{
+    BLEHALEventsTypes_t eventsSet;
+
+    IotLog( IOT_LOG_DEBUG,
+            &_logHideAll,
+            "WaitForEvents: %0x",
+            xEventsToWaitFor );
+
+    eventsSet = checkQueueForEvents( xEventsToWaitFor );
+
+    /* If event is not waiting then wait for it. */
+    if( eventsSet == eBLEHALEventNone )
+    {
+        do
+        {
+            /* TODO check event list here */
+            if( IotSemaphore_TimedWait( &eventSemaphore, timeoutMs ) == true )
+            {
+                eventsSet = checkQueueForEvents( xEventsToWaitFor );
+
+                if( eventsSet != eBLEHALEventNone )
+                {
+                    break; /* If the any of the event is received, exit. */
+                }
+            }
+            else
+            {
+                /* Timeout occurred. Exit. */
+                break;
+            }
+        } while( 1 );
+    }
+
+    return eventsSet;
 }
 
 bool IotTestBleHal_CheckBondState( void * pvEvent )
 {
     return ( ( BLETESTPairingStateChangedCallback_t * ) pvEvent )->xBondState != eBTbondStateBonding;
+}
+
+
+BTStatus_t IotTestBleHal_GetEventFromQueueWithMatch( BLEHALEventsTypes_t xEventName,
+                                                     int32_t lhandle,
+                                                     void * pxMessage,
+                                                     size_t xMessageLength,
+                                                     bool ( * pxMatch )( void * pvEvent ) )
+{
+    return popEventFromQueueWithMatch( xEventName, lhandle, pxMessage, xMessageLength, pxMatch );
+}
+
+BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
+                                             int32_t lhandle,
+                                             void * pxMessage,
+                                             size_t xMessageLength,
+                                             uint32_t timeoutMs )
+{
+    return IotTestBleHal_WaitEventFromQueueWithMatch( xEventName, lhandle, pxMessage, xMessageLength, timeoutMs, NULL );
 }
 
 /* This function first check if an event is waiting in the list. If not, it will go and wait on the queue.
@@ -1817,7 +1912,6 @@ BTStatus_t IotTestBleHal_WaitEventFromQueueWithMatch( BLEHALEventsTypes_t xEvent
                                                       bool ( * pxMatch )( void * pvEvent ) )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
-    void * pvPtr = NULL;
 
     IotLog( IOT_LOG_DEBUG,
             &_logHideAll,
@@ -1825,29 +1919,24 @@ BTStatus_t IotTestBleHal_WaitEventFromQueueWithMatch( BLEHALEventsTypes_t xEvent
             xEventName,
             ( uint32_t ) lhandle );
 
-    pvPtr = checkQueueForEventWithMatch( xEventName, lhandle, pxMatch );
+    xStatus = popEventFromQueueWithMatch( xEventName, lhandle, pxMessage, xMessageLength, pxMatch );
 
     /* If event is not waiting then wait for it. */
-    if( pvPtr == NULL )
+    if( ( xStatus != eBTStatusSuccess ) && ( timeoutMs > 0 ) )
     {
         do
         {
             /* TODO check event list here */
             if( IotSemaphore_TimedWait( &eventSemaphore, timeoutMs ) == true )
             {
-                pvPtr = checkQueueForEventWithMatch( xEventName, lhandle, pxMatch );
-
-                if( pvPtr != NULL )
-                {
-                    break; /* If the right event is received, exit. */
-                }
+                xStatus = popEventFromQueueWithMatch( xEventName, lhandle, pxMessage, xMessageLength, pxMatch );
             }
             else
             {
-                xStatus = eBTStatusFail;
+                /* We did not receive any events after timeout time. Break and return failure.*/
+                break;
             }
-        }
-        while( xStatus == eBTStatusSuccess ); /* If there is an error exit */
+        } while( xStatus != eBTStatusSuccess ); /* If right event is not received continue waiting. */
     }
 
     if( xStatus == eBTStatusSuccess )
@@ -1857,8 +1946,6 @@ BTStatus_t IotTestBleHal_WaitEventFromQueueWithMatch( BLEHALEventsTypes_t xEvent
                 "Event Received: %d, handle=0x%x",
                 xEventName,
                 ( uint32_t ) lhandle );
-        memcpy( pxMessage, pvPtr, xMessageLength );
-        IotTest_Free( pvPtr );
     }
     else
     {
@@ -1870,15 +1957,6 @@ BTStatus_t IotTestBleHal_WaitEventFromQueueWithMatch( BLEHALEventsTypes_t xEvent
     }
 
     return xStatus;
-}
-
-BTStatus_t IotTestBleHal_WaitEventFromQueue( BLEHALEventsTypes_t xEventName,
-                                             int32_t lhandle,
-                                             void * pxMessage,
-                                             size_t xMessageLength,
-                                             uint32_t timeoutMs )
-{
-    return IotTestBleHal_WaitEventFromQueueWithMatch( xEventName, lhandle, pxMessage, xMessageLength, timeoutMs, NULL );
 }
 
 void IotTestBleHal_ClearEventQueue( void )

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_common.c
@@ -1851,27 +1851,18 @@ BLEHALEventsTypes_t IotTestBleHal_WaitForEvents( BLEHALEventsTypes_t xEventsToWa
 
     eventsSet = checkQueueForEvents( xEventsToWaitFor );
 
-    /* If event is not waiting then wait for it. */
-    if( eventsSet == eBLEHALEventNone )
+    /* There are no events currently, Wait for an event for timeout period. */
+    if( ( eventsSet == eBLEHALEventNone ) && ( timeoutMs > 0 ) )
     {
-        do
+        while( IotSemaphore_TimedWait( &eventSemaphore, timeoutMs ) == true )
         {
-            /* TODO check event list here */
-            if( IotSemaphore_TimedWait( &eventSemaphore, timeoutMs ) == true )
-            {
-                eventsSet = checkQueueForEvents( xEventsToWaitFor );
+            eventsSet = checkQueueForEvents( xEventsToWaitFor );
 
-                if( eventsSet != eBLEHALEventNone )
-                {
-                    break; /* If the any of the event is received, exit. */
-                }
-            }
-            else
+            if( eventsSet != eBLEHALEventNone )
             {
-                /* Timeout occurred. Exit. */
-                break;
+                break; /* If the any of the event is received, exit. */
             }
-        } while( 1 );
+        }
     }
 
     return eventsSet;

--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -28,8 +28,7 @@
  * @brief Tests for ble.
  */
 
-
-
+#include "iot_ble_config.h"
 #include "iot_test_ble_hal_integration.h"
 extern BTCallbacks_t _xBTManagerCb;
 extern BTBleAdapterCallbacks_t _xBTBleAdapterCb;
@@ -58,7 +57,7 @@ extern BTUuid_t xAppUUID;
 extern bool bCharAddedComplete;
 extern uint16_t _bletestsMTU_SIZE;
 
-static uint8_t ucLargeBuffer[ bletestsMTU_SIZE1 + 2 ];
+static uint8_t ucLargeBuffer[ IOT_BLE_PREFERRED_MTU_SIZE + 2 ];
 
 TEST_GROUP( Full_BLE_Integration_Test );
 
@@ -198,7 +197,7 @@ TEST_GROUP_RUNNER( Full_BLE_Integration_Test )
         BTStatus_t xStatus;
         BTProperty_t pxProperty;
         BLETESTMtuChangedCallback_t xMtuChangedEvent;
-        uint16_t usMTUsize = bletestsMTU_SIZE2;
+        uint16_t usMTUsize = IOT_BLE_PREFERRED_MTU_SIZE;
 
         IotTestBleHal_SetAdvProperty();
 
@@ -506,12 +505,12 @@ TEST( Full_BLE_Integration_Test, BLE_Advertise_Before_Set_Data )
 
         IotTestBleHal_checkNotificationIndication( bletestATTR_SRVCB_CCCD_E, true );
 
-        memset( ucLargeBuffer, 'a', ( bletestsMTU_SIZE1 + 2 ) * sizeof( char ) );
+        memset( ucLargeBuffer, 'a', ( IOT_BLE_PREFERRED_MTU_SIZE + 2 ) * sizeof( char ) );
 
         xStatus = _pxGattServerInterface->pxSendIndication( _ucBLEServerIf,
                                                             usHandlesBufferB[ bletestATTR_SRVCB_CHAR_E ],
                                                             _usBLEConnId,
-                                                            bletestsMTU_SIZE1 + 2,
+                                                            IOT_BLE_PREFERRED_MTU_SIZE + 2,
                                                             ucLargeBuffer,
                                                             false );
         TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );
@@ -673,7 +672,7 @@ void prvGetResult( bletestAttSrvB_t xAttribute,
     void prvSetAdvPropertyWithNULLCb( void )
     {
         BTProperty_t pxProperty;
-        uint16_t usMTUsize = bletestsMTU_SIZE1;
+        uint16_t usMTUsize = IOT_BLE_PREFERRED_MTU_SIZE;
         BTStatus_t xStatus = eBTStatusSuccess;
 
         pxProperty.xType = eBTpropertyBdname;


### PR DESCRIPTION
BLE HAL test fixes

Description
-----------
* HAL tests are run against multiple vendors, and some events/callbacks which are optional need not be supported by all vendors. Added changes for HAL layer to wait for one among a group of events. This allows tests to skip optional events and wait for next event.
* Boards need not support changing MTU dynamically, though there is an API for supported boards. Modified tests to choose the statically compiled MTU size `IOT_BLE_PREFERRED_MTU_SIZE` defined in `iot_ble_config.h`


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.