### PR TITLE
Remove the dependency of transport_interface.h from BLE.

### DIFF
--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -18,14 +18,6 @@ afr_set_lib_metadata(IS_VISIBLE "true")
 set(src_dir "${CMAKE_CURRENT_LIST_DIR}/src")
 set(inc_dir "${CMAKE_CURRENT_LIST_DIR}/include")
 set(test_dir "${CMAKE_CURRENT_LIST_DIR}/test")
-if( EXISTS ${AFR_MODULES_DIR}/coreMQTT/source )
-    set(transport_interface_dir "${AFR_MODULES_DIR}/coreMQTT/source/interface")
-elseif( EXISTS ${AFR_MODULES_DIR}/coreHTTP/source )
-    set(transport_interface_dir "${AFR_MODULES_DIR}/coreHTTP/source/interface")
-else()
-    message( FATAL_ERROR "No transport_interface.h exists for this included interface.")
-endif()
-
 
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
@@ -53,7 +45,6 @@ afr_module_include_dirs(
     PUBLIC
         "${inc_dir}"
         "${AFR_MODULES_DIR}/logging/include"
-        "${transport_interface_dir}"
     PRIVATE
         "${test_dir}"
 )


### PR DESCRIPTION
Remove the dependency of transport_interface.h from BLE, since we allow user to choose only BLE (without CoreMQTT and CoreHTTP) from the Freertos console.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.