### PR TITLE
Fix demo initialization failure in Marvell board


### DIFF
--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -482,11 +482,13 @@ static IotNetworkManager_t networkManager =
                 {
                     if( WIFI_ConnectAP( &( xConnectParams ) ) == eWiFiSuccess )
                     {
+                        IotLogInfo("Successful WIFI_ConnectAP call from network manager");
                         wifiNetwork.state = eNetworkStateEnabled;
                         break;
                     }
                     else
                     {
+                        IotLogError("Failed WIFI_ConnectAP call from network manager");
                         if( numRetries > 0 )
                         {
                             IotClock_SleepMs( delayMilliseconds );

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -482,13 +482,11 @@ static IotNetworkManager_t networkManager =
                 {
                     if( WIFI_ConnectAP( &( xConnectParams ) ) == eWiFiSuccess )
                     {
-                        IotLogInfo("Successful WIFI_ConnectAP call from network manager");
                         wifiNetwork.state = eNetworkStateEnabled;
                         break;
                     }
                     else
                     {
-                        IotLogError("Failed WIFI_ConnectAP call from network manager");
                         if( numRetries > 0 )
                         {
                             IotClock_SleepMs( delayMilliseconds );

--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -123,22 +123,6 @@ void wm_printf(const char *format, ...)
 		&format[0]);
     UART_WriteLine(UART0_ID, (uint8_t *) ll_msg_buf_);
 }
-/**
- * @brief Application task startup hook for applications using Wi-Fi. If you are not 
- * using Wi-Fi, then start network dependent applications in the vApplicationIPNetorkEventHook
- * function. If you are not using Wi-Fi, this hook can be disabled by setting
- * configUSE_DAEMON_TASK_STARTUP_HOOK to 0.
- */
-//void vApplicationDaemonTaskStartupHook( void );
-void vStartupHook( void *pvParameters);
-
-/**
- * @brief Application IP network event hook called by the FreeRTOS+TCP stack for
- * applications using Ethernet. If you are not using Ethernet and the FreeRTOS+TCP stack,
- * start network dependent applications in vApplicationDaemonTaskStartupHook after the
- * network status is up.
- */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
 
 /**
  * @brief Connects to Wi-Fi.
@@ -171,13 +155,13 @@ int main( void )
     /* FreeRTOS+TCP stack init */
     vApplicationIPInit();
 
-    /* Create the task to run unit tests. */
-    xTaskCreate( vStartupHook,
-                 "Startup Hook",
-		             mainSTARTUP_TASK_STACK_SIZE,
-                 NULL,
-                 tskIDLE_PRIORITY + 2,
-                 NULL );
+    /* A simple example to demonstrate key and certificate provisioning in
+     * flash using PKCS#11 interface. This should be replaced
+     * by production ready key provisioning mechanism. */
+    vDevModeKeyProvisioning();
+
+    /* Start the demo tasks. */
+    DEMO_RUNNER_RunDemos();
 
     /* Start the scheduler.  Initialization that requires the OS to be running,
      * including the Wi-Fi initialization, is performed in the RTOS daemon task
@@ -243,28 +227,7 @@ static void prvMiscInitialization( void )
 
     configPRINT_STRING("FreeRTOS Started\r\n");
 }
-/*-----------------------------------------------------------*/
 
-//void vApplicationDaemonTaskStartupHook( void )
-void vStartupHook( void *pvParameters)
-{
-    configPRINT("\r\nApplication Daemon Startup \r\n");
-
-    // if( SYSTEM_Init() == pdPASS ) {
-    //     /* Connect to the Wi-Fi before running the tests. */
-    //     prvWifiConnect();
-    // } else {
-    //     configPRINT("\r\nSystem Init failed \r\n");
-    // }
-    /* A simple example to demonstrate key and certificate provisioning in
-     * flash using PKCS#11 interface. This should be replaced
-     * by production ready key provisioning mechanism. */
-    vDevModeKeyProvisioning();
-
-    /* Start the demo tasks. */
-    DEMO_RUNNER_RunDemos();
-    vTaskDelete(NULL);
-}
 /*-----------------------------------------------------------*/
 #include <FreeRTOS_Sockets.h>
 #include <FreeRTOS_DHCP.h>

--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -262,7 +262,7 @@ void vStartupTask( void * pvParameters )
     /* Start the demo tasks. */
     DEMO_RUNNER_RunDemos();
 
-    vTaskDelete();
+    vTaskDelete(NULL);
 }
 
 /*-----------------------------------------------------------*/

--- a/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c
@@ -250,12 +250,12 @@ void vStartupHook( void *pvParameters)
 {
     configPRINT("\r\nApplication Daemon Startup \r\n");
 
-    if( SYSTEM_Init() == pdPASS ) {
-        /* Connect to the Wi-Fi before running the tests. */
-        prvWifiConnect();
-    } else {
-        configPRINT("\r\nSystem Init failed \r\n");
-    }
+    // if( SYSTEM_Init() == pdPASS ) {
+    //     /* Connect to the Wi-Fi before running the tests. */
+    //     prvWifiConnect();
+    // } else {
+    //     configPRINT("\r\nSystem Init failed \r\n");
+    // }
     /* A simple example to demonstrate key and certificate provisioning in
      * flash using PKCS#11 interface. This should be replaced
      * by production ready key provisioning mechanism. */


### PR DESCRIPTION
The Marvell board encounteres frequent failures in demo jobs on CI with the following log:

```

13 1588361 [IP-task] vDHCPProcess: offer c0a82344ip

Network connection successful.

14 1888450 [IP-task] vDHCPProcess: offer c0a82344ip

Network connection successful.

15 2188554 [IP-task] vDHCPProcess: offer c0a82344ip

Network connection successful.

16 2488593 [IP-task] vDHCPProcess: offer c0a82344ip

Network connection successful.

17 2693377 [iot_thread] [ERROR][DEMO][2693377] Failed to initialize all the networks configured for18 2693377 [iot_thread] [ERROR][DEMO][2693377] Failed to initialize the demo. exiting...
19 2693377 [iot_thread] [INFO ][DEMO][2693377] -------DEMO FINISHED-------
```

The cause of the failure is from 2 calls made to `WiFi_ConnectAP` in the demo run for Marvell, one from the [aws_demos/application_code/main.c](https://github.com/aws/amazon-freertos/blob/202012.00/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c#L436) and the other from the [Network manager](https://github.com/aws/amazon-freertos/blob/202012.00/demos/network_manager/aws_iot_network_manager.c#L479) in the demo framework.

This PR fixes the issue by removing the duplicate call to connect to WiFi network from the Marvell demo `main.c` file.

**Note**: The [`prvWifiConnect`](https://github.com/aws/amazon-freertos/blob/202012.00/vendors/marvell/boards/mw300_rd/aws_demos/application_code/main.c#L363-L524) function has been retained in the `main.c` file for reference logic for WiFi initialization for station and softAP mode in Marvell board for customers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
