### PR TITLE
[demo][wifi_provisioning] Remove hard dependency on BLE

### DIFF
--- a/demos/wifi_provisioning/CMakeLists.txt
+++ b/demos/wifi_provisioning/CMakeLists.txt
@@ -11,5 +11,12 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         AFR::wifi
-        AFR::ble
 )
+
+if( BLE_SUPPORTED )
+    afr_module_dependencies(
+        ${AFR_CURRENT_MODULE}
+        INTERFACE
+            AFR::ble
+    )
+endif()


### PR DESCRIPTION
Description
-----------
See #2951 for additional context.

Out of interest for sharing with `iot_softap_wifi_provisioning` capable devices, remove `AFR::ble` dependency from `afr_demo_module(wifi_provisioning)`, so boards that _don't_ have BLE can still build `wifi_provisioning` module.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.