### PR TITLE
Update Jobs demo to use DescribeJobExecution API instead of StartNextPendingJobExecution API

### DIFF
--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -659,8 +659,6 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
                  * be used for sending jobs status updates to the AWS IoT Jobs service. */
                 memcpy( usJobsDocumentBuffer, pcJobDocLoc, ulJobDocLength );
 
-                LogInfo( ( "Document: %.*s", ulJobDocLength, usJobsDocumentBuffer ) );
-
                 /* Process the Job document and execute the job. */
                 prvProcessJobDocument( usJobIdBuffer,
                                        ( uint16_t ) ulJobIdLength,

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -157,7 +157,7 @@
  * This demo program expects this key to be in the Job document. It is a key
  * specific to this demo.
  */
-#define jobsexampleQUERY_KEY_FOR_ACTION             "tction"
+#define jobsexampleQUERY_KEY_FOR_ACTION             "action"
 
 /**
  * @brief The length of #jobsexampleQUERY_KEY_FOR_ACTION.
@@ -172,7 +172,7 @@
  * is either "publish" or "print". It represents the message that should be
  * published or printed, respectively.
  */
-#define jobsexampleQUERY_KEY_FOR_MESSAGE            "tessage"
+#define jobsexampleQUERY_KEY_FOR_MESSAGE            "message"
 
 /**
  * @brief The length of #jobsexampleQUERY_KEY_FOR_MESSAGE.
@@ -644,6 +644,9 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
                 /* Copy the Job document in buffer. This is done so that the MQTT connection buffer can
                  * be used for sending jobs status updates to the AWS IoT Jobs service. */
                 memcpy( usJobsDocumentBuffer, pcJobDocLoc, ulJobDocLength );
+
+
+                LogInfo( ( "Document: %.*s", ulJobDocLength, usJobsDocumentBuffer ) );
 
                 /* Process the Job document and execute the job. */
                 prvProcessJobDocument( pcJobId,

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -157,7 +157,7 @@
  * This demo program expects this key to be in the Job document. It is a key
  * specific to this demo.
  */
-#define jobsexampleQUERY_KEY_FOR_ACTION             jobsexampleQUERY_KEY_FOR_JOBS_DOC ".action"
+#define jobsexampleQUERY_KEY_FOR_ACTION             "tction"
 
 /**
  * @brief The length of #jobsexampleQUERY_KEY_FOR_ACTION.
@@ -172,7 +172,7 @@
  * is either "publish" or "print". It represents the message that should be
  * published or printed, respectively.
  */
-#define jobsexampleQUERY_KEY_FOR_MESSAGE            jobsexampleQUERY_KEY_FOR_JOBS_DOC ".message"
+#define jobsexampleQUERY_KEY_FOR_MESSAGE            "tessage"
 
 /**
  * @brief The length of #jobsexampleQUERY_KEY_FOR_MESSAGE.
@@ -187,7 +187,7 @@
  * is "publish". It represents the MQTT topic on which the message should be
  * published.
  */
-#define jobsexampleQUERY_KEY_FOR_TOPIC              jobsexampleQUERY_KEY_FOR_JOBS_DOC ".topic"
+#define jobsexampleQUERY_KEY_FOR_TOPIC              "topic"
 
 /**
  * @brief The length of #jobsexampleQUERY_KEY_FOR_TOPIC.

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -276,14 +276,20 @@ static NetworkContext_t xNetworkContext;
 /**
  * @brief Static buffer used to hold MQTT messages being sent and received.
  */
-static uint8_t ucSharedBuffer[ democonfigNETWORK_BUFFER_SIZE ];
+static uint8_t usMqttConnectionBuffer[ democonfigNETWORK_BUFFER_SIZE ];
+
+/**
+ * @brief Static buffer used to hold the job document received from AWS IoT
+ * Jobs service.
+ */
+static uint8_t usJobsDocumentBuffer[ democonfigNETWORK_BUFFER_SIZE ];
 
 /**
  * @brief Static buffer used to hold MQTT messages being sent and received.
  */
 static MQTTFixedBuffer_t xBuffer =
 {
-    .pBuffer = ucSharedBuffer,
+    .pBuffer = usMqttConnectionBuffer,
     .size    = democonfigNETWORK_BUFFER_SIZE
 };
 
@@ -333,8 +339,8 @@ static void prvEventCallback( MQTTContext_t * pxMqttContext,
  * @brief Process payload from NextJobExecutionChanged and DescribeJobExecution
  * API MQTT topics of AWS IoT Jobs service.
  *
- * This handler parses the payload received about the next pending job to identify
- * the action requested in the job document, and perform the appropriate
+ * This handler parses the received payload about the next pending job, identifies
+ * the action requested in the job document, and performs the appropriate
  * action to execute the job.
  *
  * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
@@ -359,14 +365,16 @@ static void prvSendUpdateForJob( char * pcJobId,
  * It parses the received job document, executes the job depending on the job "Action" type, and
  * sends an update to AWS for the Job.
  *
- * @param[in] pxPublishInfo The PUBLISH packet containing the job document received from the
- * AWS IoT Jobs service.
  * @param[in] pcJobId The ID of the job to execute.
  * @param[in] usJobIdLength The length of the job ID string.
+ * @param[in] pcJobDocument The JSON document associated with the @a pcJobID job
+ * that is to be processed.
+ * @param[in] usDocumentLength The length of the job document.
  */
-static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
-                                   char * pcJobId,
-                                   uint16_t usJobIdLength );
+static void prvProcessJobDocument( char * pcJobId,
+                                   uint16_t usJobIdLength,
+                                   char * pcJobDocument,
+                                   uint16_t jobDocumentLength );
 
 /*-----------------------------------------------------------*/
 
@@ -439,19 +447,23 @@ static void prvSendUpdateForJob( char * pcJobId,
     }
 }
 
-static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
-                                   char * pcJobId,
-                                   uint16_t usJobIdLength )
+static void prvProcessJobDocument( char * pcJobId,
+                                   uint16_t usJobIdLength,
+                                   char * pcJobDocument,
+                                   uint16_t jobDocumentLength )
 {
     char * pcAction = NULL;
     size_t uActionLength = 0U;
     JSONStatus_t xJsonStatus = JSONSuccess;
 
-    configASSERT( pxPublishInfo != NULL );
-    configASSERT( ( pxPublishInfo->pPayload != NULL ) && ( pxPublishInfo->payloadLength > 0 ) );
+    configASSERT( pcJobId != NULL );
+    configASSERT( usJobIdLength > 0 );
+    configASSERT( pcJobDocument != NULL );
+    configASSERT( jobDocumentLength > 0 );
 
-    xJsonStatus = JSON_Search( ( char * ) pxPublishInfo->pPayload,
-                               pxPublishInfo->payloadLength,
+
+    xJsonStatus = JSON_Search( pcJobDocument,
+                               jobDocumentLength,
                                jobsexampleQUERY_KEY_FOR_ACTION,
                                jobsexampleQUERY_KEY_FOR_ACTION_LENGTH,
                                &pcAction,
@@ -464,6 +476,10 @@ static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
     }
     else
     {
+        /* Send a status update to AWS IoT Jobs service for the next pending job. */
+        LogInfo( ( "Updating status of Job to IN_PROGRESS: JobId=%.*s", usJobIdLength, pcJobId ) );
+        prvSendUpdateForJob( pcJobId, usJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
+
         JobActionType xActionType = JOB_ACTION_UNKNOWN;
         char * pcMessage = NULL;
         size_t ulMessageLength = 0U;
@@ -481,8 +497,8 @@ static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
             case JOB_ACTION_PRINT:
                 LogInfo( ( "Received job contains \"print\" action." ) );
 
-                xJsonStatus = JSON_Search( ( char * ) pxPublishInfo->pPayload,
-                                           pxPublishInfo->payloadLength,
+                xJsonStatus = JSON_Search( pcJobDocument,
+                                           jobDocumentLength,
                                            jobsexampleQUERY_KEY_FOR_MESSAGE,
                                            jobsexampleQUERY_KEY_FOR_MESSAGE_LENGTH,
                                            &pcMessage,
@@ -513,8 +529,8 @@ static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
                 char * pcTopic = NULL;
                 size_t ulTopicLength = 0U;
 
-                xJsonStatus = JSON_Search( ( char * ) pxPublishInfo->pPayload,
-                                           pxPublishInfo->payloadLength,
+                xJsonStatus = JSON_Search( pcJobDocument,
+                                           jobDocumentLength,
                                            jobsexampleQUERY_KEY_FOR_TOPIC,
                                            jobsexampleQUERY_KEY_FOR_TOPIC_LENGTH,
                                            &pcTopic,
@@ -528,8 +544,8 @@ static void prvProcessJobDocument( MQTTPublishInfo_t * pxPublishInfo,
                 }
                 else
                 {
-                    xJsonStatus = JSON_Search( ( char * ) pxPublishInfo->pPayload,
-                                               pxPublishInfo->payloadLength,
+                    xJsonStatus = JSON_Search( pcJobDocument,
+                                               jobDocumentLength,
                                                jobsexampleQUERY_KEY_FOR_MESSAGE,
                                                jobsexampleQUERY_KEY_FOR_MESSAGE_LENGTH,
                                                &pcMessage,
@@ -586,7 +602,7 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
     else
     {
         char * pcJobId = NULL;
-        size_t ulJobIdLength = 0U;
+        size_t ulJobIdLength = 0UL;
 
         /* Parse the Job ID of the next pending job execution from the JSON payload. */
         if( JSON_Search( ( char * ) pxPublishInfo->pPayload,
@@ -603,16 +619,38 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
         }
         else
         {
+            char * pcJobDocLoc = NULL;
+            size_t ulJobDocLength = 0UL;
+
             configASSERT( ulJobIdLength < JOBS_JOBID_MAX_LENGTH );
             LogInfo( ( "Received a Job from AWS IoT Jobs service: JobId=%.*s",
                        ulJobIdLength, pcJobId ) );
 
-            /* Send a status update to AWS IoT Jobs service for the next pending job. */
-            LogInfo( ( "Updating status of Job to IN_PROGRESS: JobId=%.*s", ulJobIdLength, pcJobId ) );
-            prvSendUpdateForJob( pcJobId, ulJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
+            /* Search for the jobs document in the payload. */
+            if( JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                             pxPublishInfo->payloadLength,
+                             jobsexampleQUERY_KEY_FOR_JOBS_DOC,
+                             jobsexampleQUERY_KEY_FOR_JOBS_DOC_LENGTH,
+                             &pcJobDocLoc,
+                             &ulJobDocLength ) != JSONSuccess )
+            {
+                LogWarn( ( "Failed to parse document of next job received from AWS IoT Jobs service: "
+                           "Topic=%.*s, JobID=%.*s",
+                           pxPublishInfo->topicNameLength, pxPublishInfo->pTopicName,
+                           ulJobIdLength, pcJobId ) );
+            }
+            else
+            {
+                /* Copy the Job document in buffer. This is done so that the MQTT connection buffer can
+                 * be used for sending jobs status updates to the AWS IoT Jobs service. */
+                memcpy( usJobsDocumentBuffer, pcJobDocLoc, ulJobDocLength );
 
-            /* Process the Job document and execute the job. */
-            prvProcessJobDocument( pxPublishInfo, pcJobId, ( uint16_t ) ulJobIdLength );
+                /* Process the Job document and execute the job. */
+                prvProcessJobDocument( pcJobId,
+                                       ( uint16_t ) ulJobIdLength,
+                                       usJobsDocumentBuffer,
+                                       ulJobDocLength );
+            }
         }
     }
 }

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -609,7 +609,7 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
 
             /* Send a status update to AWS IoT Jobs service for the next pending job. */
             LogInfo( ( "Updating status of Job to IN_PROGRESS: JobId=%.*s", ulJobIdLength, pcJobId ) );
-            prvSendUpdateForJob( pcJobId, usJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
+            prvSendUpdateForJob( pcJobId, ulJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
 
             /* Process the Job document and execute the job. */
             prvProcessJobDocument( pxPublishInfo, pcJobId, ( uint16_t ) ulJobIdLength );


### PR DESCRIPTION
It is recommended by the AWS IoT Jobs service to use DescribeJobExecution API for scaling purposes instead of StartNextPendingJobExecution API. Thus, update the Jobs demo to replace the latter API call with the f former API call.