### PR TITLE
Add updates about test runner and ESP-IDF in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This repository contains the `FreeRTOS AWS Reference Integrations`, which are pr
 ### New Features
 
 ### Updates
+- Update FreeRTOS Test Runner to support either a configurable delay (in [PR](#2950)) or a FreeRTOS+CLI based serial prompt input command (in [PR](#2955)) to being executing tests.
+- Upgrade of ESP-IDF SDK v4.2 for Espressif boards (in [PR](#2893)). Refer to the instructions in [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_espressif.html#setup-espressif-idf42) for using ESP-IDF v4.2.
 
 ## 202012.00 December 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repository contains the `FreeRTOS AWS Reference Integrations`, which are pr
 ### New Features
 
 ### Updates
+- Fixes issues of thread-safety and message readability in the sample logging implementation. (Related PRs are #2982 and #2953.)
 - Update FreeRTOS Test Runner to support either a configurable delay (in [PR](#2950)) or a FreeRTOS+CLI based serial prompt input command (in [PR](#2955)) to being executing tests.
 - Upgrade of ESP-IDF SDK v4.2 for Espressif boards (in [PR](#2893)). Refer to the instructions in [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_espressif.html#setup-espressif-idf42) for using ESP-IDF v4.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This repository contains the `FreeRTOS AWS Reference Integrations`, which are pr
 ### New Features
 
 ### Updates
-- Fixes issues of thread-safety and message readability in the sample logging implementation. (Related PRs are #2982 and #2953.)
-- Update FreeRTOS Test Runner to support either a configurable delay (in [PR](#2950)) or a FreeRTOS+CLI based serial prompt input command (in [PR](#2955)) to being executing tests.
-- Upgrade of ESP-IDF SDK v4.2 for Espressif boards (in [PR](#2893)). Refer to the instructions in [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_espressif.html#setup-espressif-idf42) for using ESP-IDF v4.2.
+- Fixes issues of thread-safety and message readability in the sample logging implementation. (Related PRs are [#2982](https://github.com/aws/amazon-freertos/pull/2982) and [#2953](https://github.com/aws/amazon-freertos/pull/2953).)
+- Update FreeRTOS Test Runner to support either a configurable delay (in [PR](https://github.com/aws/amazon-freertos/pull/2950)) or a FreeRTOS+CLI based serial prompt input command (in [PR](https://github.com/aws/amazon-freertos/pull/2955)) to being executing tests.
+- Upgrade of ESP-IDF SDK v4.2 for Espressif boards (in [PR](https://github.com/aws/amazon-freertos/pull/2893)). Refer to the instructions in [Getting Started Guide](https://docs.aws.amazon.com/freertos/latest/userguide/getting_started_espressif.html#setup-espressif-idf42) for using ESP-IDF v4.2.
 
 ## 202012.00 December 2020
 


### PR DESCRIPTION
Add changes related to #2950, #2953, #2955, #2982 and #2893 in the `CHANGELOG.md` to convey about updates since the [202012.00](https://github.com/aws/amazon-freertos/tree/202012.00) release


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.