### PR TITLE
espressif iot_wifi.c: Do not use legacy events in event handler

### DIFF
--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -129,15 +129,15 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
     WIFIEvent_t eventInfo = { 0 };
     if (event_base == WIFI_EVENT) {
         switch(event_id) {
-            case SYSTEM_EVENT_STA_START:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_STA_START");
+            case WIFI_EVENT_STA_START:
+                ESP_LOGI(TAG, "WIFI_EVENT_STA_START");
                 xEventGroupSetBits(wifi_event_group, STARTED_BIT);
                 break;
-            case SYSTEM_EVENT_STA_CONNECTED:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_STA_CONNECTED");
+            case WIFI_EVENT_STA_CONNECTED:
+                ESP_LOGI(TAG, "WIFI_EVENT_STA_CONNECTED");
                 break;
-            case SYSTEM_EVENT_STA_DISCONNECTED:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_STA_DISCONNECTED: %d", info->disconnected.reason);
+            case WIFI_EVENT_STA_DISCONNECTED:
+                ESP_LOGI(TAG, "WIFI_EVENT_STA_DISCONNECTED: %d", info->disconnected.reason);
                 wifi_auth_failure = false;
 
                 /* Set code corresponding to the reason for disconnection */
@@ -171,23 +171,23 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
                     xWifiEventHandlers[ eWiFiEventDisconnected ]( &eventInfo );
                 }
                 break;
-            case SYSTEM_EVENT_AP_START:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_START");
+            case WIFI_EVENT_AP_START:
+                ESP_LOGI(TAG, "WIFI_EVENT_AP_START");
                 wifi_ap_state = true;
                 xEventGroupClearBits(wifi_event_group, AP_STOPPED_BIT);
                 xEventGroupSetBits(wifi_event_group, AP_STARTED_BIT);
                 break;
-            case SYSTEM_EVENT_AP_STOP:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_STOP");
+            case WIFI_EVENT_AP_STOP:
+                ESP_LOGI(TAG, "WIFI_EVENT_AP_START");
                 wifi_ap_state = false;
                 xEventGroupClearBits(wifi_event_group, AP_STARTED_BIT);
                 xEventGroupSetBits(wifi_event_group, AP_STOPPED_BIT);
                 break;
-            case SYSTEM_EVENT_AP_STACONNECTED:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_STACONNECTED");
+            case WIFI_EVENT_AP_STACONNECTED:
+                ESP_LOGI(TAG, "WIFI_EVENT_AP_STACONNECTED");
                 break;
-            case SYSTEM_EVENT_AP_STADISCONNECTED:
-                ESP_LOGI(TAG, "SYSTEM_EVENT_AP_STADISCONNECTED");
+            case WIFI_EVENT_AP_STADISCONNECTED:
+                ESP_LOGI(TAG, "WIFI_EVENT_AP_STADISCONNECTED");
                 break;
             default:
                 break;


### PR DESCRIPTION
Description
-----------
Reported by @dachalco in https://github.com/aws/amazon-freertos/pull/2951#issuecomment-772721258, where `SYSTEM_WIFI_AP_START` event is not being generated until after a STA connects to SoftAP

For event_handler registered with `esp_event_handler_instance_register`, legacy event names should not be used.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.