### PR TITLE
Rename aws_ble_gatt_server_demo to iot_ble_gatt_server_demo.

### DIFF
--- a/demos/ble/gatt_server/CMakeLists.txt
+++ b/demos/ble/gatt_server/CMakeLists.txt
@@ -10,7 +10,7 @@ afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         "${AFR_DEMOS_DIR}/include/iot_ble_gatt_server_demo.h"
-        "${CMAKE_CURRENT_LIST_DIR}/aws_ble_gatt_server_demo.c"
+        "${CMAKE_CURRENT_LIST_DIR}/iot_ble_gatt_server_demo.c"
         # Todo: Needed for Console. Fix this. BLE requires this header, but it doesn't take data from numericComparision demo.
         "${AFR_DEMOS_DIR}/include/iot_ble_numericComparison.h"
 )

--- a/demos/ble/gatt_server/CMakeLists.txt
+++ b/demos/ble/gatt_server/CMakeLists.txt
@@ -9,7 +9,7 @@ afr_set_demo_metadata(DISPLAY_NAME "BLE GATT Server Demo")
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
-        "${AFR_DEMOS_DIR}/include/aws_ble_gatt_server_demo.h"
+        "${AFR_DEMOS_DIR}/include/iot_ble_gatt_server_demo.h"
         "${CMAKE_CURRENT_LIST_DIR}/aws_ble_gatt_server_demo.c"
         # Todo: Needed for Console. Fix this. BLE requires this header, but it doesn't take data from numericComparision demo.
         "${AFR_DEMOS_DIR}/include/iot_ble_numericComparison.h"

--- a/demos/ble/gatt_server/aws_ble_gatt_server_demo.c
+++ b/demos/ble/gatt_server/aws_ble_gatt_server_demo.c
@@ -30,7 +30,7 @@
 #include "FreeRTOSConfig.h"
 #include "iot_demo_logging.h"
 #include "iot_ble_config.h"
-#include "aws_ble_gatt_server_demo.h"
+#include "iot_ble_gatt_server_demo.h"
 #include "iot_ble.h"
 #include "task.h"
 #include "semphr.h"

--- a/demos/ble/gatt_server/iot_ble_gatt_server_demo.c
+++ b/demos/ble/gatt_server/iot_ble_gatt_server_demo.c
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file aws_ble_gatt_server_demo.c
+ * @file iot_ble_gatt_server_demo.c
  * @brief Sample demo for a BLE GATT server
  */
 #include "FreeRTOSConfig.h"

--- a/demos/ble/gatt_server/iot_ble_gatt_server_demo.c
+++ b/demos/ble/gatt_server/iot_ble_gatt_server_demo.c
@@ -218,7 +218,7 @@ static const IotBleAttributeEventCallback_t pxCallBackArray[ egattDemoNbAttribut
 
 /*-----------------------------------------------------------*/
 
-int vGattDemoSvcInit( bool awsIotMqttMode,
+int vGattDemoSvcInit( bool iotMqttMode,
                       const char * pIdentifier,
                       void * pNetworkServerInfo,
                       void * pNetworkCredentialInfo,

--- a/demos/include/iot_ble_gatt_server_demo.h
+++ b/demos/include/iot_ble_gatt_server_demo.h
@@ -87,7 +87,7 @@ typedef enum
  *
  * @return pdTRUE if the GATT Service is successfully initialized, pdFALSE otherwise
  */
-int vGattDemoSvcInit( bool awsIotMqttMode,
+int vGattDemoSvcInit( bool iotMqttMode,
                       const char * pIdentifier,
                       void * pNetworkServerInfo,
                       void * pNetworkCredentialInfo,

--- a/demos/include/iot_ble_gatt_server_demo.h
+++ b/demos/include/iot_ble_gatt_server_demo.h
@@ -24,11 +24,11 @@
  */
 
 /**
- * @file aws_ble_gatt_server_demo.h
+ * @file iot_ble_gatt_server_demo.h
  * @brief Sample demo for a BLE GATT server
  */
-#ifndef AWS_BLE_GATT_SERVER_DEMO_H_
-#define AWS_BLE_GATT_SERVER_DEMO_H_
+#ifndef IOT_BLE_GATT_SERVER_DEMO_H_
+#define IOT_BLE_GATT_SERVER_DEMO_H_
 
 #include "FreeRTOS.h"
 /* The config header is always included first. */
@@ -94,4 +94,4 @@ int vGattDemoSvcInit( bool awsIotMqttMode,
                       const IotNetworkInterface_t * pNetworkInterface );
 
 
-#endif /* AWS_BLE_GATT_SERVER_DEMO_H_ */
+#endif /* IOT_BLE_GATT_SERVER_DEMO_H_ */

--- a/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
+++ b/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
@@ -32,7 +32,7 @@
       <folder Name="common_demos">
         <folder Name="include">
           <file file_name="../../../../../demos/include/aws_application_version.h" />
-          <file file_name="../../../../../demos/include/aws_ble_gatt_server_demo.h" />
+          <file file_name="../../../../../demos/include/iot_ble_gatt_server_demo.h" />
           <file file_name="../../../../../demos/include/aws_clientcredential.h" />
           <file file_name="../../../../../demos/include/aws_clientcredential_keys.h" />
           <file file_name="../../../../../demos/include/aws_demo.h" />

--- a/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
+++ b/projects/nordic/nrf52840-dk/ses/aws_demos/aws_demos.emProject
@@ -58,7 +58,7 @@
             <file file_name="../../../../../demos/ble/mqtt_ble/mqtt_demo_ble_transport.c" />
           </folder>
           <folder Name="gatt_server">
-            <file file_name="../../../../../demos/ble/gatt_server/aws_ble_gatt_server_demo.c" />
+            <file file_name="../../../../../demos/ble/gatt_server/iot_ble_gatt_server_demo.c" />
           </folder>
           <folder Name="numeric_comparison">
             <file file_name="../../../../../demos/ble/numeric_comparison/iot_ble_numericComparison.c" />


### PR DESCRIPTION
Rename aws_ble_gatt_server_demo to iot_ble_gatt_server_demo

Description
-----------
Rename aws_ble_gatt_server_demo.{c,h} to iot_ble_gatt_server_demo.{c,h} since the ble gatt server demo is not aws specific.
Also adjust the name of one of the function parameters to vGattDemoSvcInit.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.