### PR TITLE
Hygiene: move filename extraction logic from logging header to source file

### DIFF
--- a/libraries/logging/include/iot_logging_task.h
+++ b/libraries/logging/include/iot_logging_task.h
@@ -53,15 +53,41 @@ BaseType_t xLoggingTaskInitialize( uint16_t usStackSize,
  * output directly, others will use a logging task to allow log message to be
  * output in the background should the output device be too slow for output to
  * be performed inline.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
  */
 void vLoggingPrintf( const char * pcFormat,
                      ... );
+
+/**
+ * @brief Same as vLoggingPrintf but additionally takes parameters
+ * of source file location of log to add as metadata in message.
+ *
+ * @param[in] pcFile The file name or file path containing the log
+ * message. If a file path is passed, only the filename is added to
+ * the log message.
+ * @param[in] fileLineNo The line number in the @p pcFile containing
+ * the message being logged.
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
+ */
+void vLoggingPrintfWithFileAndLine( const char * pcFile,
+                                    size_t fileLineNo,
+                                    const char * pcFormat,
+                                    ... );
 
 /**
  * @brief Interface for logging message at Error level.
  *
  * This function adds a "[ERROR]" prefix to the
  * log message to label it as an error.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
  */
 void vLoggingPrintfError( const char * pcFormat,
                           ... );
@@ -71,6 +97,10 @@ void vLoggingPrintfError( const char * pcFormat,
  *
  * This function adds a "[WARN]" prefix to the
  * log message to label it as a warning.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
  */
 void vLoggingPrintfWarn( const char * pcFormat,
                          ... );
@@ -80,6 +110,10 @@ void vLoggingPrintfWarn( const char * pcFormat,
  *
  * This function adds a "[INFO]" prefix to the
  * log message to label it as an informational message.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
  */
 void vLoggingPrintfInfo( const char * pcFormat,
                          ... );
@@ -89,6 +123,10 @@ void vLoggingPrintfInfo( const char * pcFormat,
  *
  * This function adds a "[DEBUG]" prefix to the
  * log message to label it as a debug level message.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
  */
 void vLoggingPrintfDebug( const char * pcFormat,
                           ... );

--- a/libraries/logging/include/logging_stack.h
+++ b/libraries/logging/include/logging_stack.h
@@ -37,7 +37,6 @@
 
 /* Standard Include. */
 #include <stdint.h>
-#include <string.h>
 
 /**
  * @brief This config enables extra verbosity in log messages with metadata information
@@ -55,22 +54,14 @@
 
 #if LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION == 1
 
-/* Macro to extract only the file name from file path to use for metadata in
- * log messages. */
-    #if defined( _MSC_VER_ ) || defined( __ARMCC_VERSION )
-        #define FILENAME    ( strrchr( __FILE__, '\\' ) ? strrchr( __FILE__, '\\' ) + 1 : __FILE__ )
-    #else
-        #define FILENAME    ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
-    #endif
-
     #define SdkLogError( message )           SdkLogErrorC99 message
-    #define SdkLogErrorC99( format, ... )    vLoggingPrintf( "[ERROR] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
+    #define SdkLogErrorC99( format, ... )    vLoggingPrintfWithFileAndLine( __FILE__, __LINE__, "[ERROR] [%s] " format "\r\n", LIBRARY_LOG_NAME, ## __VA_ARGS__ )
     #define SdkLogWarn( message )            SdkLogWarnC99 message
-    #define SdkLogWarnC99( format, ... )     vLoggingPrintf( "[WARN] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
+    #define SdkLogWarnC99( format, ... )     vLoggingPrintfWithFileAndLine( __FILE__, __LINE__, "[WARN] [%s] " format "\r\n", LIBRARY_LOG_NAME, ## __VA_ARGS__ )
     #define SdkLogInfo( message )            SdkLogInfoC99 message
-    #define SdkLogInfoC99( format, ... )     vLoggingPrintf( "[INFO] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
+    #define SdkLogInfoC99( format, ... )     vLoggingPrintfWithFileAndLine( __FILE__, __LINE__, "[INFO] [%s] " format "\r\n", LIBRARY_LOG_NAME, ## __VA_ARGS__ )
     #define SdkLogDebug( message )           SdkLogDebugC99 message
-    #define SdkLogDebugC99( format, ... )    vLoggingPrintf( "[DEBUG] [%s] [%s:%d] " format "\r\n", LIBRARY_LOG_NAME, FILENAME, __LINE__, ## __VA_ARGS__ )
+    #define SdkLogDebugC99( format, ... )    vLoggingPrintfWithFileAndLine( __FILE__, __LINE__, "[DEBUG] [%s] " format "\r\n", LIBRARY_LOG_NAME, ## __VA_ARGS__ )
 #else /* if LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION == 1 */
     #define SdkLogError( message )           vLoggingPrintfError message
     #define SdkLogWarn( message )            vLoggingPrintfWarn message

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSConfig.h
@@ -422,12 +422,12 @@
     #define UNTESTED_FUNCTION()
 #endif
 
-/* This config enables extra verbosity in log messages with metadata information
- * about the source library and location of the log message.
- * This requires that the toolchain support C99 (for variadic macros) and the GNU
- * extension for comma elision in variadic macros (with ##__VA_ARGS__).
- * If this flag is enabled, you can change the metadata information from the logging_stack.h
- * file.*/
+/* This config enables extra metadata information of the source library and location
+ * in log messages.
+ * This config requires the toolchain to support ISO C99 and the GNU extension (for comma 
+ * elision in variadic macros i.e. with ##__VA_ARGS__).
+ * When using this flag, you can change the format or information of log messages in
+ * the logging_stack.h file.*/
 #define LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION    ( 1 )
 
 #endif /* #define FREERTOS_CONFIG_H */

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -286,7 +286,7 @@ void vLoggingPrintf( const char * pcFormat,
     va_list xArgs;
 
     va_start( xArgs, pcFormat );
-    prvLoggingPrintf( LOG_NONE, pdTRUE, pcFormat, xArgs );
+    prvLoggingPrintf( LOG_NONE, NULL, 0, pdTRUE, pcFormat, xArgs );
     va_end( xArgs );
 }
 
@@ -294,7 +294,7 @@ void vLoggingPrintf( const char * pcFormat,
 
 void vLoggingPrint( const char * pcFormat )
 {
-    prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
+    prvLoggingPrintf( LOG_NONE, NULL, 0, pdFALSE, pcFormat, NULL );
 }
 
 /*-----------------------------------------------------------*/
@@ -305,7 +305,7 @@ void vLoggingPrintfError( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_ERROR, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_ERROR, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -318,7 +318,7 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_WARN, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_WARN, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -331,7 +331,7 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_INFO, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_INFO, NULL, 0, pdTRUE, pcFormat, args );
 }
 
 /*-----------------------------------------------------------*/
@@ -342,13 +342,32 @@ void vLoggingPrintfDebug( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_DEBUG, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_DEBUG, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
 /*-----------------------------------------------------------*/
 
+void vLoggingPrintfWithFileAndLine( const char * pcFile,
+                                    size_t fileLineNo,
+                                    const char * pcFormat,
+                                    ... )
+{
+    configASSERT( pcFile != NULL );
+
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pcFormat, args );
+
+    va_end( args );
+}
+
+/*-----------------------------------------------------------*/
+
 static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              const char * pcFile,
+                              size_t fileLineNo,
                               BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs )
@@ -419,6 +438,33 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         if( pcLevelString != NULL )
         {
             xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s] ", pcLevelString );
+        }
+
+        /* If provided, add the source file and line number metadata in the message. */
+        if( pcFile != NULL )
+        {
+            /* If a file path is provided, extract only the file name from the string
+             * by looking for '/' or '\' directory seperator. */
+            const char * pcFileName = NULL;
+
+            /* Check if file path contains "\" as the directory separator. */
+            if( strrchr( pcFile, '\\' ) != NULL )
+            {
+                pcFileName = strrchr( pcFile, '\\' ) + 1;
+            }
+            /* Check if file path contains "/" as the directory separator. */
+            else if( strrchr( pcFile, '/' ) != NULL )
+            {
+                pcFileName = strrchr( pcFile, '/' ) + 1;
+            }
+            else
+            {
+                /* File path contains only file name. */
+                pcFileName = pcFile;
+            }
+
+            xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
+            configASSERT( xLength > 0 );
         }
 
         if( xArgs != NULL )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -463,7 +463,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
                 pcFileName = pcFile;
             }
 
-            xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
             configASSERT( xLength > 0 );
         }
 

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.h
@@ -42,7 +42,7 @@ void vLoggingInit( BaseType_t xLogToStdout,
                    uint16_t usRemotePort );
 
 /**
- * @brief Printf like logging interface for logging in
+ * @brief Interface for logging strings in
  * from FreeRTOS tasks in the Windows platform.
  *
  * Depending on the configuration made through vLoggingInit(),
@@ -50,6 +50,39 @@ void vLoggingInit( BaseType_t xLogToStdout,
  * transmit over a UDP port.
  */
 void vLoggingPrint( const char * pcFormat );
+
+/**
+ * @brief Printf like logging interface to log messages from FreeRTOS
+ * tasks in Windows platform.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
+ */
+void vLoggingPrintf( const char * pcFormat,
+                     ... );
+
+/**
+ * @brief Same as vLoggingPrintf but additionally takes parameters
+ * of source file location of log to add as metadata in message.
+ *
+ * @param[in] pcFile The file name or file path containing the log
+ * message. If a file path is passed, only the filename is added to
+ * the log message.
+ * @param[in] fileLineNo The line number in the @p pcFile containing
+ * the message being logged.
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
+ */
+void vLoggingPrintfWithFileAndLine( const char * pcFile,
+                                    size_t fileLineNo,
+                                    const char * pcFormat,
+                                    ... );
 
 /**
  * @brief Interface for logging message at Error level.

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/FreeRTOSConfig.h
@@ -213,12 +213,12 @@
  * take up unnecessary RAM. */
 #define configCOMMAND_INT_MAX_OUTPUT_SIZE    1
 
-/* This config enables extra verbosity in log messages with metadata information
- * about the source library and location of the log message.
- * This requires that the toolchain support C99 (for variadic macros) and the GNU
- * extension for comma elision in variadic macros (with ##__VA_ARGS__).
- * If this flag is enabled, you can change the metadata information from the logging_stack.h
- * file.*/
-#define LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION    ( 1 ) 
+/* This config enables extra metadata information of the source library and location
+ * in log messages.
+ * This config requires the toolchain to support ISO C99 and the GNU extension (for comma 
+ * elision in variadic macros i.e. with ##__VA_ARGS__).
+ * When using this flag, you can change the format or information of log messages in
+ * the logging_stack.h file.*/
+#define LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION    ( 1 )
 
 #endif /* FREERTOS_CONFIG_H */

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -466,7 +466,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
                 pcFileName = pcFile;
             }
 
-            xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
             configASSERT( xLength > 0 );
         }
 

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -286,14 +286,15 @@ void vLoggingPrintf( const char * pcFormat,
     va_list xArgs;
 
     va_start( xArgs, pcFormat );
-    prvLoggingPrintf( LOG_NONE, pdTRUE, pcFormat, xArgs );
+    prvLoggingPrintf( LOG_NONE, NULL, 0, pdTRUE, pcFormat, xArgs );
     va_end( xArgs );
 }
+
 /*-----------------------------------------------------------*/
 
 void vLoggingPrint( const char * pcFormat )
 {
-    prvLoggingPrintf( LOG_NONE, pdFALSE, pcFormat, NULL );
+    prvLoggingPrintf( LOG_NONE, NULL, 0, pdFALSE, pcFormat, NULL );
 }
 
 /*-----------------------------------------------------------*/
@@ -304,7 +305,7 @@ void vLoggingPrintfError( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_ERROR, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_ERROR, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -317,7 +318,7 @@ void vLoggingPrintfWarn( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_WARN, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_WARN, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -330,7 +331,7 @@ void vLoggingPrintfInfo( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_INFO, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_INFO, NULL, 0, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -343,7 +344,24 @@ void vLoggingPrintfDebug( const char * pcFormat,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_DEBUG, pdTRUE, pcFormat, args );
+    prvLoggingPrintf( LOG_DEBUG, NULL, 0, pdTRUE, pcFormat, args );
+
+    va_end( args );
+}
+
+/*-----------------------------------------------------------*/
+
+void vLoggingPrintfWithFileAndLine( const char * pcFile,
+                                    size_t fileLineNo,
+                                    const char * pcFormat,
+                                    ... )
+{
+    configASSERT( pcFile != NULL );
+
+    va_list args;
+
+    va_start( args, pcFormat );
+    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pcFormat, args );
 
     va_end( args );
 }
@@ -351,6 +369,8 @@ void vLoggingPrintfDebug( const char * pcFormat,
 /*-----------------------------------------------------------*/
 
 static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              const char * pcFile,
+                              size_t fileLineNo,
                               BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs )
@@ -421,6 +441,33 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         if( pcLevelString != NULL )
         {
             xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "[%s] ", pcLevelString );
+        }
+
+        /* If provided, add the source file and line number metadata in the message. */
+        if( pcFile != NULL )
+        {
+            /* If a file path is provided, extract only the file name from the string
+             * by looking for '/' or '\' directory seperator. */
+            const char * pcFileName = NULL;
+
+            /* Check if file path contains "\" as the directory separator. */
+            if( strrchr( pcFile, '\\' ) != NULL )
+            {
+                pcFileName = strrchr( pcFile, '\\' ) + 1;
+            }
+            /* Check if file path contains "/" as the directory separator. */
+            else if( strrchr( pcFile, '/' ) != NULL )
+            {
+                pcFileName = strrchr( pcFile, '/' ) + 1;
+            }
+            else
+            {
+                /* File path contains only file name. */
+                pcFileName = pcFile;
+            }
+
+            xLength += snprintf( pcPrintString + xLength, configLOGGING_MAX_MESSAGE_LENGTH - xLength, "[%s:%d] ", pcFileName, fileLineNo );
+            configASSERT( xLength > 0 );
         }
 
         if( xArgs != NULL )

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.h
@@ -42,7 +42,7 @@ void vLoggingInit( BaseType_t xLogToStdout,
                    uint16_t usRemotePort );
 
 /**
- * @brief Printf like logging interface for logging in
+ * @brief Interface for logging strings in
  * from FreeRTOS tasks in the Windows platform.
  *
  * Depending on the configuration made through vLoggingInit(),
@@ -50,6 +50,39 @@ void vLoggingInit( BaseType_t xLogToStdout,
  * transmit over a UDP port.
  */
 void vLoggingPrint( const char * pcFormat );
+
+/**
+ * @brief Printf like logging interface to log messages from FreeRTOS
+ * tasks in Windows platform.
+ *
+ * Depending on the configuration made through vLoggingInit(),
+ * this function will print to stdout, log to disk file OR
+ * transmit over a UDP port.
+ *
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
+ */
+void vLoggingPrintf( const char * pcFormat,
+                     ... );
+
+/**
+ * @brief Same as vLoggingPrintf but additionally takes parameters
+ * of source file location of log to add as metadata in message.
+ *
+ * @param[in] pcFile The file name or file path containing the log
+ * message. If a file path is passed, only the filename is added to
+ * the log message.
+ * @param[in] fileLineNo The line number in the @p pcFile containing
+ * the message being logged.
+ * @param[in] pcFormat The format string of the log message.
+ * @param[in] ... The variadic list of parameters for the format
+ * specifiers in the @p pcFormat.
+ */
+void vLoggingPrintfWithFileAndLine( const char * pcFile,
+                                    size_t fileLineNo,
+                                    const char * pcFormat,
+                                    ... );
 
 /**
  * @brief Interface for logging message at Error level.


### PR DESCRIPTION
Improve the implementation of adding filename metadata in logs (when `LOGGING_ENABLE_METADATA_WITH_C99_AND_GNU_EXTENSION` config is enabled) by moving string operation logic from `logging_stack.h` to `.c` file that encapsulates implementation of logging functions. Also, replace use of toolchain-identifying preprocessor logic with `if-else` logic that reliably extracts filename from file-path.