### PR TITLE
Fix hangups caused by blocking forever in network receive task when calling shutdown

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -664,10 +664,6 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
         IotLogWarn( "Failed to close connection." );
     }
 
-    /* Set the shutdown flag. */
-    ( void ) xEventGroupSetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
-                                 _FLAG_SHUTDOWN );
-
     return IOT_NETWORK_SUCCESS;
 }
 

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -643,11 +643,11 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
     ( void ) xEventGroupSetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
                                  _FLAG_SHUTDOWN );
 
-    /* If a receive task was created... */
     if( pNetworkConnection->receiveTask != NULL )
     {
         /* Wait for the network receive task to exit so that the socket can be shutdown safely
-         * without causing the socket to block forever. */
+         * without causing the socket to block forever if there are pending reads or writes
+         * from other tasks. */
         ( void ) xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
                                       _FLAG_RECEIVE_TASK_EXITED,
                                       pdTRUE,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
In some TCP/IP stacks like lwIP, shutting down a socket causes a pending recv to block forever. Therefore, `IotNetworkAfr_Close` is modified to wait for the network receive task to exit so that the socket can be shutdown safely without causing the socket to block forever if there are pending reads or writes being done from other tasks.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.