### PR TITLE
espressif: Add missing mbedTLS port files in build list

### DIFF
--- a/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
+++ b/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
@@ -58,7 +58,18 @@ set(
     "${MBEDTLS_DIR}/port/esp_hardware.c"
     "${MBEDTLS_DIR}/port/mbedtls_debug.c"
     "${MBEDTLS_DIR}/port/esp_aes_xts.c"
+    "${MBEDTLS_DIR}/port/esp_sha.c"
+    "${MBEDTLS_DIR}/port/esp_timing.c"
 )
+
+if(CONFIG_MBEDTLS_DYNAMIC_BUFFER)
+    list(APPEND mbedtls_srcs
+    "${MBEDTLS_DIR}/port/dynamic/esp_mbedtls_dynamic_impl.c"
+    "${MBEDTLS_DIR}/port/dynamic/esp_ssl_cli.c"
+    "${MBEDTLS_DIR}/port/dynamic/esp_ssl_srv.c"
+    "${MBEDTLS_DIR}/port/dynamic/esp_ssl_tls.c"
+    )
+endif()
 
 if("${SOC_NAME}" STREQUAL "esp32s2")
     list(APPEND mbedtls_srcs


### PR DESCRIPTION
Description
-----------
This PR adds missing mbedTLS port files

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.