### PR TITLE
Fix TI wifi test build failure 

### DIFF
--- a/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
@@ -1351,9 +1351,72 @@ BaseType_t WIFI_IsConnected( const WIFINetworkParams_t * pxNetworkParams )
 
     return xIsConnected;
 }
+/*-----------------------------------------------------------*/
 
 WIFIReturnCode_t WIFI_RegisterEvent( WIFIEventType_t xEventType, WIFIEventHandler_t xHandler )
 {
     /** Needs to implement dispatching network state change events **/
     return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetCapability( WIFICapabilityInfo_t * pxCaps )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetCountryCode( char * pcCountryCode )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_SetCountryCode( const char * pcCountryCode )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetRSSI( int8_t * pcRSSI )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetScanResults( const WIFIScanResult_t ** pxBuffer,
+                                      uint16_t * ucNumNetworks )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetStationList( WIFIStationInfo_t * pxStationList,
+                                      uint8_t * pcStationListSize )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetStatistic( WIFIStatisticInfo_t * pxStats )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartConnectAP( const WIFINetworkParams_t * pxNetworkParams )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartDisconnect( void )
+{
+        return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartScan( WIFIScanConfig_t * pxScanConfig )
+{
+        return eWiFiNotSupported;
 }

--- a/vendors/vendor/boards/board/ports/wifi/iot_wifi.c
+++ b/vendors/vendor/boards/board/ports/wifi/iot_wifi.c
@@ -70,14 +70,7 @@ WIFIReturnCode_t WIFI_Reset( void )
     /* FIX ME. */
     return eWiFiFailure;
 }
-/*-----------------------------------------------------------*/
 
-WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
-                            uint8_t ucNumNetworks )
-{
-    /* FIX ME. */
-    return eWiFiFailure;
-}
 /*-----------------------------------------------------------*/
 
 WIFIReturnCode_t WIFI_SetMode( WIFIDeviceMode_t xDeviceMode )
@@ -126,13 +119,6 @@ WIFIReturnCode_t WIFI_Ping( uint8_t * pucIPAddr,
 }
 /*-----------------------------------------------------------*/
 
-WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPConfig )
-{
-    /* FIX ME. */
-    return eWiFiNotSupported;
-}
-/*-----------------------------------------------------------*/
-
 WIFIReturnCode_t WIFI_GetMAC( uint8_t * pucMac )
 {
     /* FIX ME. */
@@ -145,6 +131,14 @@ WIFIReturnCode_t WIFI_GetHostIP( char * pcHost,
 {
     /* FIX ME. */
     return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
+                            uint8_t ucNumNetworks )
+{
+    /* FIX ME. */
+    return eWiFiFailure;
 }
 /*-----------------------------------------------------------*/
 
@@ -185,8 +179,117 @@ WIFIReturnCode_t WIFI_GetPMMode( WIFIPMMode_t * pxPMModeType,
 }
 /*-----------------------------------------------------------*/
 
+WIFIReturnCode_t WIFI_RegisterEvent( WIFIEventType_t xEventType,
+                                     WIFIEventHandler_t xHandler )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
 BaseType_t WIFI_IsConnected( const WIFINetworkParams_t * pxNetworkParams )
 {
 	/* FIX ME. */
 	return pdFALSE;
 }
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartScan( WIFIScanConfig_t * pxScanConfig )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetScanResults( const WIFIScanResult_t ** pxBuffer,
+                                      uint16_t * ucNumNetworks )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartConnectAP( const WIFINetworkParams_t * pxNetworkParams )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartDisconnect( void )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetConnectionInfo( WIFIConnectionInfo_t * pxConnectionInfo )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetIPInfo( WIFIIPConfiguration_t * pxIPConfig )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetRSSI( int8_t * pcRSSI )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetStationList( WIFIStationInfo_t * pxStationList,
+                                      uint8_t * pcStationListSize )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_StartDisconnectStation( uint8_t * pucMac )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_SetMAC( uint8_t * pucMac )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_SetCountryCode( const char * pcCountryCode )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetCountryCode( char * pcCountryCode )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetStatistic( WIFIStatisticInfo_t * pxStats )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/
+
+WIFIReturnCode_t WIFI_GetCapability( WIFICapabilityInfo_t * pxCaps )
+{
+    /* FIX ME. */
+    return eWiFiNotSupported;    
+}
+/*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
- Fix TI wifi test build failure 

```
<Linking>
 
 undefined            first referenced                                    
  symbol                  in file                                         
 ---------            ----------------                                    
 WIFI_GetCapability   ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_GetCountryCode  ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_GetRSSI         ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_GetScanResults  ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_GetStationList  ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_GetStatistic    ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_SetCountryCode  ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_StartConnectAP  ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_StartDisconnect ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 WIFI_StartScan       ./libraries/abstractions/wifi/test/iot_test_wifi.obj
 
error #10234-D: unresolved symbols remain
error #10010: errors encountered during linking; "aws_tests.out" not built
 ```

- Update the wifi port template
 
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.