### PR TITLE
Fix prvConnectToServerWithBackoffRetries to correctly return connection status

### DIFF
--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -781,7 +781,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
 
     xStatus = ( xBackoffStatus == pdPASS ) ? pdPASS : pdFAIL;
 
-    return xStatus;
+    return ( xNetworkStatus == TRANSPORT_SOCKET_STATUS_SUCCESS ) ? pdPASS : pdFAIL;
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -723,7 +723,6 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     ServerInfo_t xServerInfo = { 0 };
 
     SocketsConfig_t xSocketsConfig = { 0 };
-    BaseType_t xStatus = pdFAIL;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     BackoffAlgorithmContext_t xReconnectParams;
     BaseType_t xBackoffStatus = pdFALSE;
@@ -778,8 +777,6 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
             xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
-
-    xStatus = ( xBackoffStatus == pdPASS ) ? pdPASS : pdFAIL;
 
     return ( xNetworkStatus == TRANSPORT_SOCKET_STATUS_SUCCESS ) ? pdPASS : pdFAIL;
 }

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -723,7 +723,6 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     ServerInfo_t xServerInfo = { 0 };
 
     SocketsConfig_t xSocketsConfig = { 0 };
-    BaseType_t xStatus = pdFAIL;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     BackoffAlgorithmContext_t xReconnectParams;
     BaseType_t xBackoffStatus = pdFALSE;
@@ -779,9 +778,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
 
-    xStatus = ( xBackoffStatus == pdPASS ) ? pdPASS : pdFAIL;
-
-    return xStatus;
+    return xBackoffStatus;
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -723,6 +723,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     ServerInfo_t xServerInfo = { 0 };
 
     SocketsConfig_t xSocketsConfig = { 0 };
+    BaseType_t xStatus = pdFAIL;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     BackoffAlgorithmContext_t xReconnectParams;
     BaseType_t xBackoffStatus = pdFALSE;
@@ -778,7 +779,9 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
 
-    return xBackoffStatus;
+    xStatus = ( xBackoffStatus == pdPASS ) ? pdPASS : pdFAIL;
+
+    return xStatus;
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -723,7 +723,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     ServerInfo_t xServerInfo = { 0 };
 
     SocketsConfig_t xSocketsConfig = { 0 };
-    BaseType_t xStatus = pdPASS;
+    BaseType_t xStatus = pdFAIL;
     TransportSocketStatus_t xNetworkStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     BackoffAlgorithmContext_t xReconnectParams;
     BaseType_t xBackoffStatus = pdFALSE;
@@ -778,6 +778,8 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
             xBackoffStatus = prvBackoffForRetry( &xReconnectParams );
         }
     } while( ( xNetworkStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) && ( xBackoffStatus == pdPASS ) );
+
+    xStatus = ( xBackoffStatus == pdPASS ) ? pdPASS : pdFAIL;
 
     return xStatus;
 }


### PR DESCRIPTION
Description
-----------
The function `prvConnectToServerWithBackoffRetries` was always returning `pdPASS` regardless of whether or not the connection was successful. This caused the demo to segfault as it ended up using an invalid socket to establish a MQTT session with the broker in case of a connection failure.

This PR updates  `prvConnectToServerWithBackoffRetries` to return `pdFAIL` in case of connection failure. This ensures that the demo does not attempt to establish a MQTT session with the broker in case of a connection failure.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.