### PR TITLE
Update corePKCS11 and PKCS #11 PAL interfaces with latest changes

### DIFF
--- a/tests/unit_test/linux/config_files/core_pkcs11_config.h
+++ b/tests/unit_test/linux/config_files/core_pkcs11_config.h
@@ -97,14 +97,6 @@
 #define pkcs11configMAX_SESSIONS                           10
 
 /**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
-
-/**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
  *
  * If set to 0, OTA code signing certificate is built in via

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/config_files/core_pkcs11_config.h
@@ -93,13 +93,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS      6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
@@ -405,11 +405,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
@@ -43,6 +43,7 @@
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
+#include "core_pkcs11_pal.h"
 #include "FreeRTOS.h"
 
 /* C runtime includes. */
@@ -223,10 +224,12 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
         /* Attempt to read the object to see if something valid is there. */
         xResult = PKCS11_PAL_GetObjectValue(xHandle, &pucData, &xDataSize, &xIsPrivate );
 
-        if (xResult != CK_INVALID_HANDLE)
+        if( ( xResult != CKR_OK ) || ( pucData[ 0 ] == 0x00 ) )
         {
-            xHandle = 0;
+            xHandle = eInvalidHandle;
         }
+
+        PKCS11_PAL_GetObjectValueCleanup( pucData, xDataSize );
     }
 
     return xHandle;
@@ -357,3 +360,88 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
 }
 
 /*-----------------------------------------------------------*/
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
+}

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
@@ -43,6 +43,7 @@
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
+#include "core_pkcs11_pal.h"
 #include "FreeRTOS.h"
 
 /* C runtime includes. */
@@ -224,10 +225,12 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
         /* Attempt to read the object to see if something valid is there. */
         xResult = PKCS11_PAL_GetObjectValue(xHandle, &pucData, &xDataSize, &xIsPrivate );
 
-        if (xResult != CK_INVALID_HANDLE)
+        if( ( xResult != CKR_OK ) || ( pucData[ 0 ] == 0x00 ) )
         {
-            xHandle = 0;
+            xHandle = eInvalidHandle;
         }
+
+        PKCS11_PAL_GetObjectValueCleanup( pucData, xDataSize );
     }
 
     return xHandle;
@@ -358,3 +361,88 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
 }
 
 /*-----------------------------------------------------------*/
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
+}

--- a/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/ports/pkcs11/core_pkcs11_pal.c
@@ -406,11 +406,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/default_pkcs11_config/core_pkcs11_config.h
@@ -110,13 +110,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10UL
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -111,13 +111,6 @@ extern const char * pcPkcs11GetThingName(void);
  */
 #define pkcs11configMAX_NUM_OBJECTS      6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/default_pkcs11_config/core_pkcs11_config.h
@@ -109,13 +109,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -94,13 +94,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/espressif/boards/esp32s2/aws_demos/config_files/default_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_demos/config_files/default_pkcs11_config/core_pkcs11_config.h
@@ -110,13 +110,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10UL
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/espressif/boards/esp32s2/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_demos/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -111,13 +111,6 @@ extern const char * pcPkcs11GetThingName(void);
  */
 #define pkcs11configMAX_NUM_OBJECTS      6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/espressif/boards/esp32s2/aws_tests/config_files/default_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_tests/config_files/default_pkcs11_config/core_pkcs11_config.h
@@ -109,13 +109,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/espressif/boards/esp32s2/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_tests/config_files/ecc608a_pkcs11_config/core_pkcs11_config.h
@@ -94,13 +94,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
@@ -450,11 +450,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
@@ -26,6 +26,7 @@
 #include "task.h"
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "core_pkcs11_config.h"
 
 /* C runtime includes. */
@@ -229,7 +230,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
-
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
     initialize_nvs_partition();
 
     /* Translate from the PKCS#11 label to local storage file name. */
@@ -255,6 +260,18 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
             xHandle = eInvalidHandle;
         }
         nvs_close(handle);
+    }
+    if( xHandle != eInvalidHandle )
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -387,4 +404,85 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
     {
         vPortFree( pucData );
     }
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength * sizeof( CK_BYTE ) );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+            /* Create an object label attribute. */
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+
+    return xResult;
 }

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/core_pkcs11_config.h
@@ -105,13 +105,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/core_pkcs11_pal.c
@@ -431,11 +431,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/infineon/boards/xmc4800_iotkit/ports/pkcs11/core_pkcs11_pal.c
@@ -45,6 +45,7 @@
 
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "core_pkcs11_config.h"
 
 /* C runtime includes. */
@@ -199,6 +200,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
     if( 0 == memcmp( pxLabel,
@@ -237,6 +243,16 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
             xHandle = eAwsCodeSigningKey;
         }
     }
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    /* Zeroed out object means it has been destroyed. */
+    if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+    {
+        xHandle = eInvalidHandle;
+    }
+
+    PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
 
     return xHandle;
 }
@@ -366,6 +382,91 @@ CK_RV PKCS11_PAL_Initialize( void )
     if( E_EEPROM_XMC4_IsFlashEmpty() == false )
     {
         E_EEPROM_XMC4_ReadArray( 0, ( uint8_t * const ) &P11KeyConfig, sizeof( P11KeyConfig_t ) );
+    }
+
+    return xResult;
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
     }
 
     return xResult;

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/core_pkcs11_config.h
@@ -96,13 +96,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_pkcs11_config.h
@@ -92,13 +92,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS      6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_test_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_test_pkcs11_config.h
@@ -78,12 +78,7 @@
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 0 )
-
-/*
- * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
- */
-#define pkcs11testPREPROVISIONED_SUPPORT            ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 1 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_test_pkcs11_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_tests/config_files/core_test_pkcs11_config.h
@@ -78,7 +78,12 @@
 /*
  * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
  */
-#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 1 )
+#define pkcs11testGENERATE_KEYPAIR_SUPPORT            ( 0 )
+
+/*
+ * @brief Set to 1 if generating a device private-public key pair via C_GenerateKeyPair. 0 if not.
+ */
+#define pkcs11testPREPROVISIONED_SUPPORT            ( 1 )
 
 /**
  * @brief The PKCS #11 label for device private key for test.

--- a/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
+++ b/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c
@@ -90,7 +90,7 @@ typedef struct P11Struct_t
     P11ObjectList_t xObjectList;
     uint16_t xCertOid;
     uint16_t xPrivKeyOid;
-} P11Struct_t, * P11Context_t;
+} P11Struct_t, *P11Context_t;
 
 static P11Struct_t xP11Context;
 
@@ -115,7 +115,7 @@ typedef struct P11Session
     CK_MECHANISM_TYPE xSignMechanism;
     uint16_t usSignKeyOid;
     OptigaSha256Ctx_t xSHA256Context;
-} P11Session_t, * P11SessionPtr_t;
+} P11Session_t, *P11SessionPtr_t;
 
 
 /**
@@ -545,9 +545,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      CK_BYTE_PTR * ppucData,
-                                      CK_ULONG_PTR pulDataSize,
-                                      CK_BBOOL * pIsPrivate )
+                                 CK_BYTE_PTR * ppucData,
+                                 CK_ULONG_PTR pulDataSize,
+                                 CK_BBOOL * pIsPrivate )
 {
     BaseType_t ulReturn = CKR_OK;
     optiga_lib_status_t xReturn;
@@ -962,134 +962,131 @@ CK_RV prvAddObjectToList( CK_OBJECT_HANDLE xPalHandle,
     return xResult;
 }
 
-#if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 )
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xAppHandle )
+{
+    uint8_t * pcLabel = NULL;
+    char * pcTempLabel = NULL;
+    size_t xLabelLength = 0;
+    uint32_t ulObjectLength = 0;
+    CK_RV xResult = CKR_OK;
+    CK_BBOOL xFreeMemory = CK_FALSE;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_OBJECT_HANDLE xPalHandle;
+    CK_OBJECT_HANDLE xAppHandle2;
+    CK_LONG lOptigaOid = 0;
+    char * xEnd = NULL;
 
-    CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xAppHandle )
+    prvFindObjectInListByHandle( xAppHandle, &xPalHandle, &pcLabel, &xLabelLength );
+
+    if( pcLabel != NULL )
     {
-        uint8_t * pcLabel = NULL;
-        char * pcTempLabel = NULL;
-        size_t xLabelLength = 0;
-        uint32_t ulObjectLength = 0;
-        CK_RV xResult = CKR_OK;
-        CK_BBOOL xFreeMemory = CK_FALSE;
-        CK_BYTE_PTR pxObject = NULL;
-        CK_OBJECT_HANDLE xPalHandle;
-        CK_OBJECT_HANDLE xAppHandle2;
-        CK_LONG lOptigaOid = 0;
-        char * xEnd = NULL;
-
-        prvFindObjectInListByHandle( xAppHandle, &xPalHandle, &pcLabel, &xLabelLength );
-
-        if( pcLabel != NULL )
+        if( ( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, xLabelLength ) )
+            #if FREERTOS_ENABLE_UNIT_TESTS
+                ||
+                ( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, xLabelLength ) )
+            #endif
+            )
         {
-            if( ( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, xLabelLength ) )
-                #if FREERTOS_ENABLE_UNIT_TESTS
-                    ||
-                    ( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, xLabelLength ) )
-                #endif
-                )
+            prvFindObjectInListByLabel( ( uint8_t * ) pcLabel, strlen( ( char * ) pcLabel ), &xPalHandle, &xAppHandle2 );
+
+            if( xPalHandle != CK_INVALID_HANDLE )
             {
-                prvFindObjectInListByLabel( ( uint8_t * ) pcLabel, strlen( ( char * ) pcLabel ), &xPalHandle, &xAppHandle2 );
-
-                if( xPalHandle != CK_INVALID_HANDLE )
-                {
-                    xResult = prvDeleteObjectFromList( xAppHandle2 );
-                }
-
-                lOptigaOid = strtol( ( char * ) pcLabel, &xEnd, 16 );
-
-                CK_BYTE pucDumbData[ 68 ];
-                uint16_t ucDumbDataLength = 68;
-
-                if( OPTIGA_LIB_SUCCESS != optiga_crypt_ecc_generate_keypair( OPTIGA_ECC_NIST_P_256,
-                                                                             ( uint8_t ) OPTIGA_KEY_USAGE_SIGN,
-                                                                             FALSE,
-                                                                             &lOptigaOid,
-                                                                             pucDumbData,
-                                                                             &ucDumbDataLength ) )
-                {
-                    PKCS11_PRINT( ( "ERROR: Failed to invalidate a keypair \r\n" ) );
-                    xResult = CKR_FUNCTION_FAILED;
-                }
-            }
-            else
-            {
-                if( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, xLabelLength ) )
-                {
-                    pcTempLabel = pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
-                }
-
-                #if FREERTOS_ENABLE_UNIT_TESTS
-                    else if( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, xLabelLength ) )
-                    {
-                        pcTempLabel = pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
-                    }
-                #endif
-                else if( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, xLabelLength ) )
-                {
-                    pcTempLabel = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
-                }
-                #if FREERTOS_ENABLE_UNIT_TESTS
-                    else if( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, xLabelLength ) )
-                    {
-                        pcTempLabel = pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS;
-                    }
-                #endif
-                else if( 0 == memcmp( pcLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, xLabelLength ) )
-                {
-                    pcTempLabel = pkcs11configLABEL_CODE_VERIFICATION_KEY;
-                }
-
-                if( pcTempLabel != NULL )
-                {
-                    lOptigaOid = strtol( pcTempLabel, &xEnd, 16 );
-
-                    if( ( 0 != lOptigaOid ) && ( USHRT_MAX >= lOptigaOid ) )
-                    {
-                        /* Erase the object */
-                        CK_BYTE pucData[] = { 0 };
-                        xResult = optiga_util_write_data( ( uint16_t ) lOptigaOid,
-                                                          OPTIGA_UTIL_ERASE_AND_WRITE,
-                                                          0, /* Offset */
-                                                          pucData,
-                                                          1 );
-
-                        if( OPTIGA_LIB_SUCCESS == xResult )
-                        {
-                            prvFindObjectInListByLabel( ( uint8_t * ) pcTempLabel, strlen( ( char * ) pcTempLabel ), &xPalHandle, &xAppHandle2 );
-
-                            if( xPalHandle != CK_INVALID_HANDLE )
-                            {
-                                xResult = prvDeleteObjectFromList( xAppHandle2 );
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    xResult = CKR_KEY_HANDLE_INVALID;
-                }
+                xResult = prvDeleteObjectFromList( xAppHandle2 );
             }
 
-            if( xAppHandle2 != xAppHandle )
+            lOptigaOid = strtol( ( char * ) pcLabel, &xEnd, 16 );
+
+            CK_BYTE pucDumbData[ 68 ];
+            uint16_t ucDumbDataLength = 68;
+
+            if( OPTIGA_LIB_SUCCESS != optiga_crypt_ecc_generate_keypair( OPTIGA_ECC_NIST_P_256,
+                                                                         ( uint8_t ) OPTIGA_KEY_USAGE_SIGN,
+                                                                         FALSE,
+                                                                         &lOptigaOid,
+                                                                         pucDumbData,
+                                                                         &ucDumbDataLength ) )
             {
-                xResult = prvDeleteObjectFromList( xAppHandle );
+                PKCS11_PRINT( ( "ERROR: Failed to invalidate a keypair \r\n" ) );
+                xResult = CKR_FUNCTION_FAILED;
             }
         }
         else
         {
-            xResult = CKR_KEY_HANDLE_INVALID;
+            if( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, xLabelLength ) )
+            {
+                pcTempLabel = pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+            }
+
+            #if FREERTOS_ENABLE_UNIT_TESTS
+                else if( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, xLabelLength ) )
+                {
+                    pcTempLabel = pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                }
+            #endif
+            else if( 0 == memcmp( pcLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, xLabelLength ) )
+            {
+                pcTempLabel = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+            }
+            #if FREERTOS_ENABLE_UNIT_TESTS
+                else if( 0 == memcmp( pcLabel, pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, xLabelLength ) )
+                {
+                    pcTempLabel = pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                }
+            #endif
+            else if( 0 == memcmp( pcLabel, pkcs11configLABEL_CODE_VERIFICATION_KEY, xLabelLength ) )
+            {
+                pcTempLabel = pkcs11configLABEL_CODE_VERIFICATION_KEY;
+            }
+
+            if( pcTempLabel != NULL )
+            {
+                lOptigaOid = strtol( pcTempLabel, &xEnd, 16 );
+
+                if( ( 0 != lOptigaOid ) && ( USHRT_MAX >= lOptigaOid ) )
+                {
+                    /* Erase the object */
+                    CK_BYTE pucData[] = { 0 };
+                    xResult = optiga_util_write_data( ( uint16_t ) lOptigaOid,
+                                                      OPTIGA_UTIL_ERASE_AND_WRITE,
+                                                      0,     /* Offset */
+                                                      pucData,
+                                                      1 );
+
+                    if( OPTIGA_LIB_SUCCESS == xResult )
+                    {
+                        prvFindObjectInListByLabel( ( uint8_t * ) pcTempLabel, strlen( ( char * ) pcTempLabel ), &xPalHandle, &xAppHandle2 );
+
+                        if( xPalHandle != CK_INVALID_HANDLE )
+                        {
+                            xResult = prvDeleteObjectFromList( xAppHandle2 );
+                        }
+                    }
+                }
+            }
+            else
+            {
+                xResult = CKR_KEY_HANDLE_INVALID;
+            }
         }
 
-        if( xFreeMemory == CK_TRUE )
+        if( xAppHandle2 != xAppHandle )
         {
-            PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+            xResult = prvDeleteObjectFromList( xAppHandle );
         }
-
-        return xResult;
+    }
+    else
+    {
+        xResult = CKR_KEY_HANDLE_INVALID;
     }
 
-#endif /* if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 ) */
+    if( xFreeMemory == CK_TRUE )
+    {
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+
+    return xResult;
+}
+
 
 /*-------------------------------------------------------------*/
 

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/core_pkcs11_pal.c
@@ -412,11 +412,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/marvell/boards/mw300_rd/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/marvell/boards/mw300_rd/ports/pkcs11/core_pkcs11_pal.c
@@ -41,6 +41,7 @@
 #include "iot_crypto.h"
 #include "core_pkcs11_config.h"
 #include "FreeRTOS.h"
+#include "core_pkcs11_pal.h"
 
 /* Marvell specific Includes. */
 #include <wm_os.h>
@@ -168,6 +169,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
     char * pcFileName = NULL;
     int ret;
 
@@ -195,6 +201,16 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
         wmprintf("Error: couldn't find the object\r\n");
         return eInvalidHandle;
     }
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    /* Zeroed out object means it has been destroyed. */
+    if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+    {
+        xHandle = eInvalidHandle;
+    }
+
+    PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
 
     return xHandle;
 }
@@ -350,4 +366,89 @@ int mbedtls_hardware_poll( void * data,
 
     *olen = len;
     return 0;
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
 }

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/core_pkcs11_pal.c
@@ -40,6 +40,7 @@
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
+#include "core_pkcs11_pal.h"
 
 /* C runtime includes. */
 #include <stdio.h>
@@ -237,6 +238,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 
     char                *pcFileName = NULL;
     CK_OBJECT_HANDLE    xHandle     = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     /* Converts a label to its respective filename and handle. */
 
@@ -246,10 +252,15 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     {
         /* Check if object exists/has been created before returning. */
 
-        if( pdTRUE != hal_file_find( pcFileName, NULL ) )
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
         {
             xHandle = eInvalidHandle;
         }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -369,3 +380,87 @@ int mbedtls_hardware_poll( void * data,
     return 0;
 }
 
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
+}

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/ports/pkcs11/core_pkcs11_pal.c
@@ -424,11 +424,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/microchip/boards/curiosity_pic32mzef/aws_tests/config_files/core_pkcs11_config.h
@@ -111,13 +111,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/core_pkcs11_pal.c
@@ -39,6 +39,7 @@
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
+#include "core_pkcs11_pal.h"
 
 /* C runtime includes. */
 #include <stdio.h>
@@ -239,6 +240,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     const P11CertData_t * pCertFlash = 0;
 
     const P11KeyConfig_t * P11ConfigFlashPtr = ( const P11KeyConfig_t * ) KVA0_TO_KVA1( PKCS11_CERTIFICATE_SECTION_START_ADDRESS );
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     /* TODO: Check if object actually exists/has been created before returning. */
     if( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength )  )
@@ -271,6 +277,18 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     if(!( ( pCertFlash != 0 ) && ( pCertFlash->ulCertificatePresent == pkcs11OBJECT_FLASH_CERT_PRESENT ) ))
     {
         xHandle = eInvalidHandle;
+    }
+    else
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -443,4 +461,89 @@ static uint64_t PIC32MZ_HW_TRNG_Get( void )
     }
 
     return RNGSEED1 + ( ( uint64_t ) RNGSEED2 << 32 );
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
 }

--- a/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/microchip/boards/curiosity_pic32mzef/ports/pkcs11/core_pkcs11_pal.c
@@ -507,11 +507,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/core_pkcs11_config.h
@@ -96,13 +96,6 @@ extern const char * pcPkcs11GetThingName( void );
  */
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_tests/config_files/core_pkcs11_config.h
@@ -92,13 +92,6 @@
  */
 #define pkcs11configMAX_NUM_OBJECTS                        6
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /*
  * @brief Set to 1 if importing device private key via C_CreateObject is supported.  0 if not.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/core_pkcs11_config.h
@@ -105,13 +105,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/core_pkcs11_config.h
@@ -105,13 +105,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -547,11 +547,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -37,6 +37,7 @@
 #include "FreeRTOSIPConfig.h"
 #include "task.h"
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "iot_crypto.h"
 #include "core_pkcs11_config.h"
 

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/pkcs11/core_pkcs11_pal.c
@@ -397,7 +397,10 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 
         if( pdTRUE != prvFLASH_ReadFile( pcFileName, &pucData, &dataSize) )
         {
-            xHandle = eInvalidHandle;
+            if( pucData[0] == 0x0 )
+            {
+                xHandle = eInvalidHandle;
+            }
         }
     }
 
@@ -498,4 +501,89 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
 
     /* Since no buffer was allocated on heap, there is no cleanup
      * to be done. */    
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
 }

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/core_pkcs11_config.h
@@ -98,13 +98,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/core_pkcs11_pal.c
@@ -346,11 +346,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/nxp/boards/lpc54018iotmodule/ports/pkcs11/core_pkcs11_pal.c
@@ -37,8 +37,9 @@
 #include "FreeRTOSIPConfig.h"
 #include "iot_crypto.h"
 #include "task.h"
-#include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 
 /* Flash write */
 #include "mflash_file.h"
@@ -176,17 +177,25 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
-    uint8_t * pFile = NULL;
-    size_t xFileLength = 0;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     /* Translate from the PKCS#11 label to local storage file name. */
     prvLabelToFilenameHandle( pxLabel, &pcFileName, &xHandle );
 
     /* Check if the file exists. */
-    if( pdFALSE == mflash_read_file( pcFileName, &pFile, &xFileLength ) )
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    /* Zeroed out object means it has been destroyed. */
+    if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
     {
         xHandle = eInvalidHandle;
     }
+
+    PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
 
     return xHandle;
 }
@@ -288,6 +297,91 @@ CK_RV PKCS11_PAL_Initialize( void )
     if( pdFALSE == mflash_init( g_cert_files, 1 ) )
     {
         xResult = CKR_FUNCTION_FAILED;
+    }
+
+    return xResult;
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
     }
 
     return xResult;

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
@@ -63,12 +63,12 @@
 #define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED      0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED       0
 #define testrunnerFULL_MQTTv4_ENABLED                 0
-#define testrunnerFULL_PKCS11_ENABLED                 1
-#define testrunnerFULL_PKCS11_MODEL_ENABLED           1
+#define testrunnerFULL_PKCS11_ENABLED                 0
+#define testrunnerFULL_PKCS11_MODEL_ENABLED           0
 #define testrunnerFULL_POSIX_ENABLED                  0
 #define testrunnerFULL_SHADOW_ENABLED                 0
 #define testrunnerFULL_SHADOWv4_ENABLED               0
-#define testrunnerFULL_TCP_ENABLED                    0
+#define testrunnerFULL_TCP_ENABLED                    1
 #define testrunnerFULL_TLS_ENABLED                    0
 #define testrunnerFULL_MEMORYLEAK_ENABLED             0
 #define testrunnerFULL_OTA_CBOR_ENABLED               0

--- a/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/aws_test_runner_config.h
@@ -63,12 +63,12 @@
 #define testrunnerFULL_CORE_HTTP_AWS_IOT_ENABLED      0
 #define testrunnerFULL_MQTT_STRESS_TEST_ENABLED       0
 #define testrunnerFULL_MQTTv4_ENABLED                 0
-#define testrunnerFULL_PKCS11_ENABLED                 0
-#define testrunnerFULL_PKCS11_MODEL_ENABLED           0
+#define testrunnerFULL_PKCS11_ENABLED                 1
+#define testrunnerFULL_PKCS11_MODEL_ENABLED           1
 #define testrunnerFULL_POSIX_ENABLED                  0
 #define testrunnerFULL_SHADOW_ENABLED                 0
 #define testrunnerFULL_SHADOWv4_ENABLED               0
-#define testrunnerFULL_TCP_ENABLED                    1
+#define testrunnerFULL_TCP_ENABLED                    0
 #define testrunnerFULL_TLS_ENABLED                    0
 #define testrunnerFULL_MEMORYLEAK_ENABLED             0
 #define testrunnerFULL_OTA_CBOR_ENABLED               0

--- a/vendors/pc/boards/windows/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/pc/boards/windows/aws_tests/config_files/core_pkcs11_config.h
@@ -104,13 +104,6 @@
 #define pkcs11configMAX_SESSIONS                           250
 
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_tests/config_files/core_pkcs11_config.h
@@ -100,13 +100,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/core_pkcs11_pal.c
@@ -49,6 +49,7 @@
 
 /* Amazon FreeRTOS Includes. */
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "iot_crypto.h"
 #include "core_pkcs11_config.h"
 #include "FreeRTOS.h"
@@ -383,6 +384,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
                                         uint8_t usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
     int i;
 
     for(i = 1; i < PKCS_OBJECT_HANDLES_NUM; i++)
@@ -394,6 +400,19 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( uint8_t * pLabel,
                 xHandle = i;
             }
         }
+    }
+
+    if( xHandle != eInvalidHandle)
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -745,4 +764,89 @@ void update_data_flash_callback_function(void *event)
 		default:
 			break;
 	}
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
 }

--- a/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/renesas/boards/rx65n-rsk/ports/pkcs11/core_pkcs11_pal.c
@@ -810,11 +810,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/core_pkcs11_pal.c
@@ -751,11 +751,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/st/boards/stm32l475_discovery/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/pkcs11/core_pkcs11_pal.c
@@ -38,6 +38,7 @@
 #include "task.h"
 #include "iot_crypto.h"
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "core_pkcs11_config.h"
 
 /* C runtime includes. */
@@ -545,6 +546,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     if( ( 0 == memcmp( pxLabel, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, usLength ) ) &&
         ( ( P11KeyConfig.ulDeviceCertificateMark & pkcs11OBJECT_PRESENT_MASK ) == pkcs11OBJECT_PRESENT_MAGIC ) )
@@ -565,6 +571,19 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
              ( ( P11KeyConfig.ulDeviceKeyMark & pkcs11OBJECT_PRESENT_MASK ) == pkcs11OBJECT_PRESENT_MAGIC ) )
     {
         xHandle = eAwsDevicePublicKey;
+    }
+    
+    if( xHandle != eInvalidHandle )
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -687,3 +706,84 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
      * to be done. */
 }
 /*-----------------------------------------------------------*/
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength * sizeof( CK_BYTE ) );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+            /* Create an object label attribute. */
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+
+    return xResult;
+}

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/core_pkcs11_config.h
@@ -100,14 +100,6 @@
 #define pkcs11configMAX_SESSIONS                           10
 
 /**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
-
-/**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
  *
  * If set to 0, OTA code signing certificate is built in via

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
@@ -386,24 +386,6 @@ CK_RV PKCS11_PAL_Initialize( void )
     return CKR_OK;
 }
 
-/* PKCS #11 PAL Implementation. */
-
-/**
- * @brief Delete an object from non-volatile storage.
- *
- * @param[in] xHandle    Handle of the object to be destroyed.
- *
- * @return CKR_OK if object was successfully destroyed.
- * Otherwise, PKCS #11-style error code.
- *
- */
-#if ( pkcs11configPAL_DESTROY_SUPPORTED == 1 )
-    CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
-    {
-        ( void ) xHandle;
-        return CKR_FUNCTION_NOT_SUPPORTED;
-    }
-#endif
 
 /*-----------------------------------------------------------*/
 
@@ -428,6 +410,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     char * pcFileName = NULL;
     int16_t iStatus = 0;
     SlFsFileInfo_t FsFileInfo = { 0 };
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
 
     /* Converts a label to its respective filename and handle. */
     prvLabelToFilenameHandle( pxLabel,
@@ -443,6 +430,19 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     if( SL_ERROR_FS_FILE_NOT_EXISTS == iStatus )
     {
         xHandle = eInvalidHandle;
+    }
+
+    if( xHandle != eInvalidHandle )
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
     }
 
     return xHandle;
@@ -474,9 +474,9 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
  * error.
  */
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
-                                      CK_BYTE_PTR * ppucData,
-                                      CK_ULONG_PTR pulDataSize,
-                                      CK_BBOOL * pIsPrivate )
+                                 CK_BYTE_PTR * ppucData,
+                                 CK_ULONG_PTR pulDataSize,
+                                 CK_BBOOL * pIsPrivate )
 {
     CK_RV ulReturn = CKR_OK;
     int32_t iReadBytes = 0;
@@ -649,7 +649,6 @@ CK_OBJECT_HANDLE PKCS11_PAL_SaveObject( CK_ATTRIBUTE_PTR pxLabel,
             {
                 xHandle = eInvalidHandle;
             }
-
         }
 
         if( NULL != pcPemBuffer )
@@ -687,3 +686,88 @@ int mbedtls_hardware_poll( void * data,
 }
 
 /*-----------------------------------------------------------*/
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+    else
+    {
+        xResult = CKR_GENERAL_ERROR;
+    }
+
+    return xResult;
+}

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
@@ -731,11 +731,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {

--- a/vendors/vendor/boards/board/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/core_pkcs11_config.h
@@ -100,13 +100,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/vendor/boards/board/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/vendor/boards/board/aws_tests/config_files/core_pkcs11_config.h
@@ -94,13 +94,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/core_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/xilinx/boards/microzed/aws_tests/config_files/core_pkcs11_config.h
+++ b/vendors/xilinx/boards/microzed/aws_tests/config_files/core_pkcs11_config.h
@@ -99,13 +99,6 @@
  */
 #define pkcs11configMAX_SESSIONS                           10
 
-/**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/core_pkcs11_pal.c
@@ -32,6 +32,7 @@
 
 /* FreeRTOS Includes. */
 #include "core_pkcs11.h"
+#include "core_pkcs11_pal.h"
 #include "iot_crypto.h"
 #include "core_pkcs11_config.h"
 #include "FreeRTOS.h"
@@ -181,6 +182,11 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
                                         CK_ULONG usLength )
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    CK_RV xResult = CKR_OK;
     uint8_t * pcFileName = NULL;
     static FIL fil;
     FRESULT Res;
@@ -204,6 +210,19 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 
     f_close( &fil );
     taskEXIT_CRITICAL();
+
+    if( xHandle != eInvalidHandle )
+    {
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+        /* Zeroed out object means it has been destroyed. */
+        if( ( xResult != CKR_OK ) || ( pxObject[ 0 ] == 0x00 ) )
+        {
+            xHandle = eInvalidHandle;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
 
     return xHandle;
 }
@@ -405,4 +424,85 @@ int platform_init_fs()
 
     xil_printf( "File system initialization successful\r\n" );
     return 0;
+}
+
+/* Converts a handle to its respective label. */
+void prvHandleToLabel( char ** pcLabel,
+                       CK_OBJECT_HANDLE xHandle )
+{
+    if( pcLabel != NULL )
+    {
+        switch( xHandle )
+        {
+            case eAwsDeviceCertificate:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+                break;
+
+            case eAwsDevicePrivateKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+                break;
+
+            case eAwsDevicePublicKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+                break;
+
+            case eAwsCodeSigningKey:
+                *pcLabel = ( char * ) pkcs11configLABEL_CODE_VERIFICATION_KEY;
+                break;
+
+            default:
+                *pcLabel = NULL;
+                break;
+        }
+    }
+}
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult = CKR_OK;
+    CK_BYTE_PTR pxZeroedData = NULL;
+    CK_BYTE_PTR pxObject = NULL;
+    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
+    CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
+    CK_ULONG ulObjectLength = sizeof( CK_BYTE );
+    char * pcLabel = NULL;
+    CK_ATTRIBUTE xLabel;
+
+    prvHandleToLabel( &pcLabel, xHandle );
+
+    xLabel.type = CKA_LABEL;
+    xLabel.pValue = pcLabel;
+    xLabel.ulValueLen = strlen( pcLabel );
+
+    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+
+    if( xResult == CKR_OK )
+    {
+        /* Some ports return a pointer to memory for which using memset directly won't work. */
+        pxZeroedData = pvPortMalloc( ulObjectLength * sizeof( CK_BYTE ) );
+
+        if( NULL != pxZeroedData )
+        {
+            /* Zero out the object. */
+            ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
+            /* Create an object label attribute. */
+            /* Overwrite the object in NVM with zeros. */
+            xPalHandle2 = PKCS11_PAL_SaveObject( &xLabel, pxZeroedData, ( size_t ) ulObjectLength );
+
+            if( xPalHandle2 != xHandle )
+            {
+                xResult = CKR_GENERAL_ERROR;
+            }
+
+            vPortFree( pxZeroedData );
+        }
+        else
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
+    }
+
+    return xResult;
 }

--- a/vendors/xilinx/boards/microzed/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/xilinx/boards/microzed/ports/pkcs11/core_pkcs11_pal.c
@@ -470,11 +470,18 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 
     prvHandleToLabel( &pcLabel, xHandle );
 
-    xLabel.type = CKA_LABEL;
-    xLabel.pValue = pcLabel;
-    xLabel.ulValueLen = strlen( pcLabel );
+    if( pcLabel != NULL )
+    {
+        xLabel.type = CKA_LABEL;
+        xLabel.pValue = pcLabel;
+        xLabel.ulValueLen = strlen( pcLabel );
 
-    xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+        xResult = PKCS11_PAL_GetObjectValue( xHandle, &pxObject, &ulObjectLength, &xIsPrivate );
+    }   
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }   
 
     if( xResult == CKR_OK )
     {


### PR DESCRIPTION
Update corePKCS11 and PKCS #11 PAL interfaces with latest changes

Description
-----------
The default implementation of PKCS11_PAL_DestroyObject has been removed, so each port needs to be updated with an implementation of PKCS11_PAL_DestroyObject

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.