### PR TITLE
Add init to a uninitialized variable to resolve the check failure.

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -375,7 +375,8 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
     char cPrintString[ dlMAX_PRINT_STRING_LENGTH ];
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
-    size_t xLength, xLength2, rc;
+    size_t xLength, rc;
+    size_t xLength2 = 0;
     static BaseType_t xMessageNumber = 0;
     uint32_t ulIPAddress;
     const char * pcTaskName;

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -378,7 +378,8 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
     char cPrintString[ dlMAX_PRINT_STRING_LENGTH ];
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
-    size_t xLength, xLength2, rc;
+    size_t xLength, rc;
+    size_t xLength2 = 0;
     static BaseType_t xMessageNumber = 0;
     uint32_t ulIPAddress;
     const char * pcTaskName;


### PR DESCRIPTION
Description
-----------
To resolve the error:
https://maxis-file-service-prod-pdx.pdx.proxy.amazon.com/issues/P44273277/attachments/ec8ee721b460c4f96765ea95ae4261a2ff4c81e791a25dc72e50f459054e60db_c139b02e-130e-42d4-bed2-dff2a8072d12

The variable has chance to be used without being initialized. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.