### PR TITLE
Possible bug-fix for aws_demo_logging.c

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -119,6 +119,8 @@ static void prvCreatePrintSocket( void * pvParameter1,
  * A Windows thread will finally call printf() and fflush().
  */
 static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              const char * pcFile,
+                              size_t fileLineNo,
                               BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs );
@@ -361,7 +363,7 @@ void vLoggingPrintfWithFileAndLine( const char * pcFile,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pcFormat, args );
+    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pdTRUE, pcFormat, args );
 
     va_end( args );
 }
@@ -597,11 +599,11 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
             SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
             {
                 /* How much space is in the buffer? */
-                xLength2 = uxStreamBufferGetSpace( xLogStreamBuffer );
+                size_t uxSpace = uxStreamBufferGetSpace( xLogStreamBuffer );
 
                 /* There must be enough space to write both the string and the length of
                  * the string. */
-                if( xLength2 >= ( xLength + sizeof( xLength ) ) )
+                if( uxSpace >= ( xLength + sizeof( xLength ) ) )
                 {
                     uxStreamBufferAdd( xLogStreamBuffer,
                                        0,

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -379,7 +379,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, rc;
-    size_t xLength2 = 0;
+    size_t xLength2;
     static BaseType_t xMessageNumber = 0;
     uint32_t ulIPAddress;
     const char * pcTaskName;

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -332,6 +332,8 @@ void vLoggingPrintfInfo( const char * pcFormat,
 
     va_start( args, pcFormat );
     prvLoggingPrintf( LOG_INFO, NULL, 0, pdTRUE, pcFormat, args );
+
+    va_end( args );
 }
 
 /*-----------------------------------------------------------*/
@@ -346,6 +348,7 @@ void vLoggingPrintfDebug( const char * pcFormat,
 
     va_end( args );
 }
+
 /*-----------------------------------------------------------*/
 
 void vLoggingPrintfWithFileAndLine( const char * pcFile,
@@ -475,6 +478,13 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
                                   pcFormat,
                                   xArgs );
         }
+        else
+        {
+            xLength2 = snprintf( cPrintString + xLength,
+                                 dlMAX_PRINT_STRING_LENGTH - xLength,
+                                 "%s",
+                                 pcFormat );
+        }
 
         if( xLength2 < 0 )
         {
@@ -577,31 +587,37 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         {
             configASSERT( xLogStreamBuffer );
 
-            /* How much space is in the buffer? */
-            xLength2 = uxStreamBufferGetSpace( xLogStreamBuffer );
-
-            /* There must be enough space to write both the string and the length of
-             * the string. */
-            if( xLength2 >= ( xLength + sizeof( xLength ) ) )
+            /* First write in the length of the data, then write in the data
+             * itself.  Raising the thread priority is used as a critical section
+             * as there are potentially multiple writers.  The stream buffer is
+             * only thread safe when there is a single writer (likewise for
+             * reading from the buffer). */
+            xCurrentTask = GetCurrentThread();
+            iOriginalPriority = GetThreadPriority( xCurrentTask );
+            SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
             {
-                /* First write in the length of the data, then write in the data
-                 * itself.  Raising the thread priority is used as a critical section
-                 * as there are potentially multiple writers.  The stream buffer is
-                 * only thread safe when there is a single writer (likewise for
-                 * reading from the buffer). */
-                xCurrentTask = GetCurrentThread();
-                iOriginalPriority = GetThreadPriority( xCurrentTask );
-                SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
-                uxStreamBufferAdd( xLogStreamBuffer,
-                                   0,
-                                   ( const uint8_t * ) &( xLength ),
-                                   sizeof( xLength ) );
-                uxStreamBufferAdd( xLogStreamBuffer,
-                                   0,
-                                   ( const uint8_t * ) cOutputString,
-                                   xLength );
-                SetThreadPriority( GetCurrentThread(), iOriginalPriority );
+                /* How much space is in the buffer? */
+                xLength2 = uxStreamBufferGetSpace( xLogStreamBuffer );
+
+                /* There must be enough space to write both the string and the length of
+                 * the string. */
+                if( xLength2 >= ( xLength + sizeof( xLength ) ) )
+                {
+                    uxStreamBufferAdd( xLogStreamBuffer,
+                                       0,
+                                       ( const uint8_t * ) &( xLength ),
+                                       sizeof( xLength ) );
+                    uxStreamBufferAdd( xLogStreamBuffer,
+                                       0,
+                                       ( const uint8_t * ) cOutputString,
+                                       xLength );
+                }
+                else
+                {
+                    /* Log line will be dropped, bad luck. */
+                }
             }
+            SetThreadPriority( GetCurrentThread(), iOriginalPriority );
 
             /* xDirectPrint is initialised to pdTRUE, and while it remains true the
              * logging output function is called directly.  When the system is running

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -599,11 +599,11 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
             SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
             {
                 /* How much space is in the buffer? */
-                xLength2 = uxStreamBufferGetSpace( xLogStreamBuffer );
+                size_t uxSpace = uxStreamBufferGetSpace( xLogStreamBuffer );
 
                 /* There must be enough space to write both the string and the length of
                  * the string. */
-                if( xLength2 >= ( xLength + sizeof( xLength ) ) )
+                if( uxSpace >= ( xLength + sizeof( xLength ) ) )
                 {
                     uxStreamBufferAdd( xLogStreamBuffer,
                                        0,

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -379,7 +379,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
     char cOutputString[ dlMAX_PRINT_STRING_LENGTH ];
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, rc;
-    size_t xLength2 = 0;
+    size_t xLength2;
     static BaseType_t xMessageNumber = 0;
     uint32_t ulIPAddress;
     const char * pcTaskName;

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -119,6 +119,8 @@ static void prvCreatePrintSocket( void * pvParameter1,
  * A Windows thread will finally call printf() and fflush().
  */
 static void prvLoggingPrintf( uint8_t usLoggingLevel,
+                              const char * pcFile,
+                              size_t fileLineNo,
                               BaseType_t xFormatted,
                               const char * pcFormat,
                               va_list xArgs );
@@ -361,7 +363,7 @@ void vLoggingPrintfWithFileAndLine( const char * pcFile,
     va_list args;
 
     va_start( args, pcFormat );
-    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pcFormat, args );
+    prvLoggingPrintf( LOG_NONE, pcFile, fileLineNo, pdTRUE, pcFormat, args );
 
     va_end( args );
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
As I am mostly working on FreeRTOS+TCP these days, I rarely look at the PR's in the [amazon-freertos](https://github.com/aws/amazon-freertos) repo.

But as today I was repairing a possible bug in aws_demo_logging.c, I saw [Ming Yue's](@mingyue86010) recent [PR #2995](https://github.com/aws/amazon-freertos/pull/2995) for this module.

Ming Yue, the problem was not the uninitialised local variable `xLength2`, but the missing else clause of `if( xArgs != NULL )`:
~~~c
     if( xArgs != NULL )
     {
         xLength2 = vsnprintf( cPrintString + xLength,
                               dlMAX_PRINT_STRING_LENGTH - xLength,
                               pcFormat,
                               xArgs );
     }
+    else
+    {
+        xLength2 = snprintf( cPrintString + xLength,
+                             dlMAX_PRINT_STRING_LENGTH - xLength,
+                             "%s",
+                             pcFormat );
+    }
~~~
In earlier versions, the else clause was present.
Here is a normal use case in which 'xArgs' is set to NULL:
~~~
void vLoggingPrint( const char * pcFormat )
{
    prvLoggingPrintf( LOG_NONE, NULL, 0, pdFALSE, pcFormat, NULL );
}
~~~
Now my possible bug-fix: when checking the free space with `uxStreamBufferGetSpace()`, it must happen within the critical section, thus like this:
~~~
    SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
    {
    
        /* How much space is in the buffer? */
        xLength2 = uxStreamBufferGetSpace( xLogStreamBuffer );
    
        /* There must be enough space to write both the string and the length of
         * the string. */
        if( xLength2 >= ( xLength + sizeof( xLength ) ) )
        {
            uxStreamBufferAdd( xLogStreamBuffer,
                               0,
                               ( const uint8_t * ) &( xLength ),
                               sizeof( xLength ) );
            uxStreamBufferAdd( xLogStreamBuffer,
                               0,
                               ( const uint8_t * ) cOutputString,
                               xLength );
        }
        else
        {
            /* Log line will be dropped, bad luck. */
        }
    }
    SetThreadPriority( GetCurrentThread(), iOriginalPriority );
~~~

Otherwise a race condition is possible in which a higher-priority task comes in between and fills the stream buffer. This may cause the logging to stop working properly.
Hein

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.