### PR TITLE
Add log statement if WiFi fails to acquire IP address.

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/application_code/main.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/application_code/main.c
@@ -397,6 +397,10 @@ void prvWifiConnect( void )
                 configPRINTF( ( "IP Address acquired %d.%d.%d.%d.\r\n",
                         pucIPV4Byte[ 0 ], pucIPV4Byte[ 1 ], pucIPV4Byte[ 2 ], pucIPV4Byte[ 3 ] ) );
             }
+            else
+            {
+                configPRINTF( ( "Failed to acquire IP address.\r\n" ) );
+            }
         }
         else
         {


### PR DESCRIPTION
Add log statement if WiFi fails to acquire IP address.

Description
-----------
There is no log statement when the IP address isn't found, making issues harder to debug.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.