### PR TITLE
Expose A2DP Keep Alive Playing State to APPs

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_avsrc_profile.h
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS BLE HAL V5.1.0
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -62,6 +62,15 @@ typedef enum
     eBTAvsrcAudioStateStarted = 2,       /**< Audio Started */
 } BTAvAudioState_t;
 
+/**
+ * @brief Bluetooth AV ACL Priority
+ */
+typedef enum
+{
+    eBTAvsrcAclPriorityLow = 0,  /**< ACL Low Priority */
+    eBTAvsrcAclPriorityHigh = 1, /**< ACL High Priority */
+} BTAvsrcAclPriority_t;
+
 /** Audio callback structure */
 
 /**
@@ -82,11 +91,24 @@ typedef void (* BTAvsrcConnectionStateCallback_t)( BTAvConnectionState_t xState,
 typedef void (* BTAvsrcAudioStateCallback_t)( BTAvAudioState_t xState,
                                               BTBdaddr_t * pxBdAddr );
 
+
+/**
+ * @brief Callback invoked when ACL priority changes
+ * Priority can change when the stack enables/disables silent A2DP data while
+ * A2DP keepalive feature is enabled.
+ *
+ * @param[in] xPriority Acl Priority
+ * @param[in] pxBdAddr Address of the Remote device
+ */
+typedef void (* BTAvsrcAclPriorityCallback_t)( BTAvsrcAclPriority_t xPriority,
+                                               BTBdaddr_t * pxBdAddr );
+
 typedef struct
 {
     size_t xSize;
-    BTAvsrcConnectionStateCallback_t xConnStateCback;
-    BTAvsrcAudioStateCallback_t xAudioStateCback;
+    BTAvsrcConnectionStateCallback_t xConnStateCback; /**< Connection state callback */
+    BTAvsrcAudioStateCallback_t xAudioStateCback;     /**< Connection state callback */
+    BTAvsrcAclPriorityCallback_t xAclPriorityCback;   /**< ACL priority callback */
 } BTAvsrcCallbacks_t;
 
 /** Represents the standard AV connection interface. */


### PR DESCRIPTION
Once A2DP sink remote device is connected, based on the
keepalive configuration, silent data may be played when no valid music is
played.
The A2DP ACL priority is set to low when silent data is streamed, so this
callback will notify upper layers.

Signed-off-by: Adham Abozaeid <adhsal@amazon.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.