### PR TITLE
Add Amazon CA3 to default TLS CA chain.

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -830,11 +830,13 @@ BaseType_t TLS_Connect( void * pvContext )
             xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
                                               ( const unsigned char * ) tlsATS1_ROOT_CERTIFICATE_PEM,
                                               tlsATS1_ROOT_CERTIFICATE_LENGTH );
+
             if( 0 == xResult )
             {
                 xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
                                                   ( const unsigned char * ) tlsATS3_ROOT_CERTIFICATE_PEM,
-                                                  tlsATS3_ROOT_CERTIFICATE_PEM );
+                                                  tlsATS3_ROOT_CERTIFICATE_LENGTH );
+
                 if( 0 == xResult )
                 {
                     xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
@@ -906,7 +908,6 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
-
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -908,6 +908,7 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
+
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -830,12 +830,17 @@ BaseType_t TLS_Connect( void * pvContext )
             xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
                                               ( const unsigned char * ) tlsATS1_ROOT_CERTIFICATE_PEM,
                                               tlsATS1_ROOT_CERTIFICATE_LENGTH );
-
             if( 0 == xResult )
             {
                 xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
-                                                  ( const unsigned char * ) tlsSTARFIELD_ROOT_CERTIFICATE_PEM,
-                                                  tlsSTARFIELD_ROOT_CERTIFICATE_LENGTH );
+                                                  ( const unsigned char * ) tlsATS3_ROOT_CERTIFICATE_PEM,
+                                                  tlsATS3_ROOT_CERTIFICATE_PEM );
+                if( 0 == xResult )
+                {
+                    xResult = mbedtls_x509_crt_parse( &pxCtx->xMbedX509CA,
+                                                      ( const unsigned char * ) tlsSTARFIELD_ROOT_CERTIFICATE_PEM,
+                                                      tlsSTARFIELD_ROOT_CERTIFICATE_LENGTH );
+                }
             }
         }
 


### PR DESCRIPTION
Add Amazon CA3 to default TLS CA chain

Description
-----------
Older demos rely on the default CA chain if it is not overridden. This change introduces the ATS 3 CA to enable users to use an EC certificate chain.

See https://github.com/aws/amazon-freertos/issues/3019.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.