### PR TITLE
Always close socket on transport interface disconnect.

### DIFF
--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -549,12 +549,17 @@ TransportSocketStatus_t SecureSocketsTransport_Connect( NetworkContext_t * pNetw
 
 TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_t * pNetworkContext )
 {
-    TransportSocketStatus_t returnStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;
+    TransportSocketStatus_t returnStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
     int32_t transportSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
     SecureSocketsTransportParams_t * pSecureSocketsTransportParams = NULL;
 
     if( ( pNetworkContext != NULL ) &&
         ( pNetworkContext->pParams != NULL ) )
+    {
+        LogError( ( "Failed to close connection: pTransportInterface is NULL." ) );
+        returnStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;
+    }
+    else
     {
         pSecureSocketsTransportParams = pNetworkContext->pParams;
         /* Call Secure Sockets shutdown function to close connection. */
@@ -565,25 +570,15 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
             LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. %d", transportSocketStatus ) );
             returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
         }
-        else
-        {
-            /* Call Secure Sockets close function to close socket. */
-            transportSocketStatus = SOCKETS_Close( pSecureSocketsTransportParams->tcpSocket );
 
-            if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
-            {
-                LogError( ( "Failed to close connection: SOCKETS_Close call failed. transportSocketStatus %d", transportSocketStatus ) );
-                returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
-            }
-            else
-            {
-                returnStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
-            }
+        /* Call Secure Sockets close function to close socket. */
+        transportSocketStatus = SOCKETS_Close( pSecureSocketsTransportParams->tcpSocket );
+
+        if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
+        {
+            LogError( ( "Failed to close connection: SOCKETS_Close call failed. transportSocketStatus %d", transportSocketStatus ) );
+            returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
         }
-    }
-    else
-    {
-        LogError( ( "Failed to close connection: pTransportInterface is NULL." ) );
     }
 
     return returnStatus;

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -549,17 +549,13 @@ TransportSocketStatus_t SecureSocketsTransport_Connect( NetworkContext_t * pNetw
 
 TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_t * pNetworkContext )
 {
-    TransportSocketStatus_t returnStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
+    TransportSocketStatus_t shutdownStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;
+    TransportSocketStatus_t closeStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;
     int32_t transportSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
     SecureSocketsTransportParams_t * pSecureSocketsTransportParams = NULL;
 
-    if( ( pNetworkContext == NULL ) &&
-        ( pNetworkContext->pParams == NULL ) )
-    {
-        LogError( ( "Failed to close connection: pTransportInterface is NULL." ) );
-        returnStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;
-    }
-    else
+    if( ( pNetworkContext != NULL ) &&
+        ( pNetworkContext->pParams != NULL ) )
     {
         pSecureSocketsTransportParams = pNetworkContext->pParams;
         /* Call Secure Sockets shutdown function to close connection. */
@@ -568,7 +564,11 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
         if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {
             LogError( ( "Failed to close connection: SOCKETS_Shutdown call failed. %d", transportSocketStatus ) );
-            returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+            shutdownStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+        }
+        else
+        {
+            shutdownStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
         }
 
         /* Call Secure Sockets close function to close socket. */
@@ -577,11 +577,24 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
         if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {
             LogError( ( "Failed to close connection: SOCKETS_Close call failed. transportSocketStatus %d", transportSocketStatus ) );
-            returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+            closeStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+        }
+        else
+        {
+            closeStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
+        }
+
+        if( ( shutdownStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) || ( closeStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) )
+        {
+            shutdownStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
         }
     }
+    else
+    {
+        LogError( ( "Failed to close connection: pTransportInterface is NULL." ) );
+    }
 
-    return returnStatus;
+    return shutdownStatus;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -553,8 +553,8 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
     int32_t transportSocketStatus = ( int32_t ) SOCKETS_ERROR_NONE;
     SecureSocketsTransportParams_t * pSecureSocketsTransportParams = NULL;
 
-    if( ( pNetworkContext != NULL ) &&
-        ( pNetworkContext->pParams != NULL ) )
+    if( ( pNetworkContext == NULL ) &&
+        ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "Failed to close connection: pTransportInterface is NULL." ) );
         returnStatus = TRANSPORT_SOCKET_STATUS_INVALID_PARAMETER;

--- a/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
+++ b/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
@@ -859,6 +859,7 @@ void test_SecureSocketsTransport_Disconnect_Fail_to_ShutDown( void )
     TransportSocketStatus_t returnStatus;
 
     SOCKETS_Shutdown_ExpectAndReturn( mockTcpSocket, SOCKETS_SHUT_RDWR, MOCK_SECURE_SOCKET_ERROR );
+    SOCKETS_Close_ExpectAndReturn( mockTcpSocket, MOCK_SECURE_SOCKET_ERROR );
     returnStatus = SecureSocketsTransport_Disconnect( &networkContext );
     TEST_ASSERT_EQUAL( TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR, returnStatus );
 }


### PR DESCRIPTION
Always close socket on transport interface disconnect

Description
-----------
If a socket_shutdown call failed, socket_close would never be called in the transport interface, causing a memory leak, and ungraceful shutdown for the TCP client.

See https://github.com/aws/amazon-freertos/issues/3014.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.