### PR TITLE
Fix support for custom location of sdkconfig.defaults

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -580,7 +580,7 @@ endif()
 
 idf_build_process(esp32
                     SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig
-                    SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.defaults
+                    SDKCONFIG_DEFAULTS ${IDF_SDKCONFIG_DEFAULTS}
                     BUILD_DIR ${CMAKE_BINARY_DIR})
 
 idf_build_get_property(idf_compile_options "COMPILE_OPTIONS")

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -541,6 +541,13 @@ if (NOT IDF_SDKCONFIG_DEFAULTS)
     string(REGEX REPLACE "partition-table.csv" "${board_dir}/partition-table.csv" file_sdkconfig_default "${file_sdkconfig_default}")
     file(WRITE "${CMAKE_BINARY_DIR}/sdkconfig.defaults" "${file_sdkconfig_default}")
     set(IDF_SDKCONFIG_DEFAULTS "${CMAKE_BINARY_DIR}/sdkconfig.defaults")
+else()
+    set(ABS_SDKCONFIG_DEFAULTS)
+    foreach(DEFAULTS ${IDF_SDKCONFIG_DEFAULTS})
+        get_filename_component(ABS_DEFAULTS ${DEFAULTS} ABSOLUTE)
+        list(APPEND ABS_SDKCONFIG_DEFAULTS ${ABS_DEFAULTS})
+    endforeach()
+    set(IDF_SDKCONFIG_DEFAULTS ${ABS_SDKCONFIG_DEFAULTS})
 endif()
 
 # Set sdkconfig generation path inside build

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -515,7 +515,7 @@ endif()
 
 idf_build_process(esp32s2
                     SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig
-                    SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.defaults
+                    SDKCONFIG_DEFAULTS ${IDF_SDKCONFIG_DEFAULTS}
                     BUILD_DIR ${CMAKE_BINARY_DIR})
 
 idf_build_get_property(idf_compile_options "COMPILE_OPTIONS")

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -475,6 +475,13 @@ if (NOT IDF_SDKCONFIG_DEFAULTS)
     string(REGEX REPLACE "partition-table.csv" "${board_dir}/partition-table.csv" file_sdkconfig_default "${file_sdkconfig_default}")
     file(WRITE "${CMAKE_BINARY_DIR}/sdkconfig.defaults" "${file_sdkconfig_default}")
     set(IDF_SDKCONFIG_DEFAULTS "${CMAKE_BINARY_DIR}/sdkconfig.defaults")
+else()
+    set(ABS_SDKCONFIG_DEFAULTS)
+    foreach(DEFAULTS ${IDF_SDKCONFIG_DEFAULTS})
+        get_filename_component(ABS_DEFAULTS ${DEFAULTS} ABSOLUTE)
+        list(APPEND ABS_SDKCONFIG_DEFAULTS ${ABS_DEFAULTS})
+    endforeach()
+    set(IDF_SDKCONFIG_DEFAULTS ${ABS_SDKCONFIG_DEFAULTS})
 endif()
 
 # Set sdkconfig generation path inside build


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Reported by myself in #3026 where specifying `IDF_SDKCONFIG_DEFAULTS` breaks CMake configure step.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.