### PR TITLE
Fix indefinite wait issue in IotNetworkAfr_Destroy()

### DIFF
--- a/libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h
+++ b/libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h
@@ -46,14 +46,6 @@
 #include "aws_clientcredential_keys.h"
 
 /**
- * @brief Represents a network connection that uses FreeRTOS Secure Sockets.
- *
- * This is an incomplete type. In application code, only pointers to this type
- * should be used.
- */
-typedef struct _networkConnection IotNetworkConnectionAfr_t;
-
-/**
  * @brief Provides a default value for an #IotNetworkConnectionAfr_t.
  *
  * All instances of #IotNetworkConnectionAfr_t should be initialized with

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -180,6 +180,10 @@ static void _networkReceiveTask( void * pArgument )
 
         pNetworkConnection->bufferedByteValid = true;
 
+        /* The network receive task is created ONLY when the receive callback is set. Thus, assert
+         * check that the callback is valid. */
+        configASSERT( pNetworkConnection->receiveCallback != NULL );
+
         /* Invoke the network callback. */
         pNetworkConnection->receiveCallback( pNetworkConnection,
                                              pNetworkConnection->pReceiveContext );

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -68,18 +68,18 @@
 /**
  * @brief The event group bit to set when a connection's socket is shut down.
  */
-#define _FLAG_SHUTDOWN                ( 1 )
+#define _FLAG_SHUTDOWN                             ( 1 )
 
 /**
  * @brief The event group bit to set when a connection's receive task exits.
  */
-#define _FLAG_RECEIVE_TASK_EXITED     ( 2 )
+#define _FLAG_RECEIVE_TASK_EXITED                  ( 2 )
 
 /**
  * @brief The event group bit to set when the connection is destroyed from the
  * receive task.
  */
-#define _FLAG_CONNECTION_DESTROYED    ( 4 )
+#define _FLAG_RECEIVE_TASK_CONNECTION_DESTROYED    ( 4 )
 
 /*-----------------------------------------------------------*/
 
@@ -92,7 +92,7 @@ typedef struct _networkConnection
     IotNetworkReceiveCallback_t receiveCallback; /**< @brief Network receive callback, if any. */
     void * pReceiveContext;                      /**< @brief The context for the receive callback. */
     bool bufferedByteValid;                      /**< @brief Used to determine if the buffered byte is valid. */
-    uint8_t bufferedByte;                        /**< @brief A single byte buffered from a receive, since AFR Secure Sockets does not have poll(). */
+    uint8_t bufferedByte;                        /**< @brief A single byte buffered from a receive, since FreeRTOS Secure Sockets does not have poll(). */
 } _networkConnection_t;
 
 /*-----------------------------------------------------------*/
@@ -189,9 +189,14 @@ static void _networkReceiveTask( void * pArgument )
          * may only be called once (per its API doc). */
         connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
 
-        if( ( connectionFlags & _FLAG_CONNECTION_DESTROYED ) == _FLAG_CONNECTION_DESTROYED )
+        /* Break out of receive task loop if connection is closed or destroyed. */
+        if( ( connectionFlags & _FLAG_RECEIVE_TASK_CONNECTION_DESTROYED ) == _FLAG_RECEIVE_TASK_CONNECTION_DESTROYED )
         {
             destroyConnection = true;
+            break;
+        }
+        else if( ( connectionFlags & _FLAG_SHUTDOWN ) == _FLAG_SHUTDOWN )
+        {
             break;
         }
     }
@@ -643,7 +648,8 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
     ( void ) xEventGroupSetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
                                  _FLAG_SHUTDOWN );
 
-    if( pNetworkConnection->receiveTask != NULL )
+    /* If this function is not called from the receive task, wait for the receive task to exit. */
+    if( ( pNetworkConnection->receiveTask != NULL ) && ( xTaskGetCurrentTaskHandle() != pNetworkConnection->receiveTask ) )
     {
         /* Wait for the network receive task to exit so that the socket can be shutdown safely
          * without causing the socket to block forever if there are pending reads or writes
@@ -679,18 +685,22 @@ IotNetworkError_t IotNetworkAfr_Destroy( void * pConnection )
     {
         /* Set the flag specifying that the connection is destroyed. */
         ( void ) xEventGroupSetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
-                                     _FLAG_CONNECTION_DESTROYED );
+                                     _FLAG_RECEIVE_TASK_CONNECTION_DESTROYED );
     }
     else
     {
-        /* If a receive task was created, wait for it to exit. */
-        if( pNetworkConnection->receiveTask != NULL )
+        /* As this function should be called ONLY called after the connection is closed,
+         * the receive task should have already exited. */
+        if( pNetworkConnection->receiveCallback != NULL )
         {
-            ( void ) xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
-                                          _FLAG_RECEIVE_TASK_EXITED,
-                                          pdTRUE,
-                                          pdTRUE,
-                                          portMAX_DELAY );
+            EventBits_t connectionFlags;
+            connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
+
+            configASSERT( ( connectionFlags & _FLAG_RECEIVE_TASK_EXITED ) == _FLAG_RECEIVE_TASK_EXITED );
+
+            /* Suppress compiler warning of unused connectionFlags variable when
+             * configASSERT() is disabled. */
+            ( void ) connectionFlags;
         }
 
         _destroyConnection( pNetworkConnection );

--- a/libraries/abstractions/platform/include/platform/iot_network.h
+++ b/libraries/abstractions/platform/include/platform/iot_network.h
@@ -266,7 +266,7 @@ typedef struct IotNetworkInterface
     /**
      * @brief Free resources used by a network connection.
      *
-     * This function releases the resources of a closed connection. It should be
+     * This function releases the resources of a closed connection. It SHOULD be
      * called after @ref platform_network_function_close.
      *
      * @param[in] pConnection The network connection to destroy, defined by


### PR DESCRIPTION
### Problem

As part of the change in PR #2986, the `IotNetworkAfr_Close` function was updated to wait for the receive task to be exited and clear the `_FLAG_RECEIVE_TASK_EXITED` flag as part of the `xEventGroupWaitBits()` call. However, that affects the `IotNetworkAfr_Destroy` function to wait indefinitely as it also contains logic to block for the receive task to exit. 

### Solution

As the `IotNetworkAfr_Destroy` function is supposed to be called ONLY _after_ the connection is closed (as mentioned [here](https://github.com/aws/amazon-freertos/blob/201912.00/libraries/abstractions/platform/include/platform/iot_network.h\#L269-L270)), the receive task should have already exited (because of call to `IotNetworkAfr_Close`) before `IotNetworkAfr_Destroy` function is called, and thus, the wait for receive task to be exited is not required. 

This PR fixes the issue by removing the wait logic in the `IotNetorkAfr_Destroy` function and also makes hygiene improvements in the receive task and `IotNetworkAfr_Close` functions logic.