### PR TITLE
NimBLE AFR: Fix long read response in case of smaller MTU value.

### DIFF
--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -54,8 +54,8 @@ static SemaphoreHandle_t xSem;
 static bool semInited;
 bool xSemLock = 0;
 uint16_t gattOffset = 0;
-static bool long_read_flag;
-static size_t virtual_offset;/* Maintain offset for long read ops */
+static bool long_read_flag = false;
+static size_t virtual_offset = 0;/* Maintain offset for long read ops */
 
 void prvGattGetSemaphore()
 {
@@ -763,13 +763,13 @@ BTStatus_t prvBTSendResponse( uint16_t usConnId,
             if ( pxResponse->xAttrValue.xLen >= ( mtu_value - 1 ) )
             {
                 /* Long read or blob request if data received is of ( MTU - 1 ) size and more */
-                long_read_flag = 1;
+                long_read_flag = true;
                 prvPrepareLongReadResponse( dst_buf, pxResponse->xAttrValue.pucValue, mtu_value - 1 );
             }
             else
             {
                 /* Last long read request if data received is < ( MTU - 1 ) size */
-                long_read_flag = 0;
+                long_read_flag = false;
                 prvPrepareLongReadResponse( dst_buf, pxResponse->xAttrValue.pucValue, pxResponse->xAttrValue.xLen );
             }
 

--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -45,6 +45,8 @@
 
 #define BLE_GATT_DSC_CLT_CFG_UUID128 0xFB, 0x34, 0x9B, 0x5F, 0x80, 0x00, 0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0x02, 0x29, 0x00, 0x00
 
+#define BLE_MAX_ATTR_LEN 512
+
 static struct ble_gatt_svc_def espServices[ MAX_SERVICES + 1 ];
 static BTService_t * afrServices[ MAX_SERVICES ];
 static uint16_t serviceCnt = 0;
@@ -374,7 +376,7 @@ static int prvGATTCharAccessCb( uint16_t conn_handle,
     int rc = 0;
     bool need_rsp = 1;
     uint16_t out_len = 0;
-    uint8_t dst_buf[ 512 ] = { 0 }; /* fixme: Check allocation on stack */
+    uint8_t dst_buf[ BLE_MAX_ATTR_LEN ] = { 0 }; /* fixme: Check allocation on stack */
 
     ble_gap_conn_find( conn_handle, &desc );
 
@@ -730,7 +732,7 @@ static bool prvValidGattRequest()
 
 static void prvPrepareLongReadResponse( uint8_t * dst, uint8_t * pucValue, size_t xLen )
 {
-    if ( ( virtual_offset + xLen ) <= 512 )
+    if ( ( virtual_offset + xLen ) <= BLE_MAX_ATTR_LEN )
     {
         memcpy(dst + virtual_offset, pucValue, xLen);
         virtual_offset += xLen;
@@ -738,6 +740,7 @@ static void prvPrepareLongReadResponse( uint8_t * dst, uint8_t * pucValue, size_
     else
     {
         ESP_LOGE(TAG, "Attempting to send more than 512 Bytes; it will result in failure");
+        assert( 0 );
     }
 }
 
@@ -749,7 +752,7 @@ BTStatus_t prvBTSendResponse( uint16_t usConnId,
     struct ble_gatt_access_ctxt * ctxt = ( struct ble_gatt_access_ctxt * ) ulTransId;
 
     BTStatus_t xReturnStatus = eBTStatusSuccess;
-    uint8_t dst_buf[ 512 ] = { 0 };
+    uint8_t dst_buf[ BLE_MAX_ATTR_LEN ] = { 0 };
     size_t mtu_value = ble_att_mtu(usConnId);
 
     if( prvValidGattRequest() )


### PR DESCRIPTION
<!--- Title -->
NimBLE AFR: Fix long read response in case of smaller MTU value

Description
-----------
<!--- Describe your changes in detail -->

- NimBLE host handles offset internally, so application does not need to worry about sending the data in (MTU - 1) fragments as few other stack expect the application to do so.
- However, this NimBLE stack feature can cause issue with few vendor agnostic applications where they do the fragmentation (e.g. FFS).
- The solution proposed in this PR is to track the offset virtual offset. This way the AFR layer maintains the `virtual_offset` in case of read long characteristic response. 
- This way ESP32 NimBLE AFR porting layer will now support the applications' behavior of handling the data fragmentation depending upon MTU value by themselves. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.