### PR TITLE
Increase tcptestECHO_TEST_SYNC_TIMEOUT from 8s to 12s for espressif boards

### DIFF
--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
@@ -64,7 +64,7 @@
 /**
  * @brief The timeout for all TCP echo multi-task tests.
  */
-#define         tcptestECHO_TEST_SYNC_TIMEOUT                      80000
+#define         tcptestECHO_TEST_SYNC_TIMEOUT                      120000
 
 /**
  * @brief The stack size of the tasks created in all TCP echo multi-task tests.

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE     200
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for
@@ -47,34 +47,34 @@
  * If networking and tests are on different CPUs, an "under tolerance" is acceptable.
  * For tests where same clock is used for networking and tests.
  */
-#define         integrationtestportableTIMEOUT_UNDER_TOLERANCE     0
+#define         integrationtestportableTIMEOUT_UNDER_TOLERANCE    0
 
 /**
  *  @brief Indicates how long  receive needs to wait for data before Timeout happens.
  *
  */
-#define         integrationtestportableRECEIVE_TIMEOUT             10000
+#define         integrationtestportableRECEIVE_TIMEOUT            10000
 
 /**
  * @brief Indicates how long  send needs to wait before Timeout happens.
  *
  */
-#define         integrationtestportableSEND_TIMEOUT                10000
+#define         integrationtestportableSEND_TIMEOUT               10000
 
 /**
  * @brief The timeout for all TCP echo multi-task tests.
  */
-#define         tcptestECHO_TEST_SYNC_TIMEOUT                      120000
+#define         tcptestECHO_TEST_SYNC_TIMEOUT                     120000
 
 /**
  * @brief The stack size of the tasks created in all TCP echo multi-task tests.
  */
-#define         tcptestTCP_ECHO_TASKS_STACK_SIZE                   ( configMINIMAL_STACK_SIZE * 8 )
+#define         tcptestTCP_ECHO_TASKS_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 8 )
 
 /**
  * @brief The priority of the tasks created in all TCP echo multi-task tests.
  */
-#define         tcptestTCP_ECHO_TASKS_PRIORITY                     ( tskIDLE_PRIORITY + 5 )
+#define         tcptestTCP_ECHO_TASKS_PRIORITY                    ( tskIDLE_PRIORITY + 5 )
 
 
 #endif /*AWS_INTEGRATION_TEST_TCP_CONFIG_H */

--- a/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_tcp_config.h
@@ -64,7 +64,7 @@
 /**
  * @brief The timeout for all TCP echo multi-task tests.
  */
-#define         tcptestECHO_TEST_SYNC_TIMEOUT                      80000
+#define         tcptestECHO_TEST_SYNC_TIMEOUT                      120000
 
 /**
  * @brief The stack size of the tasks created in all TCP echo multi-task tests.

--- a/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_tests/config_files/aws_test_tcp_config.h
@@ -37,7 +37,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      20
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE     20
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for
@@ -47,34 +47,34 @@
  * If networking and tests are on different CPUs, an "under tolerance" is acceptable.
  * For tests where same clock is used for networking and tests.
  */
-#define         integrationtestportableTIMEOUT_UNDER_TOLERANCE     0
+#define         integrationtestportableTIMEOUT_UNDER_TOLERANCE    0
 
 /**
  *  @brief Indicates how long  receive needs to wait for data before Timeout happens.
  *
  */
-#define         integrationtestportableRECEIVE_TIMEOUT             10000
+#define         integrationtestportableRECEIVE_TIMEOUT            10000
 
 /**
  * @brief Indicates how long  send needs to wait before Timeout happens.
  *
  */
-#define         integrationtestportableSEND_TIMEOUT                10000
+#define         integrationtestportableSEND_TIMEOUT               10000
 
 /**
  * @brief The timeout for all TCP echo multi-task tests.
  */
-#define         tcptestECHO_TEST_SYNC_TIMEOUT                      120000
+#define         tcptestECHO_TEST_SYNC_TIMEOUT                     120000
 
 /**
  * @brief The stack size of the tasks created in all TCP echo multi-task tests.
  */
-#define         tcptestTCP_ECHO_TASKS_STACK_SIZE                   ( configMINIMAL_STACK_SIZE * 8 )
+#define         tcptestTCP_ECHO_TASKS_STACK_SIZE                  ( configMINIMAL_STACK_SIZE * 8 )
 
 /**
  * @brief The priority of the tasks created in all TCP echo multi-task tests.
  */
-#define         tcptestTCP_ECHO_TASKS_PRIORITY                     ( tskIDLE_PRIORITY + 5 )
+#define         tcptestTCP_ECHO_TASKS_PRIORITY                    ( tskIDLE_PRIORITY + 5 )
 
 
 #endif /*AWS_INTEGRATION_TEST_TCP_CONFIG_H */


### PR DESCRIPTION
Increase tcptestECHO_TEST_SYNC_TIMEOUT from 8s to 12s for espressif esp32 and esp32s2 boards

Description
-----------
The iot_test_tcp.c AFQP_SECURE_SOCKETS_Threadsafe_DifferentSocketsDifferentTasks test case fails on espressif esp32 and esp32s2 boards due to a timeout. This change Increases the timeout from 8 seconds to 12 seconds to provide ample time for the test to complete. On my esp32 and esp32s2 at the default clock speed, this test takes about 8300ms to complete.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.