### PR TITLE
Add a missing type that is needed by the OTA demo

### DIFF
--- a/demos/network_manager/aws_iot_demo_network.c
+++ b/demos/network_manager/aws_iot_demo_network.c
@@ -37,6 +37,14 @@
     #include "aws_iot_demo_network.h"
     #include "private/iot_error.h"
 
+    /**
+     * @brief Represents a network connection that uses FreeRTOS Secure Sockets.
+     *
+     * This is an incomplete type. In application code, only pointers to this
+     * type should be used.
+     */
+    typedef struct _networkConnection IotNetworkConnectionAfr_t;
+
     #if TCPIP_NETWORK_ENABLED
         #include "platform/iot_network_freertos.h"
     #endif


### PR DESCRIPTION
Add back in a missing type that is needed by the OTA demo

Description
-----------
The `IotNetworkConnectionAfr_t` type is required by the OTA demo to build. This was accidentally removed and caused a build failure with the demo. This change adds it back in to resolve the issue.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.