### PR TITLE
Add back type that is needed by the OTA demo

### DIFF
--- a/libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h
+++ b/libraries/abstractions/platform/freertos/include/platform/iot_network_freertos.h
@@ -112,6 +112,14 @@
 #define IOT_NETWORK_INTERFACE_AFR    ( &( IotNetworkAfr ) )
 
 /**
+ * @brief Represents a network connection that uses FreeRTOS Secure Sockets.
+ *
+ * This is an incomplete type. In application code, only pointers to this type
+ * should be used.
+ */
+typedef void IotNetworkConnectionAfr_t;
+
+/**
  * @brief An implementation of #IotNetworkInterface_t::create for FreeRTOS
  * Secure Sockets.
  */


### PR DESCRIPTION
Add back type that is needed by the OTA demo to build
Description
-----------
The `IotNetworkConnectionAfr_t` type is required by the OTA demo to build. This was accidentally removed and caused a build failure with the demo. This change adds it back in to resolve the issue.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.