### PR TITLE
Fix memory leak in MQTT shim

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -1514,29 +1514,9 @@ void _IotMqtt_Notify( _mqttOperation_t * pOperation )
 
 void _IotMqtt_FreePacket( uint8_t * pPacket )
 {
-    uint8_t packetType;
-
     if( pPacket != NULL )
     {
-        packetType = *pPacket;
-
-        /* Don't call free on DISCONNECT and PINGREQ; those are allocated from static
-         * memory. */
-        if( packetType != MQTT_PACKET_TYPE_DISCONNECT )
-        {
-            if( packetType != MQTT_PACKET_TYPE_PINGREQ )
-            {
-                IotMqtt_FreeMessage( pPacket );
-            }
-            else
-            {
-                EMPTY_ELSE_MARKER;
-            }
-        }
-        else
-        {
-            EMPTY_ELSE_MARKER;
-        }
+        IotMqtt_FreeMessage( pPacket );
     }
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fixes a memory leak in the MQTT shim layer, reported in the [FreeRTOS Forum](https://forums.freertos.org/t/iot-mqtt-ping-request-memory-leak/12089). Both PINGREQ: https://github.com/aws/amazon-freertos/blob/8ecf788edf8e9e6b82d2c0d30c9e1f21e6b9b62e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c#L577
and DISCONNECT: https://github.com/aws/amazon-freertos/blob/8ecf788edf8e9e6b82d2c0d30c9e1f21e6b9b62e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c#L299
allocate 2 bytes for the packet but do not free it: https://github.com/aws/amazon-freertos/blob/8ecf788edf8e9e6b82d2c0d30c9e1f21e6b9b62e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c#L1527.
This looks to be [carried over from v4_beta](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/v4_beta_deprecated/libraries/standard/mqtt/src/iot_mqtt_serialize.c#L1024), without having been changed for the shim.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
