### PR TITLE
Handle WPA WiFi connect in demo

### DIFF
--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -490,6 +490,9 @@ static IotNetworkManager_t networkManager =
                     /* Nothing to do. */
                     break;
 
+                case eWiFiSecurityWPA3:
+                case eWiFiSecurityWPA2_ent:
+                case eWiFiSecurityWEP:
                 default:
                     IotLogError( "The configured WiFi security option is not supported." );
                     status = false;

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -460,26 +460,40 @@ static IotNetworkManager_t networkManager =
 
             xConnectParams.xSecurity = xSecurity;
 
-            if( xSecurity == eWiFiSecurityWPA2 )
+            switch( xSecurity )
             {
-                if( pcPassword != NULL )
-                {
-                    xPasswordLength = strlen( clientcredentialWIFI_PASSWORD );
+                case eWiFiSecurityWPA:
+                case eWiFiSecurityWPA2:
 
-                    if( ( xPasswordLength > 0 ) && ( xPasswordLength < wificonfigMAX_PASSPHRASE_LEN ) )
+                    if( pcPassword != NULL )
                     {
-                        xConnectParams.xPassword.xWPA.ucLength = xPasswordLength;
-                        memcpy( xConnectParams.xPassword.xWPA.cPassphrase, clientcredentialWIFI_PASSWORD, xPasswordLength );
+                        xPasswordLength = strlen( clientcredentialWIFI_PASSWORD );
+
+                        if( ( xPasswordLength > 0 ) && ( xPasswordLength < wificonfigMAX_PASSPHRASE_LEN ) )
+                        {
+                            xConnectParams.xPassword.xWPA.ucLength = xPasswordLength;
+                            memcpy( xConnectParams.xPassword.xWPA.cPassphrase, clientcredentialWIFI_PASSWORD, xPasswordLength );
+                        }
+                        else
+                        {
+                            status = false;
+                        }
                     }
                     else
                     {
                         status = false;
                     }
-                }
-                else
-                {
+
+                    break;
+
+                case eWiFiSecurityOpen:
+                    /* Nothing to do. */
+                    break;
+
+                default:
+                    IotLogError( "The configured WiFi security option is not supported." );
                     status = false;
-                }
+                    break;
             }
 
             if( status == true )


### PR DESCRIPTION
Description
-----------
The demo only handles WPA2 connect, WPA connect needs the same type of credentials and can be handled in the demo.
Added a switch with all cases to make it clear which security options are not supported.

Fixes #3068 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.