### PR TITLE
Fix MQTT shim memory leaks

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
@@ -395,6 +395,9 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
         *pPacketIdentifier = packetId;
     }
 
+    /* Free allocated memory as the packet was serialized. */
+    IotMqtt_FreeMessage( subscriptionList );
+
     return status;
 }
 
@@ -477,6 +480,9 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
         *pUnsubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
     }
+
+    /* Free allocated memory as the packet was serialized. */
+    IotMqtt_FreeMessage( unsubscriptionList );
 
     return status;
 }

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c
@@ -270,6 +270,10 @@ bool IotMqtt_RemoveSubscription( _mqttSubscription_t * pSubscriptionArray,
     {
         /* Using topicFilterLength as a unique parameter to free index and make it available for other subscriptions. */
         pSubscriptionArray[ deleteIndex ].topicFilterLength = 0;
+
+        /* Free memory allocated for topic filter. */
+        IotMqtt_FreeMessage( pSubscriptionArray[ deleteIndex ].pTopicFilter );
+        pSubscriptionArray[ deleteIndex ].pTopicFilter = NULL;
         status = true;
     }
     else
@@ -299,6 +303,10 @@ void IotMqtt_RemoveAllMatches( _mqttSubscription_t * pSubscriptionArray,
                 /* Using topicFilterLength as a unique parameter to free index and make it available for other subscriptions.
                  * As topicFilterLength will be non zero for the currently used subscriptions. */
                 pSubscriptionArray[ index ].topicFilterLength = 0;
+
+                /* Free memory allocated for topic filter. */
+                IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
+                pSubscriptionArray[ index ].pTopicFilter = NULL;
             }
         }
         else
@@ -306,6 +314,9 @@ void IotMqtt_RemoveAllMatches( _mqttSubscription_t * pSubscriptionArray,
             pSubscriptionArray[ index ].topicFilterLength = 0;
 
             pSubscriptionArray[ index ].unsubscribed = true;
+
+            IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
+            pSubscriptionArray[ index ].pTopicFilter = NULL;
         }
 
         index++;

--- a/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/c_sdk/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -952,8 +952,11 @@ TEST( MQTT_Unit_API, OperationWaitTimeout )
     _mqttOperation_t * pOperation = NULL;
     IotSemaphore_t waitSem;
 
-    /* An arbitrary MQTT packet for this test. */
-    static uint8_t pPacket[ 2 ] = { MQTT_PACKET_TYPE_PINGREQ, 0x00 };
+    /* An arbitrary MQTT packet for this test. All packets are malloc'ed. */
+    uint8_t * pPacket = IotMqtt_MallocMessage( 2 );
+
+    pPacket[ 0 ] = MQTT_PACKET_TYPE_PINGREQ;
+    pPacket[ 1 ] = 0x00;
 
     /* Create the wait semaphore. */
     TEST_ASSERT_EQUAL_INT( true, IotSemaphore_Create( &waitSem, 0, 1 ) );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fixes some memory leaks in the MQTT shim, reported int the [FreeRTOS forum](https://forums.freertos.org/t/memory-leak-in-iotmqtt-mallocmessage-pointers-not-freed-after-call-to-awsiotshadow-timedupdate/12104/2). The topic filter for subscriptions is malloc'ed in `iot_mqtt_subscription.c`: https://github.com/aws/amazon-freertos/blob/5251eeaf01e09d24a666bec409bb45d8165a869e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription.c#L112
However, the allocated buffer is never freed in either [`IotMqtt_RemoveSubscription`](https://github.com/aws/amazon-freertos/blob/5251eeaf01e09d24a666bec409bb45d8165a869e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c#L260) nor [`IotMqtt_RemoveAllMatches`](https://github.com/aws/amazon-freertos/blob/5251eeaf01e09d24a666bec409bb45d8165a869e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c#L285). This frees the buffer in those locations.

Additionally, this PR:
- Resolves another memory leak in the subscription/unsubscription packet serializers, where [memory allocated for the subscription lists](https://github.com/aws/amazon-freertos/blob/5251eeaf01e09d24a666bec409bb45d8165a869e/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c#L340) is never freed.
- Fixes a unit test that was failing as a result of #3066

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
