### PR TITLE
Return error code in ST mbedtls_hardware_poll

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/st_code/entropy_hardware_poll.c
@@ -48,6 +48,7 @@
 #include <string.h>
 #include "main.h"
 #include "stm32l4xx_hal.h"
+#include "mbedtls/entropy.h"
 
 int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
@@ -65,7 +66,7 @@ int mbedtls_hardware_poll( void *data,
   
   if ((len < sizeof(uint32_t)) || (HAL_OK != status))
   {
-    return 0;
+    return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
   }
   
   memcpy(output, &random_number, sizeof(uint32_t));

--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/st_code/entropy_hardware_poll.c
@@ -47,6 +47,7 @@
 
 #include <string.h>
 #include "main.h"
+#include "mbedtls/entropy.h"
 
 int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen );
 
@@ -64,7 +65,7 @@ int mbedtls_hardware_poll( void *data,
   
   if ((len < sizeof(uint32_t)) || (HAL_OK != status))
   {
-    return 0;
+    return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
   }
   
   memcpy(output, &random_number, sizeof(uint32_t));


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Updates the ST implementation of `mbedtls_hardware_poll()` to return `MBEDTLS_ERR_ENTROPY_SOURCE_FAILED` on error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
