### PR TITLE
Fix assert in IotNetworkAfr_Destroy

### DIFF
--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -693,20 +693,6 @@ IotNetworkError_t IotNetworkAfr_Destroy( void * pConnection )
     }
     else
     {
-        /* As this function should be called ONLY called after the connection is closed,
-         * the receive task should have already exited. */
-        if( pNetworkConnection->receiveCallback != NULL )
-        {
-            EventBits_t connectionFlags;
-            connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
-
-            configASSERT( ( connectionFlags & _FLAG_RECEIVE_TASK_EXITED ) == _FLAG_RECEIVE_TASK_EXITED );
-
-            /* Suppress compiler warning of unused connectionFlags variable when
-             * configASSERT() is disabled. */
-            ( void ) connectionFlags;
-        }
-
         _destroyConnection( pNetworkConnection );
     }
 

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -657,10 +657,10 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
     {
         /* Wait for the network receive task to exit so that the socket can be shutdown safely
          * without causing the socket to block forever if there are pending reads or writes
-         * from other tasks. */
+         * from other tasks. Do not clear the flag as IotNetworkAfr_Destroy will do so. */
         ( void ) xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
                                       _FLAG_RECEIVE_TASK_EXITED,
-                                      pdTRUE,
+                                      pdFALSE,
                                       pdTRUE,
                                       portMAX_DELAY );
     }
@@ -698,7 +698,13 @@ IotNetworkError_t IotNetworkAfr_Destroy( void * pConnection )
         if( pNetworkConnection->receiveCallback != NULL )
         {
             EventBits_t connectionFlags;
-            connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
+
+            /* Clear the flag indicating the receive task has exited. */
+            connectionFlags = xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
+                                                   _FLAG_RECEIVE_TASK_EXITED,
+                                                   pdTRUE,
+                                                   pdTRUE,
+                                                   portMAX_DELAY );
 
             configASSERT( ( connectionFlags & _FLAG_RECEIVE_TASK_EXITED ) == _FLAG_RECEIVE_TASK_EXITED );
 

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -693,6 +693,20 @@ IotNetworkError_t IotNetworkAfr_Destroy( void * pConnection )
     }
     else
     {
+        /* As this function should be called ONLY called after the connection is closed,
+         * the receive task should have already exited. */
+        if( pNetworkConnection->receiveCallback != NULL )
+        {
+            EventBits_t connectionFlags;
+            connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
+
+            configASSERT( ( connectionFlags & _FLAG_RECEIVE_TASK_EXITED ) == _FLAG_RECEIVE_TASK_EXITED );
+
+            /* Suppress compiler warning of unused connectionFlags variable when
+             * configASSERT() is disabled. */
+            ( void ) connectionFlags;
+        }
+
         _destroyConnection( pNetworkConnection );
     }
 

--- a/libraries/abstractions/platform/freertos/iot_network_freertos.c
+++ b/libraries/abstractions/platform/freertos/iot_network_freertos.c
@@ -657,7 +657,7 @@ IotNetworkError_t IotNetworkAfr_Close( void * pConnection )
     {
         /* Wait for the network receive task to exit so that the socket can be shutdown safely
          * without causing the socket to block forever if there are pending reads or writes
-         * from other tasks. Do not clear the flag as IotNetworkAfr_Destroy will do so. */
+         * from other tasks. Do not clear the flag as IotNetworkAfr_Destroy checks it. */
         ( void ) xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
                                       _FLAG_RECEIVE_TASK_EXITED,
                                       pdFALSE,
@@ -698,13 +698,7 @@ IotNetworkError_t IotNetworkAfr_Destroy( void * pConnection )
         if( pNetworkConnection->receiveCallback != NULL )
         {
             EventBits_t connectionFlags;
-
-            /* Clear the flag indicating the receive task has exited. */
-            connectionFlags = xEventGroupWaitBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ),
-                                                   _FLAG_RECEIVE_TASK_EXITED,
-                                                   pdTRUE,
-                                                   pdTRUE,
-                                                   portMAX_DELAY );
+            connectionFlags = xEventGroupGetBits( ( EventGroupHandle_t ) &( pNetworkConnection->connectionFlags ) );
 
             configASSERT( ( connectionFlags & _FLAG_RECEIVE_TASK_EXITED ) == _FLAG_RECEIVE_TASK_EXITED );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Reported in #3075. #2986 updated `IotNetworkAfr_Close` to [clear](https://github.com/aws/amazon-freertos/blob/master/libraries/abstractions/platform/freertos/iot_network_freertos.c#L661) the `_FLAG_RECEIVE_TASK_EXITED` flag, and #3029 updated `IotNetworkAfr_Destroy` to remove a check for that flag, as it would otherwise wait for it indefinitely. However, it added an [assert](https://github.com/aws/amazon-freertos/blob/master/libraries/abstractions/platform/freertos/iot_network_freertos.c#L703) for the same flag that was cleared, resulting in the failure in #3075. This ~removes that assert so that it will not trigger when calling `IotNetworkAfr_Destroy`~ changes `IotNetworkAfr_Close` to not clear the flag.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
