### PR TITLE
Fix AFQP_WIFI_GetHostIP_DomainNameLengthExceeded test

### DIFF
--- a/libraries/abstractions/wifi/test/iot_test_wifi.c
+++ b/libraries/abstractions/wifi/test/iot_test_wifi.c
@@ -1121,7 +1121,7 @@ TEST( Full_WiFi, AFQP_WIFI_GetHostIP_DomainNameLengthExceeded )
 
     if( TEST_PROTECT() )
     {
-        xWiFiStatus = WIFI_GetHostIP( testwifiTEST_INVALID_DOMAIN_NAME, ucIPAddr );
+        xWiFiStatus = WIFI_GetHostIP( cDomainNameLengthExceeded, ucIPAddr );
 
         TEST_WIFI_ASSERT_REQUIRED_API( xWiFiStatus != eWiFiSuccess, xWiFiStatus );
 


### PR DESCRIPTION
Description
-----------
The test was passing an invalid domain name instead of a domain name that exceeds maximum length, as noted in issue #3088

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.