### PR TITLE
Update README cloning instructions to set core.symlinks for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodu
 
 Note: If you download the ZIP file provided by GitHub UI, you will not get the contents of the submodules. (The ZIP file is also not a valid git repository)
 
-If using Windows, set `core.symlinks` to true:
+If using Windows, set `core.symlinks` to true since copying a directory with symlinks may cause hangups:
 ```
 git config --global core.symlinks true
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodu
 
 Note: If you download the ZIP file provided by GitHub UI, you will not get the contents of the submodules. (The ZIP file is also not a valid git repository)
 
+If using Windows, set `core.symlinks` to true:
+```
+git config --global core.symlinks true
+```
+
 To clone using HTTPS:
 ```
 git clone https://github.com/aws/amazon-freertos.git --recurse-submodules


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Because some submodules have symlinks from CBMC, copying a directory in Windows may cause a hangup. This updates the instructions to set `core.symlinks` to true for Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.