### PR TITLE
Check for NULL before freeing subscriptions

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_subscription_container.c
@@ -272,8 +272,12 @@ bool IotMqtt_RemoveSubscription( _mqttSubscription_t * pSubscriptionArray,
         pSubscriptionArray[ deleteIndex ].topicFilterLength = 0;
 
         /* Free memory allocated for topic filter. */
-        IotMqtt_FreeMessage( pSubscriptionArray[ deleteIndex ].pTopicFilter );
-        pSubscriptionArray[ deleteIndex ].pTopicFilter = NULL;
+        if( pSubscriptionArray[ deleteIndex ].pTopicFilter != NULL )
+        {
+            IotMqtt_FreeMessage( pSubscriptionArray[ deleteIndex ].pTopicFilter );
+            pSubscriptionArray[ deleteIndex ].pTopicFilter = NULL;
+        }
+
         status = true;
     }
     else
@@ -305,8 +309,11 @@ void IotMqtt_RemoveAllMatches( _mqttSubscription_t * pSubscriptionArray,
                 pSubscriptionArray[ index ].topicFilterLength = 0;
 
                 /* Free memory allocated for topic filter. */
-                IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
-                pSubscriptionArray[ index ].pTopicFilter = NULL;
+                if( pSubscriptionArray[ index ].pTopicFilter != NULL )
+                {
+                    IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
+                    pSubscriptionArray[ index ].pTopicFilter = NULL;
+                }
             }
         }
         else
@@ -315,8 +322,11 @@ void IotMqtt_RemoveAllMatches( _mqttSubscription_t * pSubscriptionArray,
 
             pSubscriptionArray[ index ].unsubscribed = true;
 
-            IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
-            pSubscriptionArray[ index ].pTopicFilter = NULL;
+            if( pSubscriptionArray[ index ].pTopicFilter != NULL )
+            {
+                IotMqtt_FreeMessage( pSubscriptionArray[ index ].pTopicFilter );
+                pSubscriptionArray[ index ].pTopicFilter = NULL;
+            }
         }
 
         index++;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Reported in #3073. #3072 fixed a memory leak by freeing allocated buffers when removing subscriptions. However, for the case of `IotMqtt_RemoveAllMatches` for a `NULL` matching function, all subscriptions are removed in a loop regardless of whether or not they exist. This is fine for dynamic allocation, as `free( NULL )` does nothing, but when using static memory, `IotStaticMemory_ReturnInUse` tries to [dereference](https://github.com/aws/amazon-freertos/blob/master/libraries/c_sdk/standard/common/iot_static_memory_common.c#L126) the pointer without checking first for NULL.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
