### PR TITLE
MQTT Shim: Fix corruption of reference count in keep-alive timeout case

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c
@@ -681,13 +681,6 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
 
     IotLogDebug( "(MQTT connection %p) Keep-alive job started.", pMqttConnection );
 
-    /* Re-create the keep-alive job for rescheduling. This should never fail. */
-    taskPoolStatus = IotTaskPool_CreateJob( _IotMqtt_ProcessKeepAlive,
-                                            pContext,
-                                            IotTaskPool_GetJobStorageFromHandle( pKeepAliveJob ),
-                                            &pKeepAliveJob );
-    IotMqtt_Assert( taskPoolStatus == IOT_TASKPOOL_SUCCESS );
-
     IotMutex_Lock( &( pMqttConnection->referencesMutex ) );
 
     /* Determine whether to send a PINGREQ or check for PINGRESP. */
@@ -810,6 +803,13 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
      * response shortly. */
     if( status == true )
     {
+        /* Re-create the keep-alive job for rescheduling. This should never fail. */
+        taskPoolStatus = IotTaskPool_CreateJob( _IotMqtt_ProcessKeepAlive,
+                                                pContext,
+                                                IotTaskPool_GetJobStorageFromHandle( pKeepAliveJob ),
+                                                &pKeepAliveJob );
+        IotMqtt_Assert( taskPoolStatus == IOT_TASKPOOL_SUCCESS );
+
         if( scheduleDelay == 0U )
         {
             scheduleDelay = pMqttConnection->nextKeepAliveMs;


### PR DESCRIPTION
### Issue
 The reference count value of MQTT connection (`_mqttconnection_t.references`) decreases to zero in the `_IoTMqtt_ProcessKeepAlive` taskpool job when the ping-response (from server) times out.  
 
 ### Root Cause
 The `_IotMqtt_ProcessKeepAlive` job _always_ re-cycles the taskpool job memory (same as the one it uses while being executed) for re-scheduling the job for future ping-requests/ping-responses. However, when the job is re-cycled for the keep-alive timeout case, state of the job to changes from `IOT_TASKPOOL_STATUS_COMPLETED` to `IOT_TASKPOOL_STATUS_READY`, thereby, causing the clean-up operation (for the keep-alive timeout) to decrement the MQTT connection reference count by 2 instead of 1. (The keep-alive timeout cleanup operation calls [`_IotMqtt_CloseNetworkConnection`](https://github.com/aws/amazon-freertos/blob/202012.00/libraries/c_sdk/standard/mqtt/src/iot_mqtt_operation.c#L849) function which attempts to cancel the Keep-alive job; as the keep-alive job status has changed to `IOT_TASKPOOL_STATUS_READY`, the `IotTaskpool_TryCancel` call returns success instead of `IOT_TASKPOOL_CANCEL_FAILED`, thereby, causing the function to incorrectly decrement the MQTT connection reference count by 1.
 
### Fix 
This PR fixes the issue of taskpool job memory corruption in the keep-alive timeout case by updating the `_IotMqtt_ProcessKeepAlive` function to re-cycle the taskpool job memory ONLY when there is no keep-alive timeout.
 