### PR TITLE
esp32/esp32s2: Add mbedTLS dependencies to support esp_http_client

### DIFF
--- a/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
+++ b/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
@@ -62,6 +62,14 @@ set(
     "${MBEDTLS_DIR}/port/esp_timing.c"
 )
 
+if(NOT AFR_FREERTOS_TCP)
+    list(
+        APPEND
+        mbedtls_srcs
+        "${esp_idf_dir}/components/mbedtls/port/net_sockets.c"
+        )
+endif()
+
 if(CONFIG_MBEDTLS_DYNAMIC_BUFFER)
     list(APPEND mbedtls_srcs
     "${MBEDTLS_DIR}/port/dynamic/esp_mbedtls_dynamic_impl.c"

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -73,6 +73,20 @@ else()
     set(aws_credentials_include "${AFR_DEMOS_DIR}/include")
 endif()
 
+# mbedTLS include directories
+if(NOT AFR_FREERTOS_TCP)
+    target_include_directories(
+        afr_3rdparty_mbedtls
+        PUBLIC
+        "${esp_idf_dir}/components/lwip/include/apps"
+        "${esp_idf_dir}/components/lwip/include/apps/sntp"
+        "${esp_idf_dir}/components/lwip/lwip/src/include"
+        "${esp_idf_dir}/components/lwip/port/esp32/include"
+        "${esp_idf_dir}/components/lwip/port/esp32/include/arch"
+        "${esp_idf_dir}/components/lwip/lwip/src/include/compat"
+        )
+endif()
+
 # Kernel
 afr_mcu_port(kernel)
 afr_glob_src(driver_src DIRECTORY "${esp_idf_dir}" RECURSE)

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -63,6 +63,20 @@ else()
     set(aws_credentials_include "${AFR_DEMOS_DIR}/include")
 endif()
 
+# mbedTLS include directories
+if(NOT AFR_FREERTOS_TCP)
+    target_include_directories(
+        afr_3rdparty_mbedtls
+        PUBLIC
+        "${esp_idf_dir}/components/lwip/include/apps"
+        "${esp_idf_dir}/components/lwip/include/apps/sntp"
+        "${esp_idf_dir}/components/lwip/lwip/src/include"
+        "${esp_idf_dir}/components/lwip/port/esp32/include"
+        "${esp_idf_dir}/components/lwip/port/esp32/include/arch"
+        "${esp_idf_dir}/components/lwip/lwip/src/include/compat"
+        )
+endif()
+
 # Kernel
 afr_mcu_port(kernel)
 afr_glob_src(driver_src DIRECTORY "${esp_idf_dir}" RECURSE)


### PR DESCRIPTION
Description
-----------
Add net_sockets.c and required header files to support esp_http_client in AFR.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.