### PR TITLE
Fixes in BLE middleware and WiFi provisioning over BLE

### DIFF
--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -490,6 +490,17 @@ BTStatus_t IotBle_StartAdv( IotBle_StartAdvCallback_t pStartAdvCb );
 /* @[declare_iotble_startadv] */
 
 /**
+ * @brief Sets an application defined callback invoked when an advertisement duration has ended or
+ * advertisement stops due to an error. 
+ * 
+ * @param pStopAdvCb The application defined callback to be invoked when advertisement is stopped.
+ * @return Returns eBTStatusSuccess on successful call.
+ */
+/* @[declare_iotble_setstopadvcallback] */
+BTStatus_t IotBle_SetStopAdvCallback( IotBle_StopAdvCallback_t pStopAdvCb );
+/* @[declare_iotble_setstopadvcallback] */
+
+/**
  * @brief Stop advertisements to listen for incoming connections.
  * Triggers IotBle_StopAdvCallback_t
  * @return Returns eBTStatusSuccess on successful call.

--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -528,6 +528,7 @@ BTStatus_t IotBle_ConnParameterUpdateRequest( const BTBdaddr_t * pRemoteBdAddr,
  * For example, one service could require knowledge of connection status,
  * the it would subscribe to connectionCallback event. That API is giving the
  * flexibility of having more than one service listening to the same event.
+ * Note: API should not be invoked from within the event callback.
  *
  * @param[in] event The event.
  * @param[in] bleEventsCallbacks Callback returning status of the operation.
@@ -540,6 +541,7 @@ BTStatus_t IotBle_RegisterEventCb( IotBleEvents_t event,
 
 /**
  * @brief Remove a subscription to an event.
+ * Note: API should not be invoked from within the event callback.
  *
  * @param[in] event The event.
  * @param[in] bleEventsCallbacks The subscription to remove.

--- a/libraries/c_sdk/standard/ble/include/iot_ble.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble.h
@@ -491,8 +491,8 @@ BTStatus_t IotBle_StartAdv( IotBle_StartAdvCallback_t pStartAdvCb );
 
 /**
  * @brief Sets an application defined callback invoked when an advertisement duration has ended or
- * advertisement stops due to an error. 
- * 
+ * advertisement stops due to an error.
+ *
  * @param pStopAdvCb The application defined callback to be invoked when advertisement is stopped.
  * @return Returns eBTStatusSuccess on successful call.
  */

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -517,6 +517,15 @@ BTStatus_t IotBle_StartAdv( IotBle_StartAdvCallback_t pStartAdvCb )
 
 /*-----------------------------------------------------------*/
 
+BTStatus_t IotBle_SetStopAdvCallback( IotBle_StopAdvCallback_t pStopAdvCb )
+{
+    _BTInterface.pStopAdvCb = pStopAdvCb;
+    return eBTStatusSuccess;
+}
+
+
+/*-----------------------------------------------------------*/
+
 BTStatus_t IotBle_StopAdv( IotBle_StopAdvCallback_t pStopAdvCb )
 {
     BTStatus_t status = eBTStatusSuccess;

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gap.c
@@ -254,16 +254,14 @@ void _sspRequestCb( BTBdaddr_t * pRemoteBdAddr,
 
     if( pairingVariant == eBTsspVariantPasskeyConfirmation )
     {
-        /* If confirmation is needed, trigger the hooks on the APP side. */
-        IotMutex_Lock( &_BTInterface.threadSafetyMutex );
-
-        /* Get the event associated to the callback */
+        IotMutex_Lock( &_BTInterface.eventCallbackMutex );
+        /* If confirmation is needed, trigger the hooks on the APP side. Get the event associated to the callback */
         IotContainers_ForEach( &_BTInterface.subscrEventListHead[ eBLENumericComparisonCallback ], pEventListIndex )
         {
             pEventIndex = IotLink_Container( _bleSubscrEventListElement_t, pEventListIndex, eventList );
             pEventIndex->subscribedEventCb.pNumericComparisonCb( pRemoteBdAddr, passKey );
         }
-        IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+        IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
     }
     else
     {
@@ -282,15 +280,15 @@ void _pairingStateChangedCb( BTStatus_t status,
     IotLink_t * pEventListIndex;
     _bleSubscrEventListElement_t * pEventIndex;
 
-    IotMutex_Lock( &_BTInterface.threadSafetyMutex );
     /* Get the event associated to the callback */
+
+    IotMutex_Lock( &_BTInterface.eventCallbackMutex );
     IotContainers_ForEach( &_BTInterface.subscrEventListHead[ eBLEPairingStateChanged ], pEventListIndex )
     {
         pEventIndex = IotLink_Container( _bleSubscrEventListElement_t, pEventListIndex, eventList );
         pEventIndex->subscribedEventCb.pGAPPairingStateChangedCb( status, pRemoteBdAddr, state, securityLevel, reason );
     }
-
-    IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+    IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -823,6 +821,7 @@ BTStatus_t IotBle_Off( void )
 BTStatus_t _createSyncrhonizationObjects( void )
 {
     bool createdThreadSafetyMutex = false;
+    bool createdEventCallbackMutex = false;
     bool createdWaitCbMutex = false;
     bool createdCallbackSemaphore = false;
     BTStatus_t status = eBTStatusSuccess;
@@ -835,6 +834,19 @@ BTStatus_t _createSyncrhonizationObjects( void )
     {
         status = eBTStatusNoMem;
         IotLogError( "Cannot create thread safety mutex." );
+    }
+
+    if( status == eBTStatusSuccess )
+    {
+        if( IotMutex_Create( &_BTInterface.eventCallbackMutex, false ) == true )
+        {
+            createdEventCallbackMutex = true;
+        }
+        else
+        {
+            status = eBTStatusNoMem;
+            IotLogError( "Cannot create event callback mutex." );
+        }
     }
 
     if( status == eBTStatusSuccess )
@@ -869,6 +881,11 @@ BTStatus_t _createSyncrhonizationObjects( void )
         if( createdThreadSafetyMutex == true )
         {
             IotMutex_Destroy( &_BTInterface.threadSafetyMutex );
+        }
+
+        if( createdEventCallbackMutex == true )
+        {
+            IotMutex_Destroy( &_BTInterface.eventCallbackMutex );
         }
 
         if( createdWaitCbMutex == true )
@@ -1041,12 +1058,12 @@ BTStatus_t IotBle_RegisterEventCb( IotBleEvents_t xEvent,
 
         if( pNewEvent != NULL )
         {
-            IotMutex_Lock( &_BTInterface.threadSafetyMutex );
+            IotMutex_Lock( &_BTInterface.eventCallbackMutex );
             pNewEvent->subscribedEventCb = xBLEEventsCallbacks;
             IotListDouble_InsertHead( &_BTInterface.subscrEventListHead[ xEvent ],
                                       &pNewEvent->eventList );
 
-            IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+            IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
         }
         else
         {
@@ -1065,7 +1082,7 @@ BTStatus_t IotBle_UnRegisterEventCb( IotBleEvents_t event,
     _bleSubscrEventListElement_t * pEventIndex;
     IotLink_t * pEventListIndex;
 
-    IotMutex_Lock( &_BTInterface.threadSafetyMutex );
+    IotMutex_Lock( &_BTInterface.eventCallbackMutex );
 
     /* Get the event associated to the callback */
     IotContainers_ForEach( &_BTInterface.subscrEventListHead[ event ], pEventListIndex )
@@ -1086,7 +1103,7 @@ BTStatus_t IotBle_UnRegisterEventCb( IotBleEvents_t event,
         IotBle_Free( pEventIndex );
     }
 
-    IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+    IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
 
     return status;
 }

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
@@ -305,15 +305,16 @@ void _connectionCb( uint16_t connId,
             IotBle_Free( pConnInfoListElem );
         }
     }
+    IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
 
+    IotMutex_Lock( &_BTInterface.eventCallbackMutex );
     /* Get the event associated to the callback */
     IotContainers_ForEach( &_BTInterface.subscrEventListHead[ eBLEConnection ], pEventListIndex )
     {
         pEventIndex = IotLink_Container( _bleSubscrEventListElement_t, pEventListIndex, eventList );
         pEventIndex->subscribedEventCb.pConnectionCb( status, connId, connected, pBda );
     }
-
-    IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+    IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
 }
 
 /*-----------------------------------------------------------*/
@@ -593,14 +594,14 @@ void _mtuChangedCb( uint16_t connId,
     IotLink_t * pEventListIndex;
     _bleSubscrEventListElement_t * pEventIndex;
 
-    IotMutex_Lock( &_BTInterface.threadSafetyMutex );
     /* Get the event associated to the callback */
+    IotMutex_Lock( &_BTInterface.eventCallbackMutex );
     IotContainers_ForEach( &_BTInterface.subscrEventListHead[ eBLEMtuChanged ], pEventListIndex )
     {
         pEventIndex = IotLink_Container( _bleSubscrEventListElement_t, pEventListIndex, eventList );
         pEventIndex->subscribedEventCb.pMtuChangedCb( connId, mtu );
     }
-    IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
+    IotMutex_Unlock( &_BTInterface.eventCallbackMutex );
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_gatt.c
@@ -305,6 +305,7 @@ void _connectionCb( uint16_t connId,
             IotBle_Free( pConnInfoListElem );
         }
     }
+
     IotMutex_Unlock( &_BTInterface.threadSafetyMutex );
 
     IotMutex_Lock( &_BTInterface.eventCallbackMutex );

--- a/libraries/c_sdk/standard/ble/src/iot_ble_internal.h
+++ b/libraries/c_sdk/standard/ble/src/iot_ble_internal.h
@@ -90,6 +90,7 @@ typedef struct
     BTGattServerInterface_t * pGattServerInterface;
     uint8_t adapterIf;
     IotMutex_t threadSafetyMutex;
+    IotMutex_t eventCallbackMutex;
     IotMutex_t waitCbMutex;
     IotSemaphore_t callbackSemaphore;
     BTStatus_t cbStatus;

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -61,7 +61,12 @@
     ( ( ret == IOT_SERIALIZER_SUCCESS ) ||              \
       ( ( !pxSerializerBuf ) && ( ret == IOT_SERIALIZER_BUFFER_TOO_SMALL ) ) )
 
-#define STORAGE_INDEX( priority )    ( wifiProvisioning.numNetworks - priority - 1 )
+/**
+ * @brief Macro to check if provided network index for an operation is within range.
+ */
+#define IS_INDEX_WITHIN_RANGE( index )    ( ( index >= 0 ) && ( index < wifiProvisioning.numNetworks ) )
+
+#define STORAGE_INDEX( priority )         ( wifiProvisioning.numNetworks - priority - 1 )
 #define NETWORK_INFO_DEFAULT_PARAMS    { .status = eWiFiSuccess, .RSSI = IOT_BLE_WIFI_PROV_INVALID_NETWORK_RSSI, .connected = false, .savedIdx = IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX }
 
 
@@ -1516,7 +1521,10 @@ static void _addNetworkTask( IotTaskPool_t taskPool,
 
     if( wifiProvisioning.addNetworkRequest.savedIdx != IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX )
     {
-        ret = _connectSavedNetwork( wifiProvisioning.addNetworkRequest.savedIdx );
+        if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.addNetworkRequest.savedIdx ) )
+        {
+            ret = _connectSavedNetwork( wifiProvisioning.addNetworkRequest.savedIdx );
+        }
     }
     else
     {
@@ -1547,7 +1555,10 @@ static void _deleteNetworkTask( IotTaskPool_t taskPool,
 {
     WIFIReturnCode_t ret = eWiFiFailure;
 
-    ret = _popNetwork( wifiProvisioning.deleteNetworkRequest.idx, NULL );
+    if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.deleteNetworkRequest.idx ) )
+    {
+        ret = _popNetwork( wifiProvisioning.deleteNetworkRequest.idx, NULL );
+    }
 
     if( ret == eWiFiSuccess )
     {
@@ -1573,7 +1584,13 @@ static void _editNetworkTask( IotTaskPool_t taskPool,
 {
     WIFIReturnCode_t ret = eWiFiFailure;
 
-    ret = _moveNetwork( wifiProvisioning.editNetworkRequest.curIdx, wifiProvisioning.editNetworkRequest.newIdx );
+
+    if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.editNetworkRequest.curIdx ) &&
+        IS_INDEX_WITHIN_RANGE( wifiProvisioning.editNetworkRequest.newIdx ) )
+    {
+        ret = _moveNetwork( wifiProvisioning.editNetworkRequest.curIdx, wifiProvisioning.editNetworkRequest.newIdx );
+    }
+
     _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP, ret );
     IotSemaphore_Post( &wifiProvisioning.lock );
     IotTaskPool_RecycleJob( taskPool, job );

--- a/libraries/c_sdk/standard/ble/utest/middleware/iot_ble_gap_gatt_utest.c
+++ b/libraries/c_sdk/standard/ble/utest/middleware/iot_ble_gap_gatt_utest.c
@@ -867,6 +867,25 @@ void test_IotBleStopAdvertisement( void )
     prvTestTurnOffBLE();
 }
 
+void test_IotBleSetStopAdvertisementCallback( void )
+{
+    prvTestTurnOnBLE();
+    prvBleTestStopAdv_Stub( prvStopAdvCallback );
+
+    /* Register callback for a stop advertisement event from stack. */
+    TEST_ASSERT_EQUAL( eBTStatusSuccess, IotBle_SetStopAdvCallback( prvAdvertisementCallback ) );
+
+    /* Verify that stop advertisement event from stack invokes the callback. */
+    middlewareBleCallback.pxAdvStatusCb( eBTStatusSuccess, 0 /* stop advertisement */, false );
+    TEST_ASSERT_EQUAL( 1, numAdvertisementStatusCalls );
+
+    /* Verify that start advertisement event from stack does not invoke the callback. */
+    middlewareBleCallback.pxAdvStatusCb( eBTStatusSuccess, 1 /* start advertisement */, false );
+    TEST_ASSERT_EQUAL( 1, numAdvertisementStatusCalls );
+
+    prvTestTurnOffBLE();
+}
+
 static uint32_t eventCallbackCount[ eNbEvents ] = { 0 };
 
 static void prvMtuChangedCallback( uint16_t connId,


### PR DESCRIPTION
Description
-----------

PR contains fixes for issues mentioned in #3112 #3107 and #3113 

* Added API to set callback which is invoked for advertisements stopped without user triggering it.
* Fixed a deadlock when a middleware API is invoked from an event callback registered by application. 
* WiFi provision over BLE: Added validation and fail when invalid index range is passed from a smartphone app .
* Added unit tests for failure scenarios.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.