### PR TITLE
Fix the cmdCompleteCallback name in prvMqttUnSubscribe in ota_demo_core_mqtt.c

### DIFF
--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1563,7 +1563,7 @@ static OtaMqttStatus_t prvMqttUnSubscribe( const char * pTopicFilter,
 
 
     commandParams.blockTimeMs = MQTT_AGENT_SEND_BLOCK_TIME_MS;
-    commandParams.cmdCompleteCallback = prvMQTTSubscribeCompleteCallback;
+    commandParams.cmdCompleteCallback = prvMQTTUnsubscribeCompleteCallback;
     commandParams.pCmdCompleteCallbackContext = &commandContext;
     commandContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
     commandContext.pArgs = &subscribeArgs;


### PR DESCRIPTION
Fix the cmdCompleteCallback name in prvMqttUnSubscribe in ota_demo_core_mqtt.c

Fixes aws/amazon-freertos#3118

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.