### PR TITLE
[Mqtt shim] Memory leak fix for freeing buffers when serializing MQTT packets fails

### DIFF
--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
@@ -23,11 +23,11 @@
  * https://www.FreeRTOS.org
  */
 
- /**
-  * @file iot_mqtt_serializer_deserializer_wrapper.c
-  * @brief Implements serializer and deserializer wrapper functions for the shim.
-  */
-  /* The config header is always included first. */
+/**
+ * @file iot_mqtt_serializer_deserializer_wrapper.c
+ * @brief Implements serializer and deserializer wrapper functions for the shim.
+ */
+/* The config header is always included first. */
 #include "iot_config.h"
 
 /* Standard includes. */
@@ -53,23 +53,23 @@
  */
 #define MQTT_MAX_REMAINING_LENGTH     ( 268435455UL )
 
- /*
-  * @brief Return status codes for subscription as per the MQTT 3.1.1 spec.
-  */
+/*
+ * @brief Return status codes for subscription as per the MQTT 3.1.1 spec.
+ */
 #define SUBSCRIPTION_ACCEPTED_QOS0    ( 0x00 )               /**< @brief  Status code for accepted QOS0 subscription. */
 #define SUBSCRIPTION_ACCEPTED_QOS1    ( 0x01 )               /**< @brief  Status code for accepted QOS1 subscription. */
 #define SUBSCRIPTION_ACCEPTED_QOS2    ( 0x02 )               /**< @brief  Status code for accepted QOS1 subscription. */
 #define SUBSCRIPTION_REFUSED          ( 0x80 )               /**< @brief  Status code for refused subscription. */
 
-  /*-----------------------------------------------------------*/
+/*-----------------------------------------------------------*/
 
-  /* Generate Id for packet. */
-static uint16_t _nextPacketIdentifier(void);
+/* Generate Id for packet. */
+static uint16_t _nextPacketIdentifier( void );
 
 /*-----------------------------------------------------------*/
 
 /* Generate Id for packet. */
-static uint16_t _nextPacketIdentifier(void)
+static uint16_t _nextPacketIdentifier( void )
 {
     /* MQTT specifies 2 bytes for the packet identifier; however, operating on
      * 32-bit integers is generally faster. */
@@ -78,7 +78,7 @@ static uint16_t _nextPacketIdentifier(void)
     /* The next packet identifier will be greater by 2. This prevents packet
      * identifiers from ever being 0, which is not allowed by MQTT 3.1.1. Packet
      * identifiers will follow the sequence 1,3,5...65535,1,3,5... */
-    return (uint16_t)Atomic_Add_u32(&nextPacketIdentifier, 2);
+    return ( uint16_t ) Atomic_Add_u32( &nextPacketIdentifier, 2 );
 }
 
 /*-----------------------------------------------------------*/
@@ -91,32 +91,32 @@ static uint16_t _nextPacketIdentifier(void)
  *
  * @return The size of the encoding of length. This is always `1`, `2`, `3`, or `4`.
  */
-static size_t _remainingLengthEncodedSize(size_t length);
+static size_t _remainingLengthEncodedSize( size_t length );
 
 /*-----------------------------------------------------------*/
 
-static size_t _remainingLengthEncodedSize(size_t length)
+static size_t _remainingLengthEncodedSize( size_t length )
 {
     size_t encodedSize = 0;
 
     /* length should have already been checked before calling this function. */
-    IotMqtt_Assert(length <= MQTT_MAX_REMAINING_LENGTH);
+    IotMqtt_Assert( length <= MQTT_MAX_REMAINING_LENGTH );
 
     /* Determine how many bytes are needed to encode length.
      * The values below are taken from the MQTT 3.1.1 spec. */
 
-     /* 1 byte is needed to encode lengths between 0 and 127. */
-    if (length < 128)
+    /* 1 byte is needed to encode lengths between 0 and 127. */
+    if( length < 128 )
     {
         encodedSize = 1;
     }
     /* 2 bytes are needed to encode lengths between 128 and 16,383. */
-    else if (length < 16384)
+    else if( length < 16384 )
     {
         encodedSize = 2;
     }
     /* 3 bytes are needed to encode lengths between 16,384 and 2,097,151. */
-    else if (length < 2097152)
+    else if( length < 2097152 )
     {
         encodedSize = 3;
     }
@@ -131,23 +131,23 @@ static size_t _remainingLengthEncodedSize(size_t length)
 
 /*-----------------------------------------------------------*/
 
-uint8_t _IotMqtt_GetPacketType(void* pNetworkConnection,
-    const IotNetworkInterface_t* pNetworkInterface)
+uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
+                                const IotNetworkInterface_t * pNetworkInterface )
 {
     uint8_t packetType = 0xff;
 
     /* The MQTT packet type is in the first byte of the packet. */
-    (void)_IotMqtt_GetNextByte(pNetworkConnection,
-        pNetworkInterface,
-        &packetType);
+    ( void ) _IotMqtt_GetNextByte( pNetworkConnection,
+                                   pNetworkInterface,
+                                   &packetType );
 
     return packetType;
 }
 
 /*-----------------------------------------------------------*/
 
-size_t _IotMqtt_GetRemainingLength(void* pNetworkConnection,
-    const IotNetworkInterface_t* pNetworkInterface)
+size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
+                                    const IotNetworkInterface_t * pNetworkInterface )
 {
     uint8_t encodedByte = 0;
     size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
@@ -155,18 +155,18 @@ size_t _IotMqtt_GetRemainingLength(void* pNetworkConnection,
     /* This algorithm is copied from the MQTT v3.1.1 spec. */
     do
     {
-        if (multiplier > 2097152) /* 128 ^ 3 */
+        if( multiplier > 2097152 ) /* 128 ^ 3 */
         {
             remainingLength = MQTT_REMAINING_LENGTH_INVALID;
             break;
         }
         else
         {
-            if (_IotMqtt_GetNextByte(pNetworkConnection,
-                pNetworkInterface,
-                &encodedByte) == true)
+            if( _IotMqtt_GetNextByte( pNetworkConnection,
+                                      pNetworkInterface,
+                                      &encodedByte ) == true )
             {
-                remainingLength += (encodedByte & 0x7F) * multiplier;
+                remainingLength += ( encodedByte & 0x7F ) * multiplier;
                 multiplier *= 128;
                 bytesDecoded++;
             }
@@ -176,21 +176,21 @@ size_t _IotMqtt_GetRemainingLength(void* pNetworkConnection,
                 break;
             }
         }
-    } while ((encodedByte & 0x80) != 0);
+    } while( ( encodedByte & 0x80 ) != 0 );
 
     /* Check that the decoded remaining length conforms to the MQTT specification. */
-    if (remainingLength != MQTT_REMAINING_LENGTH_INVALID)
+    if( remainingLength != MQTT_REMAINING_LENGTH_INVALID )
     {
-        expectedSize = _remainingLengthEncodedSize(remainingLength);
+        expectedSize = _remainingLengthEncodedSize( remainingLength );
 
-        if (bytesDecoded != expectedSize)
+        if( bytesDecoded != expectedSize )
         {
             remainingLength = MQTT_REMAINING_LENGTH_INVALID;
         }
         else
         {
             /* Valid remaining length should be at most 4 bytes. */
-            IotMqtt_Assert(bytesDecoded <= 4);
+            IotMqtt_Assert( bytesDecoded <= 4 );
         }
     }
     else
@@ -204,9 +204,9 @@ size_t _IotMqtt_GetRemainingLength(void* pNetworkConnection,
 /*-----------------------------------------------------------*/
 
 /* Connect Serialize Wrapper. */
-IotMqttError_t _IotMqtt_connectSerializeWrapper(const IotMqttConnectInfo_t* pConnectInfo,
-    uint8_t** pConnectPacket,
-    size_t* pPacketSize)
+IotMqttError_t _IotMqtt_connectSerializeWrapper( const IotMqttConnectInfo_t * pConnectInfo,
+                                                 uint8_t ** pConnectPacket,
+                                                 size_t * pPacketSize )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     size_t remainingLength = 0UL;
@@ -216,9 +216,9 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper(const IotMqttConnectInfo_t* pCon
     MQTTPublishInfo_t willInfo;
 
     /* Null Check for connectInfo. */
-    IotMqtt_Assert(pConnectInfo != NULL);
-    IotMqtt_Assert(pConnectPacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert( pConnectInfo != NULL );
+    IotMqtt_Assert( pConnectPacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
 
     connectInfo.cleanSession = pConnectInfo->cleanSession;
     connectInfo.keepAliveSeconds = pConnectInfo->keepAliveSeconds;
@@ -228,50 +228,51 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper(const IotMqttConnectInfo_t* pCon
     connectInfo.userNameLength = pConnectInfo->userNameLength;
     connectInfo.pPassword = pConnectInfo->pPassword;
     connectInfo.passwordLength = pConnectInfo->passwordLength;
-    const MQTTPublishInfo_t* pWillInfo = pConnectInfo->pWillInfo != NULL ? &willInfo : NULL;
+    const MQTTPublishInfo_t * pWillInfo = pConnectInfo->pWillInfo != NULL ? &willInfo : NULL;
 
     /* NULL Check willInfo. */
-    if (pWillInfo != NULL)
+    if( pWillInfo != NULL )
     {
         willInfo.retain = pConnectInfo->pWillInfo->retain;
         willInfo.pTopicName = pConnectInfo->pWillInfo->pTopicName;
         willInfo.topicNameLength = pConnectInfo->pWillInfo->topicNameLength;
         willInfo.pPayload = pConnectInfo->pWillInfo->pPayload;
         willInfo.payloadLength = pConnectInfo->pWillInfo->payloadLength;
-        willInfo.qos = (MQTTQoS_t)pConnectInfo->pWillInfo->qos;
+        willInfo.qos = ( MQTTQoS_t ) pConnectInfo->pWillInfo->qos;
     }
 
     /* Getting Connect packet size using MQTT V4_beta2 API. */
 
-    managedMqttStatus = MQTT_GetConnectPacketSize(&connectInfo,
-        pWillInfo,
-        &remainingLength,
-        pPacketSize);
+    managedMqttStatus = MQTT_GetConnectPacketSize( &connectInfo,
+                                                   pWillInfo,
+                                                   &remainingLength,
+                                                   pPacketSize );
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode(managedMqttStatus);
+    status = convertReturnCode( managedMqttStatus );
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         /* Allocating memory for Connect packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the connect packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeConnect(&connectInfo,
-            pWillInfo,
-            remainingLength,
-            &(networkBuffer));
+        managedMqttStatus = MQTT_SerializeConnect( &connectInfo,
+                                                   pWillInfo,
+                                                   remainingLength,
+                                                   &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pConnectPacket = networkBuffer.pBuffer;
     }
@@ -282,41 +283,42 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper(const IotMqttConnectInfo_t* pCon
 /*-----------------------------------------------------------*/
 
 /* Disconnect Serialize Wrapper. */
-IotMqttError_t _IotMqtt_disconnectSerializeWrapper(uint8_t** pDisconnectPacket,
-    size_t* pPacketSize)
+IotMqttError_t _IotMqtt_disconnectSerializeWrapper( uint8_t ** pDisconnectPacket,
+                                                    size_t * pPacketSize )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
 
-    IotMqtt_Assert(pDisconnectPacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert( pDisconnectPacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
 
     /* Getting Disconnect packet size using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetDisconnectPacketSize(pPacketSize);
+    managedMqttStatus = MQTT_GetDisconnectPacketSize( pPacketSize );
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode(managedMqttStatus);
+    status = convertReturnCode( managedMqttStatus );
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         /* Allocate memory to hold the Disconnect packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Disconnect packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeDisconnect(&(networkBuffer));
+        managedMqttStatus = MQTT_SerializeDisconnect( &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pDisconnectPacket = networkBuffer.pBuffer;
     }
@@ -327,31 +329,31 @@ IotMqttError_t _IotMqtt_disconnectSerializeWrapper(uint8_t** pDisconnectPacket,
 /*-----------------------------------------------------------*/
 
 /* Subscribe Serialize Wrapper. */
-IotMqttError_t _IotMqtt_subscribeSerializeWrapper(const IotMqttSubscription_t* pSubscriptionList,
-    size_t subscriptionCount,
-    uint8_t** pSubscribePacket,
-    size_t* pPacketSize,
-    uint16_t* pPacketIdentifier)
+IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t * pSubscriptionList,
+                                                   size_t subscriptionCount,
+                                                   uint8_t ** pSubscribePacket,
+                                                   size_t * pPacketSize,
+                                                   uint16_t * pPacketIdentifier )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     size_t remainingLength = 0UL;
-    MQTTSubscribeInfo_t* subscriptionList = NULL;
+    MQTTSubscribeInfo_t * subscriptionList = NULL;
     size_t i = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     uint16_t packetId = 0;
 
-    IotMqtt_Assert(pSubscriptionList != NULL);
-    IotMqtt_Assert(pSubscribePacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
-    IotMqtt_Assert(pPacketIdentifier != NULL);
+    IotMqtt_Assert( pSubscriptionList != NULL );
+    IotMqtt_Assert( pSubscribePacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert( pPacketIdentifier != NULL );
 
     /* Allocating Memory for subscription List. */
-    subscriptionList = IotMqtt_MallocMessage(sizeof(MQTTSubscribeInfo_t) * subscriptionCount);
+    subscriptionList = IotMqtt_MallocMessage( sizeof( MQTTSubscribeInfo_t ) * subscriptionCount );
 
-    if (subscriptionList == NULL)
+    if( subscriptionList == NULL )
     {
-        IotLogError("Failed to allocate memory for subscription list.");
+        IotLogError( "Failed to allocate memory for subscription list." );
         status = IOT_MQTT_NO_MEMORY;
     }
     else
@@ -359,60 +361,62 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper(const IotMqttSubscription_t* p
         EMPTY_ELSE_MARKER;
     }
 
-    if (subscriptionList != NULL)
+    if( subscriptionList != NULL )
     {
-        for (i = 0; i < subscriptionCount; i++)
+        for( i = 0; i < subscriptionCount; i++ )
         {
-            subscriptionList[i].qos = (MQTTQoS_t)(pSubscriptionList + i)->qos;
-            subscriptionList[i].pTopicFilter = (pSubscriptionList + i)->pTopicFilter;
-            subscriptionList[i].topicFilterLength = (pSubscriptionList + i)->topicFilterLength;
+            subscriptionList[ i ].qos = ( MQTTQoS_t ) ( pSubscriptionList + i )->qos;
+            subscriptionList[ i ].pTopicFilter = ( pSubscriptionList + i )->pTopicFilter;
+            subscriptionList[ i ].topicFilterLength = ( pSubscriptionList + i )->topicFilterLength;
         }
 
         /* Getting Subscribe packet size  using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_GetSubscribePacketSize(subscriptionList,
-            subscriptionCount,
-            &remainingLength,
-            pPacketSize);
+        managedMqttStatus = MQTT_GetSubscribePacketSize( subscriptionList,
+                                                         subscriptionCount,
+                                                         &remainingLength,
+                                                         pPacketSize );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free memory allocated to subscription list on error. */
-            IotMqtt_FreeMessage(subscriptionList);
+            IotMqtt_FreeMessage( subscriptionList );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         /* Generating the packet id for subscribe packet. */
         packetId = _nextPacketIdentifier();
 
 
         /* Allocating memory for subscribe packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Subscribe packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeSubscribe(subscriptionList,
-            subscriptionCount,
-            packetId,
-            remainingLength,
-            &(networkBuffer));
+        managedMqttStatus = MQTT_SerializeSubscribe( subscriptionList,
+                                                     subscriptionCount,
+                                                     packetId,
+                                                     remainingLength,
+                                                     &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
 
             /* Free memory allocated to subscription list on error. */
-            IotMqtt_FreeMessage(subscriptionList);
+            IotMqtt_FreeMessage( subscriptionList );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pSubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
@@ -424,31 +428,31 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper(const IotMqttSubscription_t* p
 /*-----------------------------------------------------------*/
 
 /* Unsubscribe Serialize Wrapper. */
-IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper(const IotMqttSubscription_t* pUnsubscriptionList,
-    size_t unsubscriptionCount,
-    uint8_t** pUnsubscribePacket,
-    size_t* pPacketSize,
-    uint16_t* pPacketIdentifier)
+IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t * pUnsubscriptionList,
+                                                     size_t unsubscriptionCount,
+                                                     uint8_t ** pUnsubscribePacket,
+                                                     size_t * pPacketSize,
+                                                     uint16_t * pPacketIdentifier )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     size_t remainingLength = 0UL;
-    MQTTSubscribeInfo_t* unsubscriptionList = NULL;
+    MQTTSubscribeInfo_t * unsubscriptionList = NULL;
     size_t i = 0;
     uint16_t packetId = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
 
-    IotMqtt_Assert(pUnsubscriptionList != NULL);
-    IotMqtt_Assert(pUnsubscribePacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
-    IotMqtt_Assert(pPacketIdentifier != NULL);
+    IotMqtt_Assert( pUnsubscriptionList != NULL );
+    IotMqtt_Assert( pUnsubscribePacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert( pPacketIdentifier != NULL );
 
     /* Allocating Memory for unsubscription List. */
-    unsubscriptionList = IotMqtt_MallocMessage(sizeof(MQTTSubscribeInfo_t) * unsubscriptionCount);
+    unsubscriptionList = IotMqtt_MallocMessage( sizeof( MQTTSubscribeInfo_t ) * unsubscriptionCount );
 
-    if (unsubscriptionList == NULL)
+    if( unsubscriptionList == NULL )
     {
-        IotLogError("Failed to allocate memory for unsubscription list.");
+        IotLogError( "Failed to allocate memory for unsubscription list." );
         status = IOT_MQTT_NO_MEMORY;
     }
     else
@@ -456,59 +460,61 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper(const IotMqttSubscription_t*
         EMPTY_ELSE_MARKER;
     }
 
-    if (unsubscriptionList != NULL)
+    if( unsubscriptionList != NULL )
     {
-        for (i = 0; i < unsubscriptionCount; i++)
+        for( i = 0; i < unsubscriptionCount; i++ )
         {
-            unsubscriptionList[i].qos = (MQTTQoS_t)(pUnsubscriptionList + i)->qos;
-            unsubscriptionList[i].pTopicFilter = (pUnsubscriptionList + i)->pTopicFilter;
-            unsubscriptionList[i].topicFilterLength = (pUnsubscriptionList + i)->topicFilterLength;
+            unsubscriptionList[ i ].qos = ( MQTTQoS_t ) ( pUnsubscriptionList + i )->qos;
+            unsubscriptionList[ i ].pTopicFilter = ( pUnsubscriptionList + i )->pTopicFilter;
+            unsubscriptionList[ i ].topicFilterLength = ( pUnsubscriptionList + i )->topicFilterLength;
         }
 
         /* Getting Unsubscribe packet size  using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_GetUnsubscribePacketSize(unsubscriptionList,
-            unsubscriptionCount,
-            &remainingLength,
-            pPacketSize);
+        managedMqttStatus = MQTT_GetUnsubscribePacketSize( unsubscriptionList,
+                                                           unsubscriptionCount,
+                                                           &remainingLength,
+                                                           pPacketSize );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free memory allocated to unsubscription list on error. */
-            IotMqtt_FreeMessage(unsubscriptionList);
+            IotMqtt_FreeMessage( unsubscriptionList );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         /* Generating the packet id for subscribe packet. */
         packetId = _nextPacketIdentifier();
 
         /* Allocating memory for unsubscribe packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Unsubscribe packet and validate the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeUnsubscribe(unsubscriptionList,
-            unsubscriptionCount,
-            packetId,
-            remainingLength,
-            &(networkBuffer));
+        managedMqttStatus = MQTT_SerializeUnsubscribe( unsubscriptionList,
+                                                       unsubscriptionCount,
+                                                       packetId,
+                                                       remainingLength,
+                                                       &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
 
             /* Free memory allocated to unsubscription list on error. */
-            IotMqtt_FreeMessage(unsubscriptionList);
+            IotMqtt_FreeMessage( unsubscriptionList );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pUnsubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
@@ -520,71 +526,72 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper(const IotMqttSubscription_t*
 /*-----------------------------------------------------------*/
 
 /* Publish Serialize Wrapper. */
-IotMqttError_t _IotMqtt_publishSerializeWrapper(const IotMqttPublishInfo_t* pPublishInfo,
-    uint8_t** pPublishPacket,
-    size_t* pPacketSize,
-    uint16_t* pPacketIdentifier,
-    uint8_t** pPacketIdentifierHigh)
+IotMqttError_t _IotMqtt_publishSerializeWrapper( const IotMqttPublishInfo_t * pPublishInfo,
+                                                 uint8_t ** pPublishPacket,
+                                                 size_t * pPacketSize,
+                                                 uint16_t * pPacketIdentifier,
+                                                 uint8_t ** pPacketIdentifierHigh )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     size_t remainingLength = 0UL;
-    uint8_t* pBuffer = NULL;
+    uint8_t * pBuffer = NULL;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPublishInfo_t publishInfo;
     uint16_t packetId = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
 
     /* Unused parameter. */
-    (void)pPacketIdentifierHigh;
+    ( void ) pPacketIdentifierHigh;
 
     /* Null Check for publishInfo. */
-    IotMqtt_Assert(pPublishInfo != NULL);
-    IotMqtt_Assert(pPublishPacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
-    IotMqtt_Assert(pPacketIdentifier != NULL);
+    IotMqtt_Assert( pPublishInfo != NULL );
+    IotMqtt_Assert( pPublishPacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert( pPacketIdentifier != NULL );
 
     publishInfo.retain = pPublishInfo->retain;
     publishInfo.pTopicName = pPublishInfo->pTopicName;
     publishInfo.topicNameLength = pPublishInfo->topicNameLength;
     publishInfo.pPayload = pPublishInfo->pPayload;
     publishInfo.payloadLength = pPublishInfo->payloadLength;
-    publishInfo.qos = (MQTTQoS_t)pPublishInfo->qos;
+    publishInfo.qos = ( MQTTQoS_t ) pPublishInfo->qos;
     publishInfo.dup = false;
 
     /* Getting publish packet size  using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetPublishPacketSize(&publishInfo,
-        &remainingLength,
-        pPacketSize);
+    managedMqttStatus = MQTT_GetPublishPacketSize( &publishInfo,
+                                                   &remainingLength,
+                                                   pPacketSize );
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode(managedMqttStatus);
+    status = convertReturnCode( managedMqttStatus );
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         /* Generating the packet id for publish packet. */
         packetId = _nextPacketIdentifier();
 
         /* Allocating memory to hold publish packet. */
-        pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.pBuffer = pBuffer;
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the publish packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializePublish(&publishInfo,
-            packetId,
-            remainingLength,
-            &(networkBuffer));
+        managedMqttStatus = MQTT_SerializePublish( &publishInfo,
+                                                   packetId,
+                                                   remainingLength,
+                                                   &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode(managedMqttStatus);
+        status = convertReturnCode( managedMqttStatus );
 
-        if (status != IOT_MQTT_SUCCESS) {
+        if( status != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
         }
     }
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pPublishPacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
@@ -596,41 +603,42 @@ IotMqttError_t _IotMqtt_publishSerializeWrapper(const IotMqttPublishInfo_t* pPub
 /*-----------------------------------------------------------*/
 
 /* Pingreq Serialize Wrapper. */
-IotMqttError_t _IotMqtt_pingreqSerializeWrapper(uint8_t** pPingreqPacket,
-    size_t* pPacketSize)
+IotMqttError_t _IotMqtt_pingreqSerializeWrapper( uint8_t ** pPingreqPacket,
+                                                 size_t * pPacketSize )
 {
     IotMqttError_t serializeStatus = IOT_MQTT_BAD_PARAMETER;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
 
-    IotMqtt_Assert(pPingreqPacket != NULL);
-    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert( pPingreqPacket != NULL );
+    IotMqtt_Assert( pPacketSize != NULL );
 
     /* Getting pingrequest packet size  using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetPingreqPacketSize(pPacketSize);
+    managedMqttStatus = MQTT_GetPingreqPacketSize( pPacketSize );
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    serializeStatus = convertReturnCode(managedMqttStatus);
+    serializeStatus = convertReturnCode( managedMqttStatus );
 
-    if (serializeStatus == IOT_MQTT_SUCCESS)
+    if( serializeStatus == IOT_MQTT_SUCCESS )
     {
         /* Allocate memory to hold the Pingrequest packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
+        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the pingrequest packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializePingreq(&(networkBuffer));
+        managedMqttStatus = MQTT_SerializePingreq( &( networkBuffer ) );
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        serializeStatus = convertReturnCode(managedMqttStatus);
+        serializeStatus = convertReturnCode( managedMqttStatus );
 
-        if (serializeStatus != IOT_MQTT_SUCCESS) {
+        if( serializeStatus != IOT_MQTT_SUCCESS )
+        {
             /* Free allocated buffer on error. */
-            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+            IotMqtt_FreeMessage( networkBuffer.pBuffer );
         }
     }
 
-    if (serializeStatus == IOT_MQTT_SUCCESS)
+    if( serializeStatus == IOT_MQTT_SUCCESS )
     {
         *pPingreqPacket = networkBuffer.pBuffer;
     }
@@ -641,7 +649,7 @@ IotMqttError_t _IotMqtt_pingreqSerializeWrapper(uint8_t** pPingreqPacket,
 /*-----------------------------------------------------------*/
 
 /* Deserialize Connack Wrapper. */
-IotMqttError_t _IotMqtt_deserializeConnackWrapper(_mqttPacket_t* pConnack)
+IotMqttError_t _IotMqtt_deserializeConnackWrapper( _mqttPacket_t * pConnack )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -649,22 +657,22 @@ IotMqttError_t _IotMqtt_deserializeConnackWrapper(_mqttPacket_t* pConnack)
     bool sessionPresent = false;
 
     /* Null Check for connack packet. */
-    IotMqtt_Assert(pConnack != NULL);
+    IotMqtt_Assert( pConnack != NULL );
 
     pIncomingPacket.type = pConnack->type;
     pIncomingPacket.pRemainingData = pConnack->pRemainingData;
     pIncomingPacket.remainingLength = pConnack->remainingLength;
 
     /* Deserializing Connack packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pConnack->packetIdentifier), &sessionPresent);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pConnack->packetIdentifier ), &sessionPresent );
+    status = convertReturnCode( managedMqttStatus );
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Suback wrapper. */
-IotMqttError_t _IotMqtt_deserializeSubackWrapper(_mqttPacket_t* pSuback)
+IotMqttError_t _IotMqtt_deserializeSubackWrapper( _mqttPacket_t * pSuback )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -672,58 +680,58 @@ IotMqttError_t _IotMqtt_deserializeSubackWrapper(_mqttPacket_t* pSuback)
     size_t i = 0;
     uint8_t subscriptionStatus = 0;
     size_t remainingLength = pSuback->remainingLength;
-    const uint8_t* pVariableHeader = pSuback->pRemainingData;
+    const uint8_t * pVariableHeader = pSuback->pRemainingData;
 
     /* Null Check for suback packet. */
-    IotMqtt_Assert(pSuback != NULL);
+    IotMqtt_Assert( pSuback != NULL );
 
     pIncomingPacket.type = pSuback->type;
     pIncomingPacket.pRemainingData = pSuback->pRemainingData;
     pIncomingPacket.remainingLength = pSuback->remainingLength;
 
     /* Deserializing SUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pSuback->packetIdentifier), NULL);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pSuback->packetIdentifier ), NULL );
+    status = convertReturnCode( managedMqttStatus );
 
     /* Remove rejected subscription as the MQTT LTS library do not remove them, it has to handled in shim */
-    if (status == IOT_MQTT_SERVER_REFUSED)
+    if( status == IOT_MQTT_SERVER_REFUSED )
     {
         /* Iterate through each status byte in the SUBACK packet. */
-        for (i = 0; i < remainingLength - sizeof(uint16_t); i++)
+        for( i = 0; i < remainingLength - sizeof( uint16_t ); i++ )
         {
             /* Read a single status byte in SUBACK. */
-            subscriptionStatus = *(pVariableHeader + sizeof(uint16_t) + i);
+            subscriptionStatus = *( pVariableHeader + sizeof( uint16_t ) + i );
 
             /* MQTT 3.1.1 defines the following values as status codes. */
-            switch (subscriptionStatus)
+            switch( subscriptionStatus )
             {
-            case SUBSCRIPTION_ACCEPTED_QOS0:
-            case SUBSCRIPTION_ACCEPTED_QOS1:
-            case SUBSCRIPTION_ACCEPTED_QOS2:
-                IotLogDebug("Topic filter %lu accepted, max QoS %hhu.",
-                    (unsigned long)i, subscriptionStatus);
-                break;
+                case SUBSCRIPTION_ACCEPTED_QOS0:
+                case SUBSCRIPTION_ACCEPTED_QOS1:
+                case SUBSCRIPTION_ACCEPTED_QOS2:
+                    IotLogDebug( "Topic filter %lu accepted, max QoS %hhu.",
+                                 ( unsigned long ) i, subscriptionStatus );
+                    break;
 
-            case SUBSCRIPTION_REFUSED:
-                IotLogDebug("Topic filter %lu refused.",
-                    (unsigned long)i);
+                case SUBSCRIPTION_REFUSED:
+                    IotLogDebug( "Topic filter %lu refused.",
+                                 ( unsigned long ) i );
 
-                /* Remove a rejected subscription from the subscription manager. */
-                _IotMqtt_RemoveSubscriptionByPacket(pSuback->u.pMqttConnection,
-                    pSuback->packetIdentifier,
-                    (int32_t)i);
+                    /* Remove a rejected subscription from the subscription manager. */
+                    _IotMqtt_RemoveSubscriptionByPacket( pSuback->u.pMqttConnection,
+                                                         pSuback->packetIdentifier,
+                                                         ( int32_t ) i );
 
-                status = IOT_MQTT_SERVER_REFUSED;
+                    status = IOT_MQTT_SERVER_REFUSED;
 
-                break;
+                    break;
 
-            default:
-                IotLogDebug("Bad SUBSCRIBE status %hhu.",
-                    subscriptionStatus);
+                default:
+                    IotLogDebug( "Bad SUBSCRIBE status %hhu.",
+                                 subscriptionStatus );
 
-                status = IOT_MQTT_BAD_RESPONSE;
+                    status = IOT_MQTT_BAD_RESPONSE;
 
-                break;
+                    break;
             }
         }
     }
@@ -734,21 +742,21 @@ IotMqttError_t _IotMqtt_deserializeSubackWrapper(_mqttPacket_t* pSuback)
 /*-----------------------------------------------------------*/
 
 /* Deserializer Unsuback wrapper. */
-IotMqttError_t _IotMqtt_deserializeUnsubackWrapper(_mqttPacket_t* pUnsuback)
+IotMqttError_t _IotMqtt_deserializeUnsubackWrapper( _mqttPacket_t * pUnsuback )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for unsuback packet  */
-    IotMqtt_Assert(pUnsuback != NULL);
+    IotMqtt_Assert( pUnsuback != NULL );
 
     pIncomingPacket.type = pUnsuback->type;
     pIncomingPacket.pRemainingData = pUnsuback->pRemainingData;
     pIncomingPacket.remainingLength = pUnsuback->remainingLength;
     /* Deserializing UNSUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pUnsuback->packetIdentifier), NULL);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pUnsuback->packetIdentifier ), NULL );
+    status = convertReturnCode( managedMqttStatus );
 
     return status;
 }
@@ -756,49 +764,49 @@ IotMqttError_t _IotMqtt_deserializeUnsubackWrapper(_mqttPacket_t* pUnsuback)
 /*-----------------------------------------------------------*/
 
 /* Deserializer Puback wrapper. */
-IotMqttError_t _IotMqtt_deserializePubackWrapper(_mqttPacket_t* pPuback)
+IotMqttError_t _IotMqtt_deserializePubackWrapper( _mqttPacket_t * pPuback )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for puback packet. */
-    IotMqtt_Assert(pPuback != NULL);
+    IotMqtt_Assert( pPuback != NULL );
 
     pIncomingPacket.type = pPuback->type;
     pIncomingPacket.pRemainingData = pPuback->pRemainingData;
     pIncomingPacket.remainingLength = pPuback->remainingLength;
     /* Deserializing PUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pPuback->packetIdentifier), NULL);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pPuback->packetIdentifier ), NULL );
+    status = convertReturnCode( managedMqttStatus );
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Ping Response wrapper. */
-IotMqttError_t _IotMqtt_deserializePingrespWrapper(_mqttPacket_t* pPingresp)
+IotMqttError_t _IotMqtt_deserializePingrespWrapper( _mqttPacket_t * pPingresp )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for Pingresponse packet. */
-    IotMqtt_Assert(pPingresp != NULL);
+    IotMqtt_Assert( pPingresp != NULL );
 
     pIncomingPacket.type = pPingresp->type;
     pIncomingPacket.pRemainingData = pPingresp->pRemainingData;
     pIncomingPacket.remainingLength = pPingresp->remainingLength;
     /* Deserializing PINGRESP packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pPingresp->packetIdentifier), NULL);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pPingresp->packetIdentifier ), NULL );
+    status = convertReturnCode( managedMqttStatus );
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Publish wrapper. */
-IotMqttError_t _IotMqtt_deserializePublishWrapper(_mqttPacket_t* pPublish)
+IotMqttError_t _IotMqtt_deserializePublishWrapper( _mqttPacket_t * pPublish )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -806,7 +814,7 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper(_mqttPacket_t* pPublish)
     MQTTPublishInfo_t publishInfo;
 
     /* Null Check for Publish packet. */
-    IotMqtt_Assert(pPublish != NULL);
+    IotMqtt_Assert( pPublish != NULL );
 
     pIncomingPacket.type = pPublish->type;
     pIncomingPacket.pRemainingData = pPublish->pRemainingData;
@@ -814,13 +822,13 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper(_mqttPacket_t* pPublish)
 
 
     /* Deserializing publish packet received from the network. */
-    managedMqttStatus = MQTT_DeserializePublish(&pIncomingPacket, &(pPublish->packetIdentifier), &publishInfo);
+    managedMqttStatus = MQTT_DeserializePublish( &pIncomingPacket, &( pPublish->packetIdentifier ), &publishInfo );
 
-    status = convertReturnCode(managedMqttStatus);
+    status = convertReturnCode( managedMqttStatus );
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
-        pPublish->u.pIncomingPublish->u.publish.publishInfo.qos = (IotMqttQos_t)publishInfo.qos;
+        pPublish->u.pIncomingPublish->u.publish.publishInfo.qos = ( IotMqttQos_t ) publishInfo.qos;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.payloadLength = publishInfo.payloadLength;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.pPayload = publishInfo.pPayload;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.pTopicName = publishInfo.pTopicName;
@@ -834,36 +842,37 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper(_mqttPacket_t* pPublish)
 /*-----------------------------------------------------------*/
 
 /* Suback Serializer Wrapper. */
-IotMqttError_t _IotMqtt_pubackSerializeWrapper(uint16_t packetIdentifier,
-    uint8_t** pPubackPacket,
-    size_t* pPacketSize)
+IotMqttError_t _IotMqtt_pubackSerializeWrapper( uint16_t packetIdentifier,
+                                                uint8_t ** pPubackPacket,
+                                                size_t * pPacketSize )
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTFixedBuffer_t networkBuffer;
     uint8_t packetTypeByte = MQTT_PACKET_TYPE_PUBACK;
 
-    IotMqtt_Assert(pPacketSize != NULL);
-    IotMqtt_Assert(pPubackPacket != NULL);
+    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert( pPubackPacket != NULL );
 
     /* Initializing network buffer. */
-    networkBuffer.pBuffer = IotMqtt_MallocMessage(MQTT_PACKET_PUBACK_SIZE);
+    networkBuffer.pBuffer = IotMqtt_MallocMessage( MQTT_PACKET_PUBACK_SIZE );
     networkBuffer.size = MQTT_PACKET_PUBACK_SIZE;
     *pPacketSize = MQTT_PACKET_PUBACK_SIZE;
 
     /* Serializing puback packet and validating the serialize parameters to be sent on the network. */
-    managedMqttStatus = MQTT_SerializeAck(&(networkBuffer),
-        packetTypeByte,
-        packetIdentifier);
-    status = convertReturnCode(managedMqttStatus);
+    managedMqttStatus = MQTT_SerializeAck( &( networkBuffer ),
+                                           packetTypeByte,
+                                           packetIdentifier );
+    status = convertReturnCode( managedMqttStatus );
 
-    if (status == IOT_MQTT_SUCCESS)
+    if( status == IOT_MQTT_SUCCESS )
     {
         *pPubackPacket = networkBuffer.pBuffer;
     }
-    else {
+    else
+    {
         /* Free allocated buffer on error. */
-        IotMqtt_FreeMessage(networkBuffer.pBuffer);
+        IotMqtt_FreeMessage( networkBuffer.pBuffer );
     }
 
     return status;
@@ -871,48 +880,48 @@ IotMqttError_t _IotMqtt_pubackSerializeWrapper(uint16_t packetIdentifier,
 
 /*-----------------------------------------------------------*/
 
-IotMqttError_t convertReturnCode(MQTTStatus_t managedMqttStatus)
+IotMqttError_t convertReturnCode( MQTTStatus_t managedMqttStatus )
 {
     IotMqttError_t status = IOT_MQTT_SUCCESS;
 
-    switch (managedMqttStatus)
+    switch( managedMqttStatus )
     {
-    case MQTTSuccess:
-        status = IOT_MQTT_SUCCESS;
-        break;
+        case MQTTSuccess:
+            status = IOT_MQTT_SUCCESS;
+            break;
 
-    case MQTTBadParameter:
-        status = IOT_MQTT_BAD_PARAMETER;
-        break;
+        case MQTTBadParameter:
+            status = IOT_MQTT_BAD_PARAMETER;
+            break;
 
-    case MQTTNoMemory:
-        status = IOT_MQTT_NO_MEMORY;
-        break;
+        case MQTTNoMemory:
+            status = IOT_MQTT_NO_MEMORY;
+            break;
 
-    case MQTTSendFailed:
-    case MQTTRecvFailed:
-        status = IOT_MQTT_NETWORK_ERROR;
-        break;
+        case MQTTSendFailed:
+        case MQTTRecvFailed:
+            status = IOT_MQTT_NETWORK_ERROR;
+            break;
 
-    case MQTTBadResponse:
-        status = IOT_MQTT_BAD_RESPONSE;
-        break;
+        case MQTTBadResponse:
+            status = IOT_MQTT_BAD_RESPONSE;
+            break;
 
-    case MQTTServerRefused:
-        status = IOT_MQTT_SERVER_REFUSED;
-        break;
+        case MQTTServerRefused:
+            status = IOT_MQTT_SERVER_REFUSED;
+            break;
 
-    case MQTTNoDataAvailable:
-    case MQTTKeepAliveTimeout:
-        status = IOT_MQTT_TIMEOUT;
+        case MQTTNoDataAvailable:
+        case MQTTKeepAliveTimeout:
+            status = IOT_MQTT_TIMEOUT;
 
-    case MQTTIllegalState:
-    case MQTTStateCollision:
-        status = IOT_MQTT_BAD_RESPONSE;
+        case MQTTIllegalState:
+        case MQTTStateCollision:
+            status = IOT_MQTT_BAD_RESPONSE;
 
-    default:
-        status = IOT_MQTT_SUCCESS;
-        break;
+        default:
+            status = IOT_MQTT_SUCCESS;
+            break;
     }
 
     return status;

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
@@ -379,11 +379,6 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
         status = convertReturnCode( managedMqttStatus );
 
-        if( status != IOT_MQTT_SUCCESS )
-        {
-            /* Free memory allocated to subscription list on error. */
-            IotMqtt_FreeMessage( subscriptionList );
-        }
     }
 
     if( status == IOT_MQTT_SUCCESS )
@@ -411,8 +406,6 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
             /* Free allocated buffer on error. */
             IotMqtt_FreeMessage( networkBuffer.pBuffer );
 
-            /* Free memory allocated to subscription list on error. */
-            IotMqtt_FreeMessage( subscriptionList );
         }
     }
 
@@ -421,6 +414,9 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
         *pSubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
     }
+
+    /* Free allocated memory as the packet was serialized. */
+    IotMqtt_FreeMessage(subscriptionList);
 
     return status;
 }
@@ -478,11 +474,6 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
         status = convertReturnCode( managedMqttStatus );
 
-        if( status != IOT_MQTT_SUCCESS )
-        {
-            /* Free memory allocated to unsubscription list on error. */
-            IotMqtt_FreeMessage( unsubscriptionList );
-        }
     }
 
     if( status == IOT_MQTT_SUCCESS )
@@ -509,8 +500,6 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
             /* Free allocated buffer on error. */
             IotMqtt_FreeMessage( networkBuffer.pBuffer );
 
-            /* Free memory allocated to unsubscription list on error. */
-            IotMqtt_FreeMessage( unsubscriptionList );
         }
     }
 
@@ -519,6 +508,9 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
         *pUnsubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
     }
+
+    /* Free allocated memory as the packet was serialized. */
+    IotMqtt_FreeMessage(unsubscriptionList);
 
     return status;
 }

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
@@ -378,7 +378,6 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
         status = convertReturnCode( managedMqttStatus );
-
     }
 
     if( status == IOT_MQTT_SUCCESS )
@@ -405,7 +404,6 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
         {
             /* Free allocated buffer on error. */
             IotMqtt_FreeMessage( networkBuffer.pBuffer );
-
         }
     }
 
@@ -416,7 +414,7 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
     }
 
     /* Free allocated memory as the packet was serialized. */
-    IotMqtt_FreeMessage(subscriptionList);
+    IotMqtt_FreeMessage( subscriptionList );
 
     return status;
 }
@@ -473,7 +471,6 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
         status = convertReturnCode( managedMqttStatus );
-
     }
 
     if( status == IOT_MQTT_SUCCESS )
@@ -499,7 +496,6 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
         {
             /* Free allocated buffer on error. */
             IotMqtt_FreeMessage( networkBuffer.pBuffer );
-
         }
     }
 
@@ -510,7 +506,7 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
     }
 
     /* Free allocated memory as the packet was serialized. */
-    IotMqtt_FreeMessage(unsubscriptionList);
+    IotMqtt_FreeMessage( unsubscriptionList );
 
     return status;
 }

--- a/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
+++ b/libraries/c_sdk/standard/mqtt/src/iot_mqtt_serializer_deserializer_wrapper.c
@@ -23,11 +23,11 @@
  * https://www.FreeRTOS.org
  */
 
-/**
- * @file iot_mqtt_serializer_deserializer_wrapper.c
- * @brief Implements serializer and deserializer wrapper functions for the shim.
- */
-/* The config header is always included first. */
+ /**
+  * @file iot_mqtt_serializer_deserializer_wrapper.c
+  * @brief Implements serializer and deserializer wrapper functions for the shim.
+  */
+  /* The config header is always included first. */
 #include "iot_config.h"
 
 /* Standard includes. */
@@ -53,23 +53,23 @@
  */
 #define MQTT_MAX_REMAINING_LENGTH     ( 268435455UL )
 
-/*
- * @brief Return status codes for subscription as per the MQTT 3.1.1 spec.
- */
+ /*
+  * @brief Return status codes for subscription as per the MQTT 3.1.1 spec.
+  */
 #define SUBSCRIPTION_ACCEPTED_QOS0    ( 0x00 )               /**< @brief  Status code for accepted QOS0 subscription. */
 #define SUBSCRIPTION_ACCEPTED_QOS1    ( 0x01 )               /**< @brief  Status code for accepted QOS1 subscription. */
 #define SUBSCRIPTION_ACCEPTED_QOS2    ( 0x02 )               /**< @brief  Status code for accepted QOS1 subscription. */
 #define SUBSCRIPTION_REFUSED          ( 0x80 )               /**< @brief  Status code for refused subscription. */
 
+  /*-----------------------------------------------------------*/
+
+  /* Generate Id for packet. */
+static uint16_t _nextPacketIdentifier(void);
+
 /*-----------------------------------------------------------*/
 
 /* Generate Id for packet. */
-static uint16_t _nextPacketIdentifier( void );
-
-/*-----------------------------------------------------------*/
-
-/* Generate Id for packet. */
-static uint16_t _nextPacketIdentifier( void )
+static uint16_t _nextPacketIdentifier(void)
 {
     /* MQTT specifies 2 bytes for the packet identifier; however, operating on
      * 32-bit integers is generally faster. */
@@ -78,7 +78,7 @@ static uint16_t _nextPacketIdentifier( void )
     /* The next packet identifier will be greater by 2. This prevents packet
      * identifiers from ever being 0, which is not allowed by MQTT 3.1.1. Packet
      * identifiers will follow the sequence 1,3,5...65535,1,3,5... */
-    return ( uint16_t ) Atomic_Add_u32( &nextPacketIdentifier, 2 );
+    return (uint16_t)Atomic_Add_u32(&nextPacketIdentifier, 2);
 }
 
 /*-----------------------------------------------------------*/
@@ -91,32 +91,32 @@ static uint16_t _nextPacketIdentifier( void )
  *
  * @return The size of the encoding of length. This is always `1`, `2`, `3`, or `4`.
  */
-static size_t _remainingLengthEncodedSize( size_t length );
+static size_t _remainingLengthEncodedSize(size_t length);
 
 /*-----------------------------------------------------------*/
 
-static size_t _remainingLengthEncodedSize( size_t length )
+static size_t _remainingLengthEncodedSize(size_t length)
 {
     size_t encodedSize = 0;
 
     /* length should have already been checked before calling this function. */
-    IotMqtt_Assert( length <= MQTT_MAX_REMAINING_LENGTH );
+    IotMqtt_Assert(length <= MQTT_MAX_REMAINING_LENGTH);
 
     /* Determine how many bytes are needed to encode length.
      * The values below are taken from the MQTT 3.1.1 spec. */
 
-    /* 1 byte is needed to encode lengths between 0 and 127. */
-    if( length < 128 )
+     /* 1 byte is needed to encode lengths between 0 and 127. */
+    if (length < 128)
     {
         encodedSize = 1;
     }
     /* 2 bytes are needed to encode lengths between 128 and 16,383. */
-    else if( length < 16384 )
+    else if (length < 16384)
     {
         encodedSize = 2;
     }
     /* 3 bytes are needed to encode lengths between 16,384 and 2,097,151. */
-    else if( length < 2097152 )
+    else if (length < 2097152)
     {
         encodedSize = 3;
     }
@@ -131,23 +131,23 @@ static size_t _remainingLengthEncodedSize( size_t length )
 
 /*-----------------------------------------------------------*/
 
-uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
-                                const IotNetworkInterface_t * pNetworkInterface )
+uint8_t _IotMqtt_GetPacketType(void* pNetworkConnection,
+    const IotNetworkInterface_t* pNetworkInterface)
 {
     uint8_t packetType = 0xff;
 
     /* The MQTT packet type is in the first byte of the packet. */
-    ( void ) _IotMqtt_GetNextByte( pNetworkConnection,
-                                   pNetworkInterface,
-                                   &packetType );
+    (void)_IotMqtt_GetNextByte(pNetworkConnection,
+        pNetworkInterface,
+        &packetType);
 
     return packetType;
 }
 
 /*-----------------------------------------------------------*/
 
-size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
-                                    const IotNetworkInterface_t * pNetworkInterface )
+size_t _IotMqtt_GetRemainingLength(void* pNetworkConnection,
+    const IotNetworkInterface_t* pNetworkInterface)
 {
     uint8_t encodedByte = 0;
     size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
@@ -155,18 +155,18 @@ size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
     /* This algorithm is copied from the MQTT v3.1.1 spec. */
     do
     {
-        if( multiplier > 2097152 ) /* 128 ^ 3 */
+        if (multiplier > 2097152) /* 128 ^ 3 */
         {
             remainingLength = MQTT_REMAINING_LENGTH_INVALID;
             break;
         }
         else
         {
-            if( _IotMqtt_GetNextByte( pNetworkConnection,
-                                      pNetworkInterface,
-                                      &encodedByte ) == true )
+            if (_IotMqtt_GetNextByte(pNetworkConnection,
+                pNetworkInterface,
+                &encodedByte) == true)
             {
-                remainingLength += ( encodedByte & 0x7F ) * multiplier;
+                remainingLength += (encodedByte & 0x7F) * multiplier;
                 multiplier *= 128;
                 bytesDecoded++;
             }
@@ -176,21 +176,21 @@ size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
                 break;
             }
         }
-    } while( ( encodedByte & 0x80 ) != 0 );
+    } while ((encodedByte & 0x80) != 0);
 
     /* Check that the decoded remaining length conforms to the MQTT specification. */
-    if( remainingLength != MQTT_REMAINING_LENGTH_INVALID )
+    if (remainingLength != MQTT_REMAINING_LENGTH_INVALID)
     {
-        expectedSize = _remainingLengthEncodedSize( remainingLength );
+        expectedSize = _remainingLengthEncodedSize(remainingLength);
 
-        if( bytesDecoded != expectedSize )
+        if (bytesDecoded != expectedSize)
         {
             remainingLength = MQTT_REMAINING_LENGTH_INVALID;
         }
         else
         {
             /* Valid remaining length should be at most 4 bytes. */
-            IotMqtt_Assert( bytesDecoded <= 4 );
+            IotMqtt_Assert(bytesDecoded <= 4);
         }
     }
     else
@@ -204,9 +204,9 @@ size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
 /*-----------------------------------------------------------*/
 
 /* Connect Serialize Wrapper. */
-IotMqttError_t _IotMqtt_connectSerializeWrapper( const IotMqttConnectInfo_t * pConnectInfo,
-                                                 uint8_t ** pConnectPacket,
-                                                 size_t * pPacketSize )
+IotMqttError_t _IotMqtt_connectSerializeWrapper(const IotMqttConnectInfo_t* pConnectInfo,
+    uint8_t** pConnectPacket,
+    size_t* pPacketSize)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     size_t remainingLength = 0UL;
@@ -216,9 +216,9 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper( const IotMqttConnectInfo_t * pC
     MQTTPublishInfo_t willInfo;
 
     /* Null Check for connectInfo. */
-    IotMqtt_Assert( pConnectInfo != NULL );
-    IotMqtt_Assert( pConnectPacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert(pConnectInfo != NULL);
+    IotMqtt_Assert(pConnectPacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
 
     connectInfo.cleanSession = pConnectInfo->cleanSession;
     connectInfo.keepAliveSeconds = pConnectInfo->keepAliveSeconds;
@@ -228,45 +228,50 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper( const IotMqttConnectInfo_t * pC
     connectInfo.userNameLength = pConnectInfo->userNameLength;
     connectInfo.pPassword = pConnectInfo->pPassword;
     connectInfo.passwordLength = pConnectInfo->passwordLength;
-    const MQTTPublishInfo_t * pWillInfo = pConnectInfo->pWillInfo != NULL ? &willInfo : NULL;
+    const MQTTPublishInfo_t* pWillInfo = pConnectInfo->pWillInfo != NULL ? &willInfo : NULL;
 
     /* NULL Check willInfo. */
-    if( pWillInfo != NULL )
+    if (pWillInfo != NULL)
     {
         willInfo.retain = pConnectInfo->pWillInfo->retain;
         willInfo.pTopicName = pConnectInfo->pWillInfo->pTopicName;
         willInfo.topicNameLength = pConnectInfo->pWillInfo->topicNameLength;
         willInfo.pPayload = pConnectInfo->pWillInfo->pPayload;
         willInfo.payloadLength = pConnectInfo->pWillInfo->payloadLength;
-        willInfo.qos = ( MQTTQoS_t ) pConnectInfo->pWillInfo->qos;
+        willInfo.qos = (MQTTQoS_t)pConnectInfo->pWillInfo->qos;
     }
 
     /* Getting Connect packet size using MQTT V4_beta2 API. */
 
-    managedMqttStatus = MQTT_GetConnectPacketSize( &connectInfo,
-                                                   pWillInfo,
-                                                   &remainingLength,
-                                                   pPacketSize );
+    managedMqttStatus = MQTT_GetConnectPacketSize(&connectInfo,
+        pWillInfo,
+        &remainingLength,
+        pPacketSize);
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode( managedMqttStatus );
+    status = convertReturnCode(managedMqttStatus);
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         /* Allocating memory for Connect packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the connect packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeConnect( &connectInfo,
-                                                   pWillInfo,
-                                                   remainingLength,
-                                                   &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializeConnect(&connectInfo,
+            pWillInfo,
+            remainingLength,
+            &(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pConnectPacket = networkBuffer.pBuffer;
     }
@@ -277,36 +282,41 @@ IotMqttError_t _IotMqtt_connectSerializeWrapper( const IotMqttConnectInfo_t * pC
 /*-----------------------------------------------------------*/
 
 /* Disconnect Serialize Wrapper. */
-IotMqttError_t _IotMqtt_disconnectSerializeWrapper( uint8_t ** pDisconnectPacket,
-                                                    size_t * pPacketSize )
+IotMqttError_t _IotMqtt_disconnectSerializeWrapper(uint8_t** pDisconnectPacket,
+    size_t* pPacketSize)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
 
-    IotMqtt_Assert( pDisconnectPacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert(pDisconnectPacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
 
     /* Getting Disconnect packet size using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetDisconnectPacketSize( pPacketSize );
+    managedMqttStatus = MQTT_GetDisconnectPacketSize(pPacketSize);
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode( managedMqttStatus );
+    status = convertReturnCode(managedMqttStatus);
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         /* Allocate memory to hold the Disconnect packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Disconnect packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeDisconnect( &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializeDisconnect(&(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pDisconnectPacket = networkBuffer.pBuffer;
     }
@@ -317,31 +327,31 @@ IotMqttError_t _IotMqtt_disconnectSerializeWrapper( uint8_t ** pDisconnectPacket
 /*-----------------------------------------------------------*/
 
 /* Subscribe Serialize Wrapper. */
-IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t * pSubscriptionList,
-                                                   size_t subscriptionCount,
-                                                   uint8_t ** pSubscribePacket,
-                                                   size_t * pPacketSize,
-                                                   uint16_t * pPacketIdentifier )
+IotMqttError_t _IotMqtt_subscribeSerializeWrapper(const IotMqttSubscription_t* pSubscriptionList,
+    size_t subscriptionCount,
+    uint8_t** pSubscribePacket,
+    size_t* pPacketSize,
+    uint16_t* pPacketIdentifier)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     size_t remainingLength = 0UL;
-    MQTTSubscribeInfo_t * subscriptionList = NULL;
+    MQTTSubscribeInfo_t* subscriptionList = NULL;
     size_t i = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     uint16_t packetId = 0;
 
-    IotMqtt_Assert( pSubscriptionList != NULL );
-    IotMqtt_Assert( pSubscribePacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
-    IotMqtt_Assert( pPacketIdentifier != NULL );
+    IotMqtt_Assert(pSubscriptionList != NULL);
+    IotMqtt_Assert(pSubscribePacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert(pPacketIdentifier != NULL);
 
     /* Allocating Memory for subscription List. */
-    subscriptionList = IotMqtt_MallocMessage( sizeof( MQTTSubscribeInfo_t ) * subscriptionCount );
+    subscriptionList = IotMqtt_MallocMessage(sizeof(MQTTSubscribeInfo_t) * subscriptionCount);
 
-    if( subscriptionList == NULL )
+    if (subscriptionList == NULL)
     {
-        IotLogError( "Failed to allocate memory for subscription list." );
+        IotLogError("Failed to allocate memory for subscription list.");
         status = IOT_MQTT_NO_MEMORY;
     }
     else
@@ -349,54 +359,64 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
         EMPTY_ELSE_MARKER;
     }
 
-    if( subscriptionList != NULL )
+    if (subscriptionList != NULL)
     {
-        for( i = 0; i < subscriptionCount; i++ )
+        for (i = 0; i < subscriptionCount; i++)
         {
-            subscriptionList[ i ].qos = ( MQTTQoS_t ) ( pSubscriptionList + i )->qos;
-            subscriptionList[ i ].pTopicFilter = ( pSubscriptionList + i )->pTopicFilter;
-            subscriptionList[ i ].topicFilterLength = ( pSubscriptionList + i )->topicFilterLength;
+            subscriptionList[i].qos = (MQTTQoS_t)(pSubscriptionList + i)->qos;
+            subscriptionList[i].pTopicFilter = (pSubscriptionList + i)->pTopicFilter;
+            subscriptionList[i].topicFilterLength = (pSubscriptionList + i)->topicFilterLength;
         }
 
         /* Getting Subscribe packet size  using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_GetSubscribePacketSize( subscriptionList,
-                                                         subscriptionCount,
-                                                         &remainingLength,
-                                                         pPacketSize );
+        managedMqttStatus = MQTT_GetSubscribePacketSize(subscriptionList,
+            subscriptionCount,
+            &remainingLength,
+            pPacketSize);
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free memory allocated to subscription list on error. */
+            IotMqtt_FreeMessage(subscriptionList);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         /* Generating the packet id for subscribe packet. */
         packetId = _nextPacketIdentifier();
 
 
         /* Allocating memory for subscribe packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Subscribe packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeSubscribe( subscriptionList,
-                                                     subscriptionCount,
-                                                     packetId,
-                                                     remainingLength,
-                                                     &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializeSubscribe(subscriptionList,
+            subscriptionCount,
+            packetId,
+            remainingLength,
+            &(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+
+            /* Free memory allocated to subscription list on error. */
+            IotMqtt_FreeMessage(subscriptionList);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pSubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
     }
-
-    /* Free allocated memory as the packet was serialized. */
-    IotMqtt_FreeMessage( subscriptionList );
 
     return status;
 }
@@ -404,31 +424,31 @@ IotMqttError_t _IotMqtt_subscribeSerializeWrapper( const IotMqttSubscription_t *
 /*-----------------------------------------------------------*/
 
 /* Unsubscribe Serialize Wrapper. */
-IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t * pUnsubscriptionList,
-                                                     size_t unsubscriptionCount,
-                                                     uint8_t ** pUnsubscribePacket,
-                                                     size_t * pPacketSize,
-                                                     uint16_t * pPacketIdentifier )
+IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper(const IotMqttSubscription_t* pUnsubscriptionList,
+    size_t unsubscriptionCount,
+    uint8_t** pUnsubscribePacket,
+    size_t* pPacketSize,
+    uint16_t* pPacketIdentifier)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     size_t remainingLength = 0UL;
-    MQTTSubscribeInfo_t * unsubscriptionList = NULL;
+    MQTTSubscribeInfo_t* unsubscriptionList = NULL;
     size_t i = 0;
     uint16_t packetId = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
 
-    IotMqtt_Assert( pUnsubscriptionList != NULL );
-    IotMqtt_Assert( pUnsubscribePacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
-    IotMqtt_Assert( pPacketIdentifier != NULL );
+    IotMqtt_Assert(pUnsubscriptionList != NULL);
+    IotMqtt_Assert(pUnsubscribePacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert(pPacketIdentifier != NULL);
 
     /* Allocating Memory for unsubscription List. */
-    unsubscriptionList = IotMqtt_MallocMessage( sizeof( MQTTSubscribeInfo_t ) * unsubscriptionCount );
+    unsubscriptionList = IotMqtt_MallocMessage(sizeof(MQTTSubscribeInfo_t) * unsubscriptionCount);
 
-    if( unsubscriptionList == NULL )
+    if (unsubscriptionList == NULL)
     {
-        IotLogError( "Failed to allocate memory for unsubscription list." );
+        IotLogError("Failed to allocate memory for unsubscription list.");
         status = IOT_MQTT_NO_MEMORY;
     }
     else
@@ -436,53 +456,63 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
         EMPTY_ELSE_MARKER;
     }
 
-    if( unsubscriptionList != NULL )
+    if (unsubscriptionList != NULL)
     {
-        for( i = 0; i < unsubscriptionCount; i++ )
+        for (i = 0; i < unsubscriptionCount; i++)
         {
-            unsubscriptionList[ i ].qos = ( MQTTQoS_t ) ( pUnsubscriptionList + i )->qos;
-            unsubscriptionList[ i ].pTopicFilter = ( pUnsubscriptionList + i )->pTopicFilter;
-            unsubscriptionList[ i ].topicFilterLength = ( pUnsubscriptionList + i )->topicFilterLength;
+            unsubscriptionList[i].qos = (MQTTQoS_t)(pUnsubscriptionList + i)->qos;
+            unsubscriptionList[i].pTopicFilter = (pUnsubscriptionList + i)->pTopicFilter;
+            unsubscriptionList[i].topicFilterLength = (pUnsubscriptionList + i)->topicFilterLength;
         }
 
         /* Getting Unsubscribe packet size  using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_GetUnsubscribePacketSize( unsubscriptionList,
-                                                           unsubscriptionCount,
-                                                           &remainingLength,
-                                                           pPacketSize );
+        managedMqttStatus = MQTT_GetUnsubscribePacketSize(unsubscriptionList,
+            unsubscriptionCount,
+            &remainingLength,
+            pPacketSize);
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free memory allocated to unsubscription list on error. */
+            IotMqtt_FreeMessage(unsubscriptionList);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         /* Generating the packet id for subscribe packet. */
         packetId = _nextPacketIdentifier();
 
         /* Allocating memory for unsubscribe packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the Unsubscribe packet and validate the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializeUnsubscribe( unsubscriptionList,
-                                                       unsubscriptionCount,
-                                                       packetId,
-                                                       remainingLength,
-                                                       &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializeUnsubscribe(unsubscriptionList,
+            unsubscriptionCount,
+            packetId,
+            remainingLength,
+            &(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+
+            /* Free memory allocated to unsubscription list on error. */
+            IotMqtt_FreeMessage(unsubscriptionList);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pUnsubscribePacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
     }
-
-    /* Free allocated memory as the packet was serialized. */
-    IotMqtt_FreeMessage( unsubscriptionList );
 
     return status;
 }
@@ -490,66 +520,71 @@ IotMqttError_t _IotMqtt_unsubscribeSerializeWrapper( const IotMqttSubscription_t
 /*-----------------------------------------------------------*/
 
 /* Publish Serialize Wrapper. */
-IotMqttError_t _IotMqtt_publishSerializeWrapper( const IotMqttPublishInfo_t * pPublishInfo,
-                                                 uint8_t ** pPublishPacket,
-                                                 size_t * pPacketSize,
-                                                 uint16_t * pPacketIdentifier,
-                                                 uint8_t ** pPacketIdentifierHigh )
+IotMqttError_t _IotMqtt_publishSerializeWrapper(const IotMqttPublishInfo_t* pPublishInfo,
+    uint8_t** pPublishPacket,
+    size_t* pPacketSize,
+    uint16_t* pPacketIdentifier,
+    uint8_t** pPacketIdentifierHigh)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     size_t remainingLength = 0UL;
-    uint8_t * pBuffer = NULL;
+    uint8_t* pBuffer = NULL;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPublishInfo_t publishInfo;
     uint16_t packetId = 0;
     MQTTFixedBuffer_t networkBuffer = { 0 };
 
     /* Unused parameter. */
-    ( void ) pPacketIdentifierHigh;
+    (void)pPacketIdentifierHigh;
 
     /* Null Check for publishInfo. */
-    IotMqtt_Assert( pPublishInfo != NULL );
-    IotMqtt_Assert( pPublishPacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
-    IotMqtt_Assert( pPacketIdentifier != NULL );
+    IotMqtt_Assert(pPublishInfo != NULL);
+    IotMqtt_Assert(pPublishPacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert(pPacketIdentifier != NULL);
 
     publishInfo.retain = pPublishInfo->retain;
     publishInfo.pTopicName = pPublishInfo->pTopicName;
     publishInfo.topicNameLength = pPublishInfo->topicNameLength;
     publishInfo.pPayload = pPublishInfo->pPayload;
     publishInfo.payloadLength = pPublishInfo->payloadLength;
-    publishInfo.qos = ( MQTTQoS_t ) pPublishInfo->qos;
+    publishInfo.qos = (MQTTQoS_t)pPublishInfo->qos;
     publishInfo.dup = false;
 
     /* Getting publish packet size  using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetPublishPacketSize( &publishInfo,
-                                                   &remainingLength,
-                                                   pPacketSize );
+    managedMqttStatus = MQTT_GetPublishPacketSize(&publishInfo,
+        &remainingLength,
+        pPacketSize);
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    status = convertReturnCode( managedMqttStatus );
+    status = convertReturnCode(managedMqttStatus);
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         /* Generating the packet id for publish packet. */
         packetId = _nextPacketIdentifier();
 
         /* Allocating memory to hold publish packet. */
-        pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.pBuffer = pBuffer;
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the publish packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializePublish( &publishInfo,
-                                                   packetId,
-                                                   remainingLength,
-                                                   &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializePublish(&publishInfo,
+            packetId,
+            remainingLength,
+            &(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        status = convertReturnCode( managedMqttStatus );
+        status = convertReturnCode(managedMqttStatus);
+
+        if (status != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+        }
     }
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pPublishPacket = networkBuffer.pBuffer;
         *pPacketIdentifier = packetId;
@@ -561,36 +596,41 @@ IotMqttError_t _IotMqtt_publishSerializeWrapper( const IotMqttPublishInfo_t * pP
 /*-----------------------------------------------------------*/
 
 /* Pingreq Serialize Wrapper. */
-IotMqttError_t _IotMqtt_pingreqSerializeWrapper( uint8_t ** pPingreqPacket,
-                                                 size_t * pPacketSize )
+IotMqttError_t _IotMqtt_pingreqSerializeWrapper(uint8_t** pPingreqPacket,
+    size_t* pPacketSize)
 {
     IotMqttError_t serializeStatus = IOT_MQTT_BAD_PARAMETER;
     MQTTFixedBuffer_t networkBuffer = { 0 };
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
 
-    IotMqtt_Assert( pPingreqPacket != NULL );
-    IotMqtt_Assert( pPacketSize != NULL );
+    IotMqtt_Assert(pPingreqPacket != NULL);
+    IotMqtt_Assert(pPacketSize != NULL);
 
     /* Getting pingrequest packet size  using MQTT V4_beta2 API. */
-    managedMqttStatus = MQTT_GetPingreqPacketSize( pPacketSize );
+    managedMqttStatus = MQTT_GetPingreqPacketSize(pPacketSize);
 
     /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-    serializeStatus = convertReturnCode( managedMqttStatus );
+    serializeStatus = convertReturnCode(managedMqttStatus);
 
-    if( serializeStatus == IOT_MQTT_SUCCESS )
+    if (serializeStatus == IOT_MQTT_SUCCESS)
     {
         /* Allocate memory to hold the Pingrequest packet. */
-        networkBuffer.pBuffer = IotMqtt_MallocMessage( *pPacketSize );
+        networkBuffer.pBuffer = IotMqtt_MallocMessage(*pPacketSize);
         networkBuffer.size = *pPacketSize;
 
         /* Serializing the pingrequest packet and validating the serialize parameters using MQTT V4_beta2 API. */
-        managedMqttStatus = MQTT_SerializePingreq( &( networkBuffer ) );
+        managedMqttStatus = MQTT_SerializePingreq(&(networkBuffer));
 
         /* Converting status code from MQTT v4_beta2 status to MQTT v4_beta 1 status. */
-        serializeStatus = convertReturnCode( managedMqttStatus );
+        serializeStatus = convertReturnCode(managedMqttStatus);
+
+        if (serializeStatus != IOT_MQTT_SUCCESS) {
+            /* Free allocated buffer on error. */
+            IotMqtt_FreeMessage(networkBuffer.pBuffer);
+        }
     }
 
-    if( serializeStatus == IOT_MQTT_SUCCESS )
+    if (serializeStatus == IOT_MQTT_SUCCESS)
     {
         *pPingreqPacket = networkBuffer.pBuffer;
     }
@@ -601,7 +641,7 @@ IotMqttError_t _IotMqtt_pingreqSerializeWrapper( uint8_t ** pPingreqPacket,
 /*-----------------------------------------------------------*/
 
 /* Deserialize Connack Wrapper. */
-IotMqttError_t _IotMqtt_deserializeConnackWrapper( _mqttPacket_t * pConnack )
+IotMqttError_t _IotMqtt_deserializeConnackWrapper(_mqttPacket_t* pConnack)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -609,22 +649,22 @@ IotMqttError_t _IotMqtt_deserializeConnackWrapper( _mqttPacket_t * pConnack )
     bool sessionPresent = false;
 
     /* Null Check for connack packet. */
-    IotMqtt_Assert( pConnack != NULL );
+    IotMqtt_Assert(pConnack != NULL);
 
     pIncomingPacket.type = pConnack->type;
     pIncomingPacket.pRemainingData = pConnack->pRemainingData;
     pIncomingPacket.remainingLength = pConnack->remainingLength;
 
     /* Deserializing Connack packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pConnack->packetIdentifier ), &sessionPresent );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pConnack->packetIdentifier), &sessionPresent);
+    status = convertReturnCode(managedMqttStatus);
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Suback wrapper. */
-IotMqttError_t _IotMqtt_deserializeSubackWrapper( _mqttPacket_t * pSuback )
+IotMqttError_t _IotMqtt_deserializeSubackWrapper(_mqttPacket_t* pSuback)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -632,58 +672,58 @@ IotMqttError_t _IotMqtt_deserializeSubackWrapper( _mqttPacket_t * pSuback )
     size_t i = 0;
     uint8_t subscriptionStatus = 0;
     size_t remainingLength = pSuback->remainingLength;
-    const uint8_t * pVariableHeader = pSuback->pRemainingData;
+    const uint8_t* pVariableHeader = pSuback->pRemainingData;
 
     /* Null Check for suback packet. */
-    IotMqtt_Assert( pSuback != NULL );
+    IotMqtt_Assert(pSuback != NULL);
 
     pIncomingPacket.type = pSuback->type;
     pIncomingPacket.pRemainingData = pSuback->pRemainingData;
     pIncomingPacket.remainingLength = pSuback->remainingLength;
 
     /* Deserializing SUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pSuback->packetIdentifier ), NULL );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pSuback->packetIdentifier), NULL);
+    status = convertReturnCode(managedMqttStatus);
 
     /* Remove rejected subscription as the MQTT LTS library do not remove them, it has to handled in shim */
-    if( status == IOT_MQTT_SERVER_REFUSED )
+    if (status == IOT_MQTT_SERVER_REFUSED)
     {
         /* Iterate through each status byte in the SUBACK packet. */
-        for( i = 0; i < remainingLength - sizeof( uint16_t ); i++ )
+        for (i = 0; i < remainingLength - sizeof(uint16_t); i++)
         {
             /* Read a single status byte in SUBACK. */
-            subscriptionStatus = *( pVariableHeader + sizeof( uint16_t ) + i );
+            subscriptionStatus = *(pVariableHeader + sizeof(uint16_t) + i);
 
             /* MQTT 3.1.1 defines the following values as status codes. */
-            switch( subscriptionStatus )
+            switch (subscriptionStatus)
             {
-                case SUBSCRIPTION_ACCEPTED_QOS0:
-                case SUBSCRIPTION_ACCEPTED_QOS1:
-                case SUBSCRIPTION_ACCEPTED_QOS2:
-                    IotLogDebug( "Topic filter %lu accepted, max QoS %hhu.",
-                                 ( unsigned long ) i, subscriptionStatus );
-                    break;
+            case SUBSCRIPTION_ACCEPTED_QOS0:
+            case SUBSCRIPTION_ACCEPTED_QOS1:
+            case SUBSCRIPTION_ACCEPTED_QOS2:
+                IotLogDebug("Topic filter %lu accepted, max QoS %hhu.",
+                    (unsigned long)i, subscriptionStatus);
+                break;
 
-                case SUBSCRIPTION_REFUSED:
-                    IotLogDebug( "Topic filter %lu refused.",
-                                 ( unsigned long ) i );
+            case SUBSCRIPTION_REFUSED:
+                IotLogDebug("Topic filter %lu refused.",
+                    (unsigned long)i);
 
-                    /* Remove a rejected subscription from the subscription manager. */
-                    _IotMqtt_RemoveSubscriptionByPacket( pSuback->u.pMqttConnection,
-                                                         pSuback->packetIdentifier,
-                                                         ( int32_t ) i );
+                /* Remove a rejected subscription from the subscription manager. */
+                _IotMqtt_RemoveSubscriptionByPacket(pSuback->u.pMqttConnection,
+                    pSuback->packetIdentifier,
+                    (int32_t)i);
 
-                    status = IOT_MQTT_SERVER_REFUSED;
+                status = IOT_MQTT_SERVER_REFUSED;
 
-                    break;
+                break;
 
-                default:
-                    IotLogDebug( "Bad SUBSCRIBE status %hhu.",
-                                 subscriptionStatus );
+            default:
+                IotLogDebug("Bad SUBSCRIBE status %hhu.",
+                    subscriptionStatus);
 
-                    status = IOT_MQTT_BAD_RESPONSE;
+                status = IOT_MQTT_BAD_RESPONSE;
 
-                    break;
+                break;
             }
         }
     }
@@ -694,21 +734,21 @@ IotMqttError_t _IotMqtt_deserializeSubackWrapper( _mqttPacket_t * pSuback )
 /*-----------------------------------------------------------*/
 
 /* Deserializer Unsuback wrapper. */
-IotMqttError_t _IotMqtt_deserializeUnsubackWrapper( _mqttPacket_t * pUnsuback )
+IotMqttError_t _IotMqtt_deserializeUnsubackWrapper(_mqttPacket_t* pUnsuback)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for unsuback packet  */
-    IotMqtt_Assert( pUnsuback != NULL );
+    IotMqtt_Assert(pUnsuback != NULL);
 
     pIncomingPacket.type = pUnsuback->type;
     pIncomingPacket.pRemainingData = pUnsuback->pRemainingData;
     pIncomingPacket.remainingLength = pUnsuback->remainingLength;
     /* Deserializing UNSUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pUnsuback->packetIdentifier ), NULL );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pUnsuback->packetIdentifier), NULL);
+    status = convertReturnCode(managedMqttStatus);
 
     return status;
 }
@@ -716,49 +756,49 @@ IotMqttError_t _IotMqtt_deserializeUnsubackWrapper( _mqttPacket_t * pUnsuback )
 /*-----------------------------------------------------------*/
 
 /* Deserializer Puback wrapper. */
-IotMqttError_t _IotMqtt_deserializePubackWrapper( _mqttPacket_t * pPuback )
+IotMqttError_t _IotMqtt_deserializePubackWrapper(_mqttPacket_t* pPuback)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for puback packet. */
-    IotMqtt_Assert( pPuback != NULL );
+    IotMqtt_Assert(pPuback != NULL);
 
     pIncomingPacket.type = pPuback->type;
     pIncomingPacket.pRemainingData = pPuback->pRemainingData;
     pIncomingPacket.remainingLength = pPuback->remainingLength;
     /* Deserializing PUBACK packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pPuback->packetIdentifier ), NULL );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pPuback->packetIdentifier), NULL);
+    status = convertReturnCode(managedMqttStatus);
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Ping Response wrapper. */
-IotMqttError_t _IotMqtt_deserializePingrespWrapper( _mqttPacket_t * pPingresp )
+IotMqttError_t _IotMqtt_deserializePingrespWrapper(_mqttPacket_t* pPingresp)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTPacketInfo_t pIncomingPacket;
 
     /* Null Check for Pingresponse packet. */
-    IotMqtt_Assert( pPingresp != NULL );
+    IotMqtt_Assert(pPingresp != NULL);
 
     pIncomingPacket.type = pPingresp->type;
     pIncomingPacket.pRemainingData = pPingresp->pRemainingData;
     pIncomingPacket.remainingLength = pPingresp->remainingLength;
     /* Deserializing PINGRESP packet received from the network. */
-    managedMqttStatus = MQTT_DeserializeAck( &pIncomingPacket, &( pPingresp->packetIdentifier ), NULL );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_DeserializeAck(&pIncomingPacket, &(pPingresp->packetIdentifier), NULL);
+    status = convertReturnCode(managedMqttStatus);
     return status;
 }
 
 /*-----------------------------------------------------------*/
 
 /* Deserializer Publish wrapper. */
-IotMqttError_t _IotMqtt_deserializePublishWrapper( _mqttPacket_t * pPublish )
+IotMqttError_t _IotMqtt_deserializePublishWrapper(_mqttPacket_t* pPublish)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
@@ -766,7 +806,7 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper( _mqttPacket_t * pPublish )
     MQTTPublishInfo_t publishInfo;
 
     /* Null Check for Publish packet. */
-    IotMqtt_Assert( pPublish != NULL );
+    IotMqtt_Assert(pPublish != NULL);
 
     pIncomingPacket.type = pPublish->type;
     pIncomingPacket.pRemainingData = pPublish->pRemainingData;
@@ -774,13 +814,13 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper( _mqttPacket_t * pPublish )
 
 
     /* Deserializing publish packet received from the network. */
-    managedMqttStatus = MQTT_DeserializePublish( &pIncomingPacket, &( pPublish->packetIdentifier ), &publishInfo );
+    managedMqttStatus = MQTT_DeserializePublish(&pIncomingPacket, &(pPublish->packetIdentifier), &publishInfo);
 
-    status = convertReturnCode( managedMqttStatus );
+    status = convertReturnCode(managedMqttStatus);
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
-        pPublish->u.pIncomingPublish->u.publish.publishInfo.qos = ( IotMqttQos_t ) publishInfo.qos;
+        pPublish->u.pIncomingPublish->u.publish.publishInfo.qos = (IotMqttQos_t)publishInfo.qos;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.payloadLength = publishInfo.payloadLength;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.pPayload = publishInfo.pPayload;
         pPublish->u.pIncomingPublish->u.publish.publishInfo.pTopicName = publishInfo.pTopicName;
@@ -794,32 +834,36 @@ IotMqttError_t _IotMqtt_deserializePublishWrapper( _mqttPacket_t * pPublish )
 /*-----------------------------------------------------------*/
 
 /* Suback Serializer Wrapper. */
-IotMqttError_t _IotMqtt_pubackSerializeWrapper( uint16_t packetIdentifier,
-                                                uint8_t ** pPubackPacket,
-                                                size_t * pPacketSize )
+IotMqttError_t _IotMqtt_pubackSerializeWrapper(uint16_t packetIdentifier,
+    uint8_t** pPubackPacket,
+    size_t* pPacketSize)
 {
     IotMqttError_t status = IOT_MQTT_BAD_PARAMETER;
     MQTTStatus_t managedMqttStatus = MQTTBadParameter;
     MQTTFixedBuffer_t networkBuffer;
     uint8_t packetTypeByte = MQTT_PACKET_TYPE_PUBACK;
 
-    IotMqtt_Assert( pPacketSize != NULL );
-    IotMqtt_Assert( pPubackPacket != NULL );
+    IotMqtt_Assert(pPacketSize != NULL);
+    IotMqtt_Assert(pPubackPacket != NULL);
 
     /* Initializing network buffer. */
-    networkBuffer.pBuffer = IotMqtt_MallocMessage( MQTT_PACKET_PUBACK_SIZE );
+    networkBuffer.pBuffer = IotMqtt_MallocMessage(MQTT_PACKET_PUBACK_SIZE);
     networkBuffer.size = MQTT_PACKET_PUBACK_SIZE;
     *pPacketSize = MQTT_PACKET_PUBACK_SIZE;
 
     /* Serializing puback packet and validating the serialize parameters to be sent on the network. */
-    managedMqttStatus = MQTT_SerializeAck( &( networkBuffer ),
-                                           packetTypeByte,
-                                           packetIdentifier );
-    status = convertReturnCode( managedMqttStatus );
+    managedMqttStatus = MQTT_SerializeAck(&(networkBuffer),
+        packetTypeByte,
+        packetIdentifier);
+    status = convertReturnCode(managedMqttStatus);
 
-    if( status == IOT_MQTT_SUCCESS )
+    if (status == IOT_MQTT_SUCCESS)
     {
         *pPubackPacket = networkBuffer.pBuffer;
+    }
+    else {
+        /* Free allocated buffer on error. */
+        IotMqtt_FreeMessage(networkBuffer.pBuffer);
     }
 
     return status;
@@ -827,48 +871,48 @@ IotMqttError_t _IotMqtt_pubackSerializeWrapper( uint16_t packetIdentifier,
 
 /*-----------------------------------------------------------*/
 
-IotMqttError_t convertReturnCode( MQTTStatus_t managedMqttStatus )
+IotMqttError_t convertReturnCode(MQTTStatus_t managedMqttStatus)
 {
     IotMqttError_t status = IOT_MQTT_SUCCESS;
 
-    switch( managedMqttStatus )
+    switch (managedMqttStatus)
     {
-        case MQTTSuccess:
-            status = IOT_MQTT_SUCCESS;
-            break;
+    case MQTTSuccess:
+        status = IOT_MQTT_SUCCESS;
+        break;
 
-        case MQTTBadParameter:
-            status = IOT_MQTT_BAD_PARAMETER;
-            break;
+    case MQTTBadParameter:
+        status = IOT_MQTT_BAD_PARAMETER;
+        break;
 
-        case MQTTNoMemory:
-            status = IOT_MQTT_NO_MEMORY;
-            break;
+    case MQTTNoMemory:
+        status = IOT_MQTT_NO_MEMORY;
+        break;
 
-        case MQTTSendFailed:
-        case MQTTRecvFailed:
-            status = IOT_MQTT_NETWORK_ERROR;
-            break;
+    case MQTTSendFailed:
+    case MQTTRecvFailed:
+        status = IOT_MQTT_NETWORK_ERROR;
+        break;
 
-        case MQTTBadResponse:
-            status = IOT_MQTT_BAD_RESPONSE;
-            break;
+    case MQTTBadResponse:
+        status = IOT_MQTT_BAD_RESPONSE;
+        break;
 
-        case MQTTServerRefused:
-            status = IOT_MQTT_SERVER_REFUSED;
-            break;
+    case MQTTServerRefused:
+        status = IOT_MQTT_SERVER_REFUSED;
+        break;
 
-        case MQTTNoDataAvailable:
-        case MQTTKeepAliveTimeout:
-            status = IOT_MQTT_TIMEOUT;
+    case MQTTNoDataAvailable:
+    case MQTTKeepAliveTimeout:
+        status = IOT_MQTT_TIMEOUT;
 
-        case MQTTIllegalState:
-        case MQTTStateCollision:
-            status = IOT_MQTT_BAD_RESPONSE;
+    case MQTTIllegalState:
+    case MQTTStateCollision:
+        status = IOT_MQTT_BAD_RESPONSE;
 
-        default:
-            status = IOT_MQTT_SUCCESS;
-            break;
+    default:
+        status = IOT_MQTT_SUCCESS;
+        break;
     }
 
     return status;


### PR DESCRIPTION
Several wrappers in the MQTT shim allocate buffers to hold serialized packets, but do not free them on error. This PR contains the fix for freeing those buffers on error.