### PR TITLE
Make it possible to expire certificates with the system date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This repository contains the `FreeRTOS AWS Reference Integrations`, which are pr
 #### TLS Shim Layer V1.3.0
 
 - Added logic to support connecting to a TLS server that does not require mutual verification.
-
+- Provide a way for an application to determine if a certificate has expired.
 
 ## 202012.00 December 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This repository contains the `FreeRTOS AWS Reference Integrations`, which are pr
 #### TLS Shim Layer V1.3.0
 
 - Added logic to support connecting to a TLS server that does not require mutual verification.
-- Provide a way for an application to determine if a certificate has expired.
+- Provide a way for an application to determine if a certificate has expired. PR #3139
 
 ## 202012.00 December 2020
 

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -153,4 +153,24 @@ BaseType_t TLS_Send( void * pvContext,
  */
 void TLS_Cleanup( void * pvContext );
 
+/**
+ * @brief callback to verify the expiration date of the certificate
+ * 
+ * This callback will return TRUE if the date provided is in the past.
+ * 
+ * @param day the expiration date day to check
+ * @param month the expiration date month to check
+ * @param year the expiration date year to check.  Note: this is the full year i.e. 1932
+ * 
+ * @return non-zero if the date is in the past
+ */
+typedef BaseType_t (*dateIsInThePast_t)(BaseType_t, BaseType_t, BaseType_t);
+
+/**
+ * @brief function to set the callback for testing the expiration date of certificates
+ * 
+ * @param DateIsInThePast a function that tests the expiration date against the current date
+ */
+void TLS_setDateIsInThePastFunction(dateIsInThePast_t DateIsInThePast);
+
 #endif /* ifndef __AWS__TLS__H__ */

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -164,7 +164,7 @@ void TLS_Cleanup( void * pvContext );
  * 
  * @return non-zero if the date is in the past
  */
-typedef BaseType_t (*dateIsInThePast_t)(BaseType_t, BaseType_t, BaseType_t);
+typedef BaseType_t (*DateIsInThePast_t)(BaseType_t day, BaseType_t month, BaseType_t year);
 
 /**
  * @brief function to set the callback for testing the expiration date of certificates

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -100,6 +100,35 @@ typedef struct xTLS_PARAMS
 } TLSParams_t;
 
 /**
+ * @brief Defines a day,month,year time structure for testing certificate expriation
+ * 
+ * @param day The current day of the month from 1 to 31 depending upon the current month
+ * @param month The current month from 1 to 12
+ * @param year The current year (4 digits)
+ */
+typedef struct xTLS_DATE
+{
+    int day;
+    int month;
+    int year;
+} TLSDate_t;
+
+/**
+ * @brief defines a function pointer that will fill a supplied TLSDate_t with the current date.
+ * 
+ * @param date A pointer to the a TLSDate_t structure that needs to be filled with the current date.
+ * @return A boolean value indicating that the date is valid or invalid.
+ */
+typedef bool (*getDate_t)( TLSDate_t *date);
+
+/**
+ * @brief provides a function that will collect the current date
+ * 
+ * @param[in] dateFunction A function pointer to a function that does the getDate_t.
+ */
+void TLS_SetDateFunction(getDate_t dateFunction);
+
+/**
  * @brief Initializes the TLS context.
  *
  * @param[out] ppvContext Opaque context handle returned by the TLS library.

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -171,6 +171,6 @@ typedef BaseType_t (*DateIsInThePast_t)(BaseType_t day, BaseType_t month, BaseTy
  * 
  * @param DateIsInThePast a function that tests the expiration date against the current date
  */
-void TLS_setDateIsInThePastFunction(dateIsInThePast_t DateIsInThePast);
+void TLS_setDateIsInThePastFunction(DateIsInThePast_t dateIsInThePast);
 
 #endif /* ifndef __AWS__TLS__H__ */

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -155,22 +155,24 @@ void TLS_Cleanup( void * pvContext );
 
 /**
  * @brief callback to verify the expiration date of the certificate
- * 
+ *
  * This callback will return TRUE if the date provided is in the past.
- * 
+ *
  * @param day the expiration date day to check
  * @param month the expiration date month to check
  * @param year the expiration date year to check.  Note: this is the full year i.e. 1932
- * 
+ *
  * @return non-zero if the date is in the past
  */
-typedef BaseType_t (*DateIsInThePast_t)(BaseType_t day, BaseType_t month, BaseType_t year);
+typedef BaseType_t (* DateIsInThePast_t)( BaseType_t day,
+                                          BaseType_t month,
+                                          BaseType_t year );
 
 /**
  * @brief function to set the callback for testing the expiration date of certificates
- * 
+ *
  * @param DateIsInThePast a function that tests the expiration date against the current date
  */
-void TLS_setDateIsInThePastFunction(DateIsInThePast_t dateIsInThePast);
+void TLS_setDateIsInThePastFunction( DateIsInThePast_t dateIsInThePast );
 
 #endif /* ifndef __AWS__TLS__H__ */

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -100,35 +100,6 @@ typedef struct xTLS_PARAMS
 } TLSParams_t;
 
 /**
- * @brief Defines a day,month,year time structure for testing certificate expriation
- * 
- * @param day The current day of the month from 1 to 31 depending upon the current month
- * @param month The current month from 1 to 12
- * @param year The current year (4 digits)
- */
-typedef struct xTLS_DATE
-{
-    int day;
-    int month;
-    int year;
-} TLSDate_t;
-
-/**
- * @brief defines a function pointer that will fill a supplied TLSDate_t with the current date.
- * 
- * @param date A pointer to the a TLSDate_t structure that needs to be filled with the current date.
- * @return A boolean value indicating that the date is valid or invalid.
- */
-typedef bool (*getDate_t)( TLSDate_t *date);
-
-/**
- * @brief provides a function that will collect the current date
- * 
- * @param[in] dateFunction A function pointer to a function that does the getDate_t.
- */
-void TLS_SetDateFunction(getDate_t dateFunction);
-
-/**
  * @brief Initializes the TLS context.
  *
  * @param[out] ppvContext Opaque context handle returned by the TLS library.

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -180,7 +180,7 @@ static void prvFreeContext( TLSContext_t * pxCtx )
 
 BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year)
 {
-    return 0; // assume a good certificate
+    return 0; /* Assume the certificate is valid. */
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -144,7 +144,7 @@ typedef struct TLSContext
 static BaseType_t prvDefault_DateIsInThePast( BaseType_t day,
                                               BaseType_t month,
                                               BaseType_t year );
-static dateIsInThePast_t pDateIsInThePast = prvDefault_DateIsInThePast;
+static DateIsInThePast_t pDateIsInThePast = prvDefault_DateIsInThePast;
 
 /*-----------------------------------------------------------*/
 
@@ -1089,7 +1089,7 @@ void TLS_Cleanup( void * pvContext )
 
 /*-----------------------------------------------------------*/
 
-void TLS_setDateIsInThePastFunction( dateIsInThePast_t DateIsInThePast )
+void TLS_setDateIsInThePastFunction( DateIsInThePast_t DateIsInThePast )
 {
     pDateIsInThePast = DateIsInThePast;
 }

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -297,6 +297,10 @@ static int prvCheckCertificate( void * pvCtx,
             }
         }
     }
+    else
+    {
+        certificate_old = false; // do not fail if the time is invalid or there is no date function.
+    }
 
     if(certificate_old)
     {

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -52,19 +52,8 @@
 /* Custom mbedtls utls include. */
 #include "mbedtls_error.h"
 
-#ifndef configGETTHEDAY()
-#warning Undefined macro "configGETTHEDAY".
-#endif
-#ifndef configGETTHEMONTH()
-#warning Undefined macro "configGETTHEMONTH".
-#endif
-#ifndef configGETTHEYEAR()
-#warning Undefined macro "configGETTHEYEAR".
-#endif
-
 /* C runtime includes. */
 #include <string.h>
-#include <time.h>
 #include <stdio.h>
 
 /**

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -141,7 +141,9 @@ typedef struct TLSContext
 
 #define TLS_PRINT( X )    configPRINTF( X )
 
-static BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year);
+static BaseType_t prvDefault_DateIsInThePast( BaseType_t day,
+                                              BaseType_t month,
+                                              BaseType_t year );
 static dateIsInThePast_t pDateIsInThePast = prvDefault_DateIsInThePast;
 
 /*-----------------------------------------------------------*/
@@ -178,7 +180,9 @@ static void prvFreeContext( TLSContext_t * pxCtx )
     }
 }
 
-static BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year)
+static BaseType_t prvDefault_DateIsInThePast( BaseType_t day,
+                                              BaseType_t month,
+                                              BaseType_t year )
 {
     return 0; /* Assume the certificate is valid. */
 }
@@ -279,8 +283,8 @@ static int prvCheckCertificate( void * pvContext,
     BaseType_t day = pxCertificate->valid_to.day;
     BaseType_t month = pxCertificate->valid_to.mon;
     BaseType_t year = pxCertificate->valid_to.year;
-    
-    if( pDateIsInThePast(day, month, year) != 0 )
+
+    if( pDateIsInThePast( day, month, year ) != 0 )
     {
         *pulFlags |= MBEDTLS_X509_BADCERT_EXPIRED;
     }
@@ -875,7 +879,6 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
-
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );
@@ -1086,7 +1089,7 @@ void TLS_Cleanup( void * pvContext )
 
 /*-----------------------------------------------------------*/
 
-void TLS_setDateIsInThePastFunction(dateIsInThePast_t DateIsInThePast)
+void TLS_setDateIsInThePastFunction( dateIsInThePast_t DateIsInThePast )
 {
     pDateIsInThePast = DateIsInThePast;
 }

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -879,6 +879,7 @@ BaseType_t TLS_Connect( void * pvContext )
     }
 
     #ifdef MBEDTLS_DEBUG_C
+
         /* If mbedTLS is being compiled with debug support, assume that the
          * runtime configuration should use verbose output. */
         mbedtls_ssl_conf_dbg( &pxCtx->xMbedSslConfig, prvTlsDebugPrint, NULL );

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -141,8 +141,8 @@ typedef struct TLSContext
 
 #define TLS_PRINT( X )    configPRINTF( X )
 
-BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year);
-dateIsInThePast_t pDateIsInThePast = prvDefault_DateIsInThePast;
+static BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year);
+static dateIsInThePast_t pDateIsInThePast = prvDefault_DateIsInThePast;
 
 /*-----------------------------------------------------------*/
 
@@ -178,7 +178,7 @@ static void prvFreeContext( TLSContext_t * pxCtx )
     }
 }
 
-BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year)
+static BaseType_t prvDefault_DateIsInThePast(BaseType_t day, BaseType_t month, BaseType_t year)
 {
     return 0; /* Assume the certificate is valid. */
 }
@@ -697,7 +697,6 @@ BaseType_t TLS_Init( void ** ppvContext,
         pxCtx->xNetworkRecv = pxParams->pxNetworkRecv;
         pxCtx->xNetworkSend = pxParams->pxNetworkSend;
         pxCtx->pvCallerContext = pxParams->pvCallerContext;
-        pxCtx->getDate = prvGetDate_default;
 
         /* Get the function pointer list for the PKCS#11 module. */
         xCkGetFunctionList = C_GetFunctionList;


### PR DESCRIPTION
Description
-----------
This change adds a simple date check callback to allow a certificate date to be compared to the current date by the user application.  If no user date check function is supplied, it will assume the certificate is OK and use it.

The user must create a function that accepts the certificate day,month,year and returns non-zero if the day, month, year is older than the current day, month, year.  It is the user's responsibility to provide a mechanism for determining the current day, month, year.

**Note**: This PR also addresses the issue: https://github.com/aws/amazon-freertos/issues/3099 by removing `__DATE__` and `__TIME__` macros from the library.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [X] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.