### PR TITLE
Replace master with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: awslabs/git-secrets
-          ref: master
+          ref: main
           path: git-secrets
       - name: Install git-secrets
         run: cd git-secrets && sudo make install && cd ..


### PR DESCRIPTION
Replace references to master with main in ci.yml

Description
-----------
The "master" branch is to be renamed to "main". This will not automatically update any GitHub Action workflows. Hence updating ci.yml to replace references to master with main

Checklist:
----------
- [ NA] I have tested my changes. No regression in existing tests.
- [ NA] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.