### PR TITLE
ci: change git-secrets branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: awslabs/git-secrets
-          ref: main
+          ref: master
           path: git-secrets
       - name: Install git-secrets
         run: cd git-secrets && sudo make install && cd ..


### PR DESCRIPTION
ci: change git-secrets branch

Description
-----------
awslabs/git-secrets does not use a 'main' branch yet.

