### PR TITLE
Update MQTT demos to support connection over 443

### DIFF
--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -427,7 +427,17 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
 
     /* Set the Secure Socket configurations. */
     xSocketConfig.enableTls = true;
-    xSocketConfig.pAlpnProtos = NULL;
+
+    /* Pass the ALPN protocol name depending on the port being used.
+     * Please see more details about the ALPN protocol for the AWS IoT MQTT
+     * endpoint in the link below.
+     * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+     */
+    if( xServerInfo.port == 443 )
+    {
+        xSocketConfig.pAlpnProtos = socketsAWS_IOT_ALPN_MQTT;
+    }
+
     xSocketConfig.maxFragmentLength = 0;
     xSocketConfig.disableSni = false;
     xSocketConfig.sendTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -244,10 +244,6 @@ static int32_t tlsSetup( const SocketsConfig_t * pSocketsConfig,
     configASSERT( pHostName != NULL );
 
     /* ALPN options for AWS IoT. */
-    /* ppcALPNProtos is unused. putting here to align behavior in IotNetworkAfr_Create. */
-    /* coverity[misra_c_2012_rule_4_6_violation] */
-    /* coverity[misra_c_2012_rule_8_13_violation] */
-    const char * ppcALPNProtos[] = { socketsAWS_IOT_ALPN_MQTT };
 
     /* Set secured option. */
     secureSocketStatus = SOCKETS_SetSockOpt( tcpSocket,
@@ -267,8 +263,8 @@ static int32_t tlsSetup( const SocketsConfig_t * pSocketsConfig,
         secureSocketStatus = SOCKETS_SetSockOpt( tcpSocket,
                                                  0,
                                                  SOCKETS_SO_ALPN_PROTOCOLS,
-                                                 ppcALPNProtos,
-                                                 sizeof( ppcALPNProtos ) / sizeof( ppcALPNProtos[ 0 ] ) );
+                                                 pSocketsConfig->pAlpnProtos,
+                                                 sizeof( pSocketsConfig->pAlpnProtos ) );
 
         if( secureSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
@@ -121,11 +121,6 @@ typedef struct SocketsConfig
     const char * pAlpnProtos;
 
     /**
-     * @brief Length of the ALPN protocols array.
-     */
-    uint32_t alpnProtosLen;
-
-    /**
      * @brief Disable server name indication (SNI) for a TLS session.
      */
     bool disableSni;


### PR DESCRIPTION
Update all demos that use MQTT connection to support connection to IoT Core over port **443** using ALPN. 

Related Issue: #3135