### PR TITLE
Remove reference to a deprecated test file

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
@@ -170,13 +170,6 @@ endif()
 # TODO, remove network manager src.
 afr_glob_src(network_manager_src DIRECTORY "${AFR_DEMOS_DIR}/network_manager")
 
-# Build an OTA test that only builds on Windows.
-afr_module_sources(
-    test_ota
-    INTERFACE
-        "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/test/aws_test_ota_cbor.c"
-)
-
 if(AFR_IS_TESTING)
     set(exe_target aws_tests)
 else()

--- a/vendors/pc/boards/windows/CMakeLists.txt
+++ b/vendors/pc/boards/windows/CMakeLists.txt
@@ -155,13 +155,6 @@ endif()
 # -------------------------------------------------------------------------------------------------
 afr_glob_src(config_files DIRECTORY "${board_dir}/config_files")
 
-# Build an OTA test that only builds on Windows.
-afr_module_sources(
-    test_ota
-    INTERFACE
-        "${AFR_MODULES_FREERTOS_PLUS_DIR}/aws/ota/test/aws_test_ota_cbor.c"
-)
-
 if(AFR_IS_TESTING)
     set(exe_target aws_tests)
 else()


### PR DESCRIPTION
Remove reference to a deprecated test file

Description
-----------
The tinycbor test file that was specific to WinSim is no longer exists. This change removes the reference to the file in the WinSim CMake file.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.