### PR TITLE
Add OTAv3 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -110,3 +110,6 @@
 [submodule "vendors/cypress/MTB/libraries/kv-store"]
 	path = vendors/cypress/MTB/libraries/kv-store
 	url = https://github.com/cypresssemiconductorco/kv-store.git
+[submodule "libraries/ota_for_aws"]
+	path = libraries/ota_for_aws
+	url = https://github.com/aws/ota-for-aws-iot-embedded-sdk.git


### PR DESCRIPTION
<!--- Title -->
Add OTAv3 as sub-module

Description
-----------
<!--- Describe your changes in detail -->
Checkout OTA v3.0.0 library into `libraries/ota_for_aws`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.