### PR TITLE
Remove taskpool and serializer dependency for BLE

### DIFF
--- a/demos/include/aws_wifi_connect_task.h
+++ b/demos/include/aws_wifi_connect_task.h
@@ -25,7 +25,8 @@
 
 /**
  * @file aws_iot_connection_task.h
- * @brief Header file containing the WIFI auto connect task initialize and destroy APIs.
+ * @brief Header file contains APIs for managing the task which provisions WiFi networks onto 
+ * device and auto reconnects to provisioned networks in case of a WiFi access point disconnect.
  */
 
 #ifndef _AWS_WIFI_CONNECT_TASK_H_
@@ -34,15 +35,16 @@
 #include "FreeRTOS.h"
 
 /**
- * @brief Initialize the task which connects to provisioned WiFi networks.
- *
- * @return pdTRUE if task is initialized successfully.
- *
+ * @brief Initializes WiFi provisioning and creates task which manages WiFi connection running 
+ * the WiFi provision loop or auto connecting to provisioned networks in case of WiFi disconnection.
+ * 
+ * @return pdTRUE If WiFi provisioning and the task is initialized successfully.
  */
 BaseType_t xWiFiConnectTaskInitialize( void );
 
 /**
- * @brief Destroys the task for connecting to provisioned WiFi networks its associated data structures.
+ * @brief Destroys the task for managing WiFi connection as well as disable WiFi provisioning and associated
+ * data structures.
  */
 void vWiFiConnectTaskDestroy( void );
 

--- a/demos/include/aws_wifi_connect_task.h
+++ b/demos/include/aws_wifi_connect_task.h
@@ -25,7 +25,7 @@
 
 /**
  * @file aws_iot_connection_task.h
- * @brief Header file contains APIs for managing the task which provisions WiFi networks onto 
+ * @brief Header file contains APIs for managing the task which provisions WiFi networks onto
  * device and auto reconnects to provisioned networks in case of a WiFi access point disconnect.
  */
 
@@ -35,9 +35,9 @@
 #include "FreeRTOS.h"
 
 /**
- * @brief Initializes WiFi provisioning and creates task which manages WiFi connection running 
+ * @brief Initializes WiFi provisioning and creates task which manages WiFi connection running
  * the WiFi provision loop or auto connecting to provisioned networks in case of WiFi disconnection.
- * 
+ *
  * @return pdTRUE If WiFi provisioning and the task is initialized successfully.
  */
 BaseType_t xWiFiConnectTaskInitialize( void );

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -578,10 +578,9 @@ static IotNetworkManager_t networkManager =
     {
         bool ret = true;
 
-        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 ) || ( IOT_WIFI_ENABLE_SOFTAP_PROVISIONING ==  1)
+        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 ) || ( IOT_WIFI_ENABLE_SOFTAP_PROVISIONING == 1 )
             vWiFiConnectTaskDestroy();
         #endif
-    
 
         if( WIFI_IsConnected( NULL ) == pdTRUE )
         {

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -564,22 +564,6 @@ static IotNetworkManager_t networkManager =
         #else
             if( ret == true )
             {
-                #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
-                    if( IotBleWifiProv_Init() != pdTRUE )
-                    {
-                        ret = false;
-                    }
-                #endif
-                #if ( IOT_WIFI_ENABLE_SOFTAP_PROVISIONING == 1 )
-                    if( IotWifiSoftAPProv_Init() != pdTRUE )
-                    {
-                        ret = false;
-                    }
-                #endif
-            }
-
-            if( ret == true )
-            {
                 if( xWiFiConnectTaskInitialize() != pdTRUE )
                 {
                     ret = false;
@@ -594,14 +578,10 @@ static IotNetworkManager_t networkManager =
     {
         bool ret = true;
 
-        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 )
+        #if ( IOT_BLE_ENABLE_WIFI_PROVISIONING == 1 ) || ( IOT_WIFI_ENABLE_SOFTAP_PROVISIONING ==  1)
             vWiFiConnectTaskDestroy();
-            IotBleWifiProv_Deinit();
         #endif
-        #if ( IOT_WIFI_ENABLE_SOFTAP_PROVISIONING == 1 )
-            vWiFiConnectTaskDestroy();
-            IotWifiSoftAPProv_Deinit();
-        #endif
+    
 
         if( WIFI_IsConnected( NULL ) == pdTRUE )
         {

--- a/demos/wifi_provisioning/aws_wifi_connect_task.c
+++ b/demos/wifi_provisioning/aws_wifi_connect_task.c
@@ -50,7 +50,7 @@
 #endif
 
 
-#define WIFI_PROVISION_TASK_NAME        "WiFiConnectTask"
+#define WIFI_PROVISION_TASK_NAME        "WiFiManagement"
 
 /**
  * @brief Interval in milliseconds between connecting to the provisioned WiFi networks.
@@ -165,12 +165,12 @@ void prvWiFiConnectTask( void * pvParams )
         /* Checks if WiFi is already connected to an access point. */
         if( WIFI_IsConnected( NULL ) == pdFALSE )
         {
-            configPRINTF( ( "WiFi is disconnected, try connecting to provisioned networks if any. \r\n" ) );
+            configPRINTF( ( "WiFi Disconnected. Trying to connect to provisioned networks.\r\n" ) );
 
             /* Goes through the list of all provisioned networks and tries to connect them in priority order. */
             if( prvConnectToProvisionedNetworks() == pdFALSE )
             {
-                configPRINTF( ( "Cannot connect to any provisioned networks, starting WiFi provisioning loop.\r\n" ) );
+                configPRINTF( ( "Unable to connect to any provisioned networks. Starting provisioning loop.\r\n" ) );
 
                 /**
                  * If none of the connections are successfull, switch to provisioning mode by runnning

--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -54,7 +54,7 @@ afr_module_dependencies(
     PUBLIC
         AFR::ble_hal
         AFR::common
-        AFR::serializer
+        3rdparty::tinycbor
 )
 
 if( EXISTS ${CMAKE_CURRENT_LIST_DIR}/test )
@@ -81,9 +81,9 @@ afr_module_include_dirs(
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PUBLIC
-        AFR::serializer
         AFR::ble
         AFR::wifi
+        3rdparty::tinycbor
 )
 
 #BLE Wifi provisioning test

--- a/libraries/c_sdk/standard/ble/CMakeLists.txt
+++ b/libraries/c_sdk/standard/ble/CMakeLists.txt
@@ -68,6 +68,7 @@ afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         "${src_dir}/services/wifi_provisioning/iot_ble_wifi_provisioning.c"
+        "${src_dir}/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c"
 )
 
 afr_module_include_dirs(

--- a/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
@@ -36,16 +36,18 @@
 
 /**
  * @ingroup ble_data_types_enums
- * @brief This enumeration defines the different types of request processed by the WiFi provisioning library. 
+ * @brief This enumeration defines the different types of request processed by the WiFi provisioning library.
  */
 typedef enum
 {
-    IotBleWiFiProvRequestListNetwork   = 1,    /**< Request sent from a WiFi provisioning app to the device to list the access points. */       
-    IotBleWiFiProvRequestAddNetwork    = 2,    /**< Request sent from a WiFi provisioning app to the device to provision an acess point. */
-    IotBleWiFiProvRequestEditNetwork   = 3,    /**< Request sent from a WiFi provisioning app to the device to change access point priority. */
-    IotBleWiFiProvRequestDeleteNetwork = 4,    /**< Request sent from a WiFi provisioning app to the device to delete an access point. */
-    IotBleWiFiProvRequestStop          = 5     /**< Request sent from an application task to stop WiFi provisioning loop. */            
+    IotBleWiFiProvRequestInvalid = 0,       /**< Type used to denote an invalid request. */
+    IotBleWiFiProvRequestListNetwork = 1,   /**< Request sent from a WiFi provisioning app to the device to list the access points. */
+    IotBleWiFiProvRequestAddNetwork = 2,    /**< Request sent from a WiFi provisioning app to the device to provision an acess point. */
+    IotBleWiFiProvRequestEditNetwork = 3,   /**< Request sent from a WiFi provisioning app to the device to change access point priority. */
+    IotBleWiFiProvRequestDeleteNetwork = 4, /**< Request sent from a WiFi provisioning app to the device to delete an access point. */
+    IotBleWiFiProvRequestStop = 5           /**< Request sent from an application task to stop WiFi provisioning loop. */
 } IotBleWiFiProvRequest_t;
+
 /**
  * @ingroup ble_datatypes_structs
  * @brief Defines the list wifi networks request message structure sent from the provisioining app to the device.
@@ -53,8 +55,8 @@ typedef enum
  */
 typedef struct
 {
-    int16_t scanSize;                       /**< Max WiFi access points to scan in one request */
-    int16_t scanTimeoutMS;                 /**< Timeout in milliseconds for scanning */
+    int16_t scanSize;      /**< Max WiFi access points to scan in one request */
+    int16_t scanTimeoutMS; /**< Timeout in milliseconds for scanning */
 } IotBleWifiProvListNetworksRequest_t;
 
 /**
@@ -67,12 +69,13 @@ typedef struct
  */
 typedef struct
 {
-    union {
-        WIFINetworkProfile_t network;    /**< The configuration for the new WIFI access point. */
-        int16_t index;                   /**< Prirority index of an already provisioned WiFi access point. */
+    union
+    {
+        WIFINetworkProfile_t network; /**< The configuration for the new WIFI access point. */
+        int16_t index;                /**< Prirority index of an already provisioned WiFi access point. */
     } info;
-    bool isProvisioned : 1;                    /**< true if the newtwork is already provisioned, a valid pirority index should be provided. */
-    bool shouldConnect : 1;                    /**< true if the access point needs to be connected before provisioning. */
+    bool isProvisioned : 1;           /**< true if the newtwork is already provisioned, a valid pirority index should be provided. */
+    bool shouldConnect : 1;           /**< true if the access point needs to be connected before provisioning. */
 } IotBleWifiProvAddNetworkRequest_t;
 
 /**
@@ -102,15 +105,17 @@ typedef struct
  * @ingroup ble_datatypes_structs
  * @brief Defines the structure used to hold a scanned or saved network information.
  */
-typedef struct {
-    union {
-        WIFIScanResult_t * pScannedNetwork;    /**< Details of the scanned Network. */
-        WIFINetworkProfile_t * pSavedNetwork;  /**< Details of the provisioned Network. */
+typedef struct
+{
+    union
+    {
+        WIFIScanResult_t * pScannedNetwork;   /**< Details of the scanned Network. */
+        WIFINetworkProfile_t * pSavedNetwork; /**< Details of the provisioned Network. */
     } info;
-    uint16_t index;              /**< The index (priority) at which network is provisioned. */
-    bool isSavedNetwork: 1;      /**< A flag to signify whether this network is a saved network or scanned network. */
-    bool isConnected:1;          /**< A flag to signify whether this network is connected. */
-    bool isHidden:1;             /**< A flag to signify whether this is an hidden network. */
+    uint16_t index;                           /**< The index (priority) at which network is provisioned. */
+    bool isSavedNetwork : 1;                  /**< A flag to signify whether this network is a saved network or scanned network. */
+    bool isConnected : 1;                     /**< A flag to signify whether this network is connected. */
+    bool isHidden : 1;                        /**< A flag to signify whether this is an hidden network. */
 } IotBleWifiProvNetworkInfo_t;
 
 /**
@@ -119,10 +124,10 @@ typedef struct {
  */
 typedef struct IotBleWifiProvResponse
 {
-    IotBleWiFiProvRequest_t requestType;       /** Request type for which this response is sent. */
-    WIFIReturnCode_t status;                   /**< The status of the response. */
-    IotBleWifiProvNetworkInfo_t networkInfo;   /**< Network info sent as part of response for list request. */
-    bool statusOnly:1;                         /**< A flag to signify if its a status only response. */
+    IotBleWiFiProvRequest_t requestType;     /** Request type for which this response is sent. */
+    WIFIReturnCode_t status;                 /**< The status of the response. */
+    IotBleWifiProvNetworkInfo_t networkInfo; /**< Network info sent as part of response for list request. */
+    bool statusOnly : 1;                     /**< A flag to signify if its a status only response. */
 } IotBleWifiProvResponse_t;
 
 /**
@@ -138,32 +143,34 @@ typedef enum
 } IotBleWifiProvEvent_t;
 
 
-typedef struct {
+typedef struct
+{
+    bool ( * getRequestType )( const uint8_t * pMessage,
+                               size_t length,
+                               IotBleWiFiProvRequest_t * pRequeustType );
 
-    bool ( * getRequestType ) ( const uint8_t * pMessage,
-                                size_t length,
-                                IotBleWiFiProvRequest_t * pRequeustType );
-
-    bool ( * deserializeListNetworkRequest ) ( const uint8_t * pData,
-                                        size_t length,
-                                        IotBleWifiProvListNetworksRequest_t * pListNetworksRequest );
-    
-    bool ( * deserializeAddNetworkRequest ) ( const uint8_t * pData,
+    bool ( * deserializeListNetworkRequest )( const uint8_t * pData,
                                               size_t length,
-                                              IotBleWifiProvAddNetworkRequest_t * pAddNetworkRequest );
-    
-    bool ( * deserializeEditNetworkRequest ) ( const uint8_t * pData,
-                                               size_t length,
-                                               IotBleWifiProvEditNetworkRequest_t * pEditNetworkRequest );
-    
-    bool ( * deserializeDeleteNetworkRequest ) ( const uint8_t * pData,
-                                                 size_t length,
+                                              IotBleWifiProvListNetworksRequest_t * pListNetworksRequest );
+
+    bool ( * deserializeAddNetworkRequest )( const uint8_t * pData,
+                                             size_t length,
+                                             IotBleWifiProvAddNetworkRequest_t * pAddNetworkRequest );
+
+    bool ( * deserializeEditNetworkRequest )( const uint8_t * pData,
+                                              size_t length,
+                                              IotBleWifiProvEditNetworkRequest_t * pEditNetworkRequest );
+
+    bool ( * deserializeDeleteNetworkRequest )( const uint8_t * pData,
+                                                size_t length,
                                                 IotBleWifiProvDeleteNetworkRequest_t * pDeleteNetworkRequest );
-    
-    bool ( * getSerializedSizeForResponse ) ( const IotBleWifiProvResponse_t * pResponse, size_t * length );
 
-    bool ( * serializeResponse ) ( const IotBleWifiProvResponse_t * pResponse, uint8_t * pBuffer, size_t length );
+    bool ( * getSerializedSizeForResponse )( const IotBleWifiProvResponse_t * pResponse,
+                                             size_t * length );
 
+    bool ( * serializeResponse )( const IotBleWifiProvResponse_t * pResponse,
+                                  uint8_t * pBuffer,
+                                  size_t length );
 } IotBleWifiProvSerializer_t;
 
 /**
@@ -218,10 +225,10 @@ bool IotBleWifiProv_Init( void );
 
 /**
  * @brief Function which runs the process loop for Wifi provisioning.
- * Process loop can be run within a task, it waits for the incoming requests from the 
+ * Process loop can be run within a task, it waits for the incoming requests from the
  * transport interface as well as commands from the user application. Process loop terminates when
  * a stop command is sent from the application.
- * 
+ *
  * @return true if the process loop function ran successfully. false if process loop terminated due
  *         to an error.
  */

--- a/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
@@ -40,11 +40,11 @@
  */
 typedef enum
 {
-    IotBleWiFiProvRequestListNetwork,    /**< Request sent from a WiFi provisioning app to the device to list the access points. */       
-    IotBleWiFiProvRequestAddNetwork,     /**< Request sent from a WiFi provisioning app to the device to provision an acess point. */
-    IotBleWiFiProvRequestEditNetwork,    /**< Request sent from a WiFi provisioning app to the device to change access point priority. */
-    IotBleWiFiProvRequestDeleteNetwork,  /**< Request sent from a WiFi provisioning app to the device to delete an access point. */
-    IotBleWiFiProvRequestStop            /**< Request sent from an application task to stop WiFi provisioning loop. */            
+    IotBleWiFiProvRequestListNetwork   = 1,    /**< Request sent from a WiFi provisioning app to the device to list the access points. */       
+    IotBleWiFiProvRequestAddNetwork    = 2,    /**< Request sent from a WiFi provisioning app to the device to provision an acess point. */
+    IotBleWiFiProvRequestEditNetwork   = 3,    /**< Request sent from a WiFi provisioning app to the device to change access point priority. */
+    IotBleWiFiProvRequestDeleteNetwork = 4,    /**< Request sent from a WiFi provisioning app to the device to delete an access point. */
+    IotBleWiFiProvRequestStop          = 5     /**< Request sent from an application task to stop WiFi provisioning loop. */            
 } IotBleWiFiProvRequest_t;
 /**
  * @ingroup ble_datatypes_structs
@@ -100,23 +100,29 @@ typedef struct
 
 /**
  * @ingroup ble_datatypes_structs
- * @brief Defines the structure used to hold the wifi provisioning information.
+ * @brief Defines the structure used to hold a scanned or saved network information.
+ */
+typedef struct {
+    union {
+        WIFIScanResult_t * pScannedNetwork;    /**< Details of the scanned Network. */
+        WIFINetworkProfile_t * pSavedNetwork;  /**< Details of the provisioned Network. */
+    } info;
+    uint16_t index;              /**< The index (priority) at which network is provisioned. */
+    bool isSavedNetwork: 1;      /**< A flag to signify whether this network is a saved network or scanned network. */
+    bool isConnected:1;          /**< A flag to signify whether this network is connected. */
+    bool isHidden:1;             /**< A flag to signify whether this is an hidden network. */
+} IotBleWifiProvNetworkInfo_t;
+
+/**
+ * @ingroup ble_datatypes_structs
+ * @brief Defines the structure used to hold the wifi provisioning response.
  */
 typedef struct IotBleWifiProvResponse
 {
-    IotBleWiFiProvRequest_t requestType;  /** Request type for which this response is sent. */
-    WIFIReturnCode_t status;              /**< The status of the response. */
-    union {
-        WIFIScanResult_t * scannedNetwork;   /**< Details of the scanned Network. */
-        struct {
-            WIFINetworkProfile_t * network;   /**< Details of the provisioned Network. */
-            uint16_t index;                   /**< The index (priority) at which network is provisioned. */
-        } savedNetwork;
-    } networkInfo;
-    bool isProvisioned:1;        /**< A flag to signify if the network is already provisioned. */
-    bool isHidden:1;             /**< A flag to signify whether this is an hidden network. */
-    bool isConnected:1;          /**< A flag to signify whether this network is connected. */
-
+    IotBleWiFiProvRequest_t requestType;       /** Request type for which this response is sent. */
+    WIFIReturnCode_t status;                   /**< The status of the response. */
+    IotBleWifiProvNetworkInfo_t networkInfo;   /**< Network info sent as part of response for list request. */
+    bool statusOnly:1;                         /**< A flag to signify if its a status only response. */
 } IotBleWifiProvResponse_t;
 
 /**

--- a/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
+++ b/libraries/c_sdk/standard/ble/include/iot_ble_wifi_provisioning.h
@@ -86,7 +86,7 @@ typedef struct
  */
 typedef struct
 {
-    int16_t currentPriorityIndex; /**< Current Prioruty index of the provisioned WiFi network.*/
+    int16_t currentPriorityIndex; /**< Current Priority index of the provisioned WiFi network.*/
     int16_t newPriorityIndex;     /**< New priority index of the provisioned WiFi network. */
 } IotBleWifiProvEditNetworkRequest_t;
 

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_serialize.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_serialize.c
@@ -40,9 +40,9 @@
 #include "iot_ble_config.h"
 
 /* MQTT internal includes. */
-#include "iot_serializer.h"
 #include "iot_ble_data_transfer.h"
 #include "iot_ble_mqtt_serialize.h"
+#include "cbor.h"
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/
@@ -67,9 +67,9 @@
 #endif
 #include "logging_stack.h"
 
-#define _IS_VALID_SERIALIZER_RET( ret, pSerializerBuf ) \
-    ( ( ret == IOT_SERIALIZER_SUCCESS ) ||              \
-      ( ( !pSerializerBuf ) && ( ret == IOT_SERIALIZER_BUFFER_TOO_SMALL ) ) )
+#define SERIALIZER_STATUS( status, pBuffer ) \
+    ( ( status == CborNoError ) ||           \
+      ( ( !pBuffer ) && ( status == CborErrorOutOfMemory ) ) )
 
 #define _NUM_CONNECT_PARMAS            ( 4 )
 #define _NUM_DEFAULT_PUBLISH_PARMAS    ( 4 )
@@ -85,307 +85,309 @@ static inline uint16_t _getNumPublishParams( const MQTTBLEPublishInfo_t * const 
     return ( pPublish->qos > 0 ) ? ( _NUM_DEFAULT_PUBLISH_PARMAS + 1 ) : _NUM_DEFAULT_PUBLISH_PARMAS;
 }
 
-static IotSerializerError_t _serializeConnect( const MQTTBLEConnectInfo_t * const pConnectInfo,
-                                               uint8_t * const pBuffer,
-                                               size_t * const pSize );
-static IotSerializerError_t _serializePublish( const MQTTBLEPublishInfo_t * const pPublishInfo,
-                                               uint8_t * pBuffer,
-                                               size_t * pSize,
-                                               uint16_t packetIdentifier );
-static IotSerializerError_t _serializePubAck( uint16_t packetIdentifier,
-                                              uint8_t * pBuffer,
-                                              size_t * pSize );
+static CborError prvSerializeConnect( const MQTTBLEConnectInfo_t * const pConnectInfo,
+                                      uint8_t * const pBuffer,
+                                      size_t * const pSize );
+static CborError prvSerializePublish( const MQTTBLEPublishInfo_t * const pPublishInfo,
+                                      uint8_t * pBuffer,
+                                      size_t * pSize,
+                                      uint16_t packetIdentifier );
+static CborError prvSerializePubAck( uint16_t packetIdentifier,
+                                     uint8_t * pBuffer,
+                                     size_t * pSize );
 
-static IotSerializerError_t _serializeSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
-                                                 size_t subscriptionCount,
-                                                 uint8_t * const pBuffer,
-                                                 size_t * const pSize,
-                                                 uint16_t packetIdentifier );
+static CborError prvSerializeSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
+                                        size_t subscriptionCount,
+                                        uint8_t * const pBuffer,
+                                        size_t * const pSize,
+                                        uint16_t packetIdentifier );
 
-static IotSerializerError_t _serializeUnSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
-                                                   size_t subscriptionCount,
-                                                   uint8_t * const pBuffer,
-                                                   size_t * const pSize,
-                                                   uint16_t packetIdentifier );
+static CborError prvSerializeUnSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
+                                          size_t subscriptionCount,
+                                          uint8_t * const pBuffer,
+                                          size_t * const pSize,
+                                          uint16_t packetIdentifier );
 
-static IotSerializerError_t _serializeDisconnect( uint8_t * const pBuffer,
-                                                  size_t * const pSize );
-
-
-static IotSerializerError_t _serializePingRequest( uint8_t * const pBuffer,
-                                                   size_t * const pSize );
+static CborError prvSerializeDisconnect( uint8_t * const pBuffer,
+                                         size_t * const pSize );
 
 
-/* Declaration of snprintf. The header stdio.h is not included because it
- * includes conflicting symbols on some platforms. */
-extern int snprintf( char * s,
-                     size_t n,
-                     const char * format,
-                     ... );
+static CborError prvSerializePingRequest( uint8_t * const pBuffer,
+                                          size_t * const pSize );
 
 /*-----------------------------------------------------------*/
 
-static IotSerializerError_t _serializeConnect( const MQTTBLEConnectInfo_t * pConnectInfo,
-                                               uint8_t * const pBuffer,
-                                               size_t * const pSize )
+static CborError prvSerializeConnect( const MQTTBLEConnectInfo_t * pConnectInfo,
+                                      uint8_t * const pBuffer,
+                                      size_t * const pLength )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t connectMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t data = { 0 };
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 };
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_CONNECT_PARMAS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &connectMap,
-            _NUM_CONNECT_PARMAS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_CONNECT;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &connectMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-        data.value.u.string.pString = ( uint8_t * ) pConnectInfo->pClientIdentifier;
-        data.value.u.string.length = pConnectInfo->clientIdentifierLength;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &connectMap, IOT_BLE_MQTT_CLIENT_ID, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-        data.value.u.string.pString = ( uint8_t * ) clientcredentialMQTT_BROKER_ENDPOINT;
-        data.value.u.string.length = strlen( clientcredentialMQTT_BROKER_ENDPOINT );
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &connectMap, IOT_BLE_MQTT_BROKER_EP, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_BOOL;
-        data.value.u.booleanValue = pConnectInfo->cleanSession;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &connectMap, IOT_BLE_MQTT_CLEAN_SESSION, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &connectMap );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_CONNECT );
         }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_CLIENT_ID, strlen( IOT_BLE_MQTT_CLIENT_ID ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_text_string( &mapEncoder, pConnectInfo->pClientIdentifier, pConnectInfo->clientIdentifierLength );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_BROKER_EP, strlen( IOT_BLE_MQTT_BROKER_EP ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_text_string( &mapEncoder, clientcredentialMQTT_BROKER_ENDPOINT, strlen( clientcredentialMQTT_BROKER_ENDPOINT ) );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_CLEAN_SESSION, strlen( IOT_BLE_MQTT_CLEAN_SESSION ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_boolean( &mapEncoder, pConnectInfo->cleanSession );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
-static IotSerializerError_t _serializePublish( const MQTTBLEPublishInfo_t * const pPublishInfo,
-                                               uint8_t * pBuffer,
-                                               size_t * pSize,
-                                               uint16_t packetIdentifier )
+static CborError prvSerializePublish( const MQTTBLEPublishInfo_t * const pPublishInfo,
+                                      uint8_t * pBuffer,
+                                      size_t * pLength,
+                                      uint16_t packetIdentifier )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t publishMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t data = { 0 };
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 };
     uint16_t numPublishParams = _getNumPublishParams( pPublishInfo );
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
-    {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &publishMap,
-            numPublishParams );
-    }
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, numPublishParams );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_PUBLISH;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &publishMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-        data.value.u.string.pString = ( uint8_t * ) pPublishInfo->pTopicName;
-        data.value.u.string.length = pPublishInfo->topicNameLength;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &publishMap, IOT_BLE_MQTT_TOPIC, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = pPublishInfo->qos;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &publishMap, IOT_BLE_MQTT_QOS, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
-        data.value.u.string.pString = ( uint8_t * ) pPublishInfo->pPayload;
-        data.value.u.string.length = pPublishInfo->payloadLength;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &publishMap, IOT_BLE_MQTT_PAYLOAD, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pPublishInfo->qos != 0 )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-            data.value.u.signedInt = packetIdentifier;
-            error = IOT_BLE_MESG_ENCODER.appendKeyValue( &publishMap, IOT_BLE_MQTT_MESSAGE_ID, data );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_PUBLISH );
         }
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &publishMap );
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_TOPIC, strlen( IOT_BLE_MQTT_TOPIC ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_text_string( &mapEncoder, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
+        }
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        if( pBuffer == NULL )
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
-        }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_QOS, strlen( IOT_BLE_MQTT_QOS ) );
 
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_int( &mapEncoder, pPublishInfo->qos );
+        }
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_PAYLOAD, strlen( IOT_BLE_MQTT_PAYLOAD ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_byte_string( &mapEncoder, pPublishInfo->pPayload, pPublishInfo->payloadLength );
+        }
+    }
+
+    if( pPublishInfo->qos != 0 )
+    {
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MESSAGE_ID, strlen( IOT_BLE_MQTT_MESSAGE_ID ) );
+
+            if( SERIALIZER_STATUS( status, pBuffer ) == true )
+            {
+                status = cbor_encode_int( &mapEncoder, packetIdentifier );
+            }
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
-static IotSerializerError_t _serializePubAck( uint16_t packetIdentifier,
-                                              uint8_t * pBuffer,
-                                              size_t * pSize )
+static CborError prvSerializePubAck( uint16_t packetIdentifier,
+                                     uint8_t * pBuffer,
+                                     size_t * pLength )
 
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t pubAckMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t data = { 0 };
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 };
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_PUBACK_PARMAS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &pubAckMap,
-            _NUM_PUBACK_PARMAS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_PUBACK;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &pubAckMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = packetIdentifier;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &pubAckMap, IOT_BLE_MQTT_MESSAGE_ID, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &pubAckMap );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_PUBACK );
         }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MESSAGE_ID, strlen( IOT_BLE_MQTT_MESSAGE_ID ) );
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_int( &mapEncoder, packetIdentifier );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
 
-static IotSerializerError_t _serializeSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
-                                                 size_t subscriptionCount,
-                                                 uint8_t * const pBuffer,
-                                                 size_t * const pSize,
-                                                 uint16_t packetIdentifier )
+static CborError prvSerializeSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
+                                        size_t subscriptionCount,
+                                        uint8_t * const pBuffer,
+                                        size_t * const pLength,
+                                        uint16_t packetIdentifier )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t subscribeMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerEncoderObject_t subscriptionArray = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_ARRAY;
-    IotSerializerScalarData_t data = { 0 };
-    uint16_t idx;
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 }, arrayEncoder = { 0 };
+    uint16_t index;
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_SUBACK_PARAMS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &subscribeMap,
-            _NUM_SUBACK_PARAMS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_SUBSCRIBE;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &subscribeMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.openContainerWithKey(
-            &subscribeMap,
-            IOT_BLE_MQTT_TOPIC_LIST,
-            &subscriptionArray,
-            subscriptionCount );
-    }
-
-    for( idx = 0; idx < subscriptionCount; idx++ )
-    {
-        if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            data.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-            data.value.u.string.pString = ( uint8_t * ) pSubscriptionList[ idx ].pTopicFilter;
-            data.value.u.string.length = pSubscriptionList[ idx ].topicFilterLength;
-            error = IOT_BLE_MESG_ENCODER.append( &subscriptionArray, data );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_SUBSCRIBE );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_TOPIC_LIST, strlen( IOT_BLE_MQTT_TOPIC_LIST ) );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_create_array( &mapEncoder, &arrayEncoder, subscriptionCount );
+    }
+
+    for( index = 0; index < subscriptionCount; index++ )
+    {
+        if( SERIALIZER_STATUS( status, pBuffer ) )
+        {
+            status = cbor_encode_text_string( &arrayEncoder, pSubscriptionList[ index ].pTopicFilter, pSubscriptionList[ index ].topicFilterLength );
         }
         else
         {
@@ -393,27 +395,26 @@ static IotSerializerError_t _serializeSubscribe( const MQTTBLESubscribeInfo_t * 
         }
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &subscribeMap, &subscriptionArray );
+        status = cbor_encoder_close_container( &mapEncoder, &arrayEncoder );
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainerWithKey(
-            &subscribeMap,
-            IOT_BLE_MQTT_QOS_LIST,
-            &subscriptionArray,
-            subscriptionCount );
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_QOS_LIST, strlen( IOT_BLE_MQTT_QOS_LIST ) );
     }
 
-    for( idx = 0; idx < subscriptionCount; idx++ )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+        status = cbor_encoder_create_array( &mapEncoder, &arrayEncoder, subscriptionCount );
+    }
+
+    for( index = 0; index < subscriptionCount; index++ )
+    {
+        if( SERIALIZER_STATUS( status, pBuffer ) )
         {
-            data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-            data.value.u.signedInt = pSubscriptionList[ idx ].qos;
-            error = IOT_BLE_MESG_ENCODER.append( &subscriptionArray, data );
+            status = cbor_encode_int( &arrayEncoder, pSubscriptionList[ index ].qos );
         }
         else
         {
@@ -421,88 +422,87 @@ static IotSerializerError_t _serializeSubscribe( const MQTTBLESubscribeInfo_t * 
         }
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &subscribeMap, &subscriptionArray );
+        status = cbor_encoder_close_container( &mapEncoder, &arrayEncoder );
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = packetIdentifier;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &subscribeMap, IOT_BLE_MQTT_MESSAGE_ID, data );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MESSAGE_ID, strlen( IOT_BLE_MQTT_MESSAGE_ID ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &subscribeMap );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, packetIdentifier );
         }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
-static IotSerializerError_t _serializeUnSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
-                                                   size_t subscriptionCount,
-                                                   uint8_t * const pBuffer,
-                                                   size_t * const pSize,
-                                                   uint16_t packetIdentifier )
+static CborError prvSerializeUnSubscribe( const MQTTBLESubscribeInfo_t * const pSubscriptionList,
+                                          size_t subscriptionCount,
+                                          uint8_t * const pBuffer,
+                                          size_t * const pLength,
+                                          uint16_t packetIdentifier )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t subscribeMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerEncoderObject_t subscriptionArray = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_ARRAY;
-    IotSerializerScalarData_t data = { 0 };
-    uint16_t idx;
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 }, arrayEncoder = { 0 };
+    uint16_t index;
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_UNSUBACK_PARAMS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &subscribeMap,
-            _NUM_UNSUBACK_PARAMS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_UNSUBSCRIBE;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &subscribeMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.openContainerWithKey(
-            &subscribeMap,
-            IOT_BLE_MQTT_TOPIC_LIST,
-            &subscriptionArray,
-            subscriptionCount );
-    }
-
-    for( idx = 0; idx < subscriptionCount; idx++ )
-    {
-        if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            data.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-            data.value.u.string.pString = ( uint8_t * ) pSubscriptionList[ idx ].pTopicFilter;
-            data.value.u.string.length = pSubscriptionList[ idx ].topicFilterLength;
-            error = IOT_BLE_MESG_ENCODER.append( &subscriptionArray, data );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_UNSUBSCRIBE );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_TOPIC_LIST, strlen( IOT_BLE_MQTT_TOPIC_LIST ) );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_create_array( &mapEncoder, &arrayEncoder, subscriptionCount );
+    }
+
+    for( index = 0; index < subscriptionCount; index++ )
+    {
+        if( SERIALIZER_STATUS( status, pBuffer ) )
+        {
+            status = cbor_encode_text_string( &arrayEncoder, pSubscriptionList[ index ].pTopicFilter, pSubscriptionList[ index ].topicFilterLength );
         }
         else
         {
@@ -510,136 +510,265 @@ static IotSerializerError_t _serializeUnSubscribe( const MQTTBLESubscribeInfo_t 
         }
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &subscribeMap, &subscriptionArray );
+        status = cbor_encoder_close_container( &mapEncoder, &arrayEncoder );
     }
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = packetIdentifier;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &subscribeMap, IOT_BLE_MQTT_MESSAGE_ID, data );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MESSAGE_ID, strlen( IOT_BLE_MQTT_MESSAGE_ID ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &subscribeMap );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, packetIdentifier );
         }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
-static IotSerializerError_t _serializeDisconnect( uint8_t * const pBuffer,
-                                                  size_t * const pSize )
+static CborError prvSerializeDisconnect( uint8_t * const pBuffer,
+                                         size_t * const pLength )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t disconnectMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t data = { 0 };
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 };
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_DISCONNECT_PARAMS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &disconnectMap,
-            _NUM_DISCONNECT_PARAMS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_DISCONNECT;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &disconnectMap, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &disconnectMap );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_DISCONNECT );
         }
-        else
-        {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
 }
 
-static IotSerializerError_t _serializePingRequest( uint8_t * const pBuffer,
-                                                   size_t * const pSize )
+static CborError prvSerializePingRequest( uint8_t * const pBuffer,
+                                          size_t * const pLength )
 {
-    IotSerializerError_t error = IOT_SERIALIZER_SUCCESS;
-    IotSerializerEncoderObject_t encoderObj = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t pingRequest = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t data = { 0 };
+    size_t length = *pLength;
+    CborError status, result;
+    CborEncoder encoder = { 0 }, mapEncoder = { 0 };
 
-    error = IOT_BLE_MESG_ENCODER.init( &encoderObj, pBuffer, *pSize );
+    cbor_encoder_init( &encoder, pBuffer, length, 0 );
 
-    if( error == IOT_SERIALIZER_SUCCESS )
+    status = cbor_encoder_create_map( &encoder, &mapEncoder, _NUM_PINGREQUEST_PARAMS );
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
-        error = IOT_BLE_MESG_ENCODER.openContainer(
-            &encoderObj,
-            &pingRequest,
-            _NUM_PINGREQUEST_PARAMS );
-    }
+        status = cbor_encode_text_string( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE, strlen( IOT_BLE_MQTT_MSG_TYPE ) );
 
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        data.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        data.value.u.signedInt = IOT_BLE_MQTT_MSG_TYPE_PINGREQ;
-        error = IOT_BLE_MESG_ENCODER.appendKeyValue( &pingRequest, IOT_BLE_MQTT_MSG_TYPE, data );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        error = IOT_BLE_MESG_ENCODER.closeContainer( &encoderObj, &pingRequest );
-    }
-
-    if( _IS_VALID_SERIALIZER_RET( error, pBuffer ) )
-    {
-        if( pBuffer == NULL )
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &encoderObj );
+            status = cbor_encode_int( &mapEncoder, IOT_BLE_MQTT_MSG_TYPE_PINGREQ );
+        }
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        status = cbor_encoder_close_container( &encoder, &mapEncoder );
+    }
+
+    if( pBuffer == NULL )
+    {
+        *pLength = cbor_encoder_get_extra_bytes_needed( &encoder );
+    }
+    else
+    {
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
+    }
+
+    if( SERIALIZER_STATUS( status, pBuffer ) == true )
+    {
+        result = CborNoError;
+    }
+    else
+    {
+        result = status;
+    }
+
+    return result;
+}
+
+
+static CborError prvGetIntegerValueFromMap( CborValue * pMap,
+                                            const char * key,
+                                            int64_t * pValue )
+{
+    CborError status;
+    CborValue value;
+
+    status = cbor_value_map_find_value( pMap, key, &value );
+
+    if( status == CborNoError )
+    {
+        if( cbor_value_is_integer( &value ) )
+        {
+            status = cbor_value_get_int64( &value, pValue );
         }
         else
         {
-            *pSize = IOT_BLE_MESG_ENCODER.getEncodedSize( &encoderObj, pBuffer );
+            status = CborErrorImproperValue;
         }
-
-        IOT_BLE_MESG_ENCODER.destroy( &encoderObj );
-        error = IOT_SERIALIZER_SUCCESS;
     }
 
-    return error;
+    return status;
 }
+
+/**
+ * The function is used to get the pointer to a text string value instead of copying the contents to a buffer.
+ * This function only works if the string value is encoded within a definite length map and the text string encoded is
+ * of definite length. Function returns the pointer to the start of the string and the length of the string.
+ */
+static CborError prvGetTextStringValueFromDefiniteLengthMap( CborValue * pMap,
+                                                             const char * key,
+                                                             const char ** pValue,
+                                                             size_t * valueLength )
+{
+    CborError status;
+    size_t length;
+    CborValue value = { 0 }, next = { 0 };
+
+    status = cbor_value_map_find_value( pMap, key, &value );
+
+    if( status == CborNoError )
+    {
+        if( cbor_value_is_text_string( &value ) )
+        {
+            if( cbor_value_is_length_known( &value ) )
+            {
+                status = cbor_value_get_string_length( &value, &length );
+            }
+            else
+            {
+                status = CborErrorImproperValue;
+            }
+        }
+        else
+        {
+            status = CborErrorImproperValue;
+        }
+
+        if( status == CborNoError )
+        { /* Advance to the next byte after this string value. */
+            status = cbor_value_copy_text_string( &value, NULL, &length, &next );
+
+            if( status == CborNoError )
+            {
+                ( *pValue ) = ( char * ) ( cbor_value_get_next_byte( &next ) - length );
+                ( *valueLength ) = length;
+            }
+        }
+    }
+
+    return status;
+}
+
+/**
+ * The function is used to get the pointer to a byte string value instead of copying the contents to a buffer.
+ * This function only works if the string value is encoded within a definite length map and the byte string encoded is
+ * of definite length. Function returns the pointer to the start of the string and the length of the string.
+ */
+static CborError prvGetByteStringValueFromDefiniteLengthMap( CborValue * pMap,
+                                                             const char * key,
+                                                             const void ** pValue,
+                                                             size_t * valueLength )
+{
+    CborError status;
+    size_t length;
+    CborValue value = { 0 }, next = { 0 };
+
+    status = cbor_value_map_find_value( pMap, key, &value );
+
+    if( status == CborNoError )
+    {
+        if( cbor_value_is_byte_string( &value ) )
+        {
+            if( cbor_value_is_length_known( &value ) )
+            {
+                status = cbor_value_get_string_length( &value, &length );
+            }
+            else
+            {
+                status = CborErrorImproperValue;
+            }
+        }
+        else
+        {
+            status = CborErrorImproperValue;
+        }
+
+        if( status == CborNoError )
+        {
+            /* Advance to the next byte after this string value. */
+            status = cbor_value_copy_byte_string( &value, NULL, &length, &next );
+
+            if( status == CborNoError )
+            {
+                ( *pValue ) = ( void * ) ( cbor_value_get_next_byte( &next ) - length );
+                ( *valueLength ) = length;
+            }
+        }
+    }
+
+    return status;
+}
+
 
 MQTTBLEStatus_t IotBleMqtt_SerializeConnect( const MQTTBLEConnectInfo_t * const pConnectInfo,
                                              uint8_t ** const pConnectPacket,
@@ -647,13 +776,13 @@ MQTTBLEStatus_t IotBleMqtt_SerializeConnect( const MQTTBLEConnectInfo_t * const 
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
 
-    error = _serializeConnect( pConnectInfo, NULL, &bufLen );
+    error = prvSerializeConnect( pConnectInfo, NULL, &bufLen );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find length of serialized CONNECT message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -673,9 +802,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializeConnect( const MQTTBLEConnectInfo_t * const 
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializeConnect( pConnectInfo, pBuffer, &bufLen );
+        error = prvSerializeConnect( pConnectInfo, pBuffer, &bufLen );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize CONNECT message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -701,37 +830,31 @@ MQTTBLEStatus_t IotBleMqtt_SerializeConnect( const MQTTBLEConnectInfo_t * const 
     return ret;
 }
 
-MQTTBLEStatus_t IotBleMqtt_DeserializeConnack( const uint8_t * pBuffer,
+MQTTBLEStatus_t IotBleMqtt_DeserializeConnack( const uint8_t * pMessage,
                                                size_t length )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t error;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t respCode = 0;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
-    int64_t respCode = 0L;
 
-    error = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
 
-    if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    if( status == CborNoError )
     {
-        LogError( ( "Malformed CONNACK, decoding the packet failed, decoder error = %d, type: %d", error, decoderObj.type ) );
-        ret = MQTTBLEBadResponse;
+        if( !cbor_value_is_map( &map ) )
+        {
+            status = CborErrorImproperValue;
+        }
     }
 
-    if( ret == MQTTBLESuccess )
+    if( status == CborNoError )
     {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_STATUS, &decoderValue );
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_STATUS, &respCode );
 
-        if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        if( status == CborNoError )
         {
-            LogError( ( "Invalid CONNACK, response code decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            respCode = decoderValue.u.value.u.signedInt;
-
             if( ( respCode != IOT_BLE_MQTT_STATUS_CONNECTING ) &&
                 ( respCode != IOT_BLE_MQTT_STATUS_CONNECTED ) )
             {
@@ -740,10 +863,15 @@ MQTTBLEStatus_t IotBleMqtt_DeserializeConnack( const uint8_t * pBuffer,
         }
     }
 
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+    if( status != CborNoError )
+    {
+        LogError( ( "Decode connack failed with error = %d", status ) );
+        ret = MQTTBLEBadResponse;
+    }
 
     return ret;
 }
+
 MQTTBLEStatus_t IotBleMqtt_SerializePublish( const MQTTBLEPublishInfo_t * const pPublishInfo,
                                              uint8_t ** const pPublishPacket,
                                              size_t * const pPacketSize,
@@ -751,12 +879,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializePublish( const MQTTBLEPublishInfo_t * const 
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializePublish( pPublishInfo, NULL, &bufLen, packetIdentifier );
+    error = prvSerializePublish( pPublishInfo, NULL, &bufLen, packetIdentifier );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find size of serialized PUBLISH message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -776,9 +904,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializePublish( const MQTTBLEPublishInfo_t * const 
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializePublish( pPublishInfo, pBuffer, &bufLen, packetIdentifier );
+        error = prvSerializePublish( pPublishInfo, pBuffer, &bufLen, packetIdentifier );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize PUBLISH message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -811,103 +939,67 @@ void IotBleMqtt_PublishSetDup( uint8_t * const pPublishPacket,
     /** TODO: Currently DUP flag is not supported by BLE SDKs **/
 }
 
-MQTTBLEStatus_t IotBleMqtt_DeserializePublish( uint8_t * pBuffer,
+MQTTBLEStatus_t IotBleMqtt_DeserializePublish( uint8_t * pMessage,
                                                size_t length,
                                                MQTTBLEPublishInfo_t * publishInfo,
                                                uint16_t * packetIdentifier )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t xSerializerRet;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t val = 0;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    xSerializerRet = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    memset( publishInfo, 0x00, sizeof( MQTTBLEPublishInfo_t ) );
 
-    if( ( xSerializerRet != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
+
+    if( status == CborNoError )
     {
-        LogError( ( "Decoding PUBLISH packet failed, decoder error = %d, object type = %d", xSerializerRet, decoderObj.type ) );
-        ret = MQTTBLEBadResponse;
-    }
-
-    if( ret == MQTTBLESuccess )
-    {
-        xSerializerRet = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_QOS, &decoderValue );
-
-        if( ( xSerializerRet != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        if( !cbor_value_is_map( &map ) )
         {
-            LogError( ( "QOS Value decode failed, error = %d, decoded value type = %d", xSerializerRet, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            publishInfo->qos = decoderValue.u.value.u.signedInt;
+            status = CborErrorImproperValue;
         }
     }
 
-    if( ret == MQTTBLESuccess )
+    if( status == CborNoError )
     {
-        decoderValue.u.value.u.string.pString = NULL;
-        decoderValue.u.value.u.string.length = 0;
-        xSerializerRet = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_TOPIC, &decoderValue );
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_QOS, &val );
 
-        if( ( xSerializerRet != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
+        if( status == CborNoError )
         {
-            LogError( ( "Topic value decode failed, error = %d", xSerializerRet ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            publishInfo->pTopicName = ( const char * ) decoderValue.u.value.u.string.pString;
-            publishInfo->topicNameLength = decoderValue.u.value.u.string.length;
+            publishInfo->qos = ( MQTTBLEQoS_t ) val;
         }
     }
 
-    if( ret == MQTTBLESuccess )
+    if( status == CborNoError )
     {
-        decoderValue.u.value.u.string.pString = NULL;
-        decoderValue.u.value.u.string.length = 0;
-        xSerializerRet = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_PAYLOAD, &decoderValue );
-
-        if( ( xSerializerRet != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_BYTE_STRING ) )
-        {
-            LogError( ( "Payload value decode failed, error = %d", xSerializerRet ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            publishInfo->pPayload = ( const char * ) decoderValue.u.value.u.string.pString;
-            publishInfo->payloadLength = decoderValue.u.value.u.string.length;
-        }
+        status = prvGetTextStringValueFromDefiniteLengthMap( &map, IOT_BLE_MQTT_TOPIC, &publishInfo->pTopicName, ( size_t * ) &publishInfo->topicNameLength );
     }
 
-    if( ret == MQTTBLESuccess )
+    if( status == CborNoError )
+    {
+        status = prvGetByteStringValueFromDefiniteLengthMap( &map, IOT_BLE_MQTT_PAYLOAD, &publishInfo->pPayload, &publishInfo->payloadLength );
+    }
+
+    if( status == CborNoError )
     {
         if( publishInfo->qos != 0 )
         {
-            xSerializerRet = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_MESSAGE_ID, &decoderValue );
+            status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_MESSAGE_ID, &val );
 
-            if( ( xSerializerRet != IOT_SERIALIZER_SUCCESS ) ||
-                ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+            if( status == CborNoError )
             {
-                LogError( ( "Message identifier decode failed, error = %d, decoded value type = %d", xSerializerRet, decoderValue.type ) );
-                ret = MQTTBLEBadResponse;
-            }
-            else
-            {
-                *packetIdentifier = ( uint16_t ) decoderValue.u.value.u.signedInt;
+                ( *packetIdentifier ) = ( uint16_t ) ( val );
             }
         }
     }
 
-    if( ret == MQTTBLESuccess )
+    if( status != CborNoError )
     {
-        publishInfo->retain = false;
+        LogError( ( "Decode cbor publish message failed with error = %d", status ) );
+        ret = MQTTBLEBadResponse;
     }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
 
     return ret;
 }
@@ -918,12 +1010,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializePuback( uint16_t packetIdentifier,
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializePubAck( packetIdentifier, NULL, &bufLen );
+    error = prvSerializePubAck( packetIdentifier, NULL, &bufLen );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find size of serialized PUBACK message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -943,9 +1035,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializePuback( uint16_t packetIdentifier,
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializePubAck( packetIdentifier, pBuffer, &bufLen );
+        error = prvSerializePubAck( packetIdentifier, pBuffer, &bufLen );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to find size of serialized PUBACK message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -971,40 +1063,41 @@ MQTTBLEStatus_t IotBleMqtt_SerializePuback( uint16_t packetIdentifier,
     return ret;
 }
 
-MQTTBLEStatus_t IotBleMqtt_DeserializePuback( uint8_t * pBuffer,
+MQTTBLEStatus_t IotBleMqtt_DeserializePuback( uint8_t * pMessage,
                                               size_t length,
                                               uint16_t * packetIdentifier )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t error;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t val = 0;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
 
-    if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    if( status == CborNoError )
     {
-        LogError( ( "Malformed PUBACK, decoding the packet failed, decoder error = %d, object type: %d", error, decoderObj.type ) );
+        if( !cbor_value_is_map( &map ) )
+        {
+            status = CborErrorImproperValue;
+        }
+    }
+
+    if( status == CborNoError )
+    {
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_MESSAGE_ID, &val );
+
+        if( status == CborNoError )
+        {
+            ( *packetIdentifier ) = ( uint16_t ) val;
+        }
+    }
+
+    if( status != CborNoError )
+    {
+        LogError( ( "Decode cbor puback message failed with error = %d", status ) );
         ret = MQTTBLEBadResponse;
     }
-
-    if( ret == MQTTBLESuccess )
-    {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_MESSAGE_ID, &decoderValue );
-
-        if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            LogError( ( "Message ID decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            *packetIdentifier = ( uint16_t ) decoderValue.u.value.u.signedInt;
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
 
     return ret;
 }
@@ -1017,12 +1110,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializeSubscribe( const MQTTBLESubscribeInfo_t * co
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializeSubscribe( pSubscriptionList, subscriptionCount, NULL, &bufLen, *pPacketIdentifier );
+    error = prvSerializeSubscribe( pSubscriptionList, subscriptionCount, NULL, &bufLen, *pPacketIdentifier );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find serialized length of SUBSCRIBE message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -1042,9 +1135,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializeSubscribe( const MQTTBLESubscribeInfo_t * co
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializeSubscribe( pSubscriptionList, subscriptionCount, pBuffer, &bufLen, *pPacketIdentifier );
+        error = prvSerializeSubscribe( pSubscriptionList, subscriptionCount, pBuffer, &bufLen, *pPacketIdentifier );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize SUBSCRIBE message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -1070,57 +1163,52 @@ MQTTBLEStatus_t IotBleMqtt_SerializeSubscribe( const MQTTBLESubscribeInfo_t * co
     return ret;
 }
 
-MQTTBLEStatus_t IotBleMqtt_DeserializeSuback( const uint8_t * pBuffer,
+MQTTBLEStatus_t IotBleMqtt_DeserializeSuback( const uint8_t * pMessage,
                                               size_t length,
                                               uint16_t * packetIdentifier,
                                               uint8_t * pStatusCode )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t error;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t val = 0;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
 
-    if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    if( status == CborNoError )
     {
-        LogError( ( "Malformed SUBACK, decoding the packet failed, decoder error = %d, type: %d", error, decoderObj.type ) );
+        if( !cbor_value_is_map( &map ) )
+        {
+            status = CborErrorImproperValue;
+        }
+    }
+
+    if( status == CborNoError )
+    {
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_MESSAGE_ID, &val );
+
+        if( status == CborNoError )
+        {
+            ( *packetIdentifier ) = ( uint16_t ) val;
+        }
+    }
+
+    if( status == CborNoError )
+    {
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_STATUS, &val );
+
+        if( status == CborNoError )
+        {
+            ( *pStatusCode ) = ( uint8_t ) val;
+        }
+    }
+
+    if( status != CborNoError )
+    {
+        LogError( ( "Decode cbor suback message failed with error = %d", status ) );
         ret = MQTTBLEBadResponse;
     }
-
-    if( ret == MQTTBLESuccess )
-    {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_MESSAGE_ID, &decoderValue );
-
-        if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            LogError( ( "Message ID decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            *packetIdentifier = ( uint16_t ) decoderValue.u.value.u.signedInt;
-        }
-    }
-
-    if( ret == MQTTBLESuccess )
-    {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_STATUS, &decoderValue );
-
-        if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            LogError( ( "Status code decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            *pStatusCode = ( uint8_t ) ( decoderValue.u.value.u.signedInt );
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
 
     return ret;
 }
@@ -1133,12 +1221,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializeUnsubscribe( const MQTTBLESubscribeInfo_t * 
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializeUnSubscribe( pSubscriptionList, subscriptionCount, NULL, &bufLen, *pPacketIdentifier );
+    error = prvSerializeUnSubscribe( pSubscriptionList, subscriptionCount, NULL, &bufLen, *pPacketIdentifier );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find serialized length of UNSUBSCRIBE message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -1158,9 +1246,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializeUnsubscribe( const MQTTBLESubscribeInfo_t * 
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializeUnSubscribe( pSubscriptionList, subscriptionCount, pBuffer, &bufLen, *pPacketIdentifier );
+        error = prvSerializeUnSubscribe( pSubscriptionList, subscriptionCount, pBuffer, &bufLen, *pPacketIdentifier );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize UNSUBSCRIBE message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -1186,40 +1274,41 @@ MQTTBLEStatus_t IotBleMqtt_SerializeUnsubscribe( const MQTTBLESubscribeInfo_t * 
     return ret;
 }
 
-MQTTBLEStatus_t IotBleMqtt_DeserializeUnsuback( uint8_t * pBuffer,
+MQTTBLEStatus_t IotBleMqtt_DeserializeUnsuback( uint8_t * pMessage,
                                                 size_t length,
                                                 uint16_t * packetIdentifier )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t error;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t val = 0;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
 
-    if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    if( status == CborNoError )
     {
-        LogError( ( "Malformed UNSUBACK, decoding the packet failed, decoder error = %d, type:%d ", error, decoderObj.type ) );
+        if( !cbor_value_is_map( &map ) )
+        {
+            status = CborErrorImproperValue;
+        }
+    }
+
+    if( status == CborNoError )
+    {
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_MESSAGE_ID, &val );
+
+        if( status == CborNoError )
+        {
+            ( *packetIdentifier ) = ( uint16_t ) val;
+        }
+    }
+
+    if( status != CborNoError )
+    {
+        LogError( ( "Decode cbor unsuback message failed with error = %d", status ) );
         ret = MQTTBLEBadResponse;
     }
-
-    if( ret == MQTTBLESuccess )
-    {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_MESSAGE_ID, &decoderValue );
-
-        if( ( error != IOT_SERIALIZER_SUCCESS ) ||
-            ( decoderValue.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            LogError( ( "UNSUBACK Message identifier decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
-            ret = MQTTBLEBadResponse;
-        }
-        else
-        {
-            *packetIdentifier = ( uint16_t ) decoderValue.u.value.u.signedInt;
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
 
     return ret;
 }
@@ -1229,12 +1318,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializeDisconnect( uint8_t ** const pDisconnectPack
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializeDisconnect( NULL, &bufLen );
+    error = prvSerializeDisconnect( NULL, &bufLen );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find serialized length of DISCONNECT message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -1254,9 +1343,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializeDisconnect( uint8_t ** const pDisconnectPack
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializeDisconnect( pBuffer, &bufLen );
+        error = prvSerializeDisconnect( pBuffer, &bufLen );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize DISCONNECT message, error = %d", error ) );
             ret = MQTTBLEBadParameter;
@@ -1293,37 +1382,39 @@ size_t IotBleMqtt_GetRemainingLength( IotBleDataTransferChannel_t * pNetworkConn
 }
 
 
-uint8_t IotBleMqtt_GetPacketType( const uint8_t * pBuffer,
+uint8_t IotBleMqtt_GetPacketType( const uint8_t * pMessage,
                                   size_t length )
 {
-    IotSerializerDecoderObject_t decoderObj = { 0 }, decoderValue = { 0 };
-    IotSerializerError_t error;
-    uint8_t value, packetType = IOT_BLE_MQTT_MSG_TYPE_INVALID;
+    CborParser parser = { 0 };
+    CborValue map = { 0 };
+    CborError status = CborNoError;
+    int64_t val = 0;
+    uint8_t packetType = IOT_BLE_MQTT_MSG_TYPE_INVALID;
 
-    error = IOT_BLE_MESG_DECODER.init( &decoderObj, pBuffer, length );
+    status = cbor_parser_init( pMessage, length, 0, &parser, &map );
 
-    if( ( error == IOT_SERIALIZER_SUCCESS ) &&
-        ( decoderObj.type == IOT_SERIALIZER_CONTAINER_MAP ) )
+    if( status == CborNoError )
     {
-        error = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_MQTT_MSG_TYPE, &decoderValue );
-
-        if( ( error == IOT_SERIALIZER_SUCCESS ) &&
-            ( decoderValue.type == IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        if( !cbor_value_is_map( &map ) )
         {
-            value = ( uint16_t ) decoderValue.u.value.u.signedInt;
-            packetType = value;
-        }
-        else
-        {
-            LogError( ( "Packet type decode failed, error = %d, decoded value type = %d", error, decoderValue.type ) );
+            status = CborErrorImproperValue;
         }
     }
-    else
+
+    if( status == CborNoError )
     {
-        LogError( ( "Decoding the packet failed, decoder error = %d, type = %d", error, decoderObj.type ) );
+        status = prvGetIntegerValueFromMap( &map, IOT_BLE_MQTT_MSG_TYPE, &val );
+
+        if( status == CborNoError )
+        {
+            packetType = ( uint8_t ) val;
+        }
     }
 
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+    if( status != CborNoError )
+    {
+        LogError( ( "Decode cbor message failed with error = %d", status ) );
+    }
 
     return packetType;
 }
@@ -1333,12 +1424,12 @@ MQTTBLEStatus_t IotBleMqtt_SerializePingreq( uint8_t ** const pPingreqPacket,
 {
     uint8_t * pBuffer = NULL;
     size_t bufLen = 0;
-    IotSerializerError_t error;
+    CborError error;
     MQTTBLEStatus_t ret = MQTTBLESuccess;
 
-    error = _serializePingRequest( NULL, &bufLen );
+    error = prvSerializePingRequest( NULL, &bufLen );
 
-    if( error != IOT_SERIALIZER_SUCCESS )
+    if( error != CborNoError )
     {
         LogError( ( "Failed to find serialized length of DISCONNECT message, error = %d", error ) );
         ret = MQTTBLEBadParameter;
@@ -1358,9 +1449,9 @@ MQTTBLEStatus_t IotBleMqtt_SerializePingreq( uint8_t ** const pPingreqPacket,
 
     if( ret == MQTTBLESuccess )
     {
-        error = _serializePingRequest( pBuffer, &bufLen );
+        error = prvSerializePingRequest( pBuffer, &bufLen );
 
-        if( error != IOT_SERIALIZER_SUCCESS )
+        if( error != CborNoError )
         {
             LogError( ( "Failed to serialize DISCONNECT message, error = %d", error ) );
             ret = MQTTBLEBadParameter;

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -29,11 +29,12 @@
  */
 
 #include <string.h>
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "semphr.h"
 
 #include "iot_config.h"
 #include "iot_ble_config.h"
-#include "iot_serializer.h"
-#include "iot_taskpool.h"
 #include "iot_ble_wifi_provisioning.h"
 
 /* Configure logs for the functions in this file. */
@@ -46,20 +47,19 @@
 #define LIBRARY_LOG_NAME         ( "BLE_WIFI_PROV" )
 #include "iot_logging_setup.h"
 
+#define IOT_BLE_WIFI_PROVISIONING_COMMAND_TIMEOUT_MS   ( 5000 )
+
 /**
  * @cond DOXYGEN_IGNORE
- * Doxygen should ignore this section.
- *
+ * @brief Priority index value which is used to indicate the app as not to use.
  */
-#define IOT_BLE_WIFI_PROV_INVALID_NETWORK_RSSI     ( -100 )
-#define IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX    ( -1 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE     ( -1 )
 
-#define ATTR_HANDLE( svc, ch_idx )    ( ( svc )->pusHandlesBuffer[ ch_idx ] )
-#define ATTR_UUID( svc, ch_idx )      ( ( svc )->pxBLEAttributes[ ch_idx ].xCharacteristic.xUuid )
-
-#define IS_VALID_SERIALIZER_RET( ret, pxSerializerBuf ) \
-    ( ( ret == IOT_SERIALIZER_SUCCESS ) ||              \
-      ( ( !pxSerializerBuf ) && ( ret == IOT_SERIALIZER_BUFFER_TOO_SMALL ) ) )
+/**
+ * @cond DOXYGEN_IGNORE
+ * @brief The network rssi value which is used to indicate the app as not to use.
+ */
+#define IOT_BLE_WIFI_PROV_RSSI_DONT_USE     (    -100 )
 
 /**
  * @brief Macro to check if provided network index for an operation is within range.
@@ -67,62 +67,46 @@
 #define IS_INDEX_WITHIN_RANGE( index )    ( ( index >= 0 ) && ( index < wifiProvisioning.numNetworks ) )
 
 #define STORAGE_INDEX( priority )         ( wifiProvisioning.numNetworks - priority - 1 )
-#define NETWORK_INFO_DEFAULT_PARAMS    { .status = eWiFiSuccess, .RSSI = IOT_BLE_WIFI_PROV_INVALID_NETWORK_RSSI, .connected = false, .savedIdx = IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX }
 
-
-/** @endcond */
-
-/**
- * @brief Parameters used in WIFI provisioning message serialization.
- */
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_KEY        "w"
-#define IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY    "h"
-#define IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY    "t"
-#define IOT_BLE_WIFI_PROV_KEY_MGMT_KEY        "q"
-#define IOT_BLE_WIFI_PROV_SSID_KEY            "r"
-#define IOT_BLE_WIFI_PROV_BSSID_KEY           "b"
-#define IOT_BLE_WIFI_PROV_RSSI_KEY            "p"
-#define IOT_BLE_WIFI_PROV_PSK_KEY             "m"
-#define IOT_BLE_WIFI_PROV_STATUS_KEY          "s"
-#define IOT_BLE_WIFI_PROV_HIDDEN_KEY          "f"
-#define IOT_BLE_WIFI_PROV_CONNECTED_KEY       "e"
-#define IOT_BLE_WIFI_PROV_INDEX_KEY           "g"
-#define IOT_BLE_WIFI_PROV_NEWINDEX_KEY        "j"
-#define IOT_BLE_WIFI_PROV_CONNECT_KEY         "y"
-
-
-/**
- * @defgroup
- * Wifi provisioning message types.
- */
-/** @{ */
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ       ( 1 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP      ( 2 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_SAVE_NETWORK_REQ       ( 3 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_SAVE_NETWORK_RESP      ( 4 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_REQ       ( 5 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP      ( 6 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_REQ     ( 7 )
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_RESP    ( 8 )
-/** @} */
-
-#define IOT_BLE_WIFI_PROV_NUM_NETWORK_INFO_MESG_PARAMS    ( 9 )
-#define IOT_BLE_WIFI_PROV_NUM_STATUS_MESG_PARAMS          ( 2 )
-#define IOT_BLE_WIFI_PROV_DEFAULT_ALWAYS_CONNECT          ( true )
-
-
-/**
- * @brief Defines the numeric value for the WIFI security type exchanged between
- * the FreeRTOS device and companion mobile SDK.
- */
-#define IOT_BLE_WIFI_SECURITY_TYPE_OPEN        ( 0UL )
-#define IOT_BLE_WIFI_SECURITY_TYPE_WEP         ( 1UL )
-#define IOT_BLE_WIFI_SECURITY_TYPE_WPA         ( 2UL )
-#define IOT_BLE_WIFI_SECURITY_TYPE_WPA2        ( 3UL )
-#define IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT    ( 4UL )
-#define IOT_BLE_WIFI_SECURITY_TYPE_WPA3        ( 5UL )
+#define LIST_NETWORK_RESPONSE_DEFAULT                              \
+    {                                                              \
+        .RSSI = IOT_BLE_WIFI_PROV_RSSI_DONT_USE,                   \
+        .connected = false,                                        \
+        .hidden    = false,                                        \
+        .priorityIndex = IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE  \
+    }
 
 /*---------------------------------------------------------------------------------------------------------*/
+
+/**
+ * @ingroup ble_datatypes_structs
+ * @brief Structure used for internal bookkeeping of WiFi provisioning service.
+ */
+typedef struct IotBleWifiProvService
+{
+    TaskHandle_t taskHandle;                /**< Handle for the task used for WiFi provisioing. */
+    IotBleDataTransferChannel_t * pChannel; /**< A pointer to the ble connection object. */
+    uint16_t numNetworks;                   /**< Keeps track of total number of networks stored. */
+    int16_t connectedIdx;                   /**< Keeps track of the flash index of the network that is connected. */
+    QueueHandle_t messageQueue;             /**< Message queue use by the provisioning task to process incoming requests. */
+    SemaphoreHandle_t mutex;                /**< Mutex used to synchronize between application task the provsioning task .*/ 
+} IotBleWifiProvService_t;
+
+/**
+ * @brief Structure is used to hold each element in the message queue of WiFi provisioing service.
+ */
+typedef struct
+{
+    IotBleWiFiProvRequest_t type;
+    union
+    {
+        IotBleWifiProvListNetworksRequest_t  listNetworkRequest;
+        IotBleWifiProvAddNetworkRequest_t    addNetworkRequest;
+        IotBleWifiProvEditNetworkRequest_t   editNetworkRequest;
+        IotBleWifiProvDeleteNetworkRequest_t deleteNetworkRequest;
+    } m;
+
+} IotBleWifiProvMessage_t;
 
 static IotBleWifiProvService_t wifiProvisioning = { 0 };
 
@@ -130,57 +114,42 @@ static IotBleWifiProvService_t wifiProvisioning = { 0 };
 
 
 static WIFIScanResult_t scanNetworks[ IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ] = { 0 };
-
 /*
  * @brief Callback registered for BLE write and read events received for each characteristic.
  */
-static void _callback( IotBleDataTransferChannelEvent_t event,
+static void prvTransportReceiveCallback( IotBleDataTransferChannelEvent_t event,
                        IotBleDataTransferChannel_t * pChannel,
                        void * pContext );
-
-static bool _deserializeListNetworkRequest( const uint8_t * pData,
-                                            size_t length,
-                                            IotBleListNetworkRequest_t * pListNetworkRequest );
 
 /*
  * @brief Parses List Network request params and creates task to list networks.
  */
-static bool _handleListNetworkRequest( const uint8_t * pData,
+static BaseType_t prvHandleListNetworkRequest( const uint8_t * pData,
                                        size_t length );
-
-
-static bool _deserializeAddNetworkRequest( const uint8_t * pData,
-                                           size_t length,
-                                           IotBleAddNetworkRequest_t * pAddNetworkRequest );
 
 /*
  * @brief Parses Save Network request params and creates task to save the new network.
  */
 
-static bool _handleSaveNetworkRequest( const uint8_t * pData,
+static BaseType_t prvHandleAddNetworkRequest( const uint8_t * pData,
                                        size_t length );
-
-
-static bool _deserializeEditNetworkRequest( const uint8_t * pData,
-                                            size_t length,
-                                            IotBleEditNetworkRequest_t * pEditNetworkRequest );
 
 /*
  * @brief Parses Edit Network request params and creates task to edit network priority.
  */
-static bool _handleEditNetworkRequest( const uint8_t * pData,
+static BaseType_t prvHandleEditNetworkRequest( const uint8_t * pData,
                                        size_t length );
-
-static bool _deserializeDeleteNetworkRequest( const uint8_t * pData,
-                                              size_t length,
-                                              IotBleDeleteNetworkRequest_t * pDeleteNetworkRequest );
-
 /*
  * @brief Parses Delete Network request params and creates task to delete a WiFi networ.
  */
-static bool _handleDeleteNetworkRequest( const uint8_t * pData,
+static BaseType_t prvHandleDeleteNetworkRequest( const uint8_t * pData,
                                          size_t length );
 
+/*
+ * @brief Sends a status response for the request.
+ */
+static void prvSendStatusResponse( IotBleWiFiProvRequest_t responseType,
+                                 WIFIReturnCode_t status );
 
 WIFIReturnCode_t _appendNetwork( WIFINetworkProfile_t * pProfile );
 
@@ -202,109 +171,18 @@ WIFIReturnCode_t _connectSavedNetwork( uint16_t index );
 
 WIFIReturnCode_t _addNewNetwork( WIFINetworkProfile_t * pProfile,
                                  bool connect );
-
-static IotSerializerError_t _serializeNetwork( int32_t responseType,
-                                               IotBleWifiNetworkInfo_t * pNetworkInfo,
-                                               uint8_t * pBuffer,
-                                               size_t * plength );
-
-
-static IotSerializerError_t _serializeStatusResponse( int32_t responseType,
-                                                      WIFIReturnCode_t status,
-                                                      uint8_t * pBuffer,
-                                                      size_t * plength );
-
-static void _sendScanNetwork( int32_t responseType,
-                              WIFIScanResult_t * pScanNetwork );
-
-/*
- * @brief  The task lists the saved network configurations in flash and also scans nearby networks.
- * It sends the profile information for each saved and scanned networks one at a time to the GATT client.
- * Maximum number of networks to scan is set in the List network request.
- */
-static void _listNetworkTask( IotTaskPool_t taskPool,
-                              IotTaskPoolJob_t job,
-                              void * pUserContext );
-
-/*
- * @brief  The task is used to save a new WiFi configuration.
- * It first connects to the network and if successful,saves the network onto flash with the highest priority.
- */
-static void _addNetworkTask( IotTaskPool_t taskPool,
-                             IotTaskPoolJob_t job,
-                             void * pUserContext );
-
-/*
- * @brief  The task is used to reorder priorities of network profiles stored in flash.
- *  If the priority of existing connected network changes then it initiates a reconnection.
- */
-static void _editNetworkTask( IotTaskPool_t taskPool,
-                              IotTaskPoolJob_t job,
-                              void * pUserContext );
-
-/*
- * @brief  The task is used to delete a network configuration from the flash.
- * If the network is connected, it disconnects from the network and initiates a reconnection.
- */
-static void _deleteNetworkTask( IotTaskPool_t taskPool,
-                                IotTaskPoolJob_t job,
-                                void * pUserContext );
-
 /*
  * @brief Gets the number of saved networks from flash.
  */
 static uint32_t _getNumSavedNetworks( void );
 
-/*
- * @brief Sends a status response for the request.
- */
-static void _sendStatusResponse( int32_t responseType,
-                                 WIFIReturnCode_t status );
-
 /*-----------------------------------------------------------*/
 
-static bool _getRequestType( const uint8_t * pRequest,
-                             size_t requestLength,
-                             int32_t * pType )
-{
-    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    bool result = true;
-
-    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pRequest, requestLength );
-
-    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
-    {
-        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
-        result = false;
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, &value );
-
-        if( ( ret == IOT_SERIALIZER_SUCCESS ) &&
-            ( value.type == IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            *pType = ( int32_t ) ( value.u.value.u.signedInt );
-        }
-        else
-        {
-            IotLogError( "Failed to find message type, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-    }
-
-    return result;
-}
-
-static void _callback( IotBleDataTransferChannelEvent_t event,
+static void prvTransportReceiveCallback( IotBleDataTransferChannelEvent_t event,
                        IotBleDataTransferChannel_t * pChannel,
                        void * pContext )
 {
-    int32_t requestType;
+    IotBleWiFiProvRequest_t request;
     const uint8_t * pBuffer;
     size_t length;
 
@@ -312,30 +190,30 @@ static void _callback( IotBleDataTransferChannelEvent_t event,
     {
         IotBleDataTransfer_PeekReceiveBuffer( pChannel, &pBuffer, &length );
 
-        if( _getRequestType( pBuffer, length, &requestType ) == true )
+        if( IotBleWiFiProv_GetRequestTypeFromMessage( pBuffer, length, &request ) == true )
         {
-            IotLogDebug( "Received message type: %d, length %d", requestType, length );
+            IotLogDebug( "Received message type: %d, length %d", request, length );
 
-            switch( requestType )
+            switch( request )
             {
-                case IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ:
-                    _handleListNetworkRequest( pBuffer, length );
+                case IotBleWiFiProvRequestListNetwork:
+                    prvHandleListNetworkRequest( pBuffer, length );
                     break;
 
-                case IOT_BLE_WIFI_PROV_MSG_TYPE_SAVE_NETWORK_REQ:
-                    _handleSaveNetworkRequest( pBuffer, length );
+                case IotBleWiFiProvRequestAddNetwork:
+                    prvHandleAddNetworkRequest( pBuffer, length );
                     break;
 
-                case IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_REQ:
-                    _handleEditNetworkRequest( pBuffer, length );
+                case IotBleWiFiProvRequestEditNetwork:
+                    prvHandleEditNetworkRequest( pBuffer, length );
                     break;
 
-                case IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_REQ:
-                    _handleDeleteNetworkRequest( pBuffer, length );
+                case IotBleWiFiProvRequestDeleteNetwork:
+                    prvHandleDeleteNetworkRequest( pBuffer, length );
                     break;
 
                 default:
-                    IotLogWarn( "Invalid request type ( %d ) received, discarding the message", requestType );
+                    IotLogWarn( "Invalid request type ( %d ) received, discarding the message", request );
                     break;
             }
         }
@@ -345,826 +223,175 @@ static void _callback( IotBleDataTransferChannelEvent_t event,
     }
 }
 
-static bool _deserializeListNetworkRequest( const uint8_t * pData,
-                                            size_t length,
-                                            IotBleListNetworkRequest_t * pListNetworkRequest )
-{
-    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    bool result = true;
-
-    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
-
-    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
-    {
-        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
-        result = false;
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get max Networks parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( ( value.u.value.u.signedInt <= 0 ) || ( value.u.value.u.signedInt > IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ) )
-            {
-                IotLogWarn( "Networks %d exceeds configured value, truncating to  %d max network\n",
-                            ( uint16_t ) value.u.value.u.signedInt,
-                            IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS );
-                pListNetworkRequest->maxNetworks = IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS;
-            }
-            else
-            {
-                pListNetworkRequest->maxNetworks = value.u.value.u.signedInt;
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get timeout parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            pListNetworkRequest->timeoutMs = value.u.value.u.signedInt;
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
-
-    return result;
-}
-
-
 /*-----------------------------------------------------------*/
 
-static bool _handleListNetworkRequest( const uint8_t * pData,
-                                       size_t length )
+static BaseType_t prvHandleListNetworkRequest( const uint8_t * pData,
+                                               size_t length )
 {
-    bool status = false;
-    IotTaskPoolError_t taskStatus = IOT_TASKPOOL_SUCCESS;
-    IotTaskPoolJob_t job = IOT_TASKPOOL_JOB_INITIALIZER;
+    BaseType_t status;
+    IotBleWifiProvMessage_t message = { 0 };
 
-    if( IotSemaphore_TryWait( &wifiProvisioning.lock ) == true )
+    message.type = IotBleWiFiProvRequestListNetwork;
+
+    status = IotBleWiFiProv_DeserializeListNetworkRequest( pData, length, &message.m.listNetworkRequest );
+    
+    if( status == pdTRUE )
     {
-        memset( &wifiProvisioning.listNetworkRequest, 0x00, sizeof( IotBleListNetworkRequest_t ) );
+        IotLogDebug( "List network request parameters: max networks = %d, timeout = %d",
+                      message.m.listNetworkRequest.scanSize,
+                      message.m.listNetworkRequest.scanTimeoutMS );
 
-        status = _deserializeListNetworkRequest( pData, length, &wifiProvisioning.listNetworkRequest );
-
-        if( status == true )
+        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        if( status != pdTRUE )
         {
-            IotLogDebug( "List network request parameters: max networks = %d, timeout = %d",
-                         wifiProvisioning.listNetworkRequest.maxNetworks,
-                         wifiProvisioning.listNetworkRequest.timeoutMs );
-
-            taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                          _listNetworkTask,
-                                                          NULL,
-                                                          &job );
-
-            if( taskStatus == IOT_TASKPOOL_SUCCESS )
-            {
-                taskStatus = IotTaskPool_Schedule( IOT_SYSTEM_TASKPOOL, job, 0 );
-
-                if( taskStatus != IOT_TASKPOOL_SUCCESS )
-                {
-                    IotLogError( "Failed to schedule taskpool job for list network request" );
-                    IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, job );
-                    status = false;
-                }
-            }
-            else
-            {
-                IotLogError( "Failed to allocate taskpool job for list network request" );
-                status = false;
-            }
-        }
-
-        if( status == false )
-        {
-            IotSemaphore_Post( &wifiProvisioning.lock );
+            IotLogError( "Failed to enqueue list network request, queue is full." );
         }
     }
     else
     {
-        IotLogError( "Failed to process the list network request, another list network request in progress." );
-        status = false;
+        IotLogError( "Failed to deserialize list network request." );
     }
 
     return status;
 }
 
-static bool _deserializeAddNetworkRequest( const uint8_t * pData,
-                                           size_t length,
-                                           IotBleAddNetworkRequest_t * pAddNetworkRequest )
-{
-    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    bool result = true;
-
-    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
-
-    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
-    {
-        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
-        result = false;
-    }
-
-    if( result == true )
-    {
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SSID_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
-        {
-            IotLogError( "Failed to get SSID parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length >= wificonfigMAX_SSID_LEN )
-            {
-                IotLogError( "SSID, %.*s, exceeds maximum length %d",
-                             value.u.value.u.string.length,
-                             ( const char * ) value.u.value.u.string.pString,
-                             wificonfigMAX_SSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkRequest->network.ucSSID, value.u.value.u.string.pString, value.u.value.u.string.length );
-                pAddNetworkRequest->network.ucSSIDLength = ( value.u.value.u.string.length );
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_BSSID_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_BYTE_STRING ) )
-        {
-            IotLogError( "Failed to get BSSID parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length != wificonfigMAX_BSSID_LEN )
-            {
-                IotLogError( "Parameter BSSID length (%d) does not match BSSID length %d",
-                             value.u.value.u.string.length,
-                             wificonfigMAX_BSSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkRequest->network.ucBSSID, value.u.value.u.string.pString, wificonfigMAX_BSSID_LEN );
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get WIFI xSecurity parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            switch( value.u.value.u.signedInt )
-            {
-                case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityOpen;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityWEP;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityWPA;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                default:
-                    pAddNetworkRequest->network.xSecurity = eWiFiSecurityNotSupported;
-                    break;
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_PSK_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
-        {
-            IotLogError( "Failed to get password parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length >= wificonfigMAX_PASSPHRASE_LEN )
-            {
-                IotLogError( "SSID, %.*s, exceeds maximum length %d",
-                             value.u.value.u.string.length,
-                             ( const char * ) value.u.value.u.string.pString,
-                             wificonfigMAX_SSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkRequest->network.cPassword, value.u.value.u.string.pString, value.u.value.u.string.length );
-                pAddNetworkRequest->network.ucPasswordLength = ( uint8_t ) ( value.u.value.u.string.length );
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( ( value.u.value.u.signedInt >= IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX ) &&
-                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
-            {
-                pAddNetworkRequest->savedIdx = value.u.value.u.signedInt;
-            }
-            else
-            {
-                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
-                result = false;
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_CONNECT_KEY, &value );
-
-        if( ( ret == IOT_SERIALIZER_SUCCESS ) &&
-            ( value.type == IOT_SERIALIZER_SCALAR_BOOL ) )
-        {
-            pAddNetworkRequest->connect = value.u.value.u.booleanValue;
-        }
-        else if( ret == IOT_SERIALIZER_NOT_FOUND )
-        {
-            IotLogInfo( "Connect flag not set in request, using default value always connect = %d", IOT_BLE_WIFI_PROV_DEFAULT_ALWAYS_CONNECT );
-            pAddNetworkRequest->connect = IOT_BLE_WIFI_PROV_DEFAULT_ALWAYS_CONNECT;
-        }
-        else
-        {
-            IotLogError( "Error in getting connect flag, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
-
-    return result;
-}
-
 /*-----------------------------------------------------------*/
 
-static bool _handleSaveNetworkRequest( const uint8_t * pData,
-                                       size_t length )
+
+static BaseType_t prvHandleAddNetworkRequest( const uint8_t * pData,
+                                               size_t length )
 {
-    bool status = false;
-    IotTaskPoolError_t taskStatus = IOT_TASKPOOL_SUCCESS;
-    IotTaskPoolJob_t job = IOT_TASKPOOL_JOB_INITIALIZER;
+    BaseType_t status;
+    IotBleWifiProvMessage_t message = { 0 };
 
-    if( IotSemaphore_TryWait( &wifiProvisioning.lock ) == true )
+    message.type = IotBleWiFiProvRequestAddNetwork;
+
+    status = IotBleWiFiProv_DeserializeAddNetworkRequest( pData, length, &message.m.addNetworkRequest );
+    
+    if( status == pdTRUE )
     {
-        memset( &wifiProvisioning.addNetworkRequest, 0x00, sizeof( IotBleAddNetworkRequest_t ) );
-        status = _deserializeAddNetworkRequest( pData, length, &wifiProvisioning.addNetworkRequest );
+        IotLogDebug( "Add network request parameters, SSID: %.*s, index: %d, connect: %d",
+                         message.m.addNetworkRequest.accessPointInfo.ucSSIDLength,
+                         ( char * ) message.m.addNetworkRequest.accessPointInfo.ucSSID,
+                         message.m.addNetworkRequest.prirorityIndex,
+                         message.m.addNetworkRequest.shouldConnect );
 
-        if( status == true )
+        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        if( status != pdTRUE )
         {
-            IotLogDebug( "Add network request parameters, SSID: %.*s, index: %d, connect: %d",
-                         wifiProvisioning.addNetworkRequest.network.ucSSIDLength,
-                         ( char * ) wifiProvisioning.addNetworkRequest.network.ucSSID,
-                         wifiProvisioning.addNetworkRequest.savedIdx,
-                         wifiProvisioning.addNetworkRequest.connect );
-
-            taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                          _addNetworkTask,
-                                                          NULL,
-                                                          &job );
-
-            if( taskStatus == IOT_TASKPOOL_SUCCESS )
-            {
-                taskStatus = IotTaskPool_Schedule( IOT_SYSTEM_TASKPOOL, job, 0 );
-
-                if( taskStatus != IOT_TASKPOOL_SUCCESS )
-                {
-                    IotLogError( "Failed to schedule taskpool job for add network request" );
-                    IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, job );
-                    status = false;
-                }
-            }
-            else
-            {
-                IotLogError( "Failed to allocate taskpool job for add network request" );
-                status = false;
-            }
-        }
-
-        if( status == false )
-        {
-            IotSemaphore_Post( &wifiProvisioning.lock );
+            IotLogError( "Failed to enqueue add network request, queue is full." );
         }
     }
     else
     {
-        IotLogError( "Failed to process the add network request. Already a request is being processed" );
-        status = false;
+        IotLogError( "Failed to deserialize add network request." );
     }
 
     return status;
 }
 
-static bool _deserializeEditNetworkRequest( const uint8_t * pData,
-                                            size_t length,
-                                            IotBleEditNetworkRequest_t * pEditNetworkRequest )
-{
-    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    bool result = true;
-
-    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
-
-    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
-    {
-        IotLogError( "Failed to initialize decoder, error = %d, object type = %d", ret, decoderObj.type );
-        result = false;
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( ( value.u.value.u.signedInt >= 0 ) &&
-                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
-            {
-                pEditNetworkRequest->curIdx = value.u.value.u.signedInt;
-            }
-            else
-            {
-                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
-                result = false;
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_NEWINDEX_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get new network index parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( ( value.u.value.u.signedInt >= 0 ) &&
-                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
-            {
-                pEditNetworkRequest->newIdx = value.u.value.u.signedInt;
-            }
-            else
-            {
-                IotLogError( "New Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
-                result = false;
-            }
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
-
-    return result;
-}
-
 /*-----------------------------------------------------------*/
 
-static bool _handleEditNetworkRequest( const uint8_t * pData,
-                                       size_t length )
+static BaseType_t prvHandleEditNetworkRequest( const uint8_t * pData,
+                                               size_t length )
 {
-    bool status = false;
-    IotTaskPoolError_t taskStatus = IOT_TASKPOOL_SUCCESS;
-    IotTaskPoolJob_t job = IOT_TASKPOOL_JOB_INITIALIZER;
+    BaseType_t status;
+    IotBleWifiProvMessage_t message = { 0 };
 
-    if( IotSemaphore_TryWait( &wifiProvisioning.lock ) == true )
+    message.type = IotBleWiFiProvRequestEditNetwork;
+
+    status = IotBleWiFiProv_DeserializeEditNetworkRequest( pData, length, &message.m.editNetworkRequest );
+    
+    if( status == pdTRUE )
     {
-        memset( &wifiProvisioning.editNetworkRequest, 0x00, sizeof( IotBleEditNetworkRequest_t ) );
-        status = _deserializeEditNetworkRequest( pData, length, &wifiProvisioning.editNetworkRequest );
 
-        if( status == true )
+        IotLogDebug( "Edit network request parameters, Current index: %d, new index: %d",
+                         message.m.editNetworkRequest.currentPriorityIndex,
+                         message.m.editNetworkRequest.newPriorityIndex );
+
+        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        if( status != pdTRUE )
         {
-            IotLogDebug( "Edit network request parameters, Current index: %d, new index: %d",
-                         wifiProvisioning.editNetworkRequest.curIdx,
-                         wifiProvisioning.editNetworkRequest.newIdx );
-
-            taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                          _editNetworkTask,
-                                                          NULL,
-                                                          &job );
-
-            if( taskStatus == IOT_TASKPOOL_SUCCESS )
-            {
-                taskStatus = IotTaskPool_Schedule( IOT_SYSTEM_TASKPOOL, job, 0 );
-
-                if( taskStatus != IOT_TASKPOOL_SUCCESS )
-                {
-                    IotLogError( "Failed to schedule taskpool job for edit network request" );
-                    IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, job );
-                    status = false;
-                }
-            }
-        }
-        else
-        {
-            IotLogError( "Failed to allocate taskpool job for edit network request" );
-            status = false;
-        }
-
-        if( status == false )
-        {
-            IotSemaphore_Post( &wifiProvisioning.lock );
+            IotLogError( "Failed to enqueue edit network request, queue is full." );
         }
     }
     else
     {
-        IotLogError( "Failed to process the edit network request. Already a request is being processed" );
-        status = false;
+        IotLogError( "Failed to deserialize edit network request." );
     }
 
     return status;
 }
 
-static bool _deserializeDeleteNetworkRequest( const uint8_t * pData,
-                                              size_t length,
-                                              IotBleDeleteNetworkRequest_t * pDeleteNetworkRequest )
-{
-    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    bool result = true;
-
-    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
-
-    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
-    {
-        IotLogError( "Failed to initialize decoder, error = %d, object type = %d", ret, decoderObj.type );
-        result = false;
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( ( value.u.value.u.signedInt >= 0 ) &&
-                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
-            {
-                pDeleteNetworkRequest->idx = ( int16_t ) value.u.value.u.signedInt;
-            }
-            else
-            {
-                IotLogError( "Network index parameter %lld is out of range", value.u.value.u.signedInt );
-                result = false;
-            }
-        }
-    }
-
-    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
-
-    return result;
-}
-
 /*-----------------------------------------------------------*/
 
-static bool _handleDeleteNetworkRequest( const uint8_t * pData,
-                                         size_t length )
+static BaseType_t prvHandleDeleteNetworkRequest( const uint8_t * pData,
+                                               size_t length )
 {
-    bool status = false;
-    IotTaskPoolError_t taskStatus = IOT_TASKPOOL_SUCCESS;
-    IotTaskPoolJob_t job = IOT_TASKPOOL_JOB_INITIALIZER;
+    BaseType_t status;
+    IotBleWifiProvMessage_t message = { 0 };
 
-    if( IotSemaphore_TryWait( &wifiProvisioning.lock ) == true )
+    message.type = IotBleWiFiProvRequestDeleteNetwork;
+
+    status = IotBleWiFiProv_DeserializeDeleteNetworkRequest( pData, length, &message.m.deleteNetworkRequest );
+    
+    if( status == pdTRUE )
     {
-        memset( &wifiProvisioning.deleteNetworkRequest, 0x00, sizeof( IotBleDeleteNetworkRequest_t ) );
-        status = _deserializeDeleteNetworkRequest( pData, length, &wifiProvisioning.deleteNetworkRequest );
 
-        if( status == true )
+         IotLogDebug( "Delete network request parameters, index: %d",
+                         message.m.deleteNetworkRequest.priorityIndex );
+
+        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        if( status != pdTRUE )
         {
-            IotLogDebug( "Edit network request parameters, index: %d",
-                         wifiProvisioning.deleteNetworkRequest.idx );
-
-            taskStatus = IotTaskPool_CreateRecyclableJob( IOT_SYSTEM_TASKPOOL,
-                                                          _deleteNetworkTask,
-                                                          NULL,
-                                                          &job );
-
-            if( taskStatus == IOT_TASKPOOL_SUCCESS )
-            {
-                taskStatus = IotTaskPool_Schedule( IOT_SYSTEM_TASKPOOL, job, 0 );
-
-                if( taskStatus != IOT_TASKPOOL_SUCCESS )
-                {
-                    IotLogError( "Failed to schedule taskpool job for delete network request" );
-                    IotTaskPool_RecycleJob( IOT_SYSTEM_TASKPOOL, job );
-                    status = false;
-                }
-            }
-            else
-            {
-                IotLogError( "Failed to allocate taskpool job for delete network request" );
-                status = false;
-            }
-        }
-
-        if( status == false )
-        {
-            IotSemaphore_Post( &wifiProvisioning.lock );
+            IotLogError( "Failed to enqueue delete network request, queue is full." );
         }
     }
     else
     {
-        IotLogError( "Failed to process the delete network request. Already a request is being processed" );
-        status = false;
+        IotLogError( "Failed to deserialize delete network request." );
     }
 
     return status;
 }
 
-
-static IotSerializerError_t _serializeNetwork( int32_t responseType,
-                                               IotBleWifiNetworkInfo_t * pNetworkInfo,
-                                               uint8_t * pBuffer,
-                                               size_t * plength )
-{
-    IotSerializerEncoderObject_t container = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t networkMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t value = IOT_SERIALIZER_SCALAR_DATA_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    size_t length = *plength;
-
-    ret = IOT_BLE_MESG_ENCODER.init( &container, pBuffer, length );
-
-    if( ret == IOT_SERIALIZER_SUCCESS )
-    {
-        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &networkMap, IOT_BLE_WIFI_PROV_NUM_NETWORK_INFO_MESG_PARAMS );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = responseType;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = pNetworkInfo->status;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_STATUS_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-        value.value.u.string.pString = ( uint8_t * ) pNetworkInfo->pSSID;
-        value.value.u.string.length = pNetworkInfo->SSIDLength;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_SSID_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
-        value.value.u.string.pString = ( uint8_t * ) pNetworkInfo->pBSSID;
-        value.value.u.string.length = pNetworkInfo->BSSIDLength;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_BSSID_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = pNetworkInfo->security;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_BOOL;
-        value.value.u.booleanValue = pNetworkInfo->hidden;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_HIDDEN_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = pNetworkInfo->RSSI;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_RSSI_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_BOOL;
-        value.value.u.booleanValue = pNetworkInfo->connected;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_CONNECTED_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = pNetworkInfo->savedIdx;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_INDEX_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        ret = IOT_BLE_MESG_ENCODER.closeContainer( &container, &networkMap );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        if( pBuffer == NULL )
-        {
-            *plength = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &container );
-        }
-        else
-        {
-            *plength = IOT_BLE_MESG_ENCODER.getEncodedSize( &container, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &container );
-        ret = IOT_SERIALIZER_SUCCESS;
-    }
-
-    return ret;
-}
-
-static IotSerializerError_t _serializeStatusResponse( int32_t responseType,
-                                                      WIFIReturnCode_t status,
-                                                      uint8_t * pBuffer,
-                                                      size_t * plength )
-{
-    IotSerializerEncoderObject_t container = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-    IotSerializerEncoderObject_t responseMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
-    IotSerializerScalarData_t value = IOT_SERIALIZER_SCALAR_DATA_INITIALIZER;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
-    size_t length = *plength;
-
-    ret = IOT_BLE_MESG_ENCODER.init( &container, pBuffer, length );
-
-    if( ret == IOT_SERIALIZER_SUCCESS )
-    {
-        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &responseMap, IOT_BLE_WIFI_PROV_NUM_STATUS_MESG_PARAMS );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = responseType;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &responseMap, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-        value.value.u.signedInt = status;
-        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &responseMap, IOT_BLE_WIFI_PROV_STATUS_KEY, value );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        ret = IOT_BLE_MESG_ENCODER.closeContainer( &container, &responseMap );
-    }
-
-    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
-    {
-        if( pBuffer == NULL )
-        {
-            *plength = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &container );
-        }
-        else
-        {
-            *plength = IOT_BLE_MESG_ENCODER.getEncodedSize( &container, pBuffer );
-        }
-
-        IOT_BLE_MESG_ENCODER.destroy( &container );
-
-        ret = IOT_SERIALIZER_SUCCESS;
-    }
-
-    return ret;
-}
-
-
 /*-----------------------------------------------------------*/
 
-static void _sendStatusResponse( int32_t responseType,
+static void prvSendStatusResponse( IotBleWiFiProvRequest_t request,
                                  WIFIReturnCode_t status )
 {
     uint8_t * pBuffer = NULL;
     size_t mesgLen = 0;
-    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool ret;
 
-    ret = _serializeStatusResponse( responseType, status, NULL, &mesgLen );
+    ret = IotBleWifiProv_SerializeStatusResponse( request, status, NULL, &mesgLen );
 
-    if( ret == IOT_SERIALIZER_SUCCESS )
+    if( ret == true )
     {
-        IotLogDebug( "Serialized message length %d", mesgLen );
+        IotLogDebug( "Respone for request type %d, serialized message length %d.", request, mesgLen );
         pBuffer = pvPortMalloc( mesgLen );
 
         if( pBuffer != NULL )
         {
-            ret = _serializeStatusResponse( responseType, status, pBuffer, &mesgLen );
+            ret = IotBleWifiProv_SerializeStatusResponse( request, status, pBuffer, &mesgLen );
         }
         else
         {
-            ret = IOT_SERIALIZER_OUT_OF_MEMORY;
+            IotLogError("Failed to allocate message for serializing response for request type %d.", request );
+            ret = false;
         }
     }
 
-    if( ret == IOT_SERIALIZER_SUCCESS )
+    if( ret == true )
     {
         if( IotBleDataTransfer_Send( wifiProvisioning.pChannel, pBuffer, mesgLen ) != mesgLen )
         {
-            IotLogError( "Failed to send status response through ble connection" );
+            IotLogError( "Failed to send response type %d through ble connection.", responseType );
         }
     }
     else
     {
-        IotLogError( "Failed to serialize status response, error = %d\n", ret );
+        IotLogError( "Failed to serialize status response, error = %d.\n", ret );
     }
 
     if( pBuffer != NULL )
@@ -1173,6 +400,91 @@ static void _sendStatusResponse( int32_t responseType,
     }
 }
 
+/*-----------------------------------------------------------*/
+
+static void prvSendListNetworkResponse( IotBleWiFiProvListNetworkResponse_t * pResponse )
+{
+    uint8_t * message = NULL;
+    size_t messageLen = 0;
+    bool status;
+
+
+    status = IotBleWifiProv_SerializeListNetworkResponse( pResponse, NULL, &messageLen );
+
+    if( status == true )
+    {
+        message = pvPortMalloc( messageLen );
+
+        if( message != NULL )
+        {
+            status  = IotBleWifiProv_SerializeListNetworkResponse( pResponse, message, &messageLen );
+        }
+        else
+        {
+            IotLogError("Not enough memory to serialize list network response." );
+            status = false;
+        }
+    }
+    else
+    {
+        IotLogError( "Failed to serialize list network response for SSID:%.*s", pResponse->SSIDLength, ( char * ) pResponse->pSSID );
+    }
+
+
+    if( status == true )
+    {
+        if( IotBleDataTransfer_Send( wifiProvisioning.pChannel, message, messageLen ) != messageLen )
+        {
+            IotLogError( "Failed to send list network response for SSID:%.*s", pResponse->SSIDLength, ( char * ) pResponse->pSSID );
+        }
+    }
+    
+    if( message != NULL )
+    {
+        vPortFree( message );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+
+static void prvSendSavedNetwork( WIFINetworkProfile_t *pNetwork, uint16_t priority )
+{
+
+    IotBleWiFiProvListNetworkResponse_t response = LIST_NETWORK_RESPONSE_DEFAULT;
+
+    response.pSSID = pNetwork->ucSSID;
+    response.SSIDLength = pNetwork->ucSSIDLength;
+    response.pBSSID = pNetwork->ucBSSID;
+    response.BSSIDLength = wificonfigMAX_BSSID_LEN;
+    response.connected = ( wifiProvisioning.connectedIdx == priority );
+    response.security = pNetwork->xSecurity;
+    response.priorityIndex = ( int32_t ) priority;
+
+    prvSendListNetworkResponse( &response );
+
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvSendScanNetwork( WIFIScanResult_t *pNetwork )
+{
+
+    IotBleWiFiProvListNetworkResponse_t response =  LIST_NETWORK_RESPONSE_DEFAULT;
+
+    response.pSSID = pNetwork->ucSSID;
+    response.SSIDLength = pNetwork->ucSSIDLength;
+    response.pBSSID = pNetwork->ucBSSID;
+    response.BSSIDLength = wificonfigMAX_BSSID_LEN;
+    response.RSSI = pNetwork->cRSSI;
+     /**
+     * Scan hidden network is currently not supported for WiFi provisioning over BLE.
+     */
+    response.hidden = false;
+    response.security = pNetwork->xSecurity;
+
+    prvSendListNetworkResponse( &response );
+}
 
 /*-----------------------------------------------------------*/
 
@@ -1220,7 +532,7 @@ WIFIReturnCode_t _popNetwork( uint16_t index,
         }
         else if( index == wifiProvisioning.connectedIdx )
         {
-            wifiProvisioning.connectedIdx = IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX;
+            wifiProvisioning.connectedIdx = IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE;
         }
     }
 
@@ -1357,120 +669,16 @@ WIFIReturnCode_t _insertNetwork( uint16_t index,
     return ret;
 }
 
-static void _sendSavedNetwork( int32_t responseType,
-                               WIFINetworkProfile_t * pSavedNetwork,
-                               uint16_t idx )
-{
-    IotBleWifiNetworkInfo_t networkInfo = NETWORK_INFO_DEFAULT_PARAMS;
-    uint8_t * message = NULL;
-    size_t messageLen = 0;
-    IotSerializerError_t serializerRet;
-
-    networkInfo.pSSID = pSavedNetwork->ucSSID;
-    networkInfo.SSIDLength = pSavedNetwork->ucSSIDLength;
-    networkInfo.pBSSID = pSavedNetwork->ucBSSID;
-    networkInfo.BSSIDLength = wificonfigMAX_BSSID_LEN;
-    networkInfo.connected = ( wifiProvisioning.connectedIdx == idx );
-    networkInfo.security = pSavedNetwork->xSecurity;
-    networkInfo.savedIdx = ( int32_t ) idx;
-
-    serializerRet = _serializeNetwork( responseType, &networkInfo, NULL, &messageLen );
-
-    if( serializerRet == IOT_SERIALIZER_SUCCESS )
-    {
-        message = pvPortMalloc( messageLen );
-
-        if( message != NULL )
-        {
-            serializerRet = _serializeNetwork( responseType, &networkInfo, message, &messageLen );
-        }
-        else
-        {
-            serializerRet = IOT_SERIALIZER_OUT_OF_MEMORY;
-        }
-    }
-
-    if( serializerRet == IOT_SERIALIZER_SUCCESS )
-    {
-        if( IotBleDataTransfer_Send( wifiProvisioning.pChannel, message, messageLen ) != messageLen )
-        {
-            IotLogError( "Failed to send saved network ( SSID:%.*s )", pSavedNetwork->ucSSIDLength, ( char * ) pSavedNetwork->ucSSID );
-        }
-    }
-    else
-    {
-        IotLogError( "Failed to serialize saved network ( SSID:%.*s )", pSavedNetwork->ucSSIDLength, ( char * ) pSavedNetwork->ucSSID );
-    }
-
-    if( message != NULL )
-    {
-        vPortFree( message );
-    }
-}
-
-static void _sendScanNetwork( int32_t responseType,
-                              WIFIScanResult_t * pScanNetwork )
-{
-    IotBleWifiNetworkInfo_t networkInfo = NETWORK_INFO_DEFAULT_PARAMS;
-    uint8_t * message = NULL;
-    size_t messageLen = 0;
-    IotSerializerError_t serializerRet;
-
-    networkInfo.pSSID = pScanNetwork->ucSSID;
-    networkInfo.SSIDLength = pScanNetwork->ucSSIDLength;
-    networkInfo.pBSSID = pScanNetwork->ucBSSID;
-    networkInfo.BSSIDLength = wificonfigMAX_BSSID_LEN;
-    networkInfo.RSSI = pScanNetwork->cRSSI;
-
-    /**
-     * Scan hidden network is currently not supported for WiFi provisioning over BLE.
-     */
-    networkInfo.hidden = false;
-    networkInfo.security = pScanNetwork->xSecurity;
-
-    serializerRet = _serializeNetwork( responseType, &networkInfo, NULL, &messageLen );
-
-    if( serializerRet == IOT_SERIALIZER_SUCCESS )
-    {
-        message = pvPortMalloc( messageLen );
-
-        if( message != NULL )
-        {
-            serializerRet = _serializeNetwork( responseType, &networkInfo, message, &messageLen );
-        }
-        else
-        {
-            serializerRet = IOT_SERIALIZER_OUT_OF_MEMORY;
-        }
-    }
-
-    if( serializerRet == IOT_SERIALIZER_SUCCESS )
-    {
-        if( IotBleDataTransfer_Send( wifiProvisioning.pChannel, message, messageLen ) != messageLen )
-        {
-            IotLogError( "Failed to send scanned network network ( SSID:%.*s )", pScanNetwork->ucSSIDLength, ( const char * ) pScanNetwork->ucSSID );
-        }
-    }
-    else
-    {
-        IotLogError( "Failed to serialize scanned network network ( SSID:%.*s )", pScanNetwork->ucSSIDLength, ( const char * ) pScanNetwork->ucSSID );
-    }
-
-    if( message != NULL )
-    {
-        vPortFree( message );
-    }
-}
 /*-----------------------------------------------------------*/
 
-void _listNetworkTask( IotTaskPool_t taskPool,
-                       IotTaskPoolJob_t job,
-                       void * pUserContext )
+static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t *pRequest )
 {
     WIFINetworkProfile_t profile;
     uint16_t idx;
     WIFIReturnCode_t status;
     uint32_t networks_found = 0;
+
+    ( void ) pRequest->scanTimeoutMS;
 
     for( idx = 0; idx < wifiProvisioning.numNetworks; idx++ )
     {
@@ -1478,122 +686,115 @@ void _listNetworkTask( IotTaskPool_t taskPool,
 
         if( status == eWiFiSuccess )
         {
-            _sendSavedNetwork( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, &profile, idx );
+            prvSendSavedNetwork( &profile, idx );
         }
     }
 
     memset( scanNetworks, 0x00, sizeof( WIFIScanResult_t ) * IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS );
 
-    status = WIFI_Scan( scanNetworks, wifiProvisioning.listNetworkRequest.maxNetworks );
+    status = WIFI_Scan( scanNetworks, pRequest->scanSize );
 
     if( status == eWiFiSuccess )
     {
-        for( idx = 0; idx < wifiProvisioning.listNetworkRequest.maxNetworks; idx++ )
+        for( idx = 0; idx < pRequest->scanSize; idx++ )
         {
             if( scanNetworks[ idx ].ucSSIDLength > 0 )
             {
                 networks_found++;
-                _sendScanNetwork( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, &scanNetworks[ idx ] );
+                prvSendScanNetwork( &scanNetworks[ idx ] );
             }
         }
 
-        if( !networks_found )
+        if( networks_found == 0 )
         {
-            _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, status );
+            prvSendStatusResponse( IotBleWiFiProvRequestListNetwork, status );
         }
     }
     else
     {
-        _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP, status );
+        prvSendStatusResponse( IotBleWiFiProvRequestListNetwork, status );
     }
-
-    IotSemaphore_Post( &wifiProvisioning.lock );
-    IotTaskPool_RecycleJob( taskPool, job );
 }
 
 /*-----------------------------------------------------------*/
 
-static void _addNetworkTask( IotTaskPool_t taskPool,
-                             IotTaskPoolJob_t job,
-                             void * pUserContext )
+static void prvProcessAddNetworkRequest( IotBleWifiProvAddNetworkRequest_t *pRequest )
 {
-    WIFIReturnCode_t ret = eWiFiFailure;
+    WIFIReturnCode_t status = eWiFiFailure;
+    WIFINetworkProfile_t network = { 0 };
+    WIFINetworkParams_t params = { 0 };
 
-    if( wifiProvisioning.addNetworkRequest.savedIdx != IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX )
+    if( pRequest->isProvisioned == true )
     {
-        if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.addNetworkRequest.savedIdx ) )
+        if( IS_INDEX_WITHIN_RANGE( pRequest->prirorityIndex ) )
         {
-            ret = _connectSavedNetwork( wifiProvisioning.addNetworkRequest.savedIdx );
+            status = _connectSavedNetwork( pRequest->prirorityIndex );
         }
     }
     else
     {
         if( wifiProvisioning.numNetworks < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS )
         {
-            ret = _addNewNetwork( &wifiProvisioning.addNetworkRequest.network,
-                                  wifiProvisioning.addNetworkRequest.connect );
+            status = _addNewNetwork( &pRequest->accessPointInfo,
+                                     pRequest->shouldConnect );
         }
         else
         {
             IotLogError( "Failed to add a new network, max networks limit (%d) reached", IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS );
-            ret = eWiFiFailure;
+            status = eWiFiFailure;
         }
     }
 
-    _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_SAVE_NETWORK_RESP, ret );
-    IotSemaphore_Post( &wifiProvisioning.lock );
-    IotTaskPool_RecycleJob( taskPool, job );
+    prvSendStatusResponse( IotBleWiFiProvRequestAddNetwork, status );
 }
-
-
 
 /*-----------------------------------------------------------*/
 
-static void _deleteNetworkTask( IotTaskPool_t taskPool,
-                                IotTaskPoolJob_t job,
-                                void * pUserContext )
+static void prvProcessDeleteNetworkRequest( IotBleWifiProvDeleteNetworkRequest_t * pRequest )
 {
-    WIFIReturnCode_t ret = eWiFiFailure;
+    WIFIReturnCode_t status = eWiFiFailure;
+    uint16_t numNetworks = IotBleWiFiProvPal_GetNumProvisionedNetworks();
 
-    if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.deleteNetworkRequest.idx ) )
+    if( ( pRequest->priorityIndex >= 0 ) && ( pRequest->priorityIndex < numNetworks ) )
     {
-        ret = _popNetwork( wifiProvisioning.deleteNetworkRequest.idx, NULL );
+        status = IotBleWiFiProvPal_PopNetwork( ( ( numNetworks - 1 ) - pRequest->priorityIndex ), NULL );
     }
 
-    if( ret == eWiFiSuccess )
+    if( status == eWiFiSuccess )
     {
-        if( wifiProvisioning.connectedIdx == IOT_BLE_WIFI_PROV_INVALID_NETWORK_INDEX )
+        if( wifiProvisioning.connectedIdx == pRequest->priorityIndex )
         {
             ( void ) WIFI_Disconnect();
+            wifiProvisioning.connectedIdx = IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE;
         }
     }
 
-    _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_RESP, ret );
-
-    IotSemaphore_Post( &wifiProvisioning.lock );
-    IotTaskPool_RecycleJob( taskPool, job );
+    prvSendStatusResponse( IotBleWiFiProvRequestDeleteNetwork, status );
 }
-
-
 
 /*-----------------------------------------------------------*/
 
-static void _editNetworkTask( IotTaskPool_t taskPool,
-                              IotTaskPoolJob_t job,
-                              void * pUserContext )
+static void prvProcessDeleteNetworkRequest( IotBleWifiProvEditNetworkRequest_t * pRequest )
 {
-    WIFIReturnCode_t ret = eWiFiFailure;
+    WIFIReturnCode_t status = eWiFiFailure;
+    uint16_t numNetworks = IotBleWiFiProvPal_GetNumProvisionedNetworks();
 
-
-    if( IS_INDEX_WITHIN_RANGE( wifiProvisioning.editNetworkRequest.curIdx ) &&
-        IS_INDEX_WITHIN_RANGE( wifiProvisioning.editNetworkRequest.newIdx ) )
+    if( ( pRequest->currentPriorityIndex >= 0 ) && ( pRequest->currentPriorityIndex <  numNetworks ) &&
+        ( pRequest->newPriorityIndex >= 0 ) && ( pRequest->newPriorityIndex < numNetworks ) )
     {
-        ret = _moveNetwork( wifiProvisioning.editNetworkRequest.curIdx, wifiProvisioning.editNetworkRequest.newIdx );
+        status = IotBleWiFiProvPal_ChangeNetworkPriority( ( ( numNetworks - 1 ) - pRequest->currentPriorityIndex ),
+                                                          ( ( numNetworks - 1 ) - pRequest->newPriorityIndex ) );
     }
 
-    _sendStatusResponse( IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP, ret );
-    IotSemaphore_Post( &wifiProvisioning.lock );
-    IotTaskPool_RecycleJob( taskPool, job );
+    if( status == eWiFiSuccess )
+    {
+        if( pRequest->currentPriorityIndex = wifiProvisioning.connectedIdx )
+        {
+            wifiProvisioning.connectedIdx = pRequest->newPriorityIndex;
+        }
+    }
+
+    prvSendStatusResponse( IotBleWiFiProvRequestEditNetwork, status );
 }
 
 /*-----------------------------------------------------------*/
@@ -1624,25 +825,90 @@ bool IotBleWifiProv_Init( void )
 {
     bool ret = false;
 
-    ret = IotSemaphore_Create( &wifiProvisioning.lock, 1, 1 );
+    wifiProvisioning.mutex = xSemaphoreCreateMutex();
+    if( wifiProvisioning.mutex == NULL )
+    {
+        IotLogError( "Failed to create mutex for WiFi provisioning task." );
+        ret = false;
+    }
+
+    wifiProvisioning.messageQueue = xQueueCreate( 2U, sizeof( IotBleWifiProvMessage_t ) );
+    if( wifiProvisioning.messageQueue == NULL )
+    {
+        IotLogError( "Failed to create queue for WiFi provisioning task." );
+        ret = false;
+    }
 
     if( ret == true )
     {
         wifiProvisioning.numNetworks = _getNumSavedNetworks();
-
-        wifiProvisioning.pChannel = IotBleDataTransfer_Open( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING );
-
-        if( wifiProvisioning.pChannel != NULL )
-        {
-            ( void ) IotBleDataTransfer_SetCallback( wifiProvisioning.pChannel, _callback, NULL );
-        }
-        else
-        {
-            ret = false;
-        }
     }
 
     return ret;
+}
+
+void IotBleWifiProv_RunProcessLoop( void )
+{
+    IotBleWifiProvMessage_t message = { 0 };
+    bool processLoopStatus = false;
+
+
+    wifiProvisioning.pChannel = IotBleDataTransfer_Open( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING );
+    if( wifiProvisioning.pChannel != NULL )
+    {
+        processLoopStatus = IotBleDataTransfer_SetCallback( wifiProvisioning.pChannel, prvTransportReceiveCallback, NULL );
+    }
+    else
+    {
+        IotLogError( "Failed to open BLE transport channel for WiFi provisioning." );
+        processLoopStatus = false;
+    }
+
+    if( processLoopStatus == true )
+    {
+        for ( ; ; )
+        {
+            memset( &message, 0x00, sizeof( IotBleWifiProvMessage_t ) );
+            ( void ) xQueueReceive( wifiProvisioning.messageQueue, &message, portMAX_DELAY );
+
+            if( message.type = IotBleWiFiProvRequestStop )
+            {
+                xQueueReset( wifiProvisioning.messageQueue );
+                break;
+            }
+            else
+            {
+                xSemaphoreTake( wifiProvisioning.mutex, portMAX_DELAY );
+                switch( message.type )
+                {
+                    case IotBleWiFiProvRequestListNetwork:
+                        prvProcessListNetworkRequest( &message.m.listNetworkRequest );
+                        break;
+                    case IotBleWiFiProvRequestAddNetwork:
+                        prvProcessAddNetworkRequest( &message.m.addNetworkRequest );
+                        break;
+                    case IotBleWiFiProvRequestEditNetwork:
+                        prvProcessEditNetworkRequest( &message.m.editNetworkRequest );
+                        break;
+                    case IotBleWiFiProvRequestDeleteNetwork:
+                        prvProcessDeleteNetworkRequest( &message.m.deleteNetworkRequest );
+                        break;
+                    default:
+                        break;
+                }
+                xSemaphoreGive( wifiProvisioning.mutex );
+            }
+        }
+    }
+
+    if( wifiProvisioning.pChannel != NULL )
+    {
+        IotBleDataTransfer_Close( wifiProvisioning.pChannel );
+        IotBleDataTransfer_Reset( wifiProvisioning.pChannel );
+        wifiProvisioning.pChannel = NULL;
+    }
+
+    return processLoopStatus;
 }
 
 /*--------------------------------------------------------------------------------*/
@@ -1657,6 +923,8 @@ bool IotBleWifiProv_Connect( uint32_t networkIndex )
     WIFIReturnCode_t WifiRet;
     bool ret = false;
 
+    xSemaphoreTake( wifiProvisioning.mutex, portMAX_DELAY );
+
     WifiRet = _connectSavedNetwork( networkIndex );
 
     if( WifiRet == eWiFiSuccess )
@@ -1664,16 +932,17 @@ bool IotBleWifiProv_Connect( uint32_t networkIndex )
         ret = true;
     }
 
+    xSemaphoreGive( wifiProvisioning.mutex );
+
     return ret;
 }
-
 
 bool IotBleWifiProv_EraseAllNetworks( void )
 {
     bool ret = true;
     WIFIReturnCode_t WiFiRet;
 
-    IotSemaphore_Wait( &wifiProvisioning.lock );
+    xSemaphoreTake( wifiProvisioning.mutex, portMAX_DELAY );
 
     while( wifiProvisioning.numNetworks > 0 )
     {
@@ -1687,23 +956,31 @@ bool IotBleWifiProv_EraseAllNetworks( void )
         }
     }
 
-    IotSemaphore_Post( &wifiProvisioning.lock );
+    xSemaphoreGive( wifiProvisioning.mutex );
 
     return ret;
 }
 
 /*-----------------------------------------------------------*/
 
+bool IotBleWifiProv_Stop( void )
+{
+    BaseType_t status;
+    IotBleWifiProvMessage_t message = {
+        .type = IotBleWiFiProvRequestStop
+    };
+
+    status = xQueueSend( wifiProvisioning.messageQueue, &message, pdMS_TO_TICKS( IOT_BLE_WIFI_PROVISIONING_COMMAND_TIMEOUT_MS ) );
+    return ( status == pdTRUE );
+}
+
+/*-----------------------------------------------------------*/
+
 void IotBleWifiProv_Deinit( void )
 {
-    if( wifiProvisioning.pChannel != NULL )
-    {
-        IotBleDataTransfer_Close( wifiProvisioning.pChannel );
-        IotBleDataTransfer_Reset( wifiProvisioning.pChannel );
-    }
-
-    /*Delete service. */
-    IotSemaphore_Destroy( &wifiProvisioning.lock );
+    /*Delete queue and semaphore. */
+    vQueueDelete( wifiProvisioning.messageQueue );
+    vSemaphoreDelete( wifiProvisioning.mutex );
 
     memset( &wifiProvisioning, 0x00, sizeof( IotBleWifiProvService_t ) );
 }

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -40,14 +40,10 @@
 
 /* Configure logs for the functions in this file. */
 #ifdef IOT_LOG_LEVEL_GLOBAL
-    #define LIBRARY_LOG_LEVEL    IOT_LOG_LEVEL_GLOBAL
+    #define LIBRARY_LOG_LEVEL                           IOT_LOG_LEVEL_GLOBAL
 #else
-    #define LIBRARY_LOG_LEVEL    IOT_LOG_NONE
+    #define LIBRARY_LOG_LEVEL                           IOT_LOG_NONE
 #endif
-
-#undef LIBRARY_LOG_LEVEL
-#define LIBRARY_LOG_LEVEL                               IOT_LOG_DEBUG
-
 
 #define LIBRARY_LOG_NAME                                ( "BLE_WIFI_PROV" )
 #include "iot_logging_setup.h"

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -46,13 +46,14 @@
 #endif
 
 #undef LIBRARY_LOG_LEVEL
-#define LIBRARY_LOG_LEVEL    IOT_LOG_DEBUG
+#define LIBRARY_LOG_LEVEL                               IOT_LOG_DEBUG
 
 
-#define LIBRARY_LOG_NAME         ( "BLE_WIFI_PROV" )
+#define LIBRARY_LOG_NAME                                ( "BLE_WIFI_PROV" )
 #include "iot_logging_setup.h"
 
-#define IOT_BLE_WIFI_PROVISIONING_COMMAND_TIMEOUT_MS   ( 5000 )
+#define IOT_BLE_WIFI_PROVISIONING_COMMAND_TIMEOUT_MS    ( 5000 )
+
 /**
  * @brief Macro to check if provided network index for an operation is within range.
  */
@@ -60,7 +61,7 @@
 
 #define STORAGE_INDEX( priority )         ( wifiProvisioning.numNetworks - priority - 1 )
 
-#define INVALID_INDEX                     ( -1 )
+#define INVALID_INDEX    ( -1 )
 
 /*---------------------------------------------------------------------------------------------------------*/
 
@@ -70,13 +71,13 @@
  */
 typedef struct IotBleWifiProvService
 {
-    TaskHandle_t taskHandle;                 /**< Handle for the task used for WiFi provisioing. */
-    IotBleDataTransferChannel_t * pChannel;  /**< A pointer to the ble connection object. */
-    uint16_t numNetworks;                    /**< Keeps track of total number of networks stored. */
-    int16_t connectedIdx;                    /**< Keeps track of the flash index of the network that is connected. */
-    QueueHandle_t messageQueue;              /**< Message queue use by the provisioning task to process incoming requests. */
-    SemaphoreHandle_t mutex;                 /**< Mutex used to synchronize between application task the provsioning task .*/
-    IotBleWifiProvSerializer_t *pSerializer; /**< Serializer interface used to pack/unpack messages over BLE. */
+    TaskHandle_t taskHandle;                  /**< Handle for the task used for WiFi provisioing. */
+    IotBleDataTransferChannel_t * pChannel;   /**< A pointer to the ble connection object. */
+    uint16_t numNetworks;                     /**< Keeps track of total number of networks stored. */
+    int16_t connectedIdx;                     /**< Keeps track of the flash index of the network that is connected. */
+    QueueHandle_t messageQueue;               /**< Message queue use by the provisioning task to process incoming requests. */
+    SemaphoreHandle_t mutex;                  /**< Mutex used to synchronize between application task the provsioning task .*/
+    IotBleWifiProvSerializer_t * pSerializer; /**< Serializer interface used to pack/unpack messages over BLE. */
 } IotBleWifiProvService_t;
 
 /**
@@ -87,12 +88,11 @@ typedef struct
     IotBleWiFiProvRequest_t type;
     union
     {
-        IotBleWifiProvListNetworksRequest_t  listNetworkRequest;
-        IotBleWifiProvAddNetworkRequest_t    addNetworkRequest;
-        IotBleWifiProvEditNetworkRequest_t   editNetworkRequest;
+        IotBleWifiProvListNetworksRequest_t listNetworkRequest;
+        IotBleWifiProvAddNetworkRequest_t addNetworkRequest;
+        IotBleWifiProvEditNetworkRequest_t editNetworkRequest;
         IotBleWifiProvDeleteNetworkRequest_t deleteNetworkRequest;
     } m;
-
 } IotBleWifiProvMessage_t;
 
 static IotBleWifiProvService_t wifiProvisioning = { 0 };
@@ -101,42 +101,44 @@ static IotBleWifiProvService_t wifiProvisioning = { 0 };
 
 
 static WIFIScanResult_t scanNetworks[ IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ] = { 0 };
+
 /*
  * @brief Callback registered for BLE write and read events received for each characteristic.
  */
 static void prvTransportReceiveCallback( IotBleDataTransferChannelEvent_t event,
-                       IotBleDataTransferChannel_t * pChannel,
-                       void * pContext );
+                                         IotBleDataTransferChannel_t * pChannel,
+                                         void * pContext );
 
 /*
  * @brief Parses List Network request params and creates task to list networks.
  */
 static BaseType_t prvHandleListNetworkRequest( const uint8_t * pData,
-                                       size_t length );
+                                               size_t length );
 
 /*
  * @brief Parses Save Network request params and creates task to save the new network.
  */
 
 static BaseType_t prvHandleAddNetworkRequest( const uint8_t * pData,
-                                       size_t length );
+                                              size_t length );
 
 /*
  * @brief Parses Edit Network request params and creates task to edit network priority.
  */
 static BaseType_t prvHandleEditNetworkRequest( const uint8_t * pData,
-                                       size_t length );
+                                               size_t length );
+
 /*
  * @brief Parses Delete Network request params and creates task to delete a WiFi networ.
  */
 static BaseType_t prvHandleDeleteNetworkRequest( const uint8_t * pData,
-                                         size_t length );
+                                                 size_t length );
 
 /*
  * @brief Sends a status response for the request.
  */
 static void prvSendStatusResponse( IotBleWiFiProvRequest_t responseType,
-                                 WIFIReturnCode_t status );
+                                   WIFIReturnCode_t status );
 
 WIFIReturnCode_t _appendNetwork( WIFINetworkProfile_t * pProfile );
 
@@ -158,6 +160,7 @@ WIFIReturnCode_t _connectSavedNetwork( uint16_t index );
 
 WIFIReturnCode_t _addNewNetwork( WIFINetworkProfile_t * pProfile,
                                  bool connect );
+
 /*
  * @brief Gets the number of saved networks from flash.
  */
@@ -166,8 +169,8 @@ static uint32_t _getNumSavedNetworks( void );
 /*-----------------------------------------------------------*/
 
 static void prvTransportReceiveCallback( IotBleDataTransferChannelEvent_t event,
-                       IotBleDataTransferChannel_t * pChannel,
-                       void * pContext )
+                                         IotBleDataTransferChannel_t * pChannel,
+                                         void * pContext )
 {
     IotBleWiFiProvRequest_t request;
     const uint8_t * pBuffer;
@@ -180,7 +183,7 @@ static void prvTransportReceiveCallback( IotBleDataTransferChannelEvent_t event,
 
         if( wifiProvisioning.pSerializer->getRequestType( pBuffer, length, &request ) == true )
         {
-            configPRINTF(( "Received message type: %d, length %d.\r\n", request, length ));
+            configPRINTF( ( "Received message type: %d, length %d.\r\n", request, length ) );
 
             switch( request )
             {
@@ -222,14 +225,23 @@ static BaseType_t prvHandleListNetworkRequest( const uint8_t * pData,
     message.type = IotBleWiFiProvRequestListNetwork;
 
     status = wifiProvisioning.pSerializer->deserializeListNetworkRequest( pData, length, &message.m.listNetworkRequest );
-    
+
     if( status == pdTRUE )
     {
-        IotLogDebug( "List network request parameters: max networks = %d, timeout = %d",
-                      message.m.listNetworkRequest.scanSize,
-                      message.m.listNetworkRequest.scanTimeoutMS );
+        if( ( message.m.listNetworkRequest.scanSize <= 0 ) || ( message.m.listNetworkRequest.scanSize > IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ) )
+        {
+            IotLogInfo( "Networks %d exceeds configured value, truncating to  %d max network\n",
+                        ( uint16_t ) message.m.listNetworkRequest.scanSize,
+                        IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS );
+            message.m.listNetworkRequest.scanSize = IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS;
+        }
 
-        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        IotLogDebug( "List network request parameters: max networks = %d, timeout = %d",
+                     message.m.listNetworkRequest.scanSize,
+                     message.m.listNetworkRequest.scanTimeoutMS );
+
+        status = xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+
         if( status != pdTRUE )
         {
             IotLogError( "Failed to enqueue list network request, queue is full." );
@@ -247,7 +259,7 @@ static BaseType_t prvHandleListNetworkRequest( const uint8_t * pData,
 
 
 static BaseType_t prvHandleAddNetworkRequest( const uint8_t * pData,
-                                               size_t length )
+                                              size_t length )
 {
     BaseType_t status;
     IotBleWifiProvMessage_t message = { 0 };
@@ -255,17 +267,18 @@ static BaseType_t prvHandleAddNetworkRequest( const uint8_t * pData,
     message.type = IotBleWiFiProvRequestAddNetwork;
 
     status = wifiProvisioning.pSerializer->deserializeAddNetworkRequest( pData, length, &message.m.addNetworkRequest );
-    
+
     if( status == pdTRUE )
     {
         IotLogDebug( "Add network request parameters, SSID: %.*s, isProvisioned: %d, index: %d, connect: %d",
-                         message.m.addNetworkRequest.info.network.ucSSIDLength,
-                         ( char * ) message.m.addNetworkRequest.info.network.ucSSID,
-                         message.m.addNetworkRequest.isProvisioned,
-                         message.m.addNetworkRequest.info.index,
-                         message.m.addNetworkRequest.shouldConnect );
+                     message.m.addNetworkRequest.info.network.ucSSIDLength,
+                     ( char * ) message.m.addNetworkRequest.info.network.ucSSID,
+                     message.m.addNetworkRequest.isProvisioned,
+                     message.m.addNetworkRequest.info.index,
+                     message.m.addNetworkRequest.shouldConnect );
 
-        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        status = xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+
         if( status != pdTRUE )
         {
             IotLogError( "Failed to enqueue add network request, queue is full." );
@@ -290,15 +303,15 @@ static BaseType_t prvHandleEditNetworkRequest( const uint8_t * pData,
     message.type = IotBleWiFiProvRequestEditNetwork;
 
     status = wifiProvisioning.pSerializer->deserializeEditNetworkRequest( pData, length, &message.m.editNetworkRequest );
-    
+
     if( status == pdTRUE )
     {
-
         IotLogDebug( "Edit network request parameters, Current index: %d, new index: %d",
-                         message.m.editNetworkRequest.currentPriorityIndex,
-                         message.m.editNetworkRequest.newPriorityIndex );
+                     message.m.editNetworkRequest.currentPriorityIndex,
+                     message.m.editNetworkRequest.newPriorityIndex );
 
-        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+        status = xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
+
         if( status != pdTRUE )
         {
             IotLogError( "Failed to enqueue edit network request, queue is full." );
@@ -315,7 +328,7 @@ static BaseType_t prvHandleEditNetworkRequest( const uint8_t * pData,
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvHandleDeleteNetworkRequest( const uint8_t * pData,
-                                               size_t length )
+                                                 size_t length )
 {
     BaseType_t status;
     IotBleWifiProvMessage_t message = { 0 };
@@ -323,14 +336,14 @@ static BaseType_t prvHandleDeleteNetworkRequest( const uint8_t * pData,
     message.type = IotBleWiFiProvRequestDeleteNetwork;
 
     status = wifiProvisioning.pSerializer->deserializeDeleteNetworkRequest( pData, length, &message.m.deleteNetworkRequest );
-    
+
     if( status == pdTRUE )
     {
+        IotLogDebug( "Delete network request parameters, index: %d",
+                     message.m.deleteNetworkRequest.priorityIndex );
 
-         IotLogDebug( "Delete network request parameters, index: %d",
-                         message.m.deleteNetworkRequest.priorityIndex );
+        status = xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
 
-        status =  xQueueSend( wifiProvisioning.messageQueue, &message, 0 );
         if( status != pdTRUE )
         {
             IotLogError( "Failed to enqueue delete network request, queue is full." );
@@ -359,14 +372,16 @@ static void prvSendStatusResponse( IotBleWiFiProvRequest_t request,
     response.statusOnly = true;
 
     ret = wifiProvisioning.pSerializer->getSerializedSizeForResponse( &response, &mesgLen );
+
     if( ret == true )
     {
         IotLogDebug( "Respone for request type %d, serialized message length %d.", request, mesgLen );
-    
+
         pBuffer = pvPortMalloc( mesgLen );
+
         if( pBuffer == NULL )
         {
-            IotLogError("Failed to allocate message for serializing response for request type %d.", request );
+            IotLogError( "Failed to allocate message for serializing response for request type %d.", request );
             ret = false;
         }
     }
@@ -378,9 +393,10 @@ static void prvSendStatusResponse( IotBleWiFiProvRequest_t request,
     if( ret == true )
     {
         ret = wifiProvisioning.pSerializer->serializeResponse( &response, pBuffer, mesgLen );
+
         if( ret == false )
         {
-             IotLogError( "Failed to serialize status response." );
+            IotLogError( "Failed to serialize status response." );
         }
     }
 
@@ -391,7 +407,6 @@ static void prvSendStatusResponse( IotBleWiFiProvRequest_t request,
             IotLogError( "Failed to send response for request type %d through ble connection.", request );
         }
     }
-    
 
     if( pBuffer != NULL )
     {
@@ -415,7 +430,7 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
 
         if( message != NULL )
         {
-            status  = wifiProvisioning.pSerializer->serializeResponse( pResponse, message, messageLen );
+            status = wifiProvisioning.pSerializer->serializeResponse( pResponse, message, messageLen );
         }
         else
         {
@@ -428,7 +443,6 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
         IotLogError( "Failed to serialize list network response." );
     }
 
-
     if( status == true )
     {
         if( IotBleDataTransfer_Send( wifiProvisioning.pChannel, message, messageLen ) != messageLen )
@@ -436,7 +450,7 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
             IotLogError( "Failed to send list network response over BLE." );
         }
     }
-    
+
     if( message != NULL )
     {
         vPortFree( message );
@@ -446,10 +460,10 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
 /*-----------------------------------------------------------*/
 
 
-static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork, uint16_t priority )
+static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork,
+                                 uint16_t priority )
 {
-
-    IotBleWifiProvResponse_t response =  { 0 };
+    IotBleWifiProvResponse_t response = { 0 };
 
     response.requestType = IotBleWiFiProvRequestListNetwork;
     response.networkInfo.isSavedNetwork = true;
@@ -459,15 +473,13 @@ static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork, uint16_t prior
     response.networkInfo.index = priority;
 
     prvSendListNetworkResponse( &response );
-
 }
 
 /*-----------------------------------------------------------*/
 
 static void prvSendScanNetwork( WIFIScanResult_t * pNetwork )
 {
-
-    IotBleWifiProvResponse_t response =  { 0 };
+    IotBleWifiProvResponse_t response = { 0 };
 
     response.requestType = IotBleWiFiProvRequestListNetwork;
     response.networkInfo.isSavedNetwork = false;
@@ -663,7 +675,7 @@ WIFIReturnCode_t _insertNetwork( uint16_t index,
 
 /*-----------------------------------------------------------*/
 
-static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t *pRequest )
+static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * pRequest )
 {
     WIFINetworkProfile_t profile;
     uint16_t idx;
@@ -727,11 +739,12 @@ static void prvProcessAddNetworkRequest( IotBleWifiProvAddNetworkRequest_t * pRe
         {
             status = _addNewNetwork( &pRequest->info.network,
                                      pRequest->shouldConnect );
+
             if( status != eWiFiSuccess )
             {
                 IotLogError( "Failed to provision new network with SSID: %.*s, password: %.*s",
                              pRequest->info.network.ucSSIDLength,
-                             ( char * )  pRequest->info.network.ucSSID,
+                             ( char * ) pRequest->info.network.ucSSID,
                              pRequest->info.network.ucPasswordLength,
                              pRequest->info.network.cPassword );
             }
@@ -755,7 +768,6 @@ static void prvProcessDeleteNetworkRequest( IotBleWifiProvDeleteNetworkRequest_t
     if( IS_INDEX_WITHIN_RANGE( pRequest->priorityIndex ) )
     {
         status = _popNetwork( pRequest->priorityIndex, NULL );
-
     }
 
     if( status == eWiFiSuccess )
@@ -813,6 +825,7 @@ bool IotBleWifiProv_Init( void )
     bool ret = true;
 
     wifiProvisioning.mutex = xSemaphoreCreateMutex();
+
     if( wifiProvisioning.mutex == NULL )
     {
         IotLogError( "Failed to create mutex for WiFi provisioning task." );
@@ -822,6 +835,7 @@ bool IotBleWifiProv_Init( void )
     if( ret == true )
     {
         wifiProvisioning.messageQueue = xQueueCreate( 2U, sizeof( IotBleWifiProvMessage_t ) );
+
         if( wifiProvisioning.messageQueue == NULL )
         {
             IotLogError( "Failed to create queue for WiFi provisioning task." );
@@ -832,6 +846,7 @@ bool IotBleWifiProv_Init( void )
     if( ret == true )
     {
         wifiProvisioning.pSerializer = IotBleWifiProv_GetSerializer();
+
         if( wifiProvisioning.pSerializer == NULL )
         {
             ret = false;
@@ -852,9 +867,10 @@ bool IotBleWifiProv_RunProcessLoop( void )
     IotBleWifiProvMessage_t message = { 0 };
     bool processLoopStatus = false;
 
-    configPRINTF(( "Entering provisonining loop function.\r\n" ));
+    configPRINTF( ( "Entering provisonining loop function.\r\n" ) );
 
     wifiProvisioning.pChannel = IotBleDataTransfer_Open( IOT_BLE_DATA_TRANSFER_SERVICE_TYPE_WIFI_PROVISIONING );
+
     if( wifiProvisioning.pChannel != NULL )
     {
         processLoopStatus = IotBleDataTransfer_SetCallback( wifiProvisioning.pChannel, prvTransportReceiveCallback, NULL );
@@ -867,46 +883,52 @@ bool IotBleWifiProv_RunProcessLoop( void )
 
     if( processLoopStatus == true )
     {
-        configPRINTF(( "Entering loop.\r\n" ));
+        configPRINTF( ( "Entering loop.\r\n" ) );
 
-        for ( ; ; )
+        for( ; ; )
         {
             memset( &message, 0x00, sizeof( IotBleWifiProvMessage_t ) );
             ( void ) xQueueReceive( wifiProvisioning.messageQueue, &message, portMAX_DELAY );
 
             if( message.type == IotBleWiFiProvRequestStop )
             {
-                configPRINTF(( "Received stop.\r\n" ));
+                configPRINTF( ( "Received stop.\r\n" ) );
                 xQueueReset( wifiProvisioning.messageQueue );
                 break;
             }
             else
             {
-                configPRINTF(( "Received message.\r\n" ));
+                configPRINTF( ( "Received message.\r\n" ) );
                 xSemaphoreTake( wifiProvisioning.mutex, portMAX_DELAY );
+
                 switch( message.type )
                 {
                     case IotBleWiFiProvRequestListNetwork:
                         prvProcessListNetworkRequest( &message.m.listNetworkRequest );
                         break;
+
                     case IotBleWiFiProvRequestAddNetwork:
                         prvProcessAddNetworkRequest( &message.m.addNetworkRequest );
                         break;
+
                     case IotBleWiFiProvRequestEditNetwork:
                         prvProcessEditNetworkRequest( &message.m.editNetworkRequest );
                         break;
+
                     case IotBleWiFiProvRequestDeleteNetwork:
                         prvProcessDeleteNetworkRequest( &message.m.deleteNetworkRequest );
                         break;
+
                     default:
                         break;
                 }
+
                 xSemaphoreGive( wifiProvisioning.mutex );
             }
         }
     }
 
-    configPRINTF(( "Exit loop.\r\n" ));
+    configPRINTF( ( "Exit loop.\r\n" ) );
 
     if( wifiProvisioning.pChannel != NULL )
     {
@@ -973,12 +995,13 @@ bool IotBleWifiProv_EraseAllNetworks( void )
 bool IotBleWifiProv_Stop( void )
 {
     BaseType_t status;
-    IotBleWifiProvMessage_t message = {
+    IotBleWifiProvMessage_t message =
+    {
         .type = IotBleWiFiProvRequestStop
     };
 
     status = xQueueSend( wifiProvisioning.messageQueue, &message, pdMS_TO_TICKS( IOT_BLE_WIFI_PROVISIONING_COMMAND_TIMEOUT_MS ) );
-    return ( status == pdTRUE );
+    return( status == pdTRUE );
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
@@ -45,7 +45,7 @@
 
 /**
  * @defgroup
- * @brief Serialized values for the message types exchanged between wifi 
+ * @brief Serialized values for the message types exchanged between wifi
  */
 /** @{ */
 #define IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ       ( 1 )
@@ -62,23 +62,23 @@
  * @brief Strings representing the keys for the key-value pairs serialized
  * as part of request and response messages.
  */
-#define IOT_BLE_WIFI_PROV_MSG_TYPE_KEY        "w"
-#define IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY    "h"
-#define IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY    "t"
-#define IOT_BLE_WIFI_PROV_KEY_MGMT_KEY        "q"
-#define IOT_BLE_WIFI_PROV_SSID_KEY            "r"
-#define IOT_BLE_WIFI_PROV_BSSID_KEY           "b"
-#define IOT_BLE_WIFI_PROV_RSSI_KEY            "p"
-#define IOT_BLE_WIFI_PROV_PSK_KEY             "m"
-#define IOT_BLE_WIFI_PROV_STATUS_KEY          "s"
-#define IOT_BLE_WIFI_PROV_HIDDEN_KEY          "f"
-#define IOT_BLE_WIFI_PROV_CONNECTED_KEY       "e"
-#define IOT_BLE_WIFI_PROV_INDEX_KEY           "g"
-#define IOT_BLE_WIFI_PROV_NEWINDEX_KEY        "j"
-#define IOT_BLE_WIFI_PROV_CONNECT_KEY         "y"
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_KEY         "w"
+#define IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY     "h"
+#define IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY     "t"
+#define IOT_BLE_WIFI_PROV_KEY_MGMT_KEY         "q"
+#define IOT_BLE_WIFI_PROV_SSID_KEY             "r"
+#define IOT_BLE_WIFI_PROV_BSSID_KEY            "b"
+#define IOT_BLE_WIFI_PROV_RSSI_KEY             "p"
+#define IOT_BLE_WIFI_PROV_PSK_KEY              "m"
+#define IOT_BLE_WIFI_PROV_STATUS_KEY           "s"
+#define IOT_BLE_WIFI_PROV_HIDDEN_KEY           "f"
+#define IOT_BLE_WIFI_PROV_CONNECTED_KEY        "e"
+#define IOT_BLE_WIFI_PROV_INDEX_KEY            "g"
+#define IOT_BLE_WIFI_PROV_NEWINDEX_KEY         "j"
+#define IOT_BLE_WIFI_PROV_CONNECT_KEY          "y"
 
 /**
- * @brief Defines the serialized values for WiFi security types. 
+ * @brief Defines the serialized values for WiFi security types.
  */
 #define IOT_BLE_WIFI_SECURITY_TYPE_OPEN        ( 0UL )
 #define IOT_BLE_WIFI_SECURITY_TYPE_WEP         ( 1UL )
@@ -92,63 +92,68 @@
  * @cond DOXYGEN_IGNORE
  * @brief The network index which app use to signify as to not to use.
  */
-#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_INVALID    ( -1 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_INVALID               ( -1 )
 
 /**
  * @brief Number of parameters in a list network response.
  * This defines the  size of the CBOR map used to serialize the list network response messages.
  */
-#define IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS        ( 9 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS    ( 9 )
 
 /**
  * @brief Number of parameters in status response message.
  * This defines the size of the CBOR map used to serialize the list network response messages.
  */
-#define IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS          ( 2 )
+#define IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS              ( 2 )
 
 /**
- * @brief Macro defines the default behavior whether to connect to an access point along with 
+ * @brief Macro defines the default behavior whether to connect to an access point along with
  * provisioning or not. Default value can be overriden by the provisioning app by specifying connect flag
  * in add access point request message.
  */
-#define IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT          ( true )
+#define IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT              ( true )
 
 
 /**
  * @cond DOXYGEN_IGNORE
  * @brief The network rssi value which is used to indicate the app as not to use.
  */
-#define IOT_BLE_WIFI_PROV_RSSI_DONT_USE     (    -100 )
+#define IOT_BLE_WIFI_PROV_RSSI_DONT_USE             ( -100 )
 
 /**
  * @cond DOXYGEN_IGNORE
  * @brief Priority index value which is used to indicate the app as not to use.
  */
-#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE     ( -1 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE    ( -1 )
 
 
-#define SERIALIZER_STATUS( status, pBuffer )                      \
-    ( ( status == CborNoError ) ||                              \
+#define SERIALIZER_STATUS( status, pBuffer ) \
+    ( ( status == CborNoError ) ||           \
       ( ( !pBuffer ) && ( status == CborErrorOutOfMemory ) ) )
 
 static IotBleWiFiProvRequest_t prvToRequestType( int64_t value )
 
 {
     IotBleWiFiProvRequest_t ret = IotBleWiFiProvRequestInvalid;
+
     switch( value )
     {
         case IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ:
-            ret =  IotBleWiFiProvRequestListNetwork;
+            ret = IotBleWiFiProvRequestListNetwork;
             break;
+
         case IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_REQ:
-            ret =  IotBleWiFiProvRequestAddNetwork;
+            ret = IotBleWiFiProvRequestAddNetwork;
             break;
+
         case IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_REQ:
-            ret =  IotBleWiFiProvRequestEditNetwork;
+            ret = IotBleWiFiProvRequestEditNetwork;
             break;
+
         case IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_REQ:
-            ret =  IotBleWiFiProvRequestDeleteNetwork;
+            ret = IotBleWiFiProvRequestDeleteNetwork;
             break;
+
         default:
             break;
     }
@@ -156,58 +161,65 @@ static IotBleWiFiProvRequest_t prvToRequestType( int64_t value )
     return ret;
 }
 
-static bool prvToWiFiSecurityType( int64_t value, WIFISecurity_t *pResult )
+static bool prvToWiFiSecurityType( int64_t value,
+                                   WIFISecurity_t * pResult )
 {
     bool status = true;
+
     switch( value )
     {
-         case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
-            ( * pResult ) = eWiFiSecurityOpen;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
+            ( *pResult ) = eWiFiSecurityOpen;
+            break;
 
-                    case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
-                        ( * pResult ) = eWiFiSecurityWEP;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
+            ( *pResult ) = eWiFiSecurityWEP;
+            break;
 
-                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
-                        ( * pResult ) = eWiFiSecurityWPA;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
+            ( *pResult ) = eWiFiSecurityWPA;
+            break;
 
-                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
-                        ( * pResult ) = eWiFiSecurityWPA2;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
+            ( *pResult ) = eWiFiSecurityWPA2;
+            break;
 
-                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
-                        ( * pResult ) = eWiFiSecurityWPA2;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
+            ( *pResult ) = eWiFiSecurityWPA2;
+            break;
 
-                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
-                        ( * pResult ) = eWiFiSecurityWPA2;
-                        break;
+        case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
+            ( *pResult ) = eWiFiSecurityWPA2;
+            break;
 
-                    default:
-                        status = false;
-                        break;
-                }
+        default:
+            status = false;
+            break;
+    }
+
     return status;
 }
 
-static CborError prvGetOrDefaultBooleanValueFromMap( CborValue * pMap, const char * key, bool * pResult, bool defaultValue )
+static CborError prvGetOrDefaultBooleanValueFromMap( CborValue * pMap,
+                                                     const char * key,
+                                                     bool * pResult,
+                                                     bool defaultValue )
 {
     CborError status;
     CborValue value;
 
     status = cbor_value_map_find_value( pMap, key, &value );
+
     if( status == CborNoError )
     {
-        if( cbor_value_is_boolean( &value) )
+        if( cbor_value_is_boolean( &value ) )
         {
             status = cbor_value_get_boolean( &value, pResult );
         }
         else if( cbor_value_get_type( &value ) == CborInvalidType )
         {
             /* Element not found. Return default value. */
-            ( * pResult ) = defaultValue;
+            ( *pResult ) = defaultValue;
         }
         else
         {
@@ -218,15 +230,18 @@ static CborError prvGetOrDefaultBooleanValueFromMap( CborValue * pMap, const cha
     return status;
 }
 
-static CborError prvGetIntegerValueFromMap( CborValue * pMap, const char * key, int64_t * pValue )
+static CborError prvGetIntegerValueFromMap( CborValue * pMap,
+                                            const char * key,
+                                            int64_t * pValue )
 {
     CborError status;
     CborValue value;
 
     status = cbor_value_map_find_value( pMap, key, &value );
+
     if( status == CborNoError )
     {
-        if( cbor_value_is_integer( &value) )
+        if( cbor_value_is_integer( &value ) )
         {
             status = cbor_value_get_int64( &value, pValue );
         }
@@ -239,16 +254,20 @@ static CborError prvGetIntegerValueFromMap( CborValue * pMap, const char * key, 
     return status;
 }
 
-static CborError prvGetTextStringValueFromMap( CborValue * pMap, const char * key, char * pBuffer, size_t * bufLength )
+static CborError prvGetTextStringValueFromMap( CborValue * pMap,
+                                               const char * key,
+                                               char * pBuffer,
+                                               size_t * bufLength )
 {
     CborError status;
     size_t length;
     CborValue value;
 
     status = cbor_value_map_find_value( pMap, key, &value );
+
     if( status == CborNoError )
     {
-         if( cbor_value_is_text_string( &value ) )
+        if( cbor_value_is_text_string( &value ) )
         {
             if( cbor_value_is_length_known( &value ) )
             {
@@ -263,7 +282,7 @@ static CborError prvGetTextStringValueFromMap( CborValue * pMap, const char * ke
         {
             status = CborErrorImproperValue;
         }
-        
+
         if( status == CborNoError )
         {
             if( length <= *bufLength )
@@ -280,16 +299,20 @@ static CborError prvGetTextStringValueFromMap( CborValue * pMap, const char * ke
     return status;
 }
 
-static CborError prvGetByteStringValueFromMap( CborValue * pMap, const char * key, uint8_t * pBuffer, size_t * bufLength )
+static CborError prvGetByteStringValueFromMap( CborValue * pMap,
+                                               const char * key,
+                                               uint8_t * pBuffer,
+                                               size_t * bufLength )
 {
     CborError status;
     size_t length;
     CborValue value;
 
     status = cbor_value_map_find_value( pMap, key, &value );
+
     if( status == CborNoError )
     {
-         if( cbor_value_is_byte_string( &value ) )
+        if( cbor_value_is_byte_string( &value ) )
         {
             if( cbor_value_is_length_known( &value ) )
             {
@@ -304,10 +327,10 @@ static CborError prvGetByteStringValueFromMap( CborValue * pMap, const char * ke
         {
             status = CborErrorImproperValue;
         }
-        
+
         if( status == CborNoError )
         {
-            if( length <= ( * bufLength ) )
+            if( length <= ( *bufLength ) )
             {
                 status = cbor_value_copy_byte_string( &value, pBuffer, bufLength, NULL );
             }
@@ -323,10 +346,9 @@ static CborError prvGetByteStringValueFromMap( CborValue * pMap, const char * ke
 
 
 static bool IotBleWiFiProv_GetRequestTypeCbor( const uint8_t * pMessage,
-                                              size_t length,
-                                              IotBleWiFiProvRequest_t * pRequestType )
+                                               size_t length,
+                                               IotBleWiFiProvRequest_t * pRequestType )
 {
-
     CborParser parser = { 0 };
     CborValue map = { 0 };
     CborError status = CborNoError;
@@ -334,7 +356,7 @@ static bool IotBleWiFiProv_GetRequestTypeCbor( const uint8_t * pMessage,
     bool result = true;
 
     status = cbor_parser_init( pMessage, length, 0, &parser, &map );
-    
+
     if( status == CborNoError )
     {
         if( !cbor_value_is_map( &map ) )
@@ -346,20 +368,21 @@ static bool IotBleWiFiProv_GetRequestTypeCbor( const uint8_t * pMessage,
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, &requestValue );
+
         if( status == CborNoError )
         {
-            ( * pRequestType ) = prvToRequestType( requestValue );
+            ( *pRequestType ) = prvToRequestType( requestValue );
         }
     }
-    
+
     IotLogInfo( "Decode cbor request message, status = %d", status );
 
     return result;
 }
 
 static bool IotBleWiFiProv_DeserializeListNetworkRequestCbor( const uint8_t * pMessage,
-                                                          size_t length,
-                                                          IotBleWifiProvListNetworksRequest_t * pListNetworksRequest )
+                                                              size_t length,
+                                                              IotBleWifiProvListNetworksRequest_t * pListNetworksRequest )
 {
     CborParser parser = { 0 };
     CborValue map = { 0 };
@@ -380,15 +403,17 @@ static bool IotBleWiFiProv_DeserializeListNetworkRequestCbor( const uint8_t * pM
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY, &val );
+
         if( status == CborNoError )
         {
             pListNetworksRequest->scanSize = ( int16_t ) val;
         }
     }
 
-    if( status == CborNoError  )
+    if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY, &val );
+
         if( status == CborNoError )
         {
             pListNetworksRequest->scanTimeoutMS = ( int16_t ) val;
@@ -397,16 +422,15 @@ static bool IotBleWiFiProv_DeserializeListNetworkRequestCbor( const uint8_t * pM
 
     IotLogInfo( "Decode list network cbor message, status = %d", status );
 
-    return ( status == CborNoError );
+    return( status == CborNoError );
 }
 
 /*-----------------------------------------------------------*/
 
 static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMessage,
-                                                         size_t length,
-                                                         IotBleWifiProvAddNetworkRequest_t * pAddNetworkReq )
+                                                             size_t length,
+                                                             IotBleWifiProvAddNetworkRequest_t * pAddNetworkReq )
 {
-
     CborParser parser = { 0 };
     CborValue map = { 0 };
     CborError status = CborNoError;
@@ -416,17 +440,18 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
     status = cbor_parser_init( pMessage, length, 0, &parser, &map );
     memset( pAddNetworkReq, 0x00, sizeof( IotBleWifiProvAddNetworkRequest_t ) );
 
-     if( status == CborNoError )
-     {
-         if( !cbor_value_is_map( &map ) )
-         {
-             status = CborErrorImproperValue;
-         }
-     } 
+    if( status == CborNoError )
+    {
+        if( !cbor_value_is_map( &map ) )
+        {
+            status = CborErrorImproperValue;
+        }
+    }
 
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_INDEX_KEY, &val );
+
         if( status == CborNoError )
         {
             if( val != IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE )
@@ -447,6 +472,7 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
         {
             length = sizeof( pAddNetworkReq->info.network.ucSSID );
             status = prvGetTextStringValueFromMap( &map, IOT_BLE_WIFI_PROV_SSID_KEY, ( char * ) pAddNetworkReq->info.network.ucSSID, &length );
+
             if( status == CborNoError )
             {
                 pAddNetworkReq->info.network.ucSSIDLength = length;
@@ -456,7 +482,7 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
                 if( status == CborErrorOutOfMemory )
                 {
                     IotLogError( "SSID exceeds allowable length %d",
-                                sizeof( pAddNetworkReq->info.network.ucSSID ) );
+                                 sizeof( pAddNetworkReq->info.network.ucSSID ) );
                 }
             }
         }
@@ -464,14 +490,17 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
         if( status == CborNoError )
         {
             status = prvGetByteStringValueFromMap( &map, IOT_BLE_WIFI_PROV_BSSID_KEY, pAddNetworkReq->info.network.ucBSSID, &length );
+
             if( length != sizeof( pAddNetworkReq->info.network.ucBSSID ) )
             {
                 status = CborErrorImproperValue;
             }
         }
+
         if( status == CborNoError )
         {
             status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, &val );
+
             if( prvToWiFiSecurityType( val, &pAddNetworkReq->info.network.xSecurity ) == false )
             {
                 status = CborErrorImproperValue;
@@ -482,15 +511,18 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
         {
             length = sizeof( pAddNetworkReq->info.network.cPassword );
             status = prvGetTextStringValueFromMap( &map, IOT_BLE_WIFI_PROV_PSK_KEY, ( char * ) pAddNetworkReq->info.network.cPassword, &length );
+
             if( status == CborNoError )
             {
                 pAddNetworkReq->info.network.ucPasswordLength = length;
             }
         }
     }
+
     if( status == CborNoError )
     {
-        status = prvGetOrDefaultBooleanValueFromMap( &map, IOT_BLE_WIFI_PROV_CONNECT_KEY, &boolVal,  IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT );
+        status = prvGetOrDefaultBooleanValueFromMap( &map, IOT_BLE_WIFI_PROV_CONNECT_KEY, &boolVal, IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT );
+
         if( status == CborNoError )
         {
             pAddNetworkReq->shouldConnect = boolVal;
@@ -499,16 +531,15 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
 
     IotLogInfo( "Decode add network cbor message, status = %d", status );
 
-    return ( status == CborNoError );
+    return( status == CborNoError );
 }
 
 /*-----------------------------------------------------------*/
 
 static bool IotBleWiFiProv_DeserializeEditNetworkRequestCbor( const uint8_t * pMessage,
-                                                   size_t length,
-                                                   IotBleWifiProvEditNetworkRequest_t * pEditNetworkReq )
+                                                              size_t length,
+                                                              IotBleWifiProvEditNetworkRequest_t * pEditNetworkReq )
 {
-
     CborParser parser = { 0 };
     CborValue map = { 0 };
     CborError status = CborNoError;
@@ -528,6 +559,7 @@ static bool IotBleWiFiProv_DeserializeEditNetworkRequestCbor( const uint8_t * pM
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_INDEX_KEY, &val );
+
         if( status == CborNoError )
         {
             pEditNetworkReq->currentPriorityIndex = ( int16_t ) val;
@@ -537,6 +569,7 @@ static bool IotBleWiFiProv_DeserializeEditNetworkRequestCbor( const uint8_t * pM
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_NEWINDEX_KEY, &val );
+
         if( status == CborNoError )
         {
             pEditNetworkReq->newPriorityIndex = ( int16_t ) val;
@@ -545,13 +578,13 @@ static bool IotBleWiFiProv_DeserializeEditNetworkRequestCbor( const uint8_t * pM
 
     IotLogInfo( "Decode edit network cbor message, status = %d", status );
 
-    return ( status == CborNoError );
+    return( status == CborNoError );
 }
 
 
 static bool IotBleWiFiProv_DeserializeDeleteNetworkRequestCbor( const uint8_t * pMessage,
-                                                     size_t length,
-                                                     IotBleWifiProvDeleteNetworkRequest_t * pDeleteNetworkRequest )
+                                                                size_t length,
+                                                                IotBleWifiProvDeleteNetworkRequest_t * pDeleteNetworkRequest )
 {
     CborParser parser = { 0 };
     CborValue map = { 0 };
@@ -572,6 +605,7 @@ static bool IotBleWiFiProv_DeserializeDeleteNetworkRequestCbor( const uint8_t * 
     if( status == CborNoError )
     {
         status = prvGetIntegerValueFromMap( &map, IOT_BLE_WIFI_PROV_INDEX_KEY, &val );
+
         if( status == CborNoError )
         {
             pDeleteNetworkRequest->priorityIndex = ( int16_t ) val;
@@ -580,26 +614,31 @@ static bool IotBleWiFiProv_DeserializeDeleteNetworkRequestCbor( const uint8_t * 
 
     IotLogInfo( "Decode delete network cbor message, status = %d", status );
 
-    return ( status == CborNoError );
+    return( status == CborNoError );
 }
 
-static uint8_t prvToResponseType( IotBleWiFiProvRequest_t requestType ) 
+static uint8_t prvToResponseType( IotBleWiFiProvRequest_t requestType )
 {
     uint8_t responseType = 0;
-    switch ( requestType )
+
+    switch( requestType )
     {
         case IotBleWiFiProvRequestListNetwork:
             responseType = IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP;
             break;
+
         case IotBleWiFiProvRequestAddNetwork:
             responseType = IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_RESP;
             break;
+
         case IotBleWiFiProvRequestEditNetwork:
             responseType = IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP;
             break;
+
         case IotBleWiFiProvRequestDeleteNetwork:
             responseType = IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_RESP;
             break;
+
         default:
             break;
     }
@@ -608,13 +647,13 @@ static uint8_t prvToResponseType( IotBleWiFiProvRequest_t requestType )
 }
 
 static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse,
-                                                  uint8_t * pBuffer,
-                                                  size_t * pLength )
+                                      uint8_t * pBuffer,
+                                      size_t * pLength )
 {
     size_t length = *pLength;
     size_t numParams =
-                    ( pResponse->statusOnly == true ) ? IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS 
-                                                        : IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS;
+        ( pResponse->statusOnly == true ) ? IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS
+        : IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS;
     CborError status;
     CborEncoder encoder = { 0 }, mapEncoder = { 0 };
 
@@ -625,6 +664,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
     if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
         status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, strlen( IOT_BLE_WIFI_PROV_MSG_TYPE_KEY ) );
+
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_int( &mapEncoder, prvToResponseType( pResponse->requestType ) );
@@ -634,6 +674,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
     if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
         status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_STATUS_KEY, strlen( IOT_BLE_WIFI_PROV_STATUS_KEY ) );
+
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_int( &mapEncoder, pResponse->status );
@@ -645,6 +686,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_SSID_KEY, strlen( IOT_BLE_WIFI_PROV_SSID_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 if( pResponse->networkInfo.isSavedNetwork == true )
@@ -659,13 +701,13 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
                                                       ( char * ) pResponse->networkInfo.info.pScannedNetwork->ucSSID,
                                                       pResponse->networkInfo.info.pScannedNetwork->ucSSIDLength );
                 }
-                
             }
         }
 
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_BSSID_KEY, strlen( IOT_BLE_WIFI_PROV_BSSID_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 if( pResponse->networkInfo.isSavedNetwork == true )
@@ -682,10 +724,11 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
                 }
             }
         }
-        
+
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, strlen( IOT_BLE_WIFI_PROV_KEY_MGMT_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 if( pResponse->networkInfo.isSavedNetwork == true )
@@ -698,10 +741,11 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
                 }
             }
         }
-        
+
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_HIDDEN_KEY, strlen( IOT_BLE_WIFI_PROV_HIDDEN_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 status = cbor_encode_boolean( &mapEncoder, pResponse->networkInfo.isHidden );
@@ -711,6 +755,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_RSSI_KEY, strlen( IOT_BLE_WIFI_PROV_RSSI_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 if( pResponse->networkInfo.isSavedNetwork == true )
@@ -727,6 +772,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_CONNECTED_KEY, strlen( IOT_BLE_WIFI_PROV_CONNECTED_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 status = cbor_encode_boolean( &mapEncoder, pResponse->networkInfo.isConnected );
@@ -736,6 +782,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
         if( SERIALIZER_STATUS( status, pBuffer ) == true )
         {
             status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_INDEX_KEY, strlen( IOT_BLE_WIFI_PROV_INDEX_KEY ) );
+
             if( SERIALIZER_STATUS( status, pBuffer ) == true )
             {
                 if( pResponse->networkInfo.isSavedNetwork == true )
@@ -749,7 +796,7 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
             }
         }
     }
-    
+
     if( SERIALIZER_STATUS( status, pBuffer ) == true )
     {
         status = cbor_encoder_close_container( &encoder, &mapEncoder );
@@ -761,13 +808,14 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
     }
     else
     {
-        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer ) ;
+        *pLength = cbor_encoder_get_buffer_size( &encoder, pBuffer );
     }
 
     return SERIALIZER_STATUS( status, pBuffer );
 }
 
-static bool IotBleWifiProv_GetSerializeResponseSizeCbor( const IotBleWifiProvResponse_t * pResponse, size_t * pLength )
+static bool IotBleWifiProv_GetSerializeResponseSizeCbor( const IotBleWifiProvResponse_t * pResponse,
+                                                         size_t * pLength )
 {
     return prvSerializeResponseCbor( pResponse, NULL, pLength );
 }
@@ -776,7 +824,6 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
                                                   uint8_t * pBuffer,
                                                   size_t length )
 {
-
     return prvSerializeResponseCbor( pResponse, pBuffer, &length );
 }
 
@@ -791,9 +838,7 @@ IotBleWifiProvSerializer_t * IotBleWifiProv_GetSerializer( void )
         .deserializeDeleteNetworkRequest = IotBleWiFiProv_DeserializeDeleteNetworkRequestCbor,
         .getSerializedSizeForResponse    = IotBleWifiProv_GetSerializeResponseSizeCbor,
         .serializeResponse               = IotBleWifiProv_SerializeResponseCbor
-   };
+    };
 
-   return &bleWifiProvSerializer;
+    return &bleWifiProvSerializer;
 }
-
-

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
@@ -98,7 +98,7 @@
  * @brief Number of parameters in a list network response.
  * This defines the  size of the CBOR map used to serialize the list network response messages.
  */
-#define IOT_BLE_WIFI_PROV_LIST_RESPONSE_NUM_PARAMS        ( 9 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS        ( 9 )
 
 /**
  * @brief Number of parameters in status response message.
@@ -276,140 +276,6 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pDa
 
     if( result == true )
     {
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SSID_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
-        {
-            IotLogError( "Failed to get SSID parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length >= wificonfigMAX_SSID_LEN )
-            {
-                IotLogError( "SSID, %.*s, exceeds maximum length %d",
-                             value.u.value.u.string.length,
-                             ( const char * ) value.u.value.u.string.pString,
-                             wificonfigMAX_SSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkReq->info.network.ucSSID, value.u.value.u.string.pString, value.u.value.u.string.length );
-                pAddNetworkReq->info.network.ucSSIDLength = ( value.u.value.u.string.length );
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_BSSID_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_BYTE_STRING ) )
-        {
-            IotLogError( "Failed to get BSSID parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length != wificonfigMAX_BSSID_LEN )
-            {
-                IotLogError( "Parameter BSSID length (%d) does not match BSSID length %d",
-                             value.u.value.u.string.length,
-                             wificonfigMAX_BSSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkReq->info.network.ucBSSID, value.u.value.u.string.pString, wificonfigMAX_BSSID_LEN );
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
-        {
-            IotLogError( "Failed to get WIFI xSecurity parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            switch( value.u.value.u.signedInt )
-            {
-                case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityOpen;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWEP;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
-                    break;
-
-                default:
-                    pAddNetworkReq->info.network.xSecurity = eWiFiSecurityNotSupported;
-                    break;
-            }
-        }
-    }
-
-    if( result == true )
-    {
-        value.u.value.u.string.pString = NULL;
-        value.u.value.u.string.length = 0;
-        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_PSK_KEY, &value );
-
-        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
-            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
-        {
-            IotLogError( "Failed to get password parameter, error = %d, value type = %d", ret, value.type );
-            result = false;
-        }
-        else
-        {
-            if( value.u.value.u.string.length >= wificonfigMAX_PASSPHRASE_LEN )
-            {
-                IotLogError( "SSID, %.*s, exceeds maximum length %d",
-                             value.u.value.u.string.length,
-                             ( const char * ) value.u.value.u.string.pString,
-                             wificonfigMAX_SSID_LEN );
-                result = false;
-            }
-            else
-            {
-                memcpy( pAddNetworkReq->info.network.cPassword, value.u.value.u.string.pString, value.u.value.u.string.length );
-                pAddNetworkReq->info.network.ucPasswordLength = ( uint8_t ) ( value.u.value.u.string.length );
-            }
-        }
-    }
-
-    if( result == true )
-    {
         ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
 
         if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
@@ -420,17 +286,152 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pDa
         }
         else
         {
-            
-            if( ( value.u.value.u.signedInt >= 0 ) &&
-                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
+            if( value.u.value.u.signedInt != IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE )
             {
-                pAddNetworkReq->isProvisioned = true;
                 pAddNetworkReq->info.index = value.u.value.u.signedInt;
+                pAddNetworkReq->isProvisioned = true;
             }
             else
             {
-                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
+                pAddNetworkReq->isProvisioned = false;
+            }
+        }
+    }
+
+    if( pAddNetworkReq->isProvisioned == false )
+    {
+
+        if( result == true )
+        {
+            value.u.value.u.string.pString = NULL;
+            value.u.value.u.string.length = 0;
+            ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SSID_KEY, &value );
+
+            if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+                ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
+            {
+                IotLogError( "Failed to get SSID parameter, error = %d, value type = %d", ret, value.type );
                 result = false;
+            }
+            else
+            {
+                if( value.u.value.u.string.length > sizeof( pAddNetworkReq->info.network.ucSSID ) )
+                {
+                    IotLogError( "SSID, %.*s, exceeds maximum length %d",
+                                value.u.value.u.string.length,
+                                ( const char * ) value.u.value.u.string.pString,
+                                sizeof( pAddNetworkReq->info.network.ucSSID ) );
+                    result = false;
+                }
+                else
+                {
+                    memcpy( pAddNetworkReq->info.network.ucSSID, value.u.value.u.string.pString, value.u.value.u.string.length );
+                    pAddNetworkReq->info.network.ucSSIDLength = ( value.u.value.u.string.length );
+                }
+            }
+        }
+
+        if( result == true )
+        {
+            value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
+            value.u.value.u.string.pString = NULL;
+            value.u.value.u.string.length = 0;
+            ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_BSSID_KEY, &value );
+
+            if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+                ( value.type != IOT_SERIALIZER_SCALAR_BYTE_STRING ) )
+            {
+                IotLogError( "Failed to get BSSID parameter, error = %d, value type = %d", ret, value.type );
+                result = false;
+            }
+            else
+            {
+                if( value.u.value.u.string.length != sizeof( pAddNetworkReq->info.network.ucBSSID ) )
+                {
+                    IotLogError( "Parameter BSSID length (%d) does not match BSSID length %d",
+                                value.u.value.u.string.length,
+                                wificonfigMAX_BSSID_LEN );
+                    result = false;
+                }
+                else
+                {
+                    memcpy( pAddNetworkReq->info.network.ucBSSID, value.u.value.u.string.pString, value.u.value.u.string.length );
+                }
+            }
+        }
+
+        if( result == true )
+        {
+            ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, &value );
+
+            if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+                ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+            {
+                IotLogError( "Failed to get WIFI xSecurity parameter, error = %d, value type = %d", ret, value.type );
+                result = false;
+            }
+            else
+            {
+                switch( value.u.value.u.signedInt )
+                {
+                    case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityOpen;
+                        break;
+
+                    case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWEP;
+                        break;
+
+                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA;
+                        break;
+
+                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
+                        break;
+
+                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
+                        break;
+
+                    case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityWPA2;
+                        break;
+
+                    default:
+                        pAddNetworkReq->info.network.xSecurity = eWiFiSecurityNotSupported;
+                        break;
+                }
+            }
+        }
+
+        if( result == true )
+        {
+            value.u.value.u.string.pString = NULL;
+            value.u.value.u.string.length = 0;
+            ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_PSK_KEY, &value );
+
+            if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+                ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
+            {
+                IotLogError( "Failed to get password parameter, error = %d, value type = %d", ret, value.type );
+                result = false;
+            }
+            else
+            {
+                if( value.u.value.u.string.length > sizeof( pAddNetworkReq->info.network.cPassword ) )
+                {
+                    IotLogError( "SSID, %.*s, exceeds maximum length %d",
+                                value.u.value.u.string.length,
+                                ( const char * ) value.u.value.u.string.pString,
+                                sizeof( pAddNetworkReq->info.network.cPassword ) );
+                    result = false;
+                }
+                else
+                {
+                    memcpy( pAddNetworkReq->info.network.cPassword, value.u.value.u.string.pString, value.u.value.u.string.length );
+                    pAddNetworkReq->info.network.ucPasswordLength = ( uint8_t ) ( value.u.value.u.string.length );
+                }
             }
         }
     }
@@ -610,7 +611,7 @@ static uint8_t prvToResponseType( IotBleWiFiProvRequest_t requestType )
     return responseType;
 }
 
-static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse,
+static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse,
                                                   uint8_t * pBuffer,
                                                   size_t * plength )
 {
@@ -619,12 +620,14 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
     IotSerializerScalarData_t value = IOT_SERIALIZER_SCALAR_DATA_INITIALIZER;
     IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
     size_t length = *plength;
+    size_t numParams = ( pResponse->statusOnly == true ) ? IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS 
+                                                           : IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS;
 
     ret = IOT_BLE_MESG_ENCODER.init( &container, pBuffer, length );
 
     if( ret == IOT_SERIALIZER_SUCCESS )
     {
-        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &networkMap, IOT_BLE_WIFI_PROV_LIST_RESPONSE_NUM_PARAMS );
+        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &networkMap, numParams );
     }
 
     if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
@@ -641,20 +644,20 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_STATUS_KEY, value );
     }
 
-    if( pResponse->requestType == IotBleWiFiProvRequestListNetwork )
+    if( pResponse->statusOnly == false )
     {
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
-            if( pResponse->isProvisioned == true )
+            if( pResponse->networkInfo.isSavedNetwork == true )
             {
-                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.savedNetwork.network->ucSSID;
-                value.value.u.string.length = pResponse->networkInfo.savedNetwork.network->ucSSIDLength;
+                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.info.pSavedNetwork->ucSSID;
+                value.value.u.string.length = pResponse->networkInfo.info.pSavedNetwork->ucSSIDLength;
             }
             else
             {
-                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.scannedNetwork->ucSSID;
-                value.value.u.string.length = pResponse->networkInfo.scannedNetwork->ucSSIDLength;
+                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.info.pScannedNetwork->ucSSID;
+                value.value.u.string.length = pResponse->networkInfo.info.pScannedNetwork->ucSSIDLength;
             }
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_SSID_KEY, value );
         }
@@ -663,15 +666,15 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         {
             value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
 
-            if( pResponse->isProvisioned == true )
+            if( pResponse->networkInfo.isSavedNetwork == true )
             {
-                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.savedNetwork.network->ucBSSID;
-                value.value.u.string.length = sizeof( pResponse->networkInfo.savedNetwork.network->ucBSSID );
+                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.info.pSavedNetwork->ucBSSID;
+                value.value.u.string.length = sizeof( pResponse->networkInfo.info.pSavedNetwork->ucBSSID );
             }
             else
             {
-                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.scannedNetwork->ucBSSID;
-                value.value.u.string.length = sizeof( pResponse->networkInfo.scannedNetwork->ucBSSID );
+                value.value.u.string.pString = ( uint8_t * ) pResponse->networkInfo.info.pScannedNetwork->ucBSSID;
+                value.value.u.string.length = sizeof( pResponse->networkInfo.info.pScannedNetwork->ucBSSID );
             }
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_BSSID_KEY, value );
         }
@@ -679,13 +682,13 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-            if( pResponse->isProvisioned == true )
+            if( pResponse->networkInfo.isSavedNetwork == true )
             {
-                value.value.u.signedInt = pResponse->networkInfo.savedNetwork.network->xSecurity;
+                value.value.u.signedInt = pResponse->networkInfo.info.pSavedNetwork->xSecurity;
             }
             else
             {
-                value.value.u.signedInt = pResponse->networkInfo.scannedNetwork->xSecurity;
+                value.value.u.signedInt = pResponse->networkInfo.info.pScannedNetwork->xSecurity;
             }
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, value );
         }
@@ -693,20 +696,20 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_BOOL;
-            value.value.u.booleanValue = pResponse->isHidden;
+            value.value.u.booleanValue = pResponse->networkInfo.isHidden;
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_HIDDEN_KEY, value );
         }
 
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-            if( pResponse->isProvisioned == true )
+            if( pResponse->networkInfo.isSavedNetwork == true )
             {
                 value.value.u.signedInt = IOT_BLE_WIFI_PROV_RSSI_DONT_USE;
             }
             else
             {
-                value.value.u.signedInt = pResponse->networkInfo.scannedNetwork->cRSSI;
+                value.value.u.signedInt = pResponse->networkInfo.info.pScannedNetwork->cRSSI;
             }
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_RSSI_KEY, value );
         }
@@ -714,16 +717,16 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_BOOL;
-            value.value.u.booleanValue = pResponse->isConnected;
+            value.value.u.booleanValue = pResponse->networkInfo.isConnected;
             ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_CONNECTED_KEY, value );
         }
 
         if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
         {
             value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
-            if( pResponse->isProvisioned == true )
+            if( pResponse->networkInfo.isSavedNetwork == true )
             {
-                value.value.u.signedInt = pResponse->networkInfo.savedNetwork.index;
+                value.value.u.signedInt = pResponse->networkInfo.index;
             }
             else
             {
@@ -753,12 +756,25 @@ static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t
         ret = IOT_SERIALIZER_SUCCESS;
     }
 
+    if( ret != IOT_SERIALIZER_SUCCESS )
+    {
+        IotLogError( "Failed to serialize reponse, error = %d", ret );
+    }
+
     return ( ret == IOT_SERIALIZER_SUCCESS );
 }
 
-static bool IotBleWifiProv_GetSerializeResponseSizeCbor( const IotBleWifiProvResponse_t * pResponse, size_t *pLength )
+static bool IotBleWifiProv_GetSerializeResponseSizeCbor( const IotBleWifiProvResponse_t * pResponse, size_t * pLength )
 {
-    return IotBleWifiProv_SerializeResponseCbor( pResponse, NULL, pLength );
+    return prvSerializeResponseCbor( pResponse, NULL, pLength );
+}
+
+static bool IotBleWifiProv_SerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse,
+                                                  uint8_t * pBuffer,
+                                                  size_t length )
+{
+
+    return prvSerializeResponseCbor( pResponse, pBuffer, &length );
 }
 
 IotBleWifiProvSerializer_t * IotBleWifiProv_GetSerializer( void )

--- a/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
+++ b/libraries/c_sdk/standard/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
@@ -1,0 +1,744 @@
+/*
+ * FreeRTOS BLE V2.2.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file iot_ble_wifi_provisioning_serializer.c
+ * Implement APIs used for serializing messages between device and the WiFi provisioning application
+ * over BLE network.
+ */
+
+#include "iot_ble_wifi_provisioning.h"
+#include "iot_serializer.h"
+
+/**
+ * @defgroup
+ * @brief Serialized values for the message types exchanged between wifi 
+ */
+/** @{ */
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ       ( 1 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP      ( 2 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_REQ        ( 3 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_RESP       ( 4 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_REQ       ( 5 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP      ( 6 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_REQ     ( 7 )
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_RESP    ( 8 )
+/** @} */
+
+/**
+ * @brief Strings representing the keys for the key-value pairs serialized
+ * as part of request and response messages.
+ */
+#define IOT_BLE_WIFI_PROV_MSG_TYPE_KEY        "w"
+#define IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY    "h"
+#define IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY    "t"
+#define IOT_BLE_WIFI_PROV_KEY_MGMT_KEY        "q"
+#define IOT_BLE_WIFI_PROV_SSID_KEY            "r"
+#define IOT_BLE_WIFI_PROV_BSSID_KEY           "b"
+#define IOT_BLE_WIFI_PROV_RSSI_KEY            "p"
+#define IOT_BLE_WIFI_PROV_PSK_KEY             "m"
+#define IOT_BLE_WIFI_PROV_STATUS_KEY          "s"
+#define IOT_BLE_WIFI_PROV_HIDDEN_KEY          "f"
+#define IOT_BLE_WIFI_PROV_CONNECTED_KEY       "e"
+#define IOT_BLE_WIFI_PROV_INDEX_KEY           "g"
+#define IOT_BLE_WIFI_PROV_NEWINDEX_KEY        "j"
+#define IOT_BLE_WIFI_PROV_CONNECT_KEY         "y"
+
+/**
+ * @brief Defines the serialized values for WiFi security types. 
+ */
+#define IOT_BLE_WIFI_SECURITY_TYPE_OPEN        ( 0UL )
+#define IOT_BLE_WIFI_SECURITY_TYPE_WEP         ( 1UL )
+#define IOT_BLE_WIFI_SECURITY_TYPE_WPA         ( 2UL )
+#define IOT_BLE_WIFI_SECURITY_TYPE_WPA2        ( 3UL )
+#define IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT    ( 4UL )
+#define IOT_BLE_WIFI_SECURITY_TYPE_WPA3        ( 5UL )
+
+
+/**
+ * @cond DOXYGEN_IGNORE
+ * @brief The network index which app use to signify as to not to use.
+ */
+#define IOT_BLE_WIFI_PROV_NETWORK_INDEX_INVALID    ( -1 )
+
+/**
+ * @brief Number of parameters in a list network response.
+ * This defines the  size of the CBOR map used to serialize the list network response messages.
+ */
+#define IOT_BLE_WIFI_PROV_LIST_RESPONSE_NUM_PARAMS        ( 9 )
+
+/**
+ * @brief Number of parameters in status response message.
+ * This defines the size of the CBOR map used to serialize the list network response messages.
+ */
+#define IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS          ( 2 )
+
+/**
+ * @brief Macro defines the default behavior whether to connect to an access point along with 
+ * provisioning or not. Default value can be overriden by the provisioning app by specifying connect flag
+ * in add access point request message.
+ */
+#define IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT          ( true )
+
+
+#define IS_VALID_SERIALIZER_RET( ret, pxSerializerBuf ) \
+    ( ( ret == IOT_SERIALIZER_SUCCESS ) ||              \
+      ( ( !pxSerializerBuf ) && ( ret == IOT_SERIALIZER_BUFFER_TOO_SMALL ) ) )
+
+
+bool IotBleWiFiProv_GetRequestTypeFromMessage( const uint8_t * pMessage,
+                                              size_t length,
+                                              IotBleWiFiProvRequest_t * pRequeustType )
+{
+    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool result = true;
+
+    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pMessage, length );
+
+    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    {
+        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
+        result = false;
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, &value );
+
+        if( ( ret == IOT_SERIALIZER_SUCCESS ) &&
+            ( value.type == IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            switch( value.u.value.u.signedInt )
+            {
+                case IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_REQ:
+                    ( * pRequeustType ) =  IotBleWiFiProvRequestListNetwork;
+                    break;
+                case IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_REQ:
+                    ( * pRequeustType ) =  IotBleWiFiProvRequestAddNetwork;
+                    break;
+                case IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_REQ:
+                    ( * pRequeustType ) =  IotBleWiFiProvRequestEditNetwork;
+                    break;
+                case IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_REQ:
+                    ( * pRequeustType ) =  IotBleWiFiProvRequestDeleteNetwork;
+                    break;
+                default:
+                    result = false;
+                    break;
+            }
+        }
+        else
+        {
+            IotLogError( "Failed to find message type, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+    }
+
+    return result;
+}
+
+static bool IotBleWiFiProv_DeserializeListNetworksRequest( const uint8_t * pData,
+                                                          size_t length,
+                                                          IotBleWifiProvListNetworksRequest_t * pListNetworksRequest )
+{
+    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool result = true;
+
+    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
+
+    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    {
+        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
+        result = false;
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_MAX_NETWORKS_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get max Networks parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( ( value.u.value.u.signedInt <= 0 ) || ( value.u.value.u.signedInt > IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS ) )
+            {
+                IotLogWarn( "Networks %d exceeds configured value, truncating to  %d max network\n",
+                            ( uint16_t ) value.u.value.u.signedInt,
+                            IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS );
+                pListNetworksRequest->scanSize = IOT_BLE_WIFI_PROVISIONIG_MAX_SCAN_NETWORKS;
+            }
+            else
+            {
+                pListNetworksRequest->scanSize = value.u.value.u.signedInt;
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SCAN_TIMEOUT_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get timeout parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            pListNetworksRequest->scanTimeoutMS = value.u.value.u.signedInt;
+        }
+    }
+
+    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+bool IotBleWiFiProv_DeserializeAddNetworksRequest( const uint8_t * pData,
+                                                         size_t length,
+                                                         IotBleWifiProvAddNetworkRequest_t * pAddNetworkReq )
+{
+    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool result = true;
+
+
+    memset( pAddNetworkReq, 0x00, sizeof(IotBleWifiProvAddNetworkRequest_t) );
+
+    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
+
+    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    {
+        IotLogError( "Failed to initialize the decoder, error = %d, object type = %d", ret, decoderObj.type );
+        result = false;
+    }
+
+    if( result == true )
+    {
+        value.u.value.u.string.pString = NULL;
+        value.u.value.u.string.length = 0;
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_SSID_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
+        {
+            IotLogError( "Failed to get SSID parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( value.u.value.u.string.length >= wificonfigMAX_SSID_LEN )
+            {
+                IotLogError( "SSID, %.*s, exceeds maximum length %d",
+                             value.u.value.u.string.length,
+                             ( const char * ) value.u.value.u.string.pString,
+                             wificonfigMAX_SSID_LEN );
+                result = false;
+            }
+            else
+            {
+                memcpy( pAddNetworkReq->accessPointInfo.ucSSID, value.u.value.u.string.pString, value.u.value.u.string.length );
+                pAddNetworkReq->accessPointInfo.ucSSIDLength = ( value.u.value.u.string.length );
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
+        value.u.value.u.string.pString = NULL;
+        value.u.value.u.string.length = 0;
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_BSSID_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_BYTE_STRING ) )
+        {
+            IotLogError( "Failed to get BSSID parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( value.u.value.u.string.length != wificonfigMAX_BSSID_LEN )
+            {
+                IotLogError( "Parameter BSSID length (%d) does not match BSSID length %d",
+                             value.u.value.u.string.length,
+                             wificonfigMAX_BSSID_LEN );
+                result = false;
+            }
+            else
+            {
+                memcpy( pAddNetworkReq->accessPointInfo.ucBSSID, value.u.value.u.string.pString, wificonfigMAX_BSSID_LEN );
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get WIFI xSecurity parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            switch( value.u.value.u.signedInt )
+            {
+                case IOT_BLE_WIFI_SECURITY_TYPE_OPEN:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityOpen;
+                    break;
+
+                case IOT_BLE_WIFI_SECURITY_TYPE_WEP:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityWEP;
+                    break;
+
+                case IOT_BLE_WIFI_SECURITY_TYPE_WPA:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityWPA;
+                    break;
+
+                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityWPA2;
+                    break;
+
+                case IOT_BLE_WIFI_SECURITY_TYPE_WPA2_ENT:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityWPA2;
+                    break;
+
+                case IOT_BLE_WIFI_SECURITY_TYPE_WPA3:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityWPA2;
+                    break;
+
+                default:
+                    pAddNetworkReq->accessPointInfo.xSecurity = eWiFiSecurityNotSupported;
+                    break;
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        value.u.value.u.string.pString = NULL;
+        value.u.value.u.string.length = 0;
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_PSK_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_TEXT_STRING ) )
+        {
+            IotLogError( "Failed to get password parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( value.u.value.u.string.length >= wificonfigMAX_PASSPHRASE_LEN )
+            {
+                IotLogError( "SSID, %.*s, exceeds maximum length %d",
+                             value.u.value.u.string.length,
+                             ( const char * ) value.u.value.u.string.pString,
+                             wificonfigMAX_SSID_LEN );
+                result = false;
+            }
+            else
+            {
+                memcpy( pAddNetworkReq->accessPointInfo.cPassword, value.u.value.u.string.pString, value.u.value.u.string.length );
+                pAddNetworkReq->accessPointInfo.ucPasswordLength = ( uint8_t ) ( value.u.value.u.string.length );
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            
+            if( ( value.u.value.u.signedInt >= 0 ) &&
+                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
+            {
+                pAddNetworkReq->isProvisioned = true;
+                pAddNetworkReq->prirorityIndex = value.u.value.u.signedInt;
+            }
+            else
+            {
+                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
+                result = false;
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_CONNECT_KEY, &value );
+
+        if( ( ret == IOT_SERIALIZER_SUCCESS ) &&
+            ( value.type == IOT_SERIALIZER_SCALAR_BOOL ) )
+        {
+            pAddNetworkReq->shouldConnect = value.u.value.u.booleanValue;
+        }
+        else if( ret == IOT_SERIALIZER_NOT_FOUND )
+        {
+            IotLogInfo( "Connect flag not set in request, using default value, should connect = %d", IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT );
+            pAddNetworkReq->shouldConnect = IOT_BLE_WIFI_PROV_DEFAULT_SHOULD_CONNECT;
+        }
+        else
+        {
+            IotLogError( "Error in getting connect flag, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+    }
+
+    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+bool IotBleWiFiProv_DeserializeEditNetworkRequest( const uint8_t * pData,
+                                                   size_t length,
+                                                   IotBleWifiProvEditNetworkRequest_t * pEditNetworkReq )
+{
+    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool result = true;
+
+    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
+
+    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    {
+        IotLogError( "Failed to initialize decoder, error = %d, object type = %d", ret, decoderObj.type );
+        result = false;
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( ( value.u.value.u.signedInt >= 0 ) &&
+                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
+            {
+                pEditNetworkReq->currentPriorityIndex = value.u.value.u.signedInt;
+            }
+            else
+            {
+                IotLogError( "Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
+                result = false;
+            }
+        }
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_NEWINDEX_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get new network index parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( ( value.u.value.u.signedInt >= 0 ) &&
+                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
+            {
+                pEditNetworkReq->newPriorityIndex = value.u.value.u.signedInt;
+            }
+            else
+            {
+                IotLogError( "New Network index parameter ( %lld ) is out of range", value.u.value.u.signedInt );
+                result = false;
+            }
+        }
+    }
+
+    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+
+    return result;
+}
+
+
+
+bool IotBleWiFiProv_DeserializeDeleteNetworkRequest( const uint8_t * pData,
+                                                     size_t length,
+                                                     IotBleWifiProvDeleteNetworkRequest_t * pDeleteNetworkRequest )
+{
+    IotSerializerDecoderObject_t decoderObj = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerDecoderObject_t value = IOT_SERIALIZER_DECODER_OBJECT_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    bool result = true;
+
+    ret = IOT_BLE_MESG_DECODER.init( &decoderObj, ( uint8_t * ) pData, length );
+
+    if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+        ( decoderObj.type != IOT_SERIALIZER_CONTAINER_MAP ) )
+    {
+        IotLogError( "Failed to initialize decoder, error = %d, object type = %d", ret, decoderObj.type );
+        result = false;
+    }
+
+    if( result == true )
+    {
+        ret = IOT_BLE_MESG_DECODER.find( &decoderObj, IOT_BLE_WIFI_PROV_INDEX_KEY, &value );
+
+        if( ( ret != IOT_SERIALIZER_SUCCESS ) ||
+            ( value.type != IOT_SERIALIZER_SCALAR_SIGNED_INT ) )
+        {
+            IotLogError( "Failed to get network index parameter, error = %d, value type = %d", ret, value.type );
+            result = false;
+        }
+        else
+        {
+            if( ( value.u.value.u.signedInt >= 0 ) &&
+                ( value.u.value.u.signedInt < IOT_BLE_WIFI_PROVISIONING_MAX_SAVED_NETWORKS ) )
+            {
+                pDeleteNetworkRequest->priorityIndex = ( int16_t ) value.u.value.u.signedInt;
+            }
+            else
+            {
+                IotLogError( "Network index parameter %lld is out of range", value.u.value.u.signedInt );
+                result = false;
+            }
+        }
+    }
+
+    IOT_BLE_MESG_DECODER.destroy( &decoderObj );
+
+    return result;
+}
+
+IotSerializerError_t IotBleWifiProv_SerializeListNetworkResponse( IotBleWiFiProvListNetworkResponse_t * pNetworkInfo,
+                                                                  uint8_t * pBuffer,
+                                                                  size_t * plength )
+{
+    IotSerializerEncoderObject_t container = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
+    IotSerializerEncoderObject_t networkMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
+    IotSerializerScalarData_t value = IOT_SERIALIZER_SCALAR_DATA_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    size_t length = *plength;
+
+    ret = IOT_BLE_MESG_ENCODER.init( &container, pBuffer, length );
+
+    if( ret == IOT_SERIALIZER_SUCCESS )
+    {
+        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &networkMap, IOT_BLE_WIFI_PROV_LIST_RESPONSE_NUM_PARAMS );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = pNetworkInfo->status;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_STATUS_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_TEXT_STRING;
+        value.value.u.string.pString = ( uint8_t * ) pNetworkInfo->pSSID;
+        value.value.u.string.length = pNetworkInfo->SSIDLength;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_SSID_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_BYTE_STRING;
+        value.value.u.string.pString = ( uint8_t * ) pNetworkInfo->pBSSID;
+        value.value.u.string.length = pNetworkInfo->BSSIDLength;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_BSSID_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = pNetworkInfo->security;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_KEY_MGMT_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_BOOL;
+        value.value.u.booleanValue = pNetworkInfo->hidden;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_HIDDEN_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = pNetworkInfo->RSSI;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_RSSI_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_BOOL;
+        value.value.u.booleanValue = pNetworkInfo->connected;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_CONNECTED_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = pNetworkInfo->priorityIndex;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &networkMap, IOT_BLE_WIFI_PROV_INDEX_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        ret = IOT_BLE_MESG_ENCODER.closeContainer( &container, &networkMap );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        if( pBuffer == NULL )
+        {
+            *plength = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &container );
+        }
+        else
+        {
+            *plength = IOT_BLE_MESG_ENCODER.getEncodedSize( &container, pBuffer );
+        }
+
+        IOT_BLE_MESG_ENCODER.destroy( &container );
+        ret = IOT_SERIALIZER_SUCCESS;
+    }
+
+    return ( ret == IOT_SERIALIZER_SUCCESS );
+}
+
+bool IotBleWifiProv_SerializeStatusResponse( IotBleWiFiProvRequest_t request,
+                                              WIFIReturnCode_t status,
+                                              uint8_t * pBuffer,
+                                              size_t * plength )
+{
+    IotSerializerEncoderObject_t container = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
+    IotSerializerEncoderObject_t responseMap = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
+    IotSerializerScalarData_t value = IOT_SERIALIZER_SCALAR_DATA_INITIALIZER;
+    IotSerializerError_t ret = IOT_SERIALIZER_SUCCESS;
+    size_t length = *plength;
+
+    ret = IOT_BLE_MESG_ENCODER.init( &container, pBuffer, length );
+
+    if( ret == IOT_SERIALIZER_SUCCESS )
+    {
+        ret = IOT_BLE_MESG_ENCODER.openContainer( &container, &responseMap, IOT_BLE_WIFI_PROV_STATUS_MESG_NUM_PARAMS );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+
+        switch( request )
+        {
+            case IotBleWiFiProvRequestListNetwork:
+                value.value.u.signedInt = IOT_BLE_WIFI_PROV_MSG_TYPE_LIST_NETWORK_RESP;
+                break;
+            case IotBleWiFiProvRequestAddNetwork:
+                value.value.u.signedInt = IOT_BLE_WIFI_PROV_MSG_TYPE_ADD_NETWORK_RESP;
+                break;
+            case IotBleWiFiProvRequestEditNetwork:
+                value.value.u.signedInt = IOT_BLE_WIFI_PROV_MSG_TYPE_EDIT_NETWORK_RESP;
+                break;
+            case IotBleWiFiProvRequestDeleteNetwork:
+                value.value.u.signedInt = IOT_BLE_WIFI_PROV_MSG_TYPE_DELETE_NETWORK_RESP;
+                break;
+            default:
+                value.value.u.signedInt = 0;
+                ret = IOT_SERIALIZER_UNDEFINED;
+                break;
+        }
+        
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &responseMap, IOT_BLE_WIFI_PROV_MSG_TYPE_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        value.type = IOT_SERIALIZER_SCALAR_SIGNED_INT;
+        value.value.u.signedInt = status;
+        ret = IOT_BLE_MESG_ENCODER.appendKeyValue( &responseMap, IOT_BLE_WIFI_PROV_STATUS_KEY, value );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        ret = IOT_BLE_MESG_ENCODER.closeContainer( &container, &responseMap );
+    }
+
+    if( IS_VALID_SERIALIZER_RET( ret, pBuffer ) )
+    {
+        if( pBuffer == NULL )
+        {
+            *plength = IOT_BLE_MESG_ENCODER.getExtraBufferSizeNeeded( &container );
+        }
+        else
+        {
+            *plength = IOT_BLE_MESG_ENCODER.getEncodedSize( &container, pBuffer );
+        }
+
+        IOT_BLE_MESG_ENCODER.destroy( &container );
+
+        ret = IOT_SERIALIZER_SUCCESS;
+    }
+
+    return ( ret == IOT_SERIALIZER_SUCCESS );
+}

--- a/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_define.h
+++ b/libraries/c_sdk/standard/ble/test/iot_ble_wifi_prov_test_access_define.h
@@ -37,27 +37,27 @@
 BaseType_t test_HandleListNetworkRequest( uint8_t * data,
                                           size_t length )
 {
-    return _handleListNetworkRequest( data, length );
+    return prvHandleListNetworkRequest( data, length );
 }
 
 BaseType_t test_HandleSaveNetworkRequest( uint8_t * data,
                                           size_t length )
 {
-    return _handleSaveNetworkRequest( data, length );
+    return prvHandleAddNetworkRequest( data, length );
 }
 
 
 BaseType_t test_HandleEditNetworkRequest( uint8_t * data,
                                           size_t length )
 {
-    return _handleEditNetworkRequest( data, length );
+    return prvHandleEditNetworkRequest( data, length );
 }
 
 
 BaseType_t test_HandleDeleteNetworkRequest( uint8_t * data,
                                             size_t length )
 {
-    return _handleDeleteNetworkRequest( data, length );
+    return prvHandleDeleteNetworkRequest( data, length );
 }
 
 WIFIReturnCode_t test_AppendNetwork( WIFINetworkProfile_t * pProfile )


### PR DESCRIPTION
Remove taskpool and serializer dependency for BLE

Description
-----------
Refactor WiFi provisioning over BLE to use process loop function to be executed in user task instead of task pool. Modified provisioning demo to show the usage.
Modified WiFi provisioning over BLE and MQTT serializer to use tinycbor (third party serializer).
Add support for custom serializer for WiFi provisioning.
Modified tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.