### PR TITLE
Add custom metrics to Device Defender demo

### DIFF
--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -81,7 +81,7 @@
  *
  * This must be at least the number of tasks used.
  */
-#define CUSTOM_METRICS_TASKS_ARRAY_SIZE       10
+#define CUSTOM_METRICS_TASKS_ARRAY_SIZE       20
 
 /**
  * @brief Status values of the device defender report.

--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -487,6 +487,7 @@ static BaseType_t collectDeviceMetrics( void )
         else
         {
             size_t i;
+
             /* Populate the task IDs array from the collected system state array. */
             for( i = 0; i < tasksWritten; i++ )
             {

--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -463,7 +463,7 @@ static BaseType_t collectDeviceMetrics( void )
          * field of the task status will be included in the report as a "number"
          * custom metric. */
         vTaskGetInfo(
-            /* Query this task. */
+            /* NULL has the function query this task. */
             NULL,
             &taskStatus,
             /* Include the stack high water mark value. */

--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -380,7 +380,7 @@ static BaseType_t collectDeviceMetrics( void )
     TaskStatus_t taskStatus = { 0 };
     TaskStatus_t * pTaskStatusArray;
     uint32_t * pTaskIdArray;
-    UBaseType_t arraySize;
+    UBaseType_t numTasksRunning;
 
     /* Collect bytes and packets sent and received. */
     metricsCollectorStatus = GetNetworkStats( &( networkStats ) );
@@ -436,14 +436,14 @@ static BaseType_t collectDeviceMetrics( void )
     if( metricsCollectorStatus == MetricsCollectorSuccess )
     {
         /* Get task count */
-        arraySize = uxTaskGetNumberOfTasks();
+        numTasksRunning = uxTaskGetNumberOfTasks();
 
         /* Allocate pTaskStatusArray */
-        pTaskStatusArray = pvPortMalloc( arraySize * sizeof( TaskStatus_t ) );
+        pTaskStatusArray = pvPortMalloc( numTasksRunning * sizeof( TaskStatus_t ) );
 
         if( pTaskStatusArray == NULL )
         {
-            LogError( ( "Allocating pTaskStatusArray failed." ) );
+            LogError( ( "Cannot allocate memory for pTaskStatusArray array: pvPortMalloc() failed." ) );
             metricsCollectorStatus = MetricsCollectorCollectionFailed;
         }
     }
@@ -451,11 +451,11 @@ static BaseType_t collectDeviceMetrics( void )
     if( metricsCollectorStatus == MetricsCollectorSuccess )
     {
         /* Allocate pTaskIdArray */
-        pTaskIdArray = pvPortMalloc( arraySize * sizeof( uint32_t ) );
+        pTaskIdArray = pvPortMalloc( numTasksRunning * sizeof( uint32_t ) );
 
         if( pTaskIdArray == NULL )
         {
-            LogError( ( "Allocating pTaskIdArray failed." ) );
+            LogError( ( "Cannot allocate memory for pTaskStatusArray array: pvPortMalloc() failed." ) );
             metricsCollectorStatus = MetricsCollectorCollectionFailed;
         }
     }
@@ -481,7 +481,7 @@ static BaseType_t collectDeviceMetrics( void )
         /* Get the task status information for all running tasks. The task IDs
          * of each task is then extracted to include in the report as a "list of
          * numbers" custom metric */
-        tasksWritten = uxTaskGetSystemState( pTaskStatusArray, arraySize, NULL );
+        tasksWritten = uxTaskGetSystemState( pTaskStatusArray, numTasksRunning, NULL );
 
         if( tasksWritten == 0 )
         {

--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -378,7 +378,7 @@ static BaseType_t collectDeviceMetrics( void )
     size_t numOpenTcpPorts, numOpenUdpPorts, numEstablishedConnections;
     UBaseType_t tasksWritten = 0U;
     TaskStatus_t taskStatus = { 0 };
-    TaskStatus_t * pTaskStatusArray;
+    TaskStatus_t * pTaskStatusArray = NULL;
     UBaseType_t numTasksRunning;
 
     /* Collect bytes and packets sent and received. */

--- a/demos/device_defender_for_aws/metrics_collector.h
+++ b/demos/device_defender_for_aws/metrics_collector.h
@@ -90,8 +90,8 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats );
  * #MetricsCollectorCollectionFailed if the collection methods failed.
  */
 MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
-                                          uint32_t tcpPortsArrayLength,
-                                          uint32_t * pOutNumTcpOpenPorts );
+                                          size_t tcpPortsArrayLength,
+                                          size_t * pOutNumTcpOpenPorts );
 
 /**
  * @brief Get a list of the open UDP ports.
@@ -111,8 +111,8 @@ MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
  * #MetricsCollectorCollectionFailed if the collection methods failed.
  */
 MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
-                                          uint32_t udpPortsArrayLength,
-                                          uint32_t * pOutNumUdpOpenPorts );
+                                          size_t udpPortsArrayLength,
+                                          size_t * pOutNumUdpOpenPorts );
 
 /**
  * @brief Get a list of established connections.
@@ -134,7 +134,7 @@ MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
  * #MetricsCollectorCollectionFailed if the collection methods failed.
  */
 MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutNumEstablishedConnections );
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutNumEstablishedConnections );
 
 #endif /* __METRICS_COLLECTOR_H__ */

--- a/demos/device_defender_for_aws/metrics_collector/freertos_plus_tcp/metrics_collector.c
+++ b/demos/device_defender_for_aws/metrics_collector/freertos_plus_tcp/metrics_collector.c
@@ -70,12 +70,12 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
     if( metricsStatus == 0 )
     {
         /* Fill our response with values gotten from FreeRTOS+TCP. */
-        LogDebug( ( "Network stats read. Bytes received: %u, packets received: %u, "
-                    "bytes sent: %u, packets sent: %u.",
-                    ( unsigned int ) metrics.xInput.uxByteCount,
-                    ( unsigned int ) metrics.xInput.uxPacketCount,
-                    ( unsigned int ) metrics.xOutput.uxByteCount,
-                    ( unsigned int ) metrics.xOutput.uxPacketCount ) );
+        LogDebug( ( "Network stats read. Bytes received: %lu, packets received: %lu, "
+                    "bytes sent: %lu, packets sent: %lu.",
+                    ( unsigned long ) metrics.xInput.uxByteCount,
+                    ( unsigned long ) metrics.xInput.uxPacketCount,
+                    ( unsigned long ) metrics.xOutput.uxByteCount,
+                    ( unsigned long ) metrics.xOutput.uxPacketCount ) );
 
         pOutNetworkStats->bytesReceived = metrics.xInput.uxByteCount;
         pOutNetworkStats->packetsReceived = metrics.xInput.uxPacketCount;
@@ -90,14 +90,14 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
-                                          uint32_t tcpPortsArrayLength,
-                                          uint32_t * pOutNumTcpOpenPorts )
+                                          size_t tcpPortsArrayLength,
+                                          size_t * pOutNumTcpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorCollectionFailed;
 
     MetricsType_t metrics = { 0 };
     BaseType_t metricsStatus = 0;
-    uint32_t copyAmount = 0UL;
+    size_t copyAmount = 0UL;
 
     /* pOutTcpPortsArray can be NULL. */
     configASSERT( pOutNumTcpOpenPorts != NULL );
@@ -139,14 +139,14 @@ MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
-                                          uint32_t udpPortsArrayLength,
-                                          uint32_t * pOutNumUdpOpenPorts )
+                                          size_t udpPortsArrayLength,
+                                          size_t * pOutNumUdpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorCollectionFailed;
 
     MetricsType_t metrics = { 0 };
     BaseType_t metricsStatus = 0;
-    uint32_t copyAmount = 0UL;
+    size_t copyAmount = 0UL;
 
     /* pOutUdpPortsArray can be NULL. */
     configASSERT( pOutNumUdpOpenPorts != NULL );
@@ -189,16 +189,16 @@ MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutNumEstablishedConnections )
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutNumEstablishedConnections )
 {
     MetricsCollectorStatus_t status = MetricsCollectorCollectionFailed;
 
     MetricsType_t metrics = { 0 };
     BaseType_t metricsStatus = 0;
-    uint32_t copyAmount = 0UL;
+    size_t copyAmount = 0UL;
     uint32_t localIp = 0UL;
-    uint32_t i;
+    size_t i;
 
     /* pOutConnectionsArray can be NULL. */
     configASSERT( pOutNumEstablishedConnections != NULL );

--- a/demos/device_defender_for_aws/metrics_collector/lwip/metrics_collector.c
+++ b/demos/device_defender_for_aws/metrics_collector/lwip/metrics_collector.c
@@ -72,7 +72,7 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 
     if( pOutNetworkStats == NULL )
     {
-        LogError( ( "Invalid parameters. pOutNetworkStats: 0x%08x", pOutNetworkStats ) );
+        LogError( ( "Invalid parameters. pOutNetworkStats: %p", pOutNetworkStats ) );
         status = MetricsCollectorBadParameter;
     }
 
@@ -93,8 +93,8 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
-                                          uint32_t tcpPortsArrayLength,
-                                          uint32_t * pOutNumTcpOpenPorts )
+                                          size_t tcpPortsArrayLength,
+                                          size_t * pOutNumTcpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
     struct tcp_pcb_listen * pCurrPcb;
@@ -103,10 +103,10 @@ MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
     if( ( ( pOutTcpPortsArray != NULL ) && ( tcpPortsArrayLength == 0 ) ) ||
         ( pOutNumTcpOpenPorts == NULL ) )
     {
-        LogError( ( "Invalid parameters. pOutTcpPortsArray: 0x%08x,"
-                    "tcpPortsArrayLength: %u, pOutNumTcpOpenPorts: 0x%08x.",
+        LogError( ( "Invalid parameters. pOutTcpPortsArray: %p,"
+                    "tcpPortsArrayLength: %lu, pOutNumTcpOpenPorts: %p.",
                     pOutTcpPortsArray,
-                    tcpPortsArrayLength,
+                    ( unsigned long ) tcpPortsArrayLength,
                     pOutNumTcpOpenPorts ) );
         status = MetricsCollectorBadParameter;
     }
@@ -154,8 +154,8 @@ MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
-                                          uint32_t udpPortsArrayLength,
-                                          uint32_t * pOutNumUdpOpenPorts )
+                                          size_t udpPortsArrayLength,
+                                          size_t * pOutNumUdpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
     struct udp_pcb * pCurrPcb;
@@ -164,10 +164,10 @@ MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
     if( ( ( pOutUdpPortsArray != NULL ) && ( udpPortsArrayLength == 0 ) ) ||
         ( pOutNumUdpOpenPorts == NULL ) )
     {
-        LogError( ( "Invalid parameters. pOutUdpPortsArray: 0x%08x,"
-                    "udpPortsArrayLength: %u, pOutNumUdpOpenPorts: 0x%08x.",
+        LogError( ( "Invalid parameters. pOutUdpPortsArray: %p,"
+                    "udpPortsArrayLength: %lu, pOutNumUdpOpenPorts: %p.",
                     pOutUdpPortsArray,
-                    udpPortsArrayLength,
+                    ( unsigned long ) udpPortsArrayLength,
                     pOutNumUdpOpenPorts ) );
         status = MetricsCollectorBadParameter;
     }
@@ -215,8 +215,8 @@ MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutNumEstablishedConnections )
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutNumEstablishedConnections )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
     struct tcp_pcb * pCurrPcb = tcp_active_pcbs;
@@ -226,10 +226,10 @@ MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectio
     if( ( ( pOutConnectionsArray != NULL ) && ( connectionsArrayLength == 0 ) ) ||
         ( pOutNumEstablishedConnections == NULL ) )
     {
-        LogError( ( "Invalid parameters. pOutConnectionsArray: 0x%08x,"
-                    " connectionsArrayLength: %u, pOutNumEstablishedConnections: 0x%08x.",
+        LogError( ( "Invalid parameters. pOutConnectionsArray: %p,"
+                    " connectionsArrayLength: %lu, pOutNumEstablishedConnections: %p.",
                     pOutConnectionsArray,
-                    connectionsArrayLength,
+                    ( unsigned long ) connectionsArrayLength,
                     pOutNumEstablishedConnections ) );
         status = MetricsCollectorBadParameter;
     }

--- a/demos/device_defender_for_aws/metrics_collector/stub/metrics_collector.c
+++ b/demos/device_defender_for_aws/metrics_collector/stub/metrics_collector.c
@@ -89,8 +89,8 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
-                                          uint32_t tcpPortsArrayLength,
-                                          uint32_t * pOutNumTcpOpenPorts )
+                                          size_t tcpPortsArrayLength,
+                                          size_t * pOutNumTcpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
 
@@ -126,8 +126,8 @@ MetricsCollectorStatus_t GetOpenTcpPorts( uint16_t * pOutTcpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
-                                          uint32_t udpPortsArrayLength,
-                                          uint32_t * pOutNumUdpOpenPorts )
+                                          size_t udpPortsArrayLength,
+                                          size_t * pOutNumUdpOpenPorts )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
 
@@ -163,8 +163,8 @@ MetricsCollectorStatus_t GetOpenUdpPorts( uint16_t * pOutUdpPortsArray,
 /*-----------------------------------------------------------*/
 
 MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutNumEstablishedConnections )
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutNumEstablishedConnections )
 {
     MetricsCollectorStatus_t status = MetricsCollectorSuccess;
 

--- a/demos/device_defender_for_aws/metrics_collector/stub/metrics_collector.c
+++ b/demos/device_defender_for_aws/metrics_collector/stub/metrics_collector.c
@@ -74,9 +74,6 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 
     if( status == MetricsCollectorSuccess )
     {
-        /* Initialize everything to zero. */
-        memset( pOutNetworkStats, 0, sizeof( NetworkStats_t ) );
-
         /* Take a look at the comments at the top of this file. */
         LogError( ( "Using stub definition of GetNetworkStats! "
                     "Please implement for your network stack to get correct metrics." ) );

--- a/demos/device_defender_for_aws/report_builder.c
+++ b/demos/device_defender_for_aws/report_builder.c
@@ -28,10 +28,6 @@
 #include <string.h>
 #include <stdint.h>
 
-/* Kernel includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-
 /* Device Defender Client Library. */
 #include "defender.h"
 
@@ -178,8 +174,8 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
  *
  * @param[in] pBuffer The buffer to write the array of task IDs.
  * @param[in] bufferLength The length of the buffer.
- * @param[in] pTaskIdsArray The array containing the task IDs.
- * @param[in] taskIdsArrayLength Length of the pTaskIdsArray array.
+ * @param[in] pTaskStatusArray The array containing the task status structs.
+ * @param[in] taskStatusArrayLength Length of the pTaskStatusArray array.
  * @param[out] pOutCharsWritten Number of characters written to the buffer.
  *
  * @return #ReportBuilderSuccess if the array is successfully written;
@@ -187,8 +183,8 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
  */
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
                                                 size_t bufferLength,
-                                                const uint32_t * pTaskIdsArray,
-                                                size_t taskIdsArrayLength,
+                                                const TaskStatus_t * pTaskStatusArray,
+                                                size_t taskStatusArrayLength,
                                                 size_t * pOutCharsWritten );
 /*-----------------------------------------------------------*/
 
@@ -360,8 +356,8 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
                                                 size_t bufferLength,
-                                                const uint32_t * pTaskIdsArray,
-                                                size_t taskIdsArrayLength,
+                                                const TaskStatus_t * pTaskStatusArray,
+                                                size_t taskStatusArrayLength,
                                                 size_t * pOutCharsWritten )
 {
     char * pCurrentWritePos = pBuffer;
@@ -370,7 +366,7 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
     ReportBuilderStatus_t status = ReportBuilderSuccess;
 
     configASSERT( pBuffer != NULL );
-    configASSERT( pTaskIdsArray != NULL );
+    configASSERT( pTaskStatusArray != NULL );
     configASSERT( pOutCharsWritten != NULL );
 
     /* Write the JSON array open marker. */
@@ -386,12 +382,12 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
     }
 
     /* Write the array elements. */
-    for( i = 0; ( ( i < taskIdsArrayLength ) && ( status == ReportBuilderSuccess ) ); i++ )
+    for( i = 0; ( ( i < taskStatusArrayLength ) && ( status == ReportBuilderSuccess ) ); i++ )
     {
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       "%u,",
-                                      pTaskIdsArray[ i ] );
+                                      pTaskStatusArray[ i ].xTaskNumber );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -408,7 +404,7 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
     if( status == ReportBuilderSuccess )
     {
         /* Discard the last comma. */
-        if( taskIdsArrayLength > 0 )
+        if( taskStatusArrayLength > 0 )
         {
             pCurrentWritePos -= 1;
             remainingBufferLength += 1;
@@ -658,8 +654,8 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
     {
         status = writeTaskIdsArray( pCurrentWritePos,
                                     remainingBufferLength,
-                                    pMetrics->pTaskIdsArray,
-                                    pMetrics->taskIdsArrayLength,
+                                    pMetrics->pTaskStatusArray,
+                                    pMetrics->taskStatusArrayLength,
                                     &( bufferWritten ) );
 
         if( status == ReportBuilderSuccess )

--- a/demos/device_defender_for_aws/report_builder.c
+++ b/demos/device_defender_for_aws/report_builder.c
@@ -44,7 +44,7 @@
 #define JSON_ARRAY_OBJECT_SEPARATOR    ','
 
 /* Helper macro to check if snprintf was successful. */
-#define SNPRINTF_SUCCESS( retVal, bufLen )    ( ( retVal > 0 ) && ( ( uint32_t ) retVal < bufLen ) )
+#define SNPRINTF_SUCCESS( retVal, bufLen )    ( ( retVal > 0U ) && ( ( size_t ) retVal < bufLen ) )
 
 /* Formats used to generate the JSON report. */
 #define JSON_PORT_OBJECT_FORMAT \
@@ -137,10 +137,10 @@
  * #ReportBuilderBufferTooSmall if the buffer cannot hold the full array.
  */
 static ReportBuilderStatus_t writePortsArray( char * pBuffer,
-                                              uint32_t bufferLength,
+                                              size_t bufferLength,
                                               const uint16_t * pOpenPortsArray,
-                                              uint32_t openPortsArrayLength,
-                                              uint32_t * pOutCharsWritten );
+                                              size_t openPortsArrayLength,
+                                              size_t * pOutCharsWritten );
 
 /**
  * @brief Write established connections array to the given buffer in the format
@@ -168,10 +168,10 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
  * #ReportBuilderBufferTooSmall if the buffer cannot hold the full array.
  */
 static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
-                                                    uint32_t bufferLength,
+                                                    size_t bufferLength,
                                                     const Connection_t * pConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutCharsWritten );
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutCharsWritten );
 
 /**
  * @brief Write task ids array to the given buffer as a JSON array.
@@ -186,20 +186,20 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
  * #ReportBuilderBufferTooSmall if the buffer cannot hold the full array.
  */
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
-                                                uint32_t bufferLength,
+                                                size_t bufferLength,
                                                 const uint32_t * pTaskIdsArray,
                                                 size_t taskIdsArrayLength,
-                                                uint32_t * pOutCharsWritten );
+                                                size_t * pOutCharsWritten );
 /*-----------------------------------------------------------*/
 
 static ReportBuilderStatus_t writePortsArray( char * pBuffer,
-                                              uint32_t bufferLength,
+                                              size_t bufferLength,
                                               const uint16_t * pOpenPortsArray,
-                                              uint32_t openPortsArrayLength,
-                                              uint32_t * pOutCharsWritten )
+                                              size_t openPortsArrayLength,
+                                              size_t * pOutCharsWritten )
 {
     char * pCurrentWritePos = pBuffer;
-    uint32_t i, remainingBufferLength = bufferLength;
+    size_t i, remainingBufferLength = bufferLength;
     int32_t charactersWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
 
@@ -235,7 +235,7 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
         }
         else
         {
-            remainingBufferLength -= ( uint32_t ) charactersWritten;
+            remainingBufferLength -= charactersWritten;
             pCurrentWritePos += charactersWritten;
         }
     }
@@ -272,13 +272,13 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
 /*-----------------------------------------------------------*/
 
 static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
-                                                    uint32_t bufferLength,
+                                                    size_t bufferLength,
                                                     const Connection_t * pConnectionsArray,
-                                                    uint32_t connectionsArrayLength,
-                                                    uint32_t * pOutCharsWritten )
+                                                    size_t connectionsArrayLength,
+                                                    size_t * pOutCharsWritten )
 {
     char * pCurrentWritePos = pBuffer;
-    uint32_t i, remainingBufferLength = bufferLength;
+    size_t i, remainingBufferLength = bufferLength;
     int32_t charactersWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
     const Connection_t * pConn;
@@ -359,13 +359,13 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 /*-----------------------------------------------------------*/
 
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
-                                                uint32_t bufferLength,
+                                                size_t bufferLength,
                                                 const uint32_t * pTaskIdsArray,
                                                 size_t taskIdsArrayLength,
-                                                uint32_t * pOutCharsWritten )
+                                                size_t * pOutCharsWritten )
 {
     char * pCurrentWritePos = pBuffer;
-    uint32_t i, remainingBufferLength = bufferLength;
+    size_t i, remainingBufferLength = bufferLength;
     int32_t charactersWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
 
@@ -400,7 +400,7 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
         }
         else
         {
-            remainingBufferLength -= ( uint32_t ) charactersWritten;
+            remainingBufferLength -= charactersWritten;
             pCurrentWritePos += charactersWritten;
         }
     }
@@ -437,15 +437,15 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
 /*-----------------------------------------------------------*/
 
 ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
-                                          uint32_t bufferLength,
+                                          size_t bufferLength,
                                           const ReportMetrics_t * pMetrics,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReportLength )
+                                          size_t * pOutReportLength )
 {
     char * pCurrentWritePos = pBuffer;
-    uint32_t remainingBufferLength = bufferLength, bufferWritten;
+    size_t remainingBufferLength = bufferLength, bufferWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
     int32_t charactersWritten;
 
@@ -459,10 +459,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         ( pMetrics == NULL ) ||
         ( pOutReportLength == NULL ) )
     {
-        LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %u"
+        LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %lu"
                     " pMetrics: %p, pOutReportLength: %p.",
                     pBuffer,
-                    bufferLength,
+                    ( unsigned long ) bufferLength,
                     pMetrics,
                     pOutReportLength ) );
         status = ReportBuilderBadParameter;

--- a/demos/device_defender_for_aws/report_builder.c
+++ b/demos/device_defender_for_aws/report_builder.c
@@ -26,9 +26,14 @@
 /* Standard includes. */
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
-/* Demo config. */
-#include "defender_demo_config.h"
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Device Defender Client Library. */
+#include "defender.h"
 
 /* Interface include. */
 #include "report_builder.h"
@@ -44,53 +49,68 @@
 /* Formats used to generate the JSON report. */
 #define JSON_PORT_OBJECT_FORMAT \
     "{"                         \
-    "\"port\": %u"              \
+    "\"%s\": %u"                \
     "},"
 
-#define JSON_CONNECTION_OBJECT_FORMAT     \
-    "{"                                   \
-    "\"local_port\": %u,"                 \
-    "\"remote_addr\": \"%u.%u.%u.%u:%u\"" \
+#define JSON_CONNECTION_OBJECT_FORMAT \
+    "{"                               \
+    "\"%s\": %u,"                     \
+    "\"%s\": \"%u.%u.%u.%u:%u\""      \
     "},"
 
 #define JSON_REPORT_FORMAT_PART1 \
     "{"                          \
-    "\"header\": {"              \
-    "\"report_id\": %u,"         \
-    "\"version\": \"%u.%u\""     \
+    "\"%s\": {"                  \
+    "\"%s\": %u,"                \
+    "\"%s\": \"%u.%u\""          \
     "},"                         \
-    "\"metrics\": {"             \
-    "\"listening_tcp_ports\": {" \
-    "\"ports\": "
+    "\"%s\": {"                  \
+    "\"%s\": {"                  \
+    "\"%s\": "
 
 #define JSON_REPORT_FORMAT_PART2 \
     ","                          \
-    "\"total\": %u"              \
+    "\"%s\": %u"                 \
     "},"                         \
-    "\"listening_udp_ports\": {" \
-    "\"ports\": "
+    "\"%s\": {"                  \
+    "\"%s\": "
 
-#define JSON_REPORT_FORMAT_PART3     \
-    ","                              \
-    "\"total\": %u"                  \
-    "},"                             \
-    "\"network_stats\": {"           \
-    "\"bytes_in\": %u,"              \
-    "\"bytes_out\": %u,"             \
-    "\"packets_in\": %u,"            \
-    "\"packets_out\": %u"            \
-    "},"                             \
-    "\"tcp_connections\": {"         \
-    "\"established_connections\": {" \
-    "\"connections\": "
-
-#define JSON_REPORT_FORMAT_PART4 \
+#define JSON_REPORT_FORMAT_PART3 \
     ","                          \
-    "\"total\": %u"              \
+    "\"%s\": %u"                 \
+    "},"                         \
+    "\"%s\": {"                  \
+    "\"%s\": %u,"                \
+    "\"%s\": %u,"                \
+    "\"%s\": %u,"                \
+    "\"%s\": %u"                 \
+    "},"                         \
+    "\"%s\": {"                  \
+    "\"%s\": {"                  \
+    "\"%s\": "
+
+#define JSON_REPORT_FORMAT_PART4   \
+    ","                            \
+    "\"%s\": %u"                   \
+    "}"                            \
+    "}"                            \
+    "},"                           \
+    "\"%s\": {"                    \
+    "\"stack_high_water_mark\": [" \
+    "{"                            \
+    "\"%s\": %u"                   \
+    "}"                            \
+    "],"                           \
+    "\"task_numbers\": ["          \
+    "{"                            \
+    "\"%s\": "
+
+#define JSON_REPORT_FORMAT_PART5 \
     "}"                          \
-    "}"                          \
+    "]"                          \
     "}"                          \
     "}"
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -152,6 +172,24 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
                                                     const Connection_t * pConnectionsArray,
                                                     uint32_t connectionsArrayLength,
                                                     uint32_t * pOutCharsWritten );
+
+/**
+ * @brief Write task ids array to the given buffer as a JSON array.
+ *
+ * @param[in] pBuffer The buffer to write the connections array.
+ * @param[in] bufferLength The length of the buffer.
+ * @param[in] pTaskIdsArray The array containing the task ids.
+ * @param[in] pTaskIdsArrayLength Length of the pTaskIdsArray array.
+ * @param[out] pOutCharsWritten Number of characters written to the buffer.
+ *
+ * @return #ReportBuilderSuccess if the array is successfully written;
+ * #ReportBuilderBufferTooSmall if the buffer cannot hold the full array.
+ */
+static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
+                                                uint32_t bufferLength,
+                                                const uint32_t * pTaskIdsArray,
+                                                uint32_t pTaskIdsArrayLength,
+                                                uint32_t * pOutCharsWritten );
 /*-----------------------------------------------------------*/
 
 static ReportBuilderStatus_t writePortsArray( char * pBuffer,
@@ -162,8 +200,12 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
 {
     char * pCurrentWritePos = pBuffer;
     uint32_t i, remainingBufferLength = bufferLength;
-    int charactersWritten;
+    int32_t charactersWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
+
+    configASSERT( pBuffer != NULL );
+    configASSERT( pOpenPortsArray != NULL );
+    configASSERT( pOutCharsWritten != NULL );
 
     /* Write the JSON array open marker. */
     if( remainingBufferLength > 1 )
@@ -183,6 +225,7 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_PORT_OBJECT_FORMAT,
+                                      DEFENDER_REPORT_PORT_KEY,
                                       pOpenPortsArray[ i ] );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
@@ -236,9 +279,13 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 {
     char * pCurrentWritePos = pBuffer;
     uint32_t i, remainingBufferLength = bufferLength;
-    int charactersWritten;
+    int32_t charactersWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
     const Connection_t * pConn;
+
+    configASSERT( pBuffer != NULL );
+    configASSERT( pConnectionsArray != NULL );
+    configASSERT( pOutCharsWritten != NULL );
 
     /* Write the JSON array open marker. */
     if( remainingBufferLength > 1 )
@@ -259,7 +306,9 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_CONNECTION_OBJECT_FORMAT,
+                                      DEFENDER_REPORT_LOCAL_PORT_KEY,
                                       pConn->localPort,
+                                      DEFENDER_REPORT_REMOTE_ADDR_KEY,
                                       ( pConn->remoteIp >> 24 ) & 0xFF,
                                       ( pConn->remoteIp >> 16 ) & 0xFF,
                                       ( pConn->remoteIp >> 8 ) & 0xFF,
@@ -309,30 +358,113 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 }
 /*-----------------------------------------------------------*/
 
+static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
+                                                uint32_t bufferLength,
+                                                const uint32_t * pTaskIdsArray,
+                                                uint32_t pTaskIdsArrayLength,
+                                                uint32_t * pOutCharsWritten )
+{
+    char * pCurrentWritePos = pBuffer;
+    uint32_t i, remainingBufferLength = bufferLength;
+    int32_t charactersWritten;
+    ReportBuilderStatus_t status = ReportBuilderSuccess;
+
+    configASSERT( pBuffer != NULL );
+    configASSERT( pTaskIdsArray != NULL );
+    configASSERT( pOutCharsWritten != NULL );
+
+    /* Write the JSON array open marker. */
+    if( remainingBufferLength > 1 )
+    {
+        *pCurrentWritePos = JSON_ARRAY_OPEN_MARKER;
+        remainingBufferLength -= 1;
+        pCurrentWritePos += 1;
+    }
+    else
+    {
+        status = ReportBuilderBufferTooSmall;
+    }
+
+    /* Write the array elements. */
+    for( i = 0; ( ( i < pTaskIdsArrayLength ) && ( status == ReportBuilderSuccess ) ); i++ )
+    {
+        charactersWritten = snprintf( pCurrentWritePos,
+                                      remainingBufferLength,
+                                      "%u,",
+                                      pTaskIdsArray[ i ] );
+
+        if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
+        {
+            status = ReportBuilderBufferTooSmall;
+            break;
+        }
+        else
+        {
+            remainingBufferLength -= ( uint32_t ) charactersWritten;
+            pCurrentWritePos += charactersWritten;
+        }
+    }
+
+    if( status == ReportBuilderSuccess )
+    {
+        /* Discard the last comma. */
+        if( pTaskIdsArrayLength > 0 )
+        {
+            pCurrentWritePos -= 1;
+            remainingBufferLength += 1;
+        }
+
+        /* Write the JSON array close marker. */
+        if( remainingBufferLength > 1 )
+        {
+            *pCurrentWritePos = JSON_ARRAY_CLOSE_MARKER;
+            remainingBufferLength -= 1;
+            pCurrentWritePos += 1;
+        }
+        else
+        {
+            status = ReportBuilderBufferTooSmall;
+        }
+    }
+
+    if( status == ReportBuilderSuccess )
+    {
+        *pOutCharsWritten = bufferLength - remainingBufferLength;
+    }
+
+    return status;
+}
+/*-----------------------------------------------------------*/
+
 ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
                                           uint32_t bufferLength,
                                           const ReportMetrics_t * pMetrics,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReprotLength )
+                                          uint32_t * pOutReportLength )
 {
     char * pCurrentWritePos = pBuffer;
     uint32_t remainingBufferLength = bufferLength, bufferWritten;
     ReportBuilderStatus_t status = ReportBuilderSuccess;
-    int charactersWritten;
+    int32_t charactersWritten;
+
+    configASSERT( pBuffer != NULL );
+    configASSERT( pMetrics != NULL );
+    configASSERT( pOutReportLength != NULL );
+    configASSERT( bufferLength != 0 );
 
     if( ( pBuffer == NULL ) ||
         ( bufferLength == 0 ) ||
         ( pMetrics == NULL ) ||
-        ( pOutReprotLength == NULL ) )
+        ( pOutReportLength == NULL ) )
     {
         LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %u"
                     " pMetrics: %p, pOutReprotLength: %p.",
                     pBuffer,
                     bufferLength,
                     pMetrics,
-                    pOutReprotLength ) );
+                    pOutReportLength ) );
         status = ReportBuilderBadParameter;
     }
 
@@ -342,9 +474,16 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART1,
+                                      DEFENDER_REPORT_HEADER_KEY,
+                                      DEFENDER_REPORT_ID_KEY,
                                       reportId,
+                                      DEFENDER_REPORT_VERSION_KEY,
                                       majorReportVersion,
-                                      minorReportVersion );
+                                      minorReportVersion,
+                                      DEFENDER_REPORT_METRICS_KEY,
+                                      DEFENDER_REPORT_TCP_LISTENING_PORTS_KEY,
+                                      DEFENDER_REPORT_PORTS_KEY
+                                      );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -384,7 +523,11 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART2,
-                                      pMetrics->openTcpPortsArrayLength );
+                                      DEFENDER_REPORT_TOTAL_KEY,
+                                      pMetrics->openTcpPortsArrayLength,
+                                      DEFENDER_REPORT_UDP_LISTENING_PORTS_KEY,
+                                      DEFENDER_REPORT_PORTS_KEY
+                                      );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -424,11 +567,21 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART3,
+                                      DEFENDER_REPORT_TOTAL_KEY,
                                       pMetrics->openUdpPortsArrayLength,
+                                      DEFENDER_REPORT_NETWORK_STATS_KEY,
+                                      DEFENDER_REPORT_BYTES_IN_KEY,
                                       pMetrics->pNetworkStats->bytesReceived,
+                                      DEFENDER_REPORT_BYTES_OUT_KEY,
                                       pMetrics->pNetworkStats->bytesSent,
+                                      DEFENDER_REPORT_PKTS_IN_KEY,
                                       pMetrics->pNetworkStats->packetsReceived,
-                                      pMetrics->pNetworkStats->packetsSent );
+                                      DEFENDER_REPORT_PKTS_OUT_KEY,
+                                      pMetrics->pNetworkStats->packetsSent,
+                                      DEFENDER_REPORT_TCP_CONNECTIONS_KEY,
+                                      DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY,
+                                      DEFENDER_REPORT_CONNECTIONS_KEY
+                                      );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -468,7 +621,13 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART4,
-                                      pMetrics->establishedConnectionsArrayLength );
+                                      DEFENDER_REPORT_TOTAL_KEY,
+                                      pMetrics->establishedConnectionsArrayLength,
+                                      DEFENDER_REPORT_CUSTOM_METRICS_KEY,
+                                      DEFENDER_REPORT_NUMBER_KEY,
+                                      pMetrics->stackHighWaterMark,
+                                      DEFENDER_REPORT_NUMBER_LIST_KEY
+                                      );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -482,9 +641,48 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         }
     }
 
+    /* Write task ids array. */
     if( status == ReportBuilderSuccess )
     {
-        *pOutReprotLength = bufferLength - remainingBufferLength;
+        status = writeTaskIdsArray( pCurrentWritePos,
+                                    remainingBufferLength,
+                                    pMetrics->pTaskIdsArray,
+                                    pMetrics->taskIdsArrayLength,
+                                    &( bufferWritten ) );
+
+        if( status == ReportBuilderSuccess )
+        {
+            pCurrentWritePos += bufferWritten;
+            remainingBufferLength -= bufferWritten;
+        }
+        else
+        {
+            LogError( ( "Failed to write task ids array." ) );
+        }
+    }
+
+    /* Write part5. */
+    if( status == ReportBuilderSuccess )
+    {
+        charactersWritten = snprintf( pCurrentWritePos,
+                                      remainingBufferLength,
+                                      JSON_REPORT_FORMAT_PART5 );
+
+        if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
+        {
+            LogError( ( "Failed to write part 5." ) );
+            status = ReportBuilderBufferTooSmall;
+        }
+        else
+        {
+            remainingBufferLength -= charactersWritten;
+            pCurrentWritePos += charactersWritten;
+        }
+    }
+
+    if( status == ReportBuilderSuccess )
+    {
+        *pOutReportLength = bufferLength - remainingBufferLength;
     }
 
     return status;

--- a/demos/device_defender_for_aws/report_builder.c
+++ b/demos/device_defender_for_aws/report_builder.c
@@ -490,7 +490,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
             LogError( ( "Failed to write part 1 of JSON report to buffer. "
                         "Remaining buffer space is %lu. Needed %lu.",
                         ( unsigned long ) remainingBufferLength,
-                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
+                        ( unsigned long ) ( sizeof( JSON_REPORT_FORMAT_PART5 ) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -537,7 +537,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
             LogError( ( "Failed to write part 2 of JSON report to buffer. "
                         "Remaining buffer space is %lu. Needed %lu.",
                         ( unsigned long ) remainingBufferLength,
-                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
+                        ( unsigned long ) ( sizeof( JSON_REPORT_FORMAT_PART5 ) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -594,7 +594,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
             LogError( ( "Failed to write part 3 of JSON report to buffer. "
                         "Remaining buffer space is %lu. Needed %lu.",
                         ( unsigned long ) remainingBufferLength,
-                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
+                        ( unsigned long ) ( sizeof( JSON_REPORT_FORMAT_PART5 ) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -643,7 +643,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
             LogError( ( "Failed to write part 4 of JSON report to buffer. "
                         "Remaining buffer space is %lu. Needed %lu.",
                         ( unsigned long ) remainingBufferLength,
-                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
+                        ( unsigned long ) ( sizeof( JSON_REPORT_FORMAT_PART5 ) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -686,7 +686,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
             LogError( ( "Failed to write part 5 of JSON report to buffer. "
                         "Remaining buffer space is %lu. Needed %lu.",
                         ( unsigned long ) remainingBufferLength,
-                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
+                        ( unsigned long ) ( sizeof( JSON_REPORT_FORMAT_PART5 ) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else

--- a/demos/device_defender_for_aws/report_builder.c
+++ b/demos/device_defender_for_aws/report_builder.c
@@ -176,10 +176,10 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 /**
  * @brief Write task ids array to the given buffer as a JSON array.
  *
- * @param[in] pBuffer The buffer to write the connections array.
+ * @param[in] pBuffer The buffer to write the array of task IDs.
  * @param[in] bufferLength The length of the buffer.
- * @param[in] pTaskIdsArray The array containing the task ids.
- * @param[in] pTaskIdsArrayLength Length of the pTaskIdsArray array.
+ * @param[in] pTaskIdsArray The array containing the task IDs.
+ * @param[in] taskIdsArrayLength Length of the pTaskIdsArray array.
  * @param[out] pOutCharsWritten Number of characters written to the buffer.
  *
  * @return #ReportBuilderSuccess if the array is successfully written;
@@ -188,7 +188,7 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
                                                 uint32_t bufferLength,
                                                 const uint32_t * pTaskIdsArray,
-                                                uint32_t pTaskIdsArrayLength,
+                                                size_t taskIdsArrayLength,
                                                 uint32_t * pOutCharsWritten );
 /*-----------------------------------------------------------*/
 
@@ -361,7 +361,7 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
 static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
                                                 uint32_t bufferLength,
                                                 const uint32_t * pTaskIdsArray,
-                                                uint32_t pTaskIdsArrayLength,
+                                                size_t taskIdsArrayLength,
                                                 uint32_t * pOutCharsWritten )
 {
     char * pCurrentWritePos = pBuffer;
@@ -386,7 +386,7 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
     }
 
     /* Write the array elements. */
-    for( i = 0; ( ( i < pTaskIdsArrayLength ) && ( status == ReportBuilderSuccess ) ); i++ )
+    for( i = 0; ( ( i < taskIdsArrayLength ) && ( status == ReportBuilderSuccess ) ); i++ )
     {
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
@@ -408,7 +408,7 @@ static ReportBuilderStatus_t writeTaskIdsArray( char * pBuffer,
     if( status == ReportBuilderSuccess )
     {
         /* Discard the last comma. */
-        if( pTaskIdsArrayLength > 0 )
+        if( taskIdsArrayLength > 0 )
         {
             pCurrentWritePos -= 1;
             remainingBufferLength += 1;
@@ -460,7 +460,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         ( pOutReportLength == NULL ) )
     {
         LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %u"
-                    " pMetrics: %p, pOutReprotLength: %p.",
+                    " pMetrics: %p, pOutReportLength: %p.",
                     pBuffer,
                     bufferLength,
                     pMetrics,
@@ -487,7 +487,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
-            LogError( ( "Failed to write part 1." ) );
+            LogError( ( "Failed to write part 1 of JSON report to buffer. "
+                        "Remaining buffer space is %lu. Needed %lu.",
+                        ( unsigned long ) remainingBufferLength,
+                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -531,7 +534,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
-            LogError( ( "Failed to write part 2." ) );
+            LogError( ( "Failed to write part 2 of JSON report to buffer. "
+                        "Remaining buffer space is %lu. Needed %lu.",
+                        ( unsigned long ) remainingBufferLength,
+                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -585,7 +591,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
-            LogError( ( "Failed to write part 3." ) );
+            LogError( ( "Failed to write part 3 of JSON report to buffer. "
+                        "Remaining buffer space is %lu. Needed %lu.",
+                        ( unsigned long ) remainingBufferLength,
+                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -631,7 +640,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
-            LogError( ( "Failed to write part 4." ) );
+            LogError( ( "Failed to write part 4 of JSON report to buffer. "
+                        "Remaining buffer space is %lu. Needed %lu.",
+                        ( unsigned long ) remainingBufferLength,
+                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else
@@ -657,7 +669,8 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         }
         else
         {
-            LogError( ( "Failed to write task ids array." ) );
+            LogError( ( "Failed to write the task ID list custom metric to the"
+                        "JSON report." ) );
         }
     }
 
@@ -670,7 +683,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
-            LogError( ( "Failed to write part 5." ) );
+            LogError( ( "Failed to write part 5 of JSON report to buffer. "
+                        "Remaining buffer space is %lu. Needed %lu.",
+                        ( unsigned long ) remainingBufferLength,
+                        ( unsigned long ) ( sizeof(JSON_REPORT_FORMAT_PART5) - 1 ) ) );
             status = ReportBuilderBufferTooSmall;
         }
         else

--- a/demos/device_defender_for_aws/report_builder.h
+++ b/demos/device_defender_for_aws/report_builder.h
@@ -40,7 +40,13 @@ typedef enum
 } ReportBuilderStatus_t;
 
 /**
- * @brief Represents metrics to be included in the report.
+ * @brief Represents metrics to be included in the report, including custom metrics.
+ *
+ * This demo demonstrates the use of the stack high water mark and list of
+ * running task ids as custom metrics sent to AWS IoT Device Defender service.
+ *
+ * For more information on custom metrics, refer to the following AWS document:
+ * https://docs.aws.amazon.com/iot/latest/developerguide/dd-detect-custom-metrics.html
  */
 typedef struct ReportMetrics
 {
@@ -51,6 +57,10 @@ typedef struct ReportMetrics
     uint32_t openUdpPortsArrayLength;
     Connection_t * pEstablishedConnectionsArray;
     uint32_t establishedConnectionsArrayLength;
+    /* Custom metrics */
+    uint32_t stackHighWaterMark;
+    uint32_t * pTaskIdsArray;
+    uint32_t taskIdsArrayLength;
 } ReportMetrics_t;
 
 /**
@@ -62,8 +72,8 @@ typedef struct ReportMetrics
  * @param[in] pMetrics Metrics to write in the generated report.
  * @param[in] majorReportVersion Major version of the report.
  * @param[in] minorReportVersion Minor version of the report.
- * @param[in] reportId Value to be used as the reportId in the generated report.
- * @param[out] pOutReprotLength The length of the generated report.
+ * @param[in] reportId Value to be used as the ulReportId in the generated report.
+ * @param[out] pOutReportLength The length of the generated report.
  *
  * @return #ReportBuilderSuccess if the report is successfully generated;
  * #ReportBuilderBadParameter if invalid parameters are passed;
@@ -75,6 +85,6 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReprotLength );
+                                          uint32_t * pOutReportLength );
 
 #endif /* ifndef REPORT_BUILDER_H_ */

--- a/demos/device_defender_for_aws/report_builder.h
+++ b/demos/device_defender_for_aws/report_builder.h
@@ -60,7 +60,7 @@ typedef struct ReportMetrics
     /* Custom metrics */
     uint32_t stackHighWaterMark;
     uint32_t * pTaskIdsArray;
-    uint32_t taskIdsArrayLength;
+    size_t taskIdsArrayLength;
 } ReportMetrics_t;
 
 /**
@@ -72,7 +72,7 @@ typedef struct ReportMetrics
  * @param[in] pMetrics Metrics to write in the generated report.
  * @param[in] majorReportVersion Major version of the report.
  * @param[in] minorReportVersion Minor version of the report.
- * @param[in] reportId Value to be used as the ulReportId in the generated report.
+ * @param[in] reportId Value to be used as the reportId in the generated report.
  * @param[out] pOutReportLength The length of the generated report.
  *
  * @return #ReportBuilderSuccess if the report is successfully generated;

--- a/demos/device_defender_for_aws/report_builder.h
+++ b/demos/device_defender_for_aws/report_builder.h
@@ -52,11 +52,11 @@ typedef struct ReportMetrics
 {
     NetworkStats_t * pNetworkStats;
     uint16_t * pOpenTcpPortsArray;
-    uint32_t openTcpPortsArrayLength;
+    size_t openTcpPortsArrayLength;
     uint16_t * pOpenUdpPortsArray;
-    uint32_t openUdpPortsArrayLength;
+    size_t openUdpPortsArrayLength;
     Connection_t * pEstablishedConnectionsArray;
-    uint32_t establishedConnectionsArrayLength;
+    size_t establishedConnectionsArrayLength;
     /* Custom metrics */
     uint32_t stackHighWaterMark;
     uint32_t * pTaskIdsArray;
@@ -80,11 +80,11 @@ typedef struct ReportMetrics
  * #ReportBuilderBufferTooSmall if the buffer cannot hold the full report.
  */
 ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
-                                          uint32_t bufferLength,
+                                          size_t bufferLength,
                                           const ReportMetrics_t * pMetrics,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReportLength );
+                                          size_t * pOutReportLength );
 
 #endif /* ifndef REPORT_BUILDER_H_ */

--- a/demos/device_defender_for_aws/report_builder.h
+++ b/demos/device_defender_for_aws/report_builder.h
@@ -26,6 +26,10 @@
 #ifndef REPORT_BUILDER_H_
 #define REPORT_BUILDER_H_
 
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
 /* Metrics collector. */
 #include "metrics_collector.h"
 
@@ -59,8 +63,8 @@ typedef struct ReportMetrics
     size_t establishedConnectionsArrayLength;
     /* Custom metrics */
     uint32_t stackHighWaterMark;
-    uint32_t * pTaskIdsArray;
-    size_t taskIdsArrayLength;
+    TaskStatus_t * pTaskStatusArray;
+    size_t taskStatusArrayLength;
 } ReportMetrics_t;
 
 /**


### PR DESCRIPTION
Adds collection and reporting of two custom metrics to the Device Defender demo. These metrics are the stack high water mark and the list of task ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.