### PR TITLE
Fix mqtt demo metadata inclusion

### DIFF
--- a/libraries/core_mqtt_demo_dependencies.cmake
+++ b/libraries/core_mqtt_demo_dependencies.cmake
@@ -51,7 +51,7 @@ afr_module_dependencies(
 # This module enables the FreeRTOS console experience of enabling
 # library dependencies when selecting the MQTT library, so that the
 # coreMQTT demos can be downloaded.
-afr_module(NAME core_mqtt_demo_dependencies INTERNAL )
+afr_module(NAME core_mqtt_demo_dependencies)
 
 afr_set_lib_metadata(ID "core_mqtt_demo_dependencies")
 afr_set_lib_metadata(DESCRIPTION "This library implements the MQTT protocol that enables \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Fixes an issue in metadata generation where the mqtt demo dependencies would not be included

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
