### PR TITLE
Fixing PublishInfo structure not being initialized and bitmask value …

### DIFF
--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
@@ -87,7 +87,7 @@
  */
 #define PUBLISH_FLAG_RETAIN_MASK    BIT_MASK( 0 )                           /**< @brief MQTT PUBLISH retain flag. */
 #define PUBLISH_FLAG_QOS_MASK       ( BIT_MASK( 1 ) | BIT_MASK( 2 ) )       /**< @brief MQTT PUBLISH QoS1 flag. */
-#define PUBLISH_FLAG_DUP_MASK       BIT_MASK( 2 )                           /**< @brief MQTT PUBLISH duplicate flag. */
+#define PUBLISH_FLAG_DUP_MASK       BIT_MASK( 3 )                           /**< @brief MQTT PUBLISH duplicate flag. */
 #define PUBLISH_FLAG_QOS1_MASK      BIT_MASK( 1 )                           /**< @brief MQTT PUBLISH QoS1 flag. */
 #define PUBLISH_FLAG_QOS2_MASK      BIT_MASK( 2 )                           /**< @brief MQTT PUBLISH QoS2 flag. */
 
@@ -894,7 +894,7 @@ static MQTTBLEStatus_t handleIncomingPublish( StreamBufferHandle_t streamBuffer,
                                               size_t length )
 {
     MQTTBLEStatus_t status = MQTTBLESuccess;
-    MQTTBLEPublishInfo_t publishInfo;
+    MQTTBLEPublishInfo_t publishInfo ={0};
     uint16_t packetIdentifier = 0;
 
     LogDebug( ( "Processing incoming PUBLISH from channel." ) );

--- a/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
+++ b/libraries/c_sdk/standard/ble/src/services/mqtt_ble/iot_ble_mqtt_transport.c
@@ -894,7 +894,7 @@ static MQTTBLEStatus_t handleIncomingPublish( StreamBufferHandle_t streamBuffer,
                                               size_t length )
 {
     MQTTBLEStatus_t status = MQTTBLESuccess;
-    MQTTBLEPublishInfo_t publishInfo ={0};
+    MQTTBLEPublishInfo_t publishInfo = { 0 };
     uint16_t packetIdentifier = 0;
 
     LogDebug( ( "Processing incoming PUBLISH from channel." ) );


### PR DESCRIPTION
*Fixing PublishInfo structure not being initialized and bitmask value for PUBLISH_FLAG_DUP_MASK*

Description
-----------
These changes proposed by Dan Griffin from STMicroelectronics

This issue is present in the 202012.00 release, but it looks like it is still present in the main branch of amazon-freertos.

Specifically, the bug is at line 882 (in 202012.00 release) or line 897 (in main branch) of iot_ble_mqtt_transport.c:

MQTTBLEPublishInfo_t publishInfo;

publishInfo is a configuration structure that is declared without being initialized. This structure is passed to IotBleMqtt_DeserializePublish(), which also does not fully initialize it. Specifically, in the error I was encountering, if the dup member of this structure happens to be non-zero, it will not be overwritten by this function and will retain whatever value happened to be present. Later, in transportSerializePublish(), if the dup field is non-zero, the PUBLISH_FLAG_DUP_MASK flag will be set in the publishFlags field, which gets incorporated into the packet header, effectively corrupting it. When core_mqtt_serializer.c::deserializePublish() later calls processPublishFlags() to inspect this header, it will conclude that both QOS1 and QOS2 are set (because the DUP flag is equivalent to the QOS2 flag) and will error out.

Line 90: PUBLISH_FLAG_DUP_MASK bit is set to 3 instead of 2
Line 897: PublishInfo configuration structure is initialized



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.