### PR TITLE
AFR NimBLE: Fix memory overrun bug during GATT cleanup

### DIFF
--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gatt_server.c
@@ -540,7 +540,7 @@ void vESPBTGATTServerCleanup( void )
         serviceCnt = 0;
 
         memset( espServices, 0, sizeof( struct ble_gatt_svc_def ) * ( MAX_SERVICES + 1 ) );
-        memset( afrServices, 0, sizeof( struct BTService_t * ) * ( MAX_SERVICES + 1 ) );
+        memset( afrServices, 0, sizeof( struct BTService_t * ) * ( MAX_SERVICES ) );
     }
 
     if( semInited )


### PR DESCRIPTION
<!--- Title -->

Fix memory overrun issue in AFR NimBLE.

Description
-----------
<!--- Describe your changes in detail -->

The `afrServices` is allocated memory for `MAX_SERVICES`. However, current code while doing GATT cleanup accesses additional `sizeof( struct BTService_t * )` bytes of memory. This PR fixes this bug.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.