### PR TITLE
Fix: timespec bug where time is greater than 1 second

### DIFF
--- a/tests/unit_test/linux/utils/wait_for_event.c
+++ b/tests/unit_test/linux/utils/wait_for_event.c
@@ -73,7 +73,8 @@ bool event_wait_timed( struct event * ev,
     int ret = 0;
 
     clock_gettime( CLOCK_REALTIME, &ts );
-    ts.tv_sec += ms;
+    ts.tv_sec += ms / 1000;
+    ts.tv_nsec += ( ( ms % 1000 ) * 1000000 );
     pthread_mutex_lock( &ev->mutex );
 
     while( ev->event_triggered == false && ret == 0 )


### PR DESCRIPTION
 timespec bug where time is greater than 1 seconds

Description
-----------
Fixing bug handling the ms time into seconds and nanoseconds

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.