### PR TITLE
Update esp project to build with +tcp

### DIFF
--- a/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
+++ b/vendors/espressif/boards/components/mbedtls/CMakeLists.txt
@@ -62,7 +62,7 @@ set(
     "${MBEDTLS_DIR}/port/esp_timing.c"
 )
 
-if(NOT AFR_FREERTOS_TCP)
+if(NOT AFR_ESP_FREERTOS_TCP)
     list(
         APPEND
         mbedtls_srcs

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
 endif()
 
 # mbedTLS include directories
-if(NOT AFR_FREERTOS_TCP)
+if(NOT AFR_ESP_FREERTOS_TCP)
     target_include_directories(
         afr_3rdparty_mbedtls
         PUBLIC
@@ -131,6 +131,7 @@ if(AFR_ESP_FREERTOS_TCP)
     "${esp_idf_dir}/components/esp_wifi/include"
     "${esp_idf_dir}/components/esp_netif/include"
     "${esp_idf_dir}/components/esp_eth/include"
+    "${esp_idf_dir}/components/soc/soc/include"
     )
 else()
     list(APPEND kernel_inc_dirs
@@ -337,50 +338,49 @@ target_include_directories(
 )
 
 if(AFR_ESP_FREERTOS_TCP)
-# FreeRTOS Plus TCP
-afr_mcu_port(freertos_plus_tcp)
-target_sources(
-    AFR::freertos_plus_tcp::mcu_port
-    INTERFACE
-        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/BufferManagement/BufferAllocation_2.c"
-        "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/NetworkInterface/esp32/NetworkInterface.c"
-)
+    # FreeRTOS Plus TCP
+    afr_mcu_port(freertos_plus_tcp)
+    target_sources(
+        AFR::freertos_plus_tcp::mcu_port
+        INTERFACE
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/BufferManagement/BufferAllocation_2.c"
+            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_tcp/portable/NetworkInterface/esp32/NetworkInterface.c"
+    )
 
-# Secure sockets
-afr_mcu_port(secure_sockets)
-target_link_libraries(
-    AFR::secure_sockets::mcu_port
-    INTERFACE AFR::secure_sockets_freertos_plus_tcp
-)
+    # Secure sockets
+    afr_mcu_port(secure_sockets)
+    target_link_libraries(
+        AFR::secure_sockets::mcu_port
+        INTERFACE AFR::secure_sockets_freertos_plus_tcp
+    )
 else()
 
-# Secure sockets
-afr_mcu_port(secure_sockets)
+    # Secure sockets
+    afr_mcu_port(secure_sockets)
 
-target_sources(
-    AFR::secure_sockets::mcu_port
-    INTERFACE
-        "${AFR_MODULES_ABSTRACTIONS_DIR}/secure_sockets/lwip/iot_secure_sockets.c"
-)
+    target_sources(
+        AFR::secure_sockets::mcu_port
+        INTERFACE
+            "${AFR_MODULES_ABSTRACTIONS_DIR}/secure_sockets/lwip/iot_secure_sockets.c"
+    )
 
-target_include_directories(
-    AFR::secure_sockets::mcu_port
-    INTERFACE
-        "${esp_idf_dir}/components/lwip/include/apps"
-        "${esp_idf_dir}/components/lwip/include/apps/sntp"
-        "${esp_idf_dir}/components/lwip/lwip/src/include"
-        "${esp_idf_dir}/components/lwip/port/esp32/include"
-        "${esp_idf_dir}/components/lwip/port/esp32/include/arch"
-        "${esp_idf_dir}/components/lwip/include"
-)
+    target_include_directories(
+        AFR::secure_sockets::mcu_port
+        INTERFACE
+            "${esp_idf_dir}/components/lwip/include/apps"
+            "${esp_idf_dir}/components/lwip/include/apps/sntp"
+            "${esp_idf_dir}/components/lwip/lwip/src/include"
+            "${esp_idf_dir}/components/lwip/port/esp32/include"
+            "${esp_idf_dir}/components/lwip/port/esp32/include/arch"
+            "${esp_idf_dir}/components/lwip/include"
+    )
 
-target_link_libraries(
-    AFR::secure_sockets::mcu_port
-    INTERFACE
-        AFR::tls
-        AFR::wifi
-)
-
+    target_link_libraries(
+        AFR::secure_sockets::mcu_port
+        INTERFACE
+            AFR::tls
+            AFR::wifi
+    )
 endif()
 
 # Common I/O

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/FreeRTOSIPConfig.h
@@ -308,6 +308,7 @@ extern uint32_t ulRand();
 #define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
 #define ipconfigUSE_CALLBACKS                    ( 0 )
 
+#define ipconfigTCP_MEM_STATS_MAX_ALLOCATION     ( 128 )
 
 #define portINLINE                               __inline
 

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 endif()
 
 # mbedTLS include directories
-if(NOT AFR_FREERTOS_TCP)
+if(NOT AFR_ESP_FREERTOS_TCP)
     target_include_directories(
         afr_3rdparty_mbedtls
         PUBLIC


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds changes in the esp build to make it work with FreeRTOS+TCP. Although even after this change, the build is not completely fixed since LWIP is getting pulled in from the esp-idf repository as a dependency and causes multiple definitions of `wlanif_input()`.

This also fixes the macro name from `AFR_FREERTOS_TCP` to `AFR_ESP_FREERTOS_TCP` which was accidentally introduced in https://github.com/aws/amazon-freertos/pull/3115.

Related issue: https://github.com/aws/amazon-freertos/issues/3186

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.