### PR TITLE
Remove references to deleted directory

### DIFF
--- a/projects/microchip/ecc608a_plus_winsim/visual_studio/aws_tests/aws_tests.vcxproj
+++ b/projects/microchip/ecc608a_plus_winsim/visual_studio/aws_tests/aws_tests.vcxproj
@@ -66,9 +66,6 @@
 			<AdditionalDependencies>wpcap.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
 			<AdditionalLibraryDirectories>..\..\..\..\..\libraries\3rdparty\win_pcap</AdditionalLibraryDirectories>
 		</Link>
-		<PostBuildEvent>
-			<Command>copy $(SolutionDir)..\..\..\..\..\libraries\freertos_plus\aws\ota\test\test_files\*.* $(TEMP)</Command>
-		</PostBuildEvent>
 	</ItemDefinitionGroup>
 	<ItemDefinitionGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|x64&apos;">
 		<ClCompile>

--- a/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
+++ b/projects/pc/windows/visual_studio/aws_tests/aws_tests.vcxproj
@@ -66,9 +66,6 @@
 			<AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
 			<AdditionalLibraryDirectories>..\..\..\..\..\libraries\3rdparty\win_pcap</AdditionalLibraryDirectories>
 		</Link>
-		<PostBuildEvent>
-			<Command>copy $(SolutionDir)..\..\..\..\..\libraries\freertos_plus\aws\ota\test\test_files\*.* $(TEMP)</Command>
-		</PostBuildEvent>
 	</ItemDefinitionGroup>
 	<ItemDefinitionGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|x64&apos;">
 		<ClCompile>


### PR DESCRIPTION
Remove references to deleted directory

Description
-----------
* The ota\test\test_files directory does not exist anymore. Fix the
  test projects that are breaking due to references this invalid path.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.