### PR TITLE
Add MQTT Agent interface headers to cmake

### DIFF
--- a/libraries/abstractions/mqtt_agent/mqtt_agent_interface.cmake
+++ b/libraries/abstractions/mqtt_agent/mqtt_agent_interface.cmake
@@ -15,6 +15,10 @@ afr_module_sources(
     PRIVATE
         "${src_dir}/freertos_agent_message.c"
         "${src_dir}/freertos_command_pool.c"
+        # Header files added to the target so that these are available in code
+        # downloaded from the FreeRTOS console.
+        "${include_dir}/freertos_agent_message.h"
+        "${include_dir}/freertos_command_pool.h"
 )
 
 afr_module_dependencies(


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Adds the headers files of the MQTT Agent interface to the cmake file for module sources. This should fix failing build combinations where the header files were not being added.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
