### PR TITLE
Add missing .h files to the OTA CMake target

### DIFF
--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -23,9 +23,18 @@ afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
         ${OTA_SOURCES}
-        ${OTA_OS_FREERTOS_SOURCES} 
+        # Include missing OTA source .h files that are required to generate correct metadata.
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/include/ota_appversion32.h"
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/include/ota_config_defaults.h"
+        ${OTA_OS_FREERTOS_SOURCES}
+        # Include missing OTA FreeRTOS .h file that is required to generate correct metadata.
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/portable/os/ota_os_freertos.h"
         ${OTA_MQTT_SOURCES}
+        # Include missing OTA MQTT interface .h file that is required to generate correct metadata.
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/include/ota_mqtt_interface.h"
         ${OTA_HTTP_SOURCES}
+        # Include missing OTA HTTP interface .h file that is required to generate correct metadata.
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/include/ota_http_interface.h"
 )
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -5,7 +5,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake")
 
 # Remove the coreJSON and TinyCBOR files from the OTA_SOURCES and
 # OTA_INCLUDE_PRIVATE_DIR variables. This is so that the OTA target can depend
-# on the local copy of the libraries instead of the ones in the OTA repository.
+# on the libraries part of amazon-freertos instead of the ones nested in the OTA repository.
 remove( OTA_SOURCES ${JSON_SOURCES} ${TINYCBOR_SOURCES} )
 remove( OTA_INCLUDE_PRIVATE_DIRS ${JSON_INCLUDE_PUBLIC_DIRS} ${TINYCBOR_INCLUDE_DIRS} )
 

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -1,24 +1,20 @@
 afr_module( NAME ota INTERNAL )
+
 # Include OTA library's source and header path variables.
 include("${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake")
-# Create a list of all header files in the OTA library.
-# The list of header files will be added to metadata required
-# for the FreeRTOS console.
-set(OTA_HEADER_FILES "")
-foreach(ota_public_include_dir ${OTA_INCLUDE_PUBLIC_DIRS})
-    file(GLOB ota_public_include_header_files
-              LIST_DIRECTORIES false
-              ${ota_public_include_dir}/*.h )
-    list(APPEND OTA_HEADER_FILES ${ota_public_include_header_files})
-endforeach()
-# Remove the hardcoded coreJSON and TinyCBOR dependancies and add 
-# them manually later to enable them being used by other applications.
+
+# Remove the coreJSON and TinyCBOR files from the OTA_SOURCES and
+# OTA_INCLUDE_PRIVATE_DIR variables. This is so that the OTA target can depend
+# on the local copy of the libraries instead of the ones in the OTA repository.
 remove( OTA_SOURCES ${JSON_SOURCES} ${TINYCBOR_SOURCES} )
 remove( OTA_INCLUDE_PRIVATE_DIRS ${JSON_INCLUDE_PUBLIC_DIRS} ${TINYCBOR_INCLUDE_DIRS} )
+
 # Add cmake files of module to metadata.
 afr_module_cmake_files(${AFR_CURRENT_MODULE}
     ${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake
 )
+
+# Define a target for the Over-the-air Update library.
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE
@@ -34,7 +30,7 @@ afr_module_sources(
         "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/include/ota_mqtt_interface.h"
         ${OTA_HTTP_SOURCES}
         # Include missing OTA HTTP interface .h file that is required to generate correct metadata.
-        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/include/ota_http_interface.h"
+        "${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/include/ota_http_interface.h"
 )
 afr_module_include_dirs(
     ${AFR_CURRENT_MODULE}


### PR DESCRIPTION
Add missing .h files to the OTA CMake target

Description
-----------
The OTA CMake target is defined based on various CMake variables in the OTA library. These variables are missing some of the .h header files. This does not cause any issues with the build process, but it does cause issues generating metadata that is ingested by some tools. This PR adds the missing header files directly to the CMake target for the OTA library to resolve this.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.