### PR TITLE
Full TCP non-blocking test fix

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1557,7 +1557,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
             }
             else if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
             {
-                /* Since we are in non blocking mode, SOCKETS_EWOULDBLOCK error is fine because the TCP stack may 
+                /* Since we are in non blocking mode, SOCKETS_EWOULDBLOCK error is fine because the TCP stack may
                  * still be processing the packet. Any other error is not expected and we break if we receive any other error. */
                 break;
             }

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1568,7 +1568,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                  * There is a timeout added below so that this code doesn't spin in this loop
                  * indefinately. */
             }
-            
+
             /* Do not wait more than xWaitTime even if the error is SOCKETS_EWOULDBLOCK. */
             if( ( xEndTime - xStartTime ) > xWaitTime )
             {

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1495,6 +1495,7 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
     TickType_t xStartTime;
     TickType_t xEndTime;
     TickType_t xTimeout = 0;
+    TickType_t xWaitTime = 1000;
     uint8_t * pucTxBuffer = ( uint8_t * ) pcTxBuffer;
     uint8_t * pucRxBuffer = ( uint8_t * ) pcRxBuffer;
     size_t xMessageLength = 1200;
@@ -1558,6 +1559,12 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
             /* Since we are in non blocking mode, this error is expected if the TCP stack is
              * still processing the packet. */
             if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
+            {
+                break;
+            }
+            
+            /* Do not wait more than xWaitTime even if the error is SOCKETS_EWOULDBLOCK. */
+            if( ( xEndTime - xStartTime ) > xWaitTime )
             {
                 break;
             }

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1555,11 +1555,6 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                 xNumBytesReceived += lNumBytes;
             }
 
-            if( lNumBytes < 0 )
-            {
-                break;
-            }
-
             xEndTime = xTaskGetTickCount();
         }
         while( xMessageLength > xNumBytesReceived );

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1555,12 +1555,18 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                  */
                 xNumBytesReceived += lNumBytes;
             }
-            
-            /* Since we are in non blocking mode, this error is expected if the TCP stack is
-             * still processing the packet. */
-            if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
+            else if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
             {
+                /* Since we are in non blocking mode, this error is expected if the TCP stack is
+                 * still processing the packet. */
                 break;
+            }
+            else
+            {
+                /* Do nothing. Maybe we have got SOCKETS_EWOULDBLOCK which indicates that we have
+                 * to wait OR the received number of bytes is zero which is strange but acceptable.
+                 * There is a timeout added below so that this code doesn't spin in this loop
+                 * indefinately. */
             }
             
             /* Do not wait more than xWaitTime even if the error is SOCKETS_EWOULDBLOCK. */

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1554,6 +1554,13 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
                  */
                 xNumBytesReceived += lNumBytes;
             }
+            
+            /* Since we are in non blocking mode, this error is expected if the TCP stack is
+             * still processing the packet. */
+            if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
+            {
+                break;
+            }
 
             xEndTime = xTaskGetTickCount();
         }

--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -1557,8 +1557,8 @@ static void prvSOCKETS_NonBlocking_Test( Server_t xConn )
             }
             else if( ( lNumBytes < 0 ) && ( lNumBytes != SOCKETS_EWOULDBLOCK ) )
             {
-                /* Since we are in non blocking mode, this error is expected if the TCP stack is
-                 * still processing the packet. */
+                /* Since we are in non blocking mode, SOCKETS_EWOULDBLOCK error is fine because the TCP stack may 
+                 * still be processing the packet. Any other error is not expected and we break if we receive any other error. */
                 break;
             }
             else


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The full TCP test suite should expect the `SOCKETS_EWOULDBLOCK` error since it is in non-blocking mode. It should not be treated as an actual error since the TCP stack might be working on incoming packets (such as offloaded tcp stacks which do not preempt the test task).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.