### PR TITLE
Test: add missing assert

### DIFF
--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -162,6 +162,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
         }
 
         printf( "Expected Pri = 7, actual = %d\r\n", ( int ) attrData );
+        TEST_ASSERT_EQUAL( 7, attrData );
     }
 #endif /* if ( INCLUDE_uxTaskPriorityGet == 1 ) */
 


### PR DESCRIPTION
Add missing assert in test case  IotThreads_ThreadPriority

Description
-----------
The test was finishing omitting a final assert



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.