### PR TITLE
Change casts from implicit to explicit in TI OTA PAL

### DIFF
--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -143,7 +143,7 @@ OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C )
     /* Check for null file handle since the agent may legitimately call this before a file is opened. */
     if( C->pFile != ( int32_t ) NULL )
     {
-        lResult = sl_FsClose( C->pFile, ( _u8 * ) NULL, ( _u8 * ) pcTI_AbortSig, CONST_STRLEN( pcTI_AbortSig ) );
+        lResult = sl_FsClose( ( _i32 ) C->pFile, ( _u8 * ) NULL, ( _u8 * ) pcTI_AbortSig, CONST_STRLEN( pcTI_AbortSig ) );
         C->pFile = ( int32_t ) NULL;
 
         if( lResult != 0 )
@@ -200,7 +200,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                 if( lResult > 0 )
                 {
                     LogInfo( ( "Receive file created. Token: %u", ulToken ) );
-                    C->pFile = lResult;
+                    C->pFile = ( uint8_t* )lResult;
                     mainErr = OtaPalSuccess;
                 }
                 else
@@ -535,7 +535,7 @@ int16_t otaPal_WriteBlock( OtaFileContext_t * const C,
 
     for( ulRetry = 0UL; ulRetry <= OTA_MAX_PAL_WRITE_RETRIES; ulRetry++ )
     {
-        lResult = sl_FsWrite( C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
+        lResult = sl_FsWrite( ( _i32 )C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
 
         if( lResult >= 0 )
         {


### PR DESCRIPTION
Change casts from implicit to explicit in TI OTA PAL

Description
-----------
The IAR project for the TI cc3220 platform was failing to build due to errors related to implicit type casts. This PR updates these to be explicit type casts.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.