### PR TITLE
Fix TI OTA PAL qualification test failures

### DIFF
--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -143,7 +143,7 @@ OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C )
     /* Check for null file handle since the agent may legitimately call this before a file is opened. */
     if( C->pFile != ( int32_t ) NULL )
     {
-        lResult = sl_FsClose( C->pFile, ( _u8 * ) NULL, ( _u8 * ) pcTI_AbortSig, CONST_STRLEN( pcTI_AbortSig ) );
+        lResult = sl_FsClose( ( _i32 ) C->pFile, ( _u8 * ) NULL, ( _u8 * ) pcTI_AbortSig, CONST_STRLEN( pcTI_AbortSig ) );
         C->pFile = ( int32_t ) NULL;
 
         if( lResult != 0 )
@@ -200,7 +200,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                 if( lResult > 0 )
                 {
                     LogInfo( ( "Receive file created. Token: %u", ulToken ) );
-                    C->pFile = lResult;
+                    C->pFile = ( uint8_t* )lResult;
                     mainErr = OtaPalSuccess;
                 }
                 else
@@ -535,7 +535,7 @@ int16_t otaPal_WriteBlock( OtaFileContext_t * const C,
 
     for( ulRetry = 0UL; ulRetry <= OTA_MAX_PAL_WRITE_RETRIES; ulRetry++ )
     {
-        lResult = sl_FsWrite( C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
+        lResult = sl_FsWrite( ( _i32 )C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
 
         if( lResult >= 0 )
         {

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -200,7 +200,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                 if( lResult > 0 )
                 {
                     LogInfo( ( "Receive file created. Token: %u", ulToken ) );
-                    C->pFile = ( uint8_t* )lResult;
+                    C->pFile = ( uint8_t * ) lResult;
                     mainErr = OtaPalSuccess;
                 }
                 else
@@ -267,7 +267,7 @@ static int32_t prvCreateBootInfoFile( void )
                              SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_MAX_SIZE( sizeof( sBootInfo ) ) |
                              SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
                              SL_FS_CREATE_PUBLIC_WRITE | SL_FS_CREATE_NOSIGNATURE,
-                             ( _u32 * ) &ulToken );     /*lint !e9087 Safe because uint32_t ulToken and _u32 are the same size on CC3220SF. */
+                             ( _u32 * ) &ulToken ); /*lint !e9087 Safe because uint32_t ulToken and _u32 are the same size on CC3220SF. */
 
     if( lFileHandle < 0 )
     {
@@ -535,7 +535,7 @@ int16_t otaPal_WriteBlock( OtaFileContext_t * const C,
 
     for( ulRetry = 0UL; ulRetry <= OTA_MAX_PAL_WRITE_RETRIES; ulRetry++ )
     {
-        lResult = sl_FsWrite( ( _i32 )C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
+        lResult = sl_FsWrite( ( _i32 ) C->pFile, ulOffset + ulWritten, &pcData[ ulWritten ], ulBlockSize );
 
         if( lResult >= 0 )
         {

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -162,6 +162,11 @@ OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C )
          * transfer (therefore interpreted as an abort). */
         prvRollbackBundle();
     }
+    else
+    {
+        /* The file handle is already NULL, so succeed by default. */
+        mainErr = OtaPalSuccess;
+    }
 
     return OTA_PAL_COMBINE_ERR( mainErr, OTA_PAL_SUB_ERR( subErr ) );
 }

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -163,7 +163,7 @@ OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C )
         prvRollbackBundle();
     }
 
-    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+    return OTA_PAL_COMBINE_ERR( mainErr, OTA_PAL_SUB_ERR( subErr ) );
 }
 
 
@@ -194,7 +194,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                             SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
                             SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
                             SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
-                /* The file remains open until the OTA agent calls prvPAL_CloseFile() after transfer or failure. */
+                /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */
                 lResult = sl_FsOpen( ( _u8 * ) C->pFilePath, ( _u32 ) ulFlags, ( _u32 * ) &ulToken );
 
                 if( lResult > 0 )
@@ -247,7 +247,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
         subErr = OTA_MAX_MCU_IMAGE_SIZE;
     }
 
-    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+    return OTA_PAL_COMBINE_ERR( mainErr, OTA_PAL_SUB_ERR( subErr ) );
 }
 
 
@@ -348,7 +348,7 @@ OtaPalStatus_t otaPal_CloseFile( OtaFileContext_t * const C )
             break;
     }
 
-    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+    return OTA_PAL_COMBINE_ERR( mainErr, OTA_PAL_SUB_ERR( subErr ) );
 }
 
 
@@ -370,7 +370,7 @@ OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const C )
     /* We shouldn't actually get here if the board supports the auto reset.
      * But, it doesn't hurt anything if we do although someone will need to
      * reset the device for the new image to boot. */
-    return OtaPalActivateFailed;
+    return OTA_PAL_COMBINE_ERR( OtaPalActivateFailed, 0 );
 }
 
 
@@ -458,7 +458,7 @@ OtaPalStatus_t otaPal_SetPlatformImageState( OtaFileContext_t * const C,
         mainErr = OtaPalBadImageState;
     }
 
-    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+    return OTA_PAL_COMBINE_ERR( mainErr, OTA_PAL_SUB_ERR( subErr ) );
 }
 
 /* Get the state of the currently running image.


### PR DESCRIPTION
Fix TI OTA PAL qualification test failures.

Description
-----------
* Change implicit type casts to explicit type casts in the TI OTA PAL to prevent build errors with IAR.
* Add error bitmasks to the OTA PAL return statements for OTA related errors.

Note: With these changes, all 25 of the PAL tests are passing.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.