### PR TITLE
Restrict domain name length for Inventek module's DNS lookup function

### DIFF
--- a/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_tests/application_code/main.c
@@ -59,7 +59,7 @@
 #define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 4 )
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 15 )
 
-#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 8 )
+#define mainTEST_RUNNER_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 10 )
 
 /* Number of times to retry to join an AP before giving up. */
 #define mainWIFI_JOIN_AP_RETRIES            ( 2 )

--- a/vendors/st/boards/stm32l475_discovery/ports/wifi/iot_wifi.c
+++ b/vendors/st/boards/stm32l475_discovery/ports/wifi/iot_wifi.c
@@ -535,9 +535,27 @@ WIFIReturnCode_t WIFI_GetHostIP( char * pcHost,
                                  uint8_t * pucIPAddr )
 {
     WIFIReturnCode_t xRetVal = eWiFiFailure;
+    size_t xHostnameLength;
 
     configASSERT( pcHost != NULL );
     configASSERT( pucIPAddr != NULL );
+
+    /* The inventek WiFi module supports maximum domain name length of 64.
+     * Trying to resolve a longer name leaves the module in a non-responsive
+     * state. The following check prevents calling ES_WIFI_DNS_LookUp for
+     * longer names, thereby preventing the module from going into a
+     * non-responsive state.
+     *
+     * The following is from the datasheet of the module:
+     *
+     * 'D0' DNS Lookup:
+     * This command performs a DNS lookup of a Domain Name to get its IPv4
+     * address. The Domain Name is limited to 64 characters. */
+    xHostnameLength = strlen( pcHost );
+    if( xHostnameLength > 64 )
+    {
+        return eWiFiFailure;
+    }
 
     /* Try to acquire the semaphore. */
     if( xSemaphoreTake( xWiFiModule.xSemaphoreHandle, xSemaphoreWaitTicks ) == pdTRUE )


### PR DESCRIPTION
Description
-----------

The inventek WiFi module supports maximum domain name length of 64. Trying to resolve a longer name leaves the module in a non-responsive state. This PR adds a check to prevent calling `ES_WIFI_DNS_LookUp` for longer names, thereby preventing the module from going into a non-responsive state.

The following is from the datasheet of the module:
```
'D0' DNS Lookup:
This command performs a DNS lookup of a Domain Name to get its IPv4 address. The Domain Name is limited to 64 characters.
```

This PR also increases the stack size of test runner task to address a stack overflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.