### PR TITLE
Update Espressif port for OTA

### DIFF
--- a/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/param.h>
 #include "ota.h"
 #include "ota_pal.h"
 #include "ota_interface_private.h"
@@ -400,7 +401,7 @@ OtaPalStatus_t otaPal_CheckFileSignature( OtaFileContext_t * const pFileContext 
     void * pvSigVerifyContext;
     uint8_t * pucSignerCert = 0;
     static spi_flash_mmap_memory_t ota_data_map;
-    const void * buf = NULL;
+    uint32_t mmu_free_pages_count, len, flash_offset = 0;
 
     /* Verify an ECDSA-SHA256 signature. */
     if( CRYPTO_SignatureVerificationStart( &pvSigVerifyContext, cryptoASYMMETRIC_ALGORITHM_ECDSA,
@@ -418,18 +419,33 @@ OtaPalStatus_t otaPal_CheckFileSignature( OtaFileContext_t * const pFileContext 
         return OTA_PAL_COMBINE_ERR( OtaPalBadSignerCert, 0 );
     }
 
-    esp_err_t ret = esp_partition_mmap( ota_ctx.update_partition, 0, ota_ctx.data_write_len,
-                                        SPI_FLASH_MMAP_DATA, &buf, &ota_data_map );
+    mmu_free_pages_count = spi_flash_mmap_get_free_pages( SPI_FLASH_MMAP_DATA );
+    len = ota_ctx.data_write_len;
 
-    if( ret != ESP_OK )
+    while( len > 0 )
     {
-        ESP_LOGE( TAG, "partition mmap failed %d", ret );
-        result = OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, 0 );
-        goto end;
-    }
+        /* Data we could map in case we are not aligned to PAGE boundary is one page size lesser.
+         * 0x0000FFFF is mmap aligned mask for 64K boundary */
+        uint32_t mmu_page_offset = ( ( flash_offset & 0x0000FFFF ) != 0 ) ? 1 : 0;
+        /* Read the image that fits in the free MMU pages */
+        uint32_t partial_image_len = MIN( len, ( ( mmu_free_pages_count - mmu_page_offset ) * SPI_FLASH_MMU_PAGE_SIZE ) );
+        const void * buf = NULL;
 
-    CRYPTO_SignatureVerificationUpdate( pvSigVerifyContext, buf, ota_ctx.data_write_len );
-    spi_flash_munmap( ota_data_map );
+        esp_err_t ret = esp_partition_mmap( ota_ctx.update_partition, flash_offset, partial_image_len,
+                                            SPI_FLASH_MMAP_DATA, &buf, &ota_data_map );
+
+        if( ret != ESP_OK )
+        {
+            ESP_LOGE( TAG, "partition mmap failed %d", ret );
+            result = kOTA_Err_SignatureCheckFailed;
+            goto end;
+        }
+
+        CRYPTO_SignatureVerificationUpdate( pvSigVerifyContext, buf, partial_image_len );
+        spi_flash_munmap( ota_data_map );
+        flash_offset += partial_image_len;
+        len -= partial_image_len;
+    }
 
     if( CRYPTO_SignatureVerificationFinal( pvSigVerifyContext, ( char * ) pucSignerCert, ulSignerCertSize,
                                            pFileContext->pSignature->data, pFileContext->pSignature->size ) == pdFALSE )

--- a/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
@@ -437,7 +437,7 @@ OtaPalStatus_t otaPal_CheckFileSignature( OtaFileContext_t * const pFileContext 
         if( ret != ESP_OK )
         {
             ESP_LOGE( TAG, "partition mmap failed %d", ret );
-            result = kOTA_Err_SignatureCheckFailed;
+            result = OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, 0 );
             goto end;
         }
 


### PR DESCRIPTION
<!--- Title -->
Update Espressif port for OTA

Description
-----------
<!--- Describe your changes in detail -->
* Fix for validating image size > 3MB by splitting image into chunks.
* Based on PR from Espressif https://github.com/aws/amazon-freertos/pull/3155

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.