### PR TITLE
Add missing .h file to OTA port CMakeList files

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -429,6 +429,7 @@ target_sources(
     AFR::ota::mcu_port
     INTERFACE
         "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.h"
         "${afr_ports_dir}/ota_pal_for_aws/aws_esp_ota_ops.c"
         "${afr_ports_dir}/ota_pal_for_aws/aws_esp_ota_ops.h"
 )

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -370,6 +370,7 @@ target_sources(
     AFR::ota::mcu_port
     INTERFACE
         "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.h"
         "${afr_ports_dir}/ota_pal_for_aws/aws_esp_ota_ops.c"
         "${afr_ports_dir}/ota_pal_for_aws/aws_esp_ota_ops.h"
 )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/CMakeLists.txt
@@ -143,6 +143,7 @@ target_sources(
     AFR::ota::mcu_port
     INTERFACE
         "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.h"
 )
 target_include_directories(
     AFR::ota::mcu_port

--- a/vendors/pc/boards/windows/CMakeLists.txt
+++ b/vendors/pc/boards/windows/CMakeLists.txt
@@ -128,7 +128,9 @@ target_link_libraries(
 afr_mcu_port(ota)
 target_sources(
     AFR::ota::mcu_port
-    INTERFACE "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+    INTERFACE
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.h"
 )
 
 target_include_directories(


### PR DESCRIPTION
Add missing .h file to OTA port CMakeList files

Description
-----------
Multiple ports were not listing the ota_pal.h file in the CMakeLists.txt file. This does not cause any issues building, but it does cause issues with some of the metadata based tools. This change adds the missing lines to resolve this.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.