### PR TITLE
Add CMake files of OTA dependency to the metadata

### DIFF
--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -9,7 +9,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake")
 remove( OTA_SOURCES ${JSON_SOURCES} ${TINYCBOR_SOURCES} )
 remove( OTA_INCLUDE_PRIVATE_DIRS ${JSON_INCLUDE_PUBLIC_DIRS} ${TINYCBOR_INCLUDE_DIRS} )
 
-# Add cmake file of the OTA library and its depencencies to the metadata.
+# Add cmake files of the OTA library and its dependencies to the metadata.
 afr_module_cmake_files(${AFR_CURRENT_MODULE}
     ${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake
     ${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/dependency/coreJSON/jsonFilePaths.cmake

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -9,9 +9,10 @@ include("${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake")
 remove( OTA_SOURCES ${JSON_SOURCES} ${TINYCBOR_SOURCES} )
 remove( OTA_INCLUDE_PRIVATE_DIRS ${JSON_INCLUDE_PUBLIC_DIRS} ${TINYCBOR_INCLUDE_DIRS} )
 
-# Add cmake files of module to metadata.
+# Add cmake file of the OTA library and its depencencies to the metadata.
 afr_module_cmake_files(${AFR_CURRENT_MODULE}
     ${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/otaFilePaths.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/ota_for_aws/source/dependency/coreJSON/jsonFilePaths.cmake
 )
 
 # Define a target for the Over-the-air Update library.


### PR DESCRIPTION
Add CMake files of OTA dependency to the metadata

Description
-----------
The otaFilePaths.cmake file includes another CMake file inside of it. This adds a requirement that the nested CMake file has to be added to the metadata alongside the OTA library. This change adds this dependent CMake file to the metadata.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.