### PR TITLE
Marvell: fix WiFi reconnect issue

### DIFF
--- a/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
+++ b/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
@@ -142,7 +142,9 @@ int net_configure_address(struct wlan_ip_config *addr, void *intrfc_handle)
 		wlan_wlcmgr_send_msg(WIFI_EVENT_NET_STA_ADDR_CONFIG,
 			        WIFI_EVENT_REASON_SUCCESS, NULL);
 		*ipLOCAL_IP_ADDRESS_POINTER = 0x00UL;
-		/* The network is not up until DHCP has completed. */
+		/* The network is not up until DHCP has completed. Reset the
+		 * DHCP state machine to start the process of acquiring an IP
+		 * address. */
 		vDHCPProcess( pdTRUE, eInitialWait );
 
 		while (*ipLOCAL_IP_ADDRESS_POINTER == 0)

--- a/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
+++ b/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
@@ -145,7 +145,8 @@ int net_configure_address(struct wlan_ip_config *addr, void *intrfc_handle)
 		/* The network is not up until DHCP has completed. Reset the
 		 * DHCP state machine to start the process of acquiring an IP
 		 * address. */
-		vDHCPProcess( pdTRUE, eInitialWait );
+		vDHCPProcess( pdTRUE, /* Reset the DHCP state machine. */
+                              eInitialWait /* This parameter doesn't matter when the first parameter is pdTRUE. */ );
 
 		while (*ipLOCAL_IP_ADDRESS_POINTER == 0)
 			os_thread_sleep(10);

--- a/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
+++ b/vendors/marvell/WMSDK/mw320/sdk/src/platform/net/freertos-plus-tcp/net.c
@@ -26,6 +26,7 @@
 #include "list.h"
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_DHCP.h"
 
 #include <wlan.h>
 #include <wm_net.h>
@@ -142,7 +143,7 @@ int net_configure_address(struct wlan_ip_config *addr, void *intrfc_handle)
 			        WIFI_EVENT_REASON_SUCCESS, NULL);
 		*ipLOCAL_IP_ADDRESS_POINTER = 0x00UL;
 		/* The network is not up until DHCP has completed. */
-		xSendEventToIPTask( eDHCPEvent );
+		vDHCPProcess( pdTRUE, eInitialWait );
 
 		while (*ipLOCAL_IP_ADDRESS_POINTER == 0)
 			os_thread_sleep(10);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The PR https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/62 modified the DHCP state machine to accept two parameters to avoid race conditions.
In the case of Marvell, the old code was not modified. To try and reset DHCP state machine, it sent an event to IP-task with `eInitialWait` as the payload. But, this does not work with the new code since DHCP state machine is at some other state and the request to switch to `eInitialWait` state is ignored.

This PR fixes that. Instead of sending an event to IP-task, we should directly reset the DHCP state machine by passing a `pdTRUE` as a param to the `vDHCPProcess`.

Link to the test [here](https://amazon-freertos-ci.corp.amazon.com/job/freertos_refinteg/job/custom_job_pipeline/491).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.