### PR TITLE
Overflow bug in windows aws_demo_logging.c

### DIFF
--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -537,7 +537,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         }
 
         /* Check if the buffer has room for "\r\n" and make it if not. */
-        if (xLength > ( dlMAX_PRINT_STRING_LENGTH - 3 ) )
+        if ( xLength > ( dlMAX_PRINT_STRING_LENGTH - 3 ) )
         {
             xLength -= 3;
         }

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -527,13 +527,27 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         }
         else if ( xLength2 < ( dlMAX_PRINT_STRING_LENGTH - xLength ) )
         {
-            /* Buffer required is larger than allocated, not complete log is in buffer. */
-            xLength += ( dlMAX_PRINT_STRING_LENGTH - xLength );
+            /* Complete log is in buffer. */
+            xLength += xLength2;
         }
         else
         {
-            /* Complete log is in buffer. */
-            xLength += xLength2;
+            /* Buffer required is larger than allocated, not complete log is in buffer. */
+            xLength = dlMAX_PRINT_STRING_LENGTH ;
+        }
+
+        /* Check if the buffer has room for "\r\n" and make it if not. */
+        if (xLength > ( dlMAX_PRINT_STRING_LENGTH - 3 ) )
+        {
+            xLength -= 3;
+        }
+
+        /* Add newline characters if the message does not end with them.*/
+        ulFormatLen = strlen( pcFormat );
+
+        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
+        {
+            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "%s", "\r\n" );
         }
 
         /* Add newline characters if the message does not end with them.*/

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -539,7 +539,7 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
         /* Check if the buffer has room for "\r\n" and make it if not. */
         if ( xLength > ( dlMAX_PRINT_STRING_LENGTH - 3 ) )
         {
-            xLength -= 3;
+            xLength = dlMAX_PRINT_STRING_LENGTH - 3;
         }
 
         /* Add newline characters if the message does not end with them.*/

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -550,14 +550,6 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
             xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "%s", "\r\n" );
         }
 
-        /* Add newline characters if the message does not end with them.*/
-        ulFormatLen = strlen( pcFormat );
-
-        if( ( ulFormatLen >= 2 ) && ( strncmp( pcFormat + ulFormatLen, "\r\n", 2 ) != 0 ) )
-        {
-            xLength += snprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, "%s", "\r\n" );
-        }
-
         /* For ease of viewing, copy the string into another buffer, converting
          * IP addresses to dot notation on the way. */
         pcSource = cPrintString;

--- a/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/aws_demo_logging.c
@@ -525,8 +525,16 @@ static void prvLoggingPrintf( uint8_t usLoggingLevel,
             xLength2 = 0;
             cPrintString[ xLength ] = '\0';
         }
-
-        xLength += xLength2;
+        else if ( xLength2 < ( dlMAX_PRINT_STRING_LENGTH - xLength ) )
+        {
+            /* Buffer required is larger than allocated, not complete log is in buffer. */
+            xLength += ( dlMAX_PRINT_STRING_LENGTH - xLength );
+        }
+        else
+        {
+            /* Complete log is in buffer. */
+            xLength += xLength2;
+        }
 
         /* Add newline characters if the message does not end with them.*/
         ulFormatLen = strlen( pcFormat );


### PR DESCRIPTION
<!--- Title -->
Fix bug which was causing memory corruption in aws_demo_logging.c 

Description
-----------
<!--- Describe your changes in detail -->
The vsnprintf returns the number of characters that would have been written if n had been sufficiently large and not actual number of characters . This was causing overflow and memory corruption.

This is blocking issue for OTA release.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.