### PR TITLE
Add the CMakeLists.txt file with the ota_demo_version target to the metadata

### DIFF
--- a/demos/common/ota_demo_helpers/CMakeLists.txt
+++ b/demos/common/ota_demo_helpers/CMakeLists.txt
@@ -1,5 +1,11 @@
 afr_module( INTERNAL NAME ota_demo_version )
 
+# Add this CMakeLists.txt file to the metadata. This is required because the
+# name of the CMake target does not match the name of the folder.
+afr_module_cmake_files(${AFR_CURRENT_MODULE}
+    ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+)
+
 afr_module_sources(
     ${AFR_CURRENT_MODULE}
     PRIVATE


### PR DESCRIPTION
Add the CMakeLists.txt file with the ota_demo_version target to the metadata

Description
-----------
When the CMake target name does not match the parent folder, an explicit call to afr_module_cmake_files has to be made to include the CMakeLists.txt file to metadata.

The "ota_demo_version" target is contained in a file where the name of the folder does not correspond to the name of the target. This is incorrect and causes issues with the metadata. This change rectifies this.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.