### PR TITLE
Update OTA Demo metadata to match demo configs

### DIFF
--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -2,7 +2,7 @@
 afr_demo_module(ota_core_http)
 
 # Set the default demo that is enabled in the downloaded package.
-afr_set_demo_metadata(ID "OTA_DEMO_CORE_HTTP")
+afr_set_demo_metadata(ID "OTA_HTTP_UPDATE_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Example that demonstrate the OTA, coreMQTT and coreHTTP libraries")
 afr_set_demo_metadata(DISPLAY_NAME "OTA over HTTP Demo")
 

--- a/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
@@ -2,7 +2,7 @@
 afr_demo_module(ota_core_mqtt)
 
 # Set the default demo that is enabled in the downloaded package.
-afr_set_demo_metadata(ID "OTA_DEMO_CORE_MQTT")
+afr_set_demo_metadata(ID "OTA_MQTT_UPDATE_DEMO")
 afr_set_demo_metadata(DESCRIPTION "Example that demonstrate the OTA and coreMQTT libraries")
 afr_set_demo_metadata(DISPLAY_NAME "OTA over MQTT Demo")
 


### PR DESCRIPTION
Update OTA Demo metadata to match demo configs

Description
-----------
The "ID" CMake metadata must be identical with the macro used for configuring the which demo runs, if the macro had "CONFIG_" and "_ENABLED" removed from the front and back of it.

This change updates the OTA demo "ID" metadata to match the values found in the demo config file.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.