### PR TITLE
Add dependency of mbedtls to nordic bootloader

### DIFF
--- a/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
+++ b/vendors/nordic/boards/nrf52840-dk/CMakeLists.txt
@@ -394,8 +394,9 @@ target_link_libraries(
     INTERFACE
         3rdparty::jsmn
         3rdparty::pkcs11
-        # Require this for bootloader
+        # Require tinycrypt and mbedtls for bootloader
         3rdparty::tinycrypt
+        3rdparty::mbedtls
 )
 
 # BLE


### PR DESCRIPTION

Description
-----------

Add dependency on mbedtls in Nordic CMake file for bootloader.
 
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.