### PR TITLE
Test: enable logging, remove printf, reinit static variable

### DIFF
--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -110,6 +110,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
     }
 
     TEST_ASSERT_EQUAL( 4321, attrData );
+    attrData = 1234;
 }
 
 /*-----------------------------------------------------------*/
@@ -137,7 +138,6 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
         }
 
         TEST_ASSERT_EQUAL( 0, attrData );
-        printf( "Expected Pri = 0, actual = %d\r\n", ( int ) attrData );
         attrData = -1;
 
         /* Create thread with max priority - 1*/
@@ -149,8 +149,8 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
             vTaskDelay( 1 );
         }
 
-        printf( "Expected Pri = %d, actual = %d\r\n", ( int ) ( configMAX_PRIORITIES - 1U ), ( int ) attrData );
         TEST_ASSERT_EQUAL( ( configMAX_PRIORITIES - 1U ), attrData );
+        attrData = -1;
     }
 #endif /* if ( INCLUDE_uxTaskPriorityGet == 1 ) */
 

--- a/libraries/abstractions/platform/test/iot_test_platform_threads.c
+++ b/libraries/abstractions/platform/test/iot_test_platform_threads.c
@@ -109,6 +109,7 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
     }
 
     TEST_ASSERT_EQUAL( 4321, attrData );
+    attrData = 1234;
 }
 
 /*-----------------------------------------------------------*/
@@ -136,7 +137,6 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
         }
 
         TEST_ASSERT_EQUAL( 0, attrData );
-        printf( "Expected Pri = 0, actual = %d\r\n", ( int ) attrData );
         attrData = -1;
 
         /* Create thread with priority 5 */
@@ -148,7 +148,6 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
             vTaskDelay( 1 );
         }
 
-        printf( "Expected Pri = 5, actual = %d\r\n", ( int ) attrData );
         TEST_ASSERT_EQUAL( 5, attrData );
         attrData = -1;
 
@@ -161,8 +160,8 @@ TEST( UTIL_Platform_Threads, IotThreads_CreateDetachedThread )
             vTaskDelay( 1 );
         }
 
-        printf( "Expected Pri = 7, actual = %d\r\n", ( int ) attrData );
         TEST_ASSERT_EQUAL( 7, attrData );
+        attrData = -1;
     }
 #endif /* if ( INCLUDE_uxTaskPriorityGet == 1 ) */
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -28,15 +28,15 @@
  * level for all libraries; the library-specific settings override the global
  * setting. If both the library-specific and global settings are undefined,
  * no logs will be printed. */
-#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_INFO
-#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
-#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_INFO
-#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_INFO
-#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_INFO
-#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_INFO
-#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_INFO
-#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_INFO
-#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_INFO
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_DEBUG
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_DEBUG
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_DEBUG
 
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -28,15 +28,15 @@
  * level for all libraries; the library-specific settings override the global
  * setting. If both the library-specific and global settings are undefined,
  * no logs will be printed. */
-#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_ERROR
-#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_ERROR
-#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_ERROR
-#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_NONE
+#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_NONE
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_NONE
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_NONE
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_NONE
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_NONE
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_NONE
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_NONE
 
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -28,15 +28,15 @@
  * level for all libraries; the library-specific settings override the global
  * setting. If both the library-specific and global settings are undefined,
  * no logs will be printed. */
-#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_DEBUG
-#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_DEBUG
-#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_DEBUG
-#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_DEBUG
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_ERROR
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_ERROR
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_ERROR
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_ERROR
 
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/iot_config.h
@@ -24,6 +24,20 @@
 #ifndef IOT_CONFIG_H_
 #define IOT_CONFIG_H_
 
+/* Library logging configuration. IOT_LOG_LEVEL_GLOBAL provides a global log
+ * level for all libraries; the library-specific settings override the global
+ * setting. If both the library-specific and global settings are undefined,
+ * no logs will be printed. */
+#define IOT_LOG_LEVEL_GLOBAL                    IOT_LOG_INFO
+#define IOT_LOG_LEVEL_DEMO                      IOT_LOG_INFO
+#define IOT_LOG_LEVEL_PLATFORM                  IOT_LOG_INFO
+#define IOT_LOG_LEVEL_NETWORK                   IOT_LOG_INFO
+#define IOT_LOG_LEVEL_TASKPOOL                  IOT_LOG_INFO
+#define IOT_LOG_LEVEL_MQTT                      IOT_LOG_INFO
+#define AWS_IOT_LOG_LEVEL_SHADOW                IOT_LOG_INFO
+#define AWS_IOT_LOG_LEVEL_DEFENDER              IOT_LOG_INFO
+#define IOT_LOG_LEVEL_HTTPS                     IOT_LOG_INFO
+
 /* Platform thread stack size and priority. */
 #define IOT_THREAD_DEFAULT_STACK_SIZE           2048
 #define IOT_THREAD_DEFAULT_PRIORITY             5


### PR DESCRIPTION
Test: enable logging, remove printf, reinit static variable

Description
-----------
Enable logging in TI boards
remove printf - suspect to cause a freeze
re-init static variable, causing failure when run thread test "threadPriorityTestFunction"  in a loop

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.