### PR TITLE
Reduce HTTP multithread demo queue size

### DIFF
--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -136,7 +136,7 @@
 
 /* The default value for the stack size to use for HTTP tasks. */
 #ifndef httpexampleTASK_STACK_SIZE
-    #define httpexampleTASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
+    #define httpexampleTASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 2 )
 #endif
 
 /**

--- a/demos/network_manager/aws_iot_network_manager.c
+++ b/demos/network_manager/aws_iot_network_manager.c
@@ -95,8 +95,10 @@
 
 /**
  * @brief Stack size for network manager task.
+ * The task executes other application callbacks in its task context, so tune the stack size according
+ * to application subscription callback requirements.
  */
-#define NETWORK_MANAGER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 4 )
+#define NETWORK_MANAGER_TASK_STACK_SIZE          ( configMINIMAL_STACK_SIZE * 2 )
 
 /**
  * @brief Structure holds information for each network and the runtime state of it.

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/espressif/boards/esp32s2/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 5 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 5 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/pc/boards/windows/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/vendor/boards/board/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -137,7 +137,7 @@
 /**
  * @brief The number of items that can be held in each queue.
  */
-#define democonfigQUEUE_SIZE                        ( 10 )
+#define democonfigQUEUE_SIZE                        ( 2 )
 
 
 #endif /* ifndef HTTP_DEMO_S3_DOWNLOAD_MULTITHREADED_CONFIG_H */


### PR DESCRIPTION
Description
-----------

HTTP multithread demo allocates queue to hold outstanding responses. Currently response item size is 2K bytes and queue size is 10, so it consumes 20K of heap size. Reducing queue size to 2 elements to hold outstanding responses. 
Also reduced task stack size of  demo task and network manager task from  8K to 4K bytes.



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.