### PR TITLE
Fix cmake metadata for ggd

### DIFF
--- a/demos/greengrass_connectivity/CMakeLists.txt
+++ b/demos/greengrass_connectivity/CMakeLists.txt
@@ -14,5 +14,5 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         AFR::greengrass
-        AFR::core_mqtt
+        AFR::core_mqtt_demo_dependencies
 )

--- a/demos/greengrass_connectivity/CMakeLists.txt
+++ b/demos/greengrass_connectivity/CMakeLists.txt
@@ -9,7 +9,17 @@ afr_module_sources(
     ${AFR_CURRENT_MODULE}
     INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/aws_greengrass_discovery_demo.c"
+        # Add the header file added to the target's metadata so that it
+        # is available in code downloaded from the FreeRTOS console.
+        ${AFR_DEMOS_DIR}/include/aws_iot_metrics.h
 )
+
+afr_module_include_dirs(
+    ${AFR_CURRENT_MODULE}
+    INTERFACE
+       "${AFR_DEMOS_DIR}/include"
+)
+
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     INTERFACE

--- a/libraries/freertos_plus/aws/greengrass/CMakeLists.txt
+++ b/libraries/freertos_plus/aws/greengrass/CMakeLists.txt
@@ -35,7 +35,6 @@ afr_module_dependencies(
     PUBLIC
         AFR::secure_sockets
     PRIVATE
-        AFR::core_mqtt
         3rdparty::jsmn
 )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Possible for the following build combinations error:
```
CMake Error at tools/cmake/afr_module.cmake:317 (message):
  Module greengrass has an nonexistent AFR dependency core_mqtt.
```
The greengrass library does not have a dependency on coreMQTT, so the entry was removed, while the demo depends on everything the coreMQTT Mutual auth demo depends on, so that was added

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
