### PR TITLE
Fix Cypress Psoc64 Full_Wifi Test.

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_tests/application_code/main.c
@@ -70,6 +70,9 @@
 #include "bt_hal_manager_types.h"
 #endif
 
+/* For kvstore_init() */
+#include "kvstore.h"
+
 /* Logging Task Defines. */
 #define mainLOGGING_MESSAGE_QUEUE_LENGTH    ( 90 )
 #define mainLOGGING_TASK_STACK_SIZE         ( configMINIMAL_STACK_SIZE * 8 )
@@ -287,6 +290,9 @@ void vApplicationDaemonTaskStartupHook( void )
         printf( "Retarget IO initialization failed \r\n" );
     }
 
+    result = kvstore_init();
+    CY_ASSERT(CY_RSLT_SUCCESS == result);
+
 #ifdef CY_BOOT_USE_EXTERNAL_FLASH
 #ifdef PDL_CODE
     if (qspi_init_sfdp(1) < 0)
@@ -494,6 +500,7 @@ void vAssertCalled(const char * pcFile,
     */
     if (xTaskGetCurrentTaskHandle() == xRunTestTaskHandle)
     {
+        configPRINTF( ("vAssertCalled %s, %ld\n", pcFile, (long)ulLine) );
         TEST_ABORT();
     }
     else


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix Cypress PSoc64 Full_Wifi AFQP_WIFI_NetworkGetNonExistingNetwork and AFQP_WIFI_NetworkDelete_DeleteNonExistingNetwork test case.

The bug was introduced by this PR https://github.com/aws/amazon-freertos/pull/3128/. It using kvstore code but forget initialize it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.