### PR TITLE
Add loggging dependency to greengrass

### DIFF
--- a/libraries/freertos_plus/aws/greengrass/CMakeLists.txt
+++ b/libraries/freertos_plus/aws/greengrass/CMakeLists.txt
@@ -34,6 +34,7 @@ afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PUBLIC
         AFR::secure_sockets
+        AFR::logging
     PRIVATE
         3rdparty::jsmn
 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Follow up to #3280, where greengrass was also missing a dependency on logging

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
