### PR TITLE
Update OTA PAL port for TI to enable filetype support

### DIFF
--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -191,15 +191,14 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
         {
             ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
                         SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
-                        SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
-                        SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
+                        SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN );
 
             /* Create a boot info file for configuring watchdog timer. */
             lResult = prvCreateBootInfoFile();
         }
         else
         {
-            ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
+            ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE );
 
             /* Set the lResult explicitly as we do not create a boot info file
              * for downloading non firmware files. */
@@ -214,7 +213,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
             do
             {
                 /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */
-                lResult = sl_FsOpen( ( _u8 * ) C->pFilePath, ( _u32 ) ulFlags, ( _u32 * ) &ulToken );
+                lResult = sl_FsOpen( ( _u8 * ) C->pFilePath, ( _u32 ) ( ulFlags | SL_FS_CREATE_MAX_SIZE( C->fileSize ) ), ( _u32 * ) &ulToken );
 
                 if( lResult > 0 )
                 {
@@ -241,8 +240,11 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                     }
                     else
                     {
-                        /* Attempt to roll back the bundle and try again. */
-                        prvRollbackBundle();
+                        if( C->fileType == 0 )
+                        {
+                            /* Attempt to roll back the bundle and try again. */
+                            prvRollbackBundle();
+                        }
                     }
 
                     lRetry++;

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -196,10 +196,8 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
             do
             {
-                LogInfo( ( "FileType: %d", C->fileType ) );
                 if( C->fileType == 0)
                 {
-                    LogInfo( ( "Debug1" ) );
                     ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
                             SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
                             SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
@@ -207,7 +205,6 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                 }
                 else
                 {
-                    LogInfo( ( "Debug2" ) );
                     ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
                 }
                 /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -186,8 +186,19 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
     if( C->fileSize <= OTA_MAX_MCU_IMAGE_SIZE )
     {
-        lResult = prvCreateBootInfoFile();
-        LogInfo( ( "Boot info file result: %d",lResult ) );
+        if( C->fileType == 0)
+        {
+            ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
+                    SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
+                    SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
+                    SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
+            lResult = prvCreateBootInfoFile();
+        }
+        else
+        {
+            ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
+            lResult = 1;
+        }
 
         /* prvCreateBootInfoFile returns the number of bytes written or negative error. 0 is not allowed. */
         if( lResult > 0 )
@@ -196,17 +207,6 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
             do
             {
-                if( C->fileType == 0)
-                {
-                    ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
-                            SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
-                            SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
-                            SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
-                }
-                else
-                {
-                    ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
-                }
                 /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */
                 lResult = sl_FsOpen( ( _u8 * ) C->pFilePath, ( _u32 ) ulFlags, ( _u32 * ) &ulToken );
 

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -196,8 +196,10 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
             do
             {
+                LogInfo( ( "FileType: %d", C->fileType ) );
                 if( C->fileType == 0)
                 {
+                    LogInfo( ( "Debug1" ) );
                     ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
                             SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
                             SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
@@ -205,6 +207,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
                 }
                 else
                 {
+                    LogInfo( ( "Debug2" ) );
                     ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
                 }
                 /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -187,6 +187,7 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
     if( C->fileSize <= OTA_MAX_MCU_IMAGE_SIZE )
     {
         lResult = prvCreateBootInfoFile();
+        LogInfo( ( "Boot info file result: %d",lResult ) );
 
         /* prvCreateBootInfoFile returns the number of bytes written or negative error. 0 is not allowed. */
         if( lResult > 0 )
@@ -195,10 +196,17 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
             do
             {
-                ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
+                if( C->fileType == 0)
+                {
+                    ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
                             SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
                             SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
                             SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
+                }
+                else
+                {
+                    ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
+                }
                 /* The file remains open until the OTA agent calls otaPal_CloseFile() after transfer or failure. */
                 lResult = sl_FsOpen( ( _u8 * ) C->pFilePath, ( _u32 ) ulFlags, ( _u32 * ) &ulToken );
 

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -186,17 +186,23 @@ OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
 
     if( C->fileSize <= OTA_MAX_MCU_IMAGE_SIZE )
     {
-        if( C->fileType == 0)
+        /* Update the Access mode flags based on the type of file. */
+        if( C->fileType == 0 )
         {
             ulFlags = ( SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_FAILSAFE | /*lint -e9027 -e9028 -e9029 We don't own the TI problematic macros. */
-                    SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
-                    SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
-                    SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
+                        SL_FS_CREATE_PUBLIC_WRITE | SL_FS_WRITE_BUNDLE_FILE |
+                        SL_FS_CREATE_SECURE | SL_FS_CREATE_VENDOR_TOKEN |
+                        SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE ) );
+
+            /* Create a boot info file for configuring watchdog timer. */
             lResult = prvCreateBootInfoFile();
         }
         else
         {
             ulFlags = SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_NOSIGNATURE | SL_FS_CREATE_MAX_SIZE( OTA_MAX_MCU_IMAGE_SIZE );
+
+            /* Set the lResult explicitly as we do not create a boot info file
+             * for downloading non firmware files. */
             lResult = 1;
         }
 


### PR DESCRIPTION
<!--- Title -->
Update OTA PAL port for TI to enable filetype support

Description
-----------
<!--- Describe your changes in detail -->
* Currently the update only succeeds if the file name is `/sys/mcuflashimg.bin`. 
* Added a check on the filetype in the FileContext to attach `SECURE` flags only for Firmware images

Assumptions:
* FileType for firmware is always 0
* Other filetype do not need to be signed and/or bundled

Note:
The fix works for files with `.bin` extensions

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.