### PR TITLE
Adjust stack size for coreHTTP multithread demo

### DIFF
--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -146,7 +146,7 @@
 #endif
 
 #ifndef httpexampleTASK_STACK_SIZE
-    #define httpexampleTASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 2 )
+    #define httpexampleTASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 4 )
 #endif
 
 /**

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/main.c
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/application_code/main.c
@@ -445,49 +445,7 @@ void Error_Handler( void )
         HAL_Delay( 200 );
     }
 }
-/*-----------------------------------------------------------*/
 
-/**
- * @brief Warn user if pvPortMalloc fails.
- *
- * Called if a call to pvPortMalloc() fails because there is insufficient
- * free memory available in the FreeRTOS heap.  pvPortMalloc() is called
- * internally by FreeRTOS API functions that create tasks, queues, software
- * timers, and semaphores.  The size of the FreeRTOS heap is set by the
- * configTOTAL_HEAP_SIZE configuration constant in FreeRTOSConfig.h.
- *
- */
-void vApplicationMallocFailedHook()
-{
-    taskDISABLE_INTERRUPTS();
-
-    for( ; ; )
-    {
-    }
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Loop forever if stack overflow is detected.
- *
- * If configCHECK_FOR_STACK_OVERFLOW is set to 1,
- * this hook provides a location for applications to
- * define a response to a stack overflow.
- *
- * Use this hook to help identify that a stack overflow
- * has occurred.
- *
- */
-void vApplicationStackOverflowHook( TaskHandle_t xTask,
-                                    char * pcTaskName )
-{
-    portDISABLE_INTERRUPTS();
-
-    /* Loop forever */
-    for( ; ; )
-    {
-    }
-}
 /*-----------------------------------------------------------*/
 
 void vApplicationIdleHook( void )


### PR DESCRIPTION


Description
-----------
Adjust stack size based on tests.
Remove port specific stack overflow hook for STM32 to use common hook defined in demos `iot_demo_freertos.c` and tests `iot_test_freertos.c`. These functions have logging enabled. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.