### PR TITLE
AFR NimBLE: Disable RPA feature on ESP port

### DIFF
--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -524,19 +524,6 @@ static void bleprph_on_sync( void )
         xStatus = eBTStatusFail;
     }
 
-    /**
-     * Configure Resolvable Private Address (RPA).
-     */
-    if( xStatus == eBTStatusSuccess )
-    {
-        rc = ble_hs_pvcy_rpa_config( 1 );
-        if( rc != 0 )
-        {
-            ESP_LOGE( TAG, "Failed to enable RPA config, reason = %d\n", rc );
-            xStatus = eBTStatusFail;
-        }
-    }
-
     /** If status is ok and callback is set, trigger the callback.
      *  If status is fail, no need to trig a callback as original call failed.
      **/
@@ -626,16 +613,7 @@ BTStatus_t prvBTDisable()
     BTStatus_t xStatus = eBTStatusFail;
     int rc;
 
-    rc = ble_hs_pvcy_rpa_config( 0 );
-    if( rc != 0 )
-    {
-        ESP_LOGE( TAG, "Failed to disable RPA config, reason = %d\n", rc );
-    }
-
-    if( rc == 0 )
-    {
-        rc = nimble_port_stop();
-    }
+    rc = nimble_port_stop();
 
     if( rc == 0 )
     {

--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
@@ -43,6 +43,7 @@
 
 BTBleAdapterCallbacks_t xBTBleAdapterCallbacks;
 static struct ble_gap_adv_params xAdv_params;
+static uint8_t own_addr_type = BLE_OWN_ADDR_PUBLIC;
 
 #define IOT_BLE_ADVERTISING_DURATION_MS    ( 10 )
 
@@ -255,13 +256,6 @@ BTStatus_t prvToggleSecureConnectionOnlyMode( bool bEnable )
     return xStatus;
 }
 
-void prvEnableRPA( void )
-{
-    ble_hs_cfg.sm_our_key_dist   = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
-    ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
-}
-
-
 BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
@@ -291,11 +285,6 @@ BTStatus_t prvBTBleAdapterInit( const BTBleAdapterCallbacks_t * pxCallbacks )
     if( xStatus == eBTStatusSuccess )
     {
         xStatus = prvToggleSecureConnectionOnlyMode( xProperties.bSecureConnectionOnly );
-    }
-
-    if( xStatus == eBTStatusSuccess )
-    {
-        prvEnableRPA();
     }
 
     if( pxCallbacks != NULL )
@@ -435,8 +424,7 @@ BTStatus_t prvBTStartAdv( uint8_t ucAdapterIf )
     int xESPStatus;
     BTStatus_t xStatus = eBTStatusSuccess;
 
-    /* Set address type to always random as RPA is enabled. */
-    xESPStatus = ble_gap_adv_start( BLE_OWN_ADDR_RANDOM, NULL, lAdvDurationMS,
+    xESPStatus = ble_gap_adv_start( own_addr_type, NULL, lAdvDurationMS,
                                     &xAdv_params, prvGAPeventHandler, NULL );
 
     if( xESPStatus != 0 )

--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
@@ -236,6 +236,13 @@ BTStatus_t prvToggleBondableFlag( bool bEnable )
     BTStatus_t xStatus = eBTStatusSuccess;
 
     ble_hs_cfg.sm_bonding = bEnable;
+
+    if ( bEnable )
+    {
+        ble_hs_cfg.sm_our_key_dist   = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
+        ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
+    }
+
     return xStatus;
 }
 


### PR DESCRIPTION
<!--- Title -->

AFR NimBLE: Disable RPA feature on ESP port

Description
-----------
<!--- Describe your changes in detail -->
Few integration/functional test failures were observed with RPA feature enabled. The test cases need to be updated to take into account RPA feature. Till the cases are updated, disabling RPA feature.

Change list:
1. Disable RPA feature in ESP port.
2. Change `own_addr_type` in advertisement to public from random.
3. Configure distribution of LTK & IRK during bonding enable procedure itself. This step will help to mitigate issue observed with bond lost issue and device flash getting repeated entries of the same (RPA enabled) peer device.

I have run AFQP tests with the change and all the AFQP tests passed. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.