### PR TITLE
Nuvoton: M487 support OTA-v3

### DIFF
--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos/aws_demos.uvproj
@@ -146,7 +146,7 @@
 						<RestoreSysVw>1</RestoreSysVw>
 					</Target>
 					<RunDebugAfterBuild>0</RunDebugAfterBuild>
-					<TargetSelection>20</TargetSelection>
+					<TargetSelection>19</TargetSelection>
 					<SimDlls>
 						<CpuDll/>
 						<CpuDllArguments/>
@@ -374,7 +374,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot; CONFIG_MEDTLS_USE_AFR_MEMORY RVDS_ARMCM4_NUC4xx __little_endian__=1 NDEBUG</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/coreMQTT_Agent;../../../../../demos/device_defender_for_aws;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/jsmn</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/coreMQTT_Agent;../../../../../demos/device_defender_for_aws;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/jsmn;../../../../../demos/common/mqtt_subscription_manager;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws;../../../../../libraries/ota_for_aws/source/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/ota_for_aws/source/portable/os</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -2605,6 +2605,121 @@
 						</File>
 					</Files>
 				</Group>
+        <Group>
+          <GroupName>demos/ota/ota_demo_core_mqtt/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota_demo_core_mqtt.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\ota\ota_demo_core_mqtt\ota_demo_core_mqtt.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>demos/common/</GroupName>
+          <Files>
+            <File>
+              <FileName>mqtt_subscription_manager.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\common\mqtt_subscription_manager\mqtt_subscription_manager.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_application_version.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\common\ota_demo_helpers\ota_application_version.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>numaker_iot_m487_wifi/ports/ota_pal_for_aws/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota_pal.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_pal_spim.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal_spim.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>libraries/ota_for_aws/source/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_base64.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_base64.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_cbor.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_cbor.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_interface.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_interface.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_mqtt.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_mqtt.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_os_freertos.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\portable\os\ota_os_freertos.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>libraries/3rdparty/tinycbor/</GroupName>
+          <Files>
+            <File>
+              <FileName>cborencoder.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborencoder_close_container_checked.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborerrorstrings.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser_dup_string.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty_stdio.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c</FilePath>
+            </File>
+          </Files>
+        </Group>
 			</Groups>
 		</Target>
 	</Targets>

--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_demos_eth/aws_demos_eth.uvproj
@@ -148,7 +148,7 @@
 						<RestoreSysVw>1</RestoreSysVw>
 					</Target>
 					<RunDebugAfterBuild>0</RunDebugAfterBuild>
-					<TargetSelection>-1</TargetSelection>
+					<TargetSelection>19</TargetSelection>
 					<SimDlls>
 						<CpuDll></CpuDll>
 						<CpuDllArguments></CpuDllArguments>
@@ -377,7 +377,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot;  CONFIG_MEDTLS_USE_AFR_MEMORY RVDS_ARMCM4_NUC4xx __little_endian__=1 NDEBUG M487_ETH_DEMO</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/tools/tcp_utilities/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../demos/common/http_demo_helpers;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/common/pkcs11_helpers;../../../../../demos/device_defender_for_aws;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../tests/integration_test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/coreMQTT_Agent;</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/tools/tcp_utilities/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/application_code/nuvoton_code;../../../../../demos/include;../../../../../demos/network_manager;../../../../../demos/common/http_demo_helpers;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/common/pkcs11_helpers;../../../../../demos/device_defender_for_aws;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../tests/integration_test;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/NetworkInterface/M487;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/abstractions/pkcs11/mbedtls;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/3rdparty/http_parser;../../../../../libraries/3rdparty/jsmn;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../demos/coreMQTT_Agent;../../../../../demos/common/mqtt_subscription_manager;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws;../../../../../libraries/ota_for_aws/source/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/ota_for_aws/source/portable/os;../../../../../libraries/abstractions/platform/include/platform</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -2683,6 +2683,121 @@
                     </File>
                   </Files>
                 </Group>
+        <Group>
+          <GroupName>demos/ota/ota_demo_core_mqtt/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota_demo_core_mqtt.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\ota\ota_demo_core_mqtt\ota_demo_core_mqtt.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>demos/common/</GroupName>
+          <Files>
+            <File>
+              <FileName>mqtt_subscription_manager.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\common\mqtt_subscription_manager\mqtt_subscription_manager.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_application_version.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\demos\common\ota_demo_helpers\ota_application_version.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>numaker_iot_m487_wifi/ports/ota_pal_for_aws/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota_pal.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_pal_spim.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal_spim.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>libraries/ota_for_aws/source/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_base64.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_base64.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_cbor.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_cbor.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_interface.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_interface.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_mqtt.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\ota_mqtt.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_os_freertos.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\ota_for_aws\source\portable\os\ota_os_freertos.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>libraries/3rdparty/tinycbor/</GroupName>
+          <Files>
+            <File>
+              <FileName>cborencoder.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborencoder_close_container_checked.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborerrorstrings.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser_dup_string.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty_stdio.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c</FilePath>
+            </File>
+          </Files>
+        </Group>
             </Groups>
 		</Target>
 	</Targets>

--- a/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_tests/aws_tests.uvproj
+++ b/projects/nuvoton/numaker_iot_m487_wifi/uvision/aws_tests/aws_tests.uvproj
@@ -374,7 +374,7 @@
 							<MiscControls>--diag_suppress=550,177,C4017,111,2770,223</MiscControls>
 							<Define>MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot; MBEDTLS_USER_CONFIG_FILE=\&quot;mbedtls_user_config.h\&quot; CONFIG_MEDTLS_USE_AFR_MEMORY UNITY_INCLUDE_CONFIG_H RVDS_ARMCM4_NUC4xx __LITTLE_ENDIAN__ FREERTOS_ENABLE_UNIT_TESTS M487 __little_endian__=1 NDEBUG</Define>
 							<Undefine/>
-							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code;../../../../../tests/include;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/include;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/jsmn</IncludePath>
+							<IncludePath>../../../../../freertos_kernel/include;../../../../../freertos_kernel/portable/RVDS/ARM_CM4F;../../../../../vendors/nuvoton/sdk/CMSIS/Include;../../../../../vendors/nuvoton/sdk/Device/Nuvoton/numaker_iot_m487_wifi/Include;../../../../../vendors/nuvoton/sdk/middleware/wifi_esp8266;../../../../../vendors/nuvoton/sdk/StdDriver/inc;../../../../../libraries/freertos_plus/standard/crypto/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/include;../../../../../libraries/freertos_plus/standard/freertos_plus_tcp/portable/Compiler/Keil;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/application_code/nuvoton_code;../../../../../tests/include;../../../../../libraries/c_sdk/standard/common/include/private;../../../../../libraries/c_sdk/standard/common/include;../../../../../libraries/abstractions/platform/include;../../../../../libraries/abstractions/platform/freertos/include;../../../../../libraries/abstractions/platform/include/platform;../../../../../libraries/logging/include;../../../../../demos/dev_mode_key_provisioning/include;../../../../../libraries/abstractions/pkcs11/corePKCS11/source/include;../../../../../libraries/freertos_plus/standard/utils/include;../../../../../libraries/abstractions/secure_sockets/include;../../../../../libraries/freertos_plus/standard/tls/include;../../../../../libraries/abstractions/wifi/include;../../../../../libraries/freertos_plus/aws/greengrass/test;../../../../../libraries/freertos_plus/aws/greengrass/include;../../../../../libraries/freertos_plus/aws/greengrass/src;../../../../../libraries/coreMQTT/source/include;../../../../../libraries/coreMQTT/source/interface;../../../../../libraries/abstractions/backoff_algorithm/source/include;../../../../../demos/common/pkcs11_helpers;../../../../../libraries/abstractions/transport/secure_sockets;../../../../../libraries/freertos_plus/standard/freertos_plus_cli/include;../../../../../libraries/coreMQTT-Agent/source/include;../../../../../libraries/abstractions/mqtt_agent/include;../../../../../libraries/abstractions/mqtt_agent;../../../../../libraries/coreHTTP/source/include;../../../../../libraries/coreHTTP/source/interface;../../../../../libraries/coreHTTP/source/dependency/3rdparty/http_parser;../../../../../demos/common/http_demo_helpers;../../../../../libraries/coreJSON/source/include;../../../../../libraries/device_shadow_for_aws/source/include;../../../../../demos/common/mqtt_demo_helpers;../../../../../demos/include;../../../../../libraries/device_defender_for_aws/source/include;../../../../../libraries/jobs_for_aws/source/include;../../../../../libraries/3rdparty/unity/src;../../../../../libraries/3rdparty/unity/extras/fixture/src;../../../../../libraries/3rdparty/pkcs11;../../../../../libraries/3rdparty/mbedtls/include;../../../../../libraries/3rdparty/mbedtls_config;../../../../../libraries/3rdparty/mbedtls/include/mbedtls;../../../../../libraries/3rdparty/mbedtls_utils;../../../../../libraries/3rdparty/jsmn;../../../../../vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws;../../../../../libraries/ota_for_aws/source/include;../../../../../libraries/3rdparty/tinycbor/src;../../../../../libraries/ota_for_aws/source/portable/os;../../../../../tests/integration_test/ota_pal</IncludePath>
 						</VariousControls>
 					</Cads>
 					<Aads>
@@ -2625,6 +2625,71 @@
 						</File>
 					</Files>
 				</Group>
+        <Group>
+          <GroupName>numaker_iot_m487_wifi/ports/ota_pal_for_aws/</GroupName>
+          <Files>
+            <File>
+              <FileName>ota_pal.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal.c</FilePath>
+            </File>
+            <File>
+              <FileName>ota_pal_spim.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\vendors\nuvoton\boards\numaker_iot_m487_wifi\ports\ota_pal_for_aws\ota_pal_spim.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>libraries/3rdparty/tinycbor/</GroupName>
+          <Files>
+            <File>
+              <FileName>cborencoder.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborencoder_close_container_checked.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborerrorstrings.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborparser_dup_string.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c</FilePath>
+            </File>
+            <File>
+              <FileName>cborpretty_stdio.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>tests/integration_test/ota_pal</GroupName>
+          <Files>
+            <File>
+              <FileName>aws_test_ota_pal.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\tests\integration_test\ota_pal\aws_test_ota_pal.c</FilePath>
+            </File>
+          </Files>
+        </Group>
 			</Groups>
 		</Target>
 	</Targets>

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -150,6 +150,27 @@ target_sources(
         "${afr_ports_dir}/pkcs11/core_pkcs11_pal.c"
 )
 
+# OTA
+afr_mcu_port(ota)
+target_sources(
+    AFR::ota::mcu_port
+    INTERFACE
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal.c"
+        "${afr_ports_dir}/ota_pal_for_aws/ota_pal_spim.c"
+)
+target_include_directories(
+    AFR::ota::mcu_port
+    INTERFACE
+            "${afr_ports_dir}/ota_pal_for_aws"
+)
+target_link_libraries(
+    AFR::ota::mcu_port
+    INTERFACE
+        AFR::crypto
+        AFR::pkcs11
+        AFR::ota
+)
+
 if(AFR_ENABLE_ETH)
 
     # FreeRTOS Plus TCP

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/CMakeLists.txt
@@ -171,6 +171,13 @@ target_link_libraries(
         AFR::ota
 )
 
+if(AFR_ENABLE_TESTS)
+    target_include_directories(
+        AFR::ota::mcu_port
+        INTERFACE "${PROJECT_SOURCE_DIR}/tests/integration_test/ota_pal"
+    )
+endif()
+
 if(AFR_ENABLE_ETH)
 
     # FreeRTOS Plus TCP

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/FreeRTOSConfig.h
@@ -60,7 +60,7 @@
 #define configTICK_RATE_HZ                           ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                         ( 7 )
 #define configMINIMAL_STACK_SIZE                     ( ( uint16_t ) 256 )
-#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 116 * 1024 ) )
+#define configTOTAL_HEAP_SIZE                        ( ( size_t ) ( 119 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                      ( 16 )
 #define configUSE_TRACE_FACILITY                     1
 #define configUSE_16_BIT_TICKS                       0

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/aws_demo_config.h
@@ -37,6 +37,8 @@
  *          CONFIG_CORE_MQTT_AGENT_DEMO_ENABLED
  *          CONFIG_DEVICE_SHADOW_DEMO_ENABLED
  *          CONFIG_DEVICE_DEFENDER_DEMO_ENABLED
+ *          CONFIG_OTA_MQTT_UPDATE_DEMO_ENABLED
+ *          CONFIG_OTA_HTTP_UPDATE_DEMO_ENABLED
  *          CONFIG_JOBS_DEMO_ENABLED
  *          CONFIG_GREENGRASS_DISCOVERY_DEMO_ENABLED
  *          CONFIG_TCP_ECHO_CLIENT_DEMO_ENABLED
@@ -47,7 +49,7 @@
 #define CONFIG_CORE_MQTT_MUTUAL_AUTH_DEMO_ENABLED
 
 /* Default configuration for all demos. Individual demos can override these below */
-#define democonfigDEMO_STACKSIZE       ( configMINIMAL_STACK_SIZE * 20 )
+#define democonfigDEMO_STACKSIZE       ( configMINIMAL_STACK_SIZE * 6 )
 #define democonfigDEMO_PRIORITY        ( tskIDLE_PRIORITY + 5 )
 
 #ifndef M487_ETH_DEMO

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_config.h
@@ -81,7 +81,7 @@
  * service so we will only send the request message after being idle for this
  * amount of time.
  */
-#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+#define otaconfigFILE_REQUEST_WAIT_MS           10000U
 
 /**
  * @brief The maximum allowed length of the thing name used by the OTA agent.
@@ -92,7 +92,7 @@
  * allocate static storage for the Thing name used in all OTA base topics.
  * Namely $aws/things/<thingName>
  */
-#define otaconfigMAX_THINGNAME_LEN              64U
+#define otaconfigMAX_THINGNAME_LEN              128U
 
 /**
  * @brief The maximum number of data blocks requested from OTA streaming service.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_config.h
@@ -1,0 +1,186 @@
+/*
+ * AWS IoT Device SDK for Embedded C V202009.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file ota_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef OTA_CONFIG_H_
+#define OTA_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Logging related header files are required to be included in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
+ * 3. Include the header file "logging_stack.h".
+ */
+
+/* Include header that defines log levels. */
+#include "logging_levels.h"
+
+/* Configure name and log level for the OTA library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME     "OTA"
+#endif
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/* Include OTA demo configurations. */
+#include "ota_demo_config.h"
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
+
+/**
+ * @brief Size of the file data block message (excluding the header).
+ */
+#define otaconfigFILE_BLOCK_SIZE                ( 1UL << otaconfigLOG2_FILE_BLOCK_SIZE )
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service
+ * if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA
+ * service so we will only send the request message after being idle for this
+ * amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the
+ * broker. Likewise, the OTA agent requires the developer to construct and pass
+ * in the Thing name when initializing the OTA agent. The agent uses this size to
+ * allocate static storage for the Thing name used in all OTA base topics.
+ * Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              64U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in response. The maximum
+ * limit for this must be calculated from the maximum data response limit (128 KB
+ * from service) divided by the block size. For example if block size is set as 1
+ * KB then the maximum number of data blocks that we can request is
+ * 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower
+ * based on how many data blocks response is expected for each data requests.
+ * @note This must be set larger than zero.
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         1U
+
+/**
+ * @brief The maximum number of requests allowed to send without a response before
+ * we abort.
+ *
+ * This configuration parameter sets the maximum number of times the requests are
+ * made over the selected communication channel before aborting and returning error.
+ */
+#define otaconfigMAX_NUM_REQUEST_MOMENTUM       32U
+
+/**
+ * @brief The number of data buffers reserved by the OTA agent.
+ *
+ * This configurations parameter sets the maximum number of static data buffers used by
+ * the OTA agent for job and file data blocks received.
+ */
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       otaconfigMAX_NUM_BLOCKS_REQUEST + 1
+
+/**
+ * @brief How frequently the device will report its OTA progress to the cloud.
+ *
+ * Device will update the job status with the number of blocks it has received every certain
+ * number of blocks it receives. For example, 25 means device will update job status every 25 blocks
+ * it receives.
+ */
+#define otaconfigOTA_UPDATE_STATUS_FREQUENCY    25U
+
+/**
+ * @brief Allow update to same or lower version.
+ *
+ * Set this to 1 to allow downgrade or same version update.This configurations parameter
+ * disables version check and allows update to a same or lower version.This is provided for
+ * testing purpose and it is recommended to always update to higher version and keep this
+ * configuration disabled.
+ */
+#define otaconfigAllowDowngrade                 0U
+
+/**
+ * @brief The protocol selected for OTA control operations.
+ *
+ * This configurations parameter sets the default protocol for all the OTA control
+ * operations like requesting OTA job, updating the job status etc.
+ *
+ * @note Only MQTT is supported at this time for control operations.
+ */
+#define configENABLED_CONTROL_PROTOCOL          ( OTA_CONTROL_OVER_MQTT )
+
+/**
+ * @brief The protocol selected for OTA data operations.
+ *
+ * This configurations parameter sets the protocols selected for the data operations
+ * like requesting file blocks from the service.
+ *
+ * @note Both MQTT and HTTP is supported for data transfer. This configuration parameter
+ * can be set to following -
+ * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
+ * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
+ * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ *
+ * @note To enable data over HTTP, you must remove `AWSIOT_NETWORK_TYPE_BLE` from
+ * `configENABLED_NETWORKS` in `aws_iot_network_config.h`
+ */
+#define configENABLED_DATA_PROTOCOLS            ( OTA_DATA_OVER_MQTT )
+
+/**
+ * @brief The preferred protocol selected for OTA data operations.
+ *
+ * Primary data protocol will be the protocol used for downloading file if more than
+ * one protocol is selected while creating OTA job. Default primary data protocol is MQTT
+ * and following update here to switch to HTTP as primary.
+ *
+ * @note Use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
+ */
+
+#define configOTA_PRIMARY_DATA_PROTOCOL    ( OTA_DATA_OVER_MQTT )
+
+#endif /* OTA_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/ota_demo_config.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file ota_demo_config.h
+ * @brief Configuration options for the OTA related demos.
+ */
+
+#ifndef OTA_DEMO_CONFIG_H_
+#define OTA_DEMO_CONFIG_H_
+
+/**
+ * @brief Certificate used for validating code signing signatures in the OTA PAL.
+ */
+#ifndef otapalconfigCODE_SIGNING_CERTIFICATE
+    #define otapalconfigCODE_SIGNING_CERTIFICATE    "Insert code signing certificate..."
+#endif
+
+/**
+ * @brief Major version of the firmware.
+ *
+ * This is used in the OTA demo to set the appFirmwareVersion variable
+ * that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#ifndef APP_VERSION_MAJOR
+    #define APP_VERSION_MAJOR    0
+#endif
+
+/**
+ * @brief Minor version of the firmware.
+ *
+ * This is used in the OTA demo to set the appFirmwareVersion variable
+ * that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#ifndef APP_VERSION_MINOR
+    #define APP_VERSION_MINOR    9
+#endif
+
+/**
+ * @brief Build version of the firmware.
+ *
+ * This is used in the OTA demo to set the appFirmwareVersion variable
+ * that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#ifndef APP_VERSION_BUILD
+    #define APP_VERSION_BUILD    2
+#endif
+
+/**
+ * @brief Timeout for which MQTT library keeps polling the transport interface,
+ * when no byte is received.
+ * The timeout is honoured only after the first byte is read and while remaining
+ * bytes are read from network interface. Keeping this timeout to a sufficiently
+ * large value so as to account for delay of receipt of a large block of message.
+ */
+#define MQTT_RECV_POLLING_TIMEOUT_MS            ( 1000U )
+
+/**
+ * @brief The length of the queue used to hold commands for the agent.
+ */
+#define MQTT_AGENT_COMMAND_QUEUE_LENGTH         ( 25 )
+
+/**
+ * @brief Dimensions the buffer used to serialise and deserialise MQTT packets.
+ * @note Specified in bytes.  Must be large enough to hold the maximum
+ * anticipated MQTT payload.
+ */
+#define MQTT_AGENT_NETWORK_BUFFER_SIZE          ( 3000 )
+
+/**
+ * @breif Maximum time MQTT agent waits in the queue for any pending MQTT
+ * operations. The wait time is kept smallest possible to increase the
+ * responsiveness of MQTT agent while processing  pending MQTT operations as
+ * well as receive packets from network.
+ */
+#define MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME    ( 1U )
+
+#endif /* OTA_DEMO_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/aws_test_ota_config.h
@@ -1,0 +1,96 @@
+/*
+ * FreeRTOS V1.1.4
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file aws_test_ota_config.h
+ * @brief Port-specific variables for firmware Over-the-Air Update tests. */
+
+#ifndef AWS_TEST_OTA_CONFIG_H_
+#define AWS_TEST_OTA_CONFIG_H_
+
+/**
+ * @brief Path to cert for OTA test PAL. Used to verify signature.
+ * If applicable, the device must be pre-provisioned with this certificate. Please see
+ * test/common/ota/test_files for the set of certificates.
+ */
+#define otatestpalCERTIFICATE_FILE                         "tests\\integration_test\\ota_pal\\test_files\\ecdsa-sha256-signer.crt.pem.test"
+
+/**
+ * @brief Some devices have a hard-coded name for the firmware image to boot.
+ */
+#define otatestpalFIRMWARE_FILE                            "dummy.bin"
+
+/**
+ * @brief Some boards OTA PAL layers will use the file names passed into it for the
+ * image and the certificates because their non-volatile memory is abstracted by a
+ * file system. Set this to 1 if that is the case for your device.
+ */
+#define otatestpalUSE_FILE_SYSTEM                          0
+
+/**
+ * @brief 1 if otaPal_CheckFileSignature() is implemented in aws_ota_pal.c.
+ */
+#define otatestpalCHECK_FILE_SIGNATURE_SUPPORTED           1
+
+/**
+ * @brief 1 if otaPal_ReadAndAssumeCertificate() is implemented in aws_ota_pal.c.
+ */
+#define otatestpalREAD_AND_ASSUME_CERTIFICATE_SUPPORTED    1
+
+/**
+ * @brief 1 if using PKCS #11 to access the code sign certificate from NVM.
+ */
+#define otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11    1
+
+/**
+ * @brief Include of signature testing data applicable to this device.
+ */
+#include "aws_test_ota_pal_ecdsa_sha256_signature.h"
+
+/**
+ * @brief Major version of the firmware.
+ *
+ *        This is used in the OTA demo to set the appFirmwareVersion variable
+ *        that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#define APP_VERSION_MAJOR    0
+
+/**
+ * @brief Minor version of the firmware.
+ *
+ *        This is used in the OTA demo to set the appFirmwareVersion variable
+ *        that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#define APP_VERSION_MINOR    9
+
+/**
+ * @brief Build version of the firmware.
+ *
+ *        This is used in the OTA demo to set the appFirmwareVersion variable
+ *        that is declared in the ota_appversion32.h file in the OTA library.
+ */
+#define APP_VERSION_BUILD    2
+
+#endif /* ifndef AWS_TEST_OTA_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/ota_config.h
@@ -82,7 +82,7 @@
  * service so we will only send the request message after being idle for this
  * amount of time.
  */
-#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+#define otaconfigFILE_REQUEST_WAIT_MS           10000U
 
 /**
  * @brief The maximum allowed length of the thing name used by the OTA agent.

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/ota_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_tests/config_files/ota_config.h
@@ -1,0 +1,188 @@
+/*
+ * AWS IoT Device SDK for Embedded C V202009.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file ota_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef OTA_CONFIG_H_
+#define OTA_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Logging related header files are required to be included in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
+ * 3. Include the header file "logging_stack.h".
+ */
+
+/* Include header that defines log levels. */
+#include "logging_levels.h"
+
+/* Configure name and log level for the OTA library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME     "OTA"
+#endif
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/* Include config file used for testing the OTA PAL. This config file defines
+ * the otapalconfigCODE_SIGNING_CERTIFICATE macro. */
+#include "aws_test_ota_config.h"
+
+/**
+ * @brief Log base 2 of the size of the file data block message (excluding the header).
+ *
+ * 10 bits yields a data block size of 1KB.
+ */
+#define otaconfigLOG2_FILE_BLOCK_SIZE           10UL
+
+/**
+ * @brief Size of the file data block message (excluding the header).
+ */
+#define otaconfigFILE_BLOCK_SIZE                ( 1UL << otaconfigLOG2_FILE_BLOCK_SIZE )
+
+/**
+ * @brief Milliseconds to wait for the self test phase to succeed before we force reset.
+ */
+#define otaconfigSELF_TEST_RESPONSE_WAIT_MS     16000U
+
+/**
+ * @brief Milliseconds to wait before requesting data blocks from the OTA service
+ * if nothing is happening.
+ *
+ * The wait timer is reset whenever a data block is received from the OTA
+ * service so we will only send the request message after being idle for this
+ * amount of time.
+ */
+#define otaconfigFILE_REQUEST_WAIT_MS           2500U
+
+/**
+ * @brief The maximum allowed length of the thing name used by the OTA agent.
+ *
+ * AWS IoT requires Thing names to be unique for each device that connects to the
+ * broker. Likewise, the OTA agent requires the developer to construct and pass
+ * in the Thing name when initializing the OTA agent. The agent uses this size to
+ * allocate static storage for the Thing name used in all OTA base topics.
+ * Namely $aws/things/<thingName>
+ */
+#define otaconfigMAX_THINGNAME_LEN              128U
+
+/**
+ * @brief The maximum number of data blocks requested from OTA streaming service.
+ *
+ * This configuration parameter is sent with data requests and represents the
+ * maximum number of data blocks the service will send in response. The maximum
+ * limit for this must be calculated from the maximum data response limit (128 KB
+ * from service) divided by the block size. For example if block size is set as 1
+ * KB then the maximum number of data blocks that we can request is
+ * 128/1 = 128 blocks. Configure this parameter to this maximum limit or lower
+ * based on how many data blocks response is expected for each data requests.
+ * @note This must be set larger than zero.
+ */
+#define otaconfigMAX_NUM_BLOCKS_REQUEST         1U
+
+/**
+ * @brief The maximum number of requests allowed to send without a response before
+ * we abort.
+ *
+ * This configuration parameter sets the maximum number of times the requests are
+ * made over the selected communication channel before aborting and returning error.
+ */
+#define otaconfigMAX_NUM_REQUEST_MOMENTUM       32U
+
+/**
+ * @brief The number of data buffers reserved by the OTA agent.
+ *
+ * This configurations parameter sets the maximum number of static data buffers used by
+ * the OTA agent for job and file data blocks received.
+ */
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       otaconfigMAX_NUM_BLOCKS_REQUEST + 1
+
+/**
+ * @brief How frequently the device will report its OTA progress to the cloud.
+ *
+ * Device will update the job status with the number of blocks it has received every certain
+ * number of blocks it receives. For example, 25 means device will update job status every 25 blocks
+ * it receives.
+ */
+#define otaconfigOTA_UPDATE_STATUS_FREQUENCY    25U
+
+/**
+ * @brief Allow update to same or lower version.
+ *
+ * Set this to 1 to allow downgrade or same version update.This configurations parameter
+ * disables version check and allows update to a same or lower version.This is provided for
+ * testing purpose and it is recommended to always update to higher version and keep this
+ * configuration disabled.
+ */
+#define otaconfigAllowDowngrade                 0U
+
+/**
+ * @brief The protocol selected for OTA control operations.
+ *
+ * This configurations parameter sets the default protocol for all the OTA control
+ * operations like requesting OTA job, updating the job status etc.
+ *
+ * @note Only MQTT is supported at this time for control operations.
+ */
+#define configENABLED_CONTROL_PROTOCOL          ( OTA_CONTROL_OVER_MQTT )
+
+/**
+ * @brief The protocol selected for OTA data operations.
+ *
+ * This configurations parameter sets the protocols selected for the data operations
+ * like requesting file blocks from the service.
+ *
+ * @note Both MQTT and HTTP is supported for data transfer. This configuration parameter
+ * can be set to following -
+ * Enable data over MQTT - ( OTA_DATA_OVER_MQTT )
+ * Enable data over HTTP - ( OTA_DATA_OVER_HTTP)
+ * Enable data over both MQTT & HTTP ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP )
+ * For M487 paltform + freertos_plus_tcp, M487 memory footprint can't afford OTA_DATA_OVER_HTTP.
+ *
+ * @note To enable data over HTTP, you must remove `AWSIOT_NETWORK_TYPE_BLE` from
+ * `configENABLED_NETWORKS` in `aws_iot_network_config.h`
+ */
+#define configENABLED_DATA_PROTOCOLS            ( OTA_DATA_OVER_MQTT )
+
+/**
+ * @brief The preferred protocol selected for OTA data operations.
+ *
+ * Primary data protocol will be the protocol used for downloading file if more than
+ * one protocol is selected while creating OTA job. Default primary data protocol is MQTT
+ * and following update here to switch to HTTP as primary.
+ *
+ * @note Use OTA_DATA_OVER_HTTP for HTTP as primary data protocol.
+ */
+
+#define configOTA_PRIMARY_DATA_PROTOCOL    ( OTA_DATA_OVER_MQTT )
+
+#endif /* OTA_CONFIG_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal.c
@@ -1,0 +1,1017 @@
+/*
+ * FreeRTOS OTA PAL for Nuvoton Numaker-IoT-M487
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* OTA PAL implementation for M487 platform. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include "core_pkcs11.h"
+#include "iot_crypto.h"
+#include "ota.h"
+#include "ota_interface_private.h"
+#include "ota_platform_interface.h"
+#include "ota_pal.h"
+#include "core_pkcs11_config.h"
+#include "ota_config.h"
+
+#include "NuMicro.h"
+
+/* Specify the OTA signature algorithm we support on this platform. */
+const char OTA_JsonFileSignatureKey[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ] = "sig-sha256-ecdsa";
+static const char codeSigningCertificatePEM[] = otapalconfigCODE_SIGNING_CERTIFICATE;
+
+/* definitions shared with the resident bootloader. */
+#define AWS_BOOT_IMAGE_SIGNATURE         "@AFRTOS"
+#define AWS_BOOT_IMAGE_SIGNATURE_SIZE    ( 7U )
+
+/* PAL error codes. */
+
+#define AWS_BOOT_FLAG_IMG_NEW               0xffU /* 11111111b A new image that hasn't yet been run. */
+#define AWS_BOOT_FLAG_IMG_PENDING_COMMIT    0xfeU /* 11111110b Image is pending commit and is ready for self test. */
+#define AWS_BOOT_FLAG_IMG_VALID             0xfcU /* 11111100b The image was accepted as valid by the self test code. */
+#define AWS_BOOT_FLAG_IMG_INVALID           0xf8U /* 11111000b The image was NOT accepted by the self test code. */
+
+#define NVT_OTA_META_BASE                   ( 0x70000UL )      /* OTA meta data storage start address in APROM  */
+#define NVT_BOOT_IMG_HEAD_BASE              (NVT_OTA_META_BASE)
+#define NVT_BOOT_IMG_TRAIL_BASE             (NVT_OTA_META_BASE + FMC_FLASH_PAGE_SIZE)
+
+/*
+ * Image Header.
+ */
+
+typedef union
+{
+    uint32_t ulAlign[ 2 ]; /* Force image header to be 8 bytes. */
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+    struct
+    {
+        char cImgSignature[ AWS_BOOT_IMAGE_SIGNATURE_SIZE ]; /* Signature identifying a valid application: AWS_BOOT_IMAGE_SIGNATURE. */
+        uint8_t ucImgFlags;                                  /* Flags from the AWS_BOOT_IMAGE_FLAG_IMG*, above. */
+    };                                                       
+} BootImageHeader_t;
+
+
+/* Boot application image descriptor.
+ * Total size is 32 bytes (NVM programming does 4 bytes at a time)
+ * This is the descriptor used by the bootloader
+ * to maintain the application images.
+ */
+typedef struct
+{
+    BootImageHeader_t xImgHeader; /* Application image header (8 bytes). */
+    uint32_t ulSequenceNum;       /* OTA sequence number. Higher is newer. */
+    /* Use byte pointers for image addresses so pointer math doesn't use incorrect scalars. */
+    const uint8_t * pvStartAddr;  /* Image start address. */
+    const uint8_t * pvEndAddr;    /* Image end address. */
+    const uint8_t * pvExecAddr;   /* Execution start address. */
+    uint32_t ulHardwareID;        /* Unique Hardware ID. */
+    uint32_t ulReserved;          /* Reserved. *//*lint -e754 -e830 intentionally unreferenced alignment word. */
+} BootImageDescriptor_t;
+
+//static BootImageDescriptor_t xCurBootImgDesc;         /* current Boot Image in progress. */
+
+/*
+ * Image Trailer.
+ */
+typedef struct
+{
+    uint8_t aucSignatureType[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ]; /* Signature Type. */
+    uint32_t ulSignatureSize;                                    /* Signature size. */
+    uint8_t aucSignature[ kOTA_MaxSignatureSize ];               /* Signature */
+} BootImageTrailer_t;
+
+typedef struct
+{
+    const OtaFileContext_t * pxCurOTAFile; /* Current OTA file to be processed. */
+    uint32_t ulImageOffset;              /* offset/address of the application image. */
+} OTA_OperationDescriptor_t;
+
+/* NOTE that this implementation supports only one OTA at a time since it uses a single static instance. */
+static OTA_OperationDescriptor_t xCurOTAOpDesc;         /* current OTA operation in progress. */
+static OTA_OperationDescriptor_t * pxCurOTADesc = NULL; /* pointer to current OTA operation. */
+
+static OtaPalStatus_t otaPal_CheckFileSignature( OtaFileContext_t * const C );
+static uint8_t * otaPal_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize );
+
+/*-----------------------------------------------------------*/
+static __inline bool prvContextValidate( OtaFileContext_t * C )
+{
+    return( ( pxCurOTADesc != NULL ) && ( C != NULL ) &&
+            ( pxCurOTADesc->pxCurOTAFile == C ) &&
+            ( C->pFile == ( uint8_t * ) pxCurOTADesc ) ); /*lint !e9034 This preserves the abstraction layer. */
+}
+
+
+static __inline void prvContextClose( OtaFileContext_t * C )
+{
+    if( NULL != C )
+    {
+        C->pFile = NULL;
+    }
+
+    xCurOTAOpDesc.pxCurOTAFile = NULL;
+    pxCurOTADesc = NULL;
+}
+
+static bool_t prvFLASH_update(uint32_t u32StartAddr, uint8_t * pucData, uint32_t ulDataSize)
+{
+    uint32_t    u32Addr;               /* flash address */
+    uint32_t    u32data;               /* flash data    */
+    uint32_t    *pDataSrc;             /* flash data    */    
+    uint32_t    u32EndAddr = (u32StartAddr + ulDataSize);
+    uint32_t    u32Pattern = 0xFFFFFFFF;
+    bool_t result = pdFALSE;
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    FMC_Open();                        /* Enable FMC ISP function */
+    FMC_ENABLE_AP_UPDATE();            /* Enable APROM update. */
+    FMC_Erase(u32StartAddr);    
+     /* Verify if each data word from flash u32StartAddr to u32EndAddr be 0xFFFFFFFF.  */
+    for (u32Addr = u32StartAddr; u32Addr < u32EndAddr; u32Addr += 4)
+    {
+        u32data = FMC_Read(u32Addr);   /* Read a flash word from address u32Addr. */
+
+        if (u32data != u32Pattern )     /* Verify if data matched. */
+        {
+            LogError(( "[%s] FMC_Read data verify failed at address 0x%x, read=0x%x, expect=0x%x\n", __FUNCTION__, u32Addr, u32data, u32Pattern));   
+            result = pdFALSE;                 /* data verify failed */
+            goto lexit;
+        }
+    }
+    
+    pDataSrc = (uint32_t *) pucData;
+    /* Fill flash range from u32StartAddr to u32EndAddr */
+    for (u32Addr = u32StartAddr; u32Addr < u32EndAddr; u32Addr += 4)
+    {
+        FMC_Write(u32Addr, *pDataSrc);          /* Program flash */
+        //printf("#### FMC write: 0x%x, val:0x%x \n", u32Addr, *pDataSrc);
+        pDataSrc++;
+    }    
+    result = pdTRUE; 
+    
+lexit:   
+    FMC_DISABLE_AP_UPDATE();           /* Disable APROM update. */
+    FMC_Close();                       /* Disable FMC ISP function */
+    /* Lock protected registers */
+    SYS_LockReg();   
+    
+    return result;
+    
+}
+
+
+#define OTA_SPI_BANK_START  0x00
+#define OTA_SPI_BANK_SIZE   0x80000
+
+static bool_t prvSPI_FLASH_EraseBank()
+{
+
+  bool_t result = pdFALSE;
+  // FIX ME
+  /* Erase SPI flash 512KB bank before program. */
+  result = NVT_SPI_Flash_Bank_Erase(OTA_SPI_BANK_START, OTA_SPI_BANK_SIZE);
+  return result;
+}
+
+#define ROUND_SIZE(a, b)            (((a + b - 1) / b) * b)
+/* To use 2nd SPI bank to backup current active image */
+static bool prvSPI_FLASH_BackupBank(uint32_t dstAddress, uint32_t srcAddress, uint32_t srcSize)
+{
+  int spiBlockSzie =  (4*1024);     // W25Q32 block size is 4KB, chip size is 4MB
+  uint32_t  startAddress = dstAddress + spiBlockSzie;
+  uint32_t  bankSize = ROUND_SIZE(srcSize, spiBlockSzie);
+  bool      result = false;
+  int       ret;
+
+  BootImageDescriptor_t xDescImage;
+  memcpy(xDescImage.xImgHeader.cImgSignature, AWS_BOOT_IMAGE_SIGNATURE, AWS_BOOT_IMAGE_SIGNATURE_SIZE);
+  xDescImage.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_VALID;
+  xDescImage.pvStartAddr = 0x00;
+  xDescImage.pvEndAddr = xDescImage.pvStartAddr + (srcSize - 1);
+  xDescImage.pvExecAddr = 0x00;
+  xDescImage.ulReserved = startAddress; /* Backup image's SPI Flash start address */
+
+    /*
+     *  Erase flash page
+     */
+    if( (startAddress + bankSize) > (OTA_SPI_BANK_SIZE*2) )  
+    {
+        LogError(("[%s] FAILED!\n", __FUNCTION__));
+        LogError(("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", __FUNCTION__, (startAddress + bankSize), (OTA_SPI_BANK_SIZE*2)));
+        goto lexit;
+    }
+    LogInfo(("[%s] Erase SPI flash bank 0x%x ~ 0x%x ...", __FUNCTION__, dstAddress, (startAddress + bankSize)));
+    if( NVT_SPI_Flash_Bank_Erase(dstAddress, bankSize + spiBlockSzie) == pdTRUE )
+    {
+        result = true;
+        LogInfo(("[%s] done.\n", __FUNCTION__));
+    } else {
+       result = false;
+       LogError(("[%s] fail.\n", __FUNCTION__));
+       goto lexit;
+    }
+    /*
+     *  Copy src image to SPI flash
+     */
+    LogInfo(("[%s] Backup src image to SPI flash backup-bank 0x%x from 0x%x...", __FUNCTION__, startAddress, srcAddress));
+    
+    uint32_t ulOffset;
+    uint8_t *pacData;   
+
+    for (ulOffset = 0; ulOffset < srcSize; ulOffset += spiBlockSzie )
+    {
+        pacData = (uint8_t *)srcAddress + ulOffset;
+        if( NVT_SPI_Flash_Block_Write( startAddress + ulOffset, pacData, spiBlockSzie) < 0 )
+        {
+            LogError(( "[%s] ERROR - SPI Flash write image failed\r\n", __FUNCTION__ ));
+            result = false;
+            goto lexit;
+        }
+    }
+    
+    /* Write Image Meta data in 1st block of backup bank */
+    if( NVT_SPI_Flash_Block_Write( dstAddress, (const uint8_t*)&xDescImage, sizeof(BootImageDescriptor_t)) < 0 )
+    {
+        LogError(( "[%s] ERROR - SPI Flash write Image header failed\r\n", __FUNCTION__ ));
+        result = false;
+        goto lexit;
+    }
+
+    /* Mark FMC image-header ulReserved field as SPI address of backup image */
+    const BootImageDescriptor_t * pxAppImgDesc;
+    BootImageDescriptor_t xDescCopy;
+    pxAppImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+    xDescCopy = *pxAppImgDesc;                    /* Copy image descriptor from flash into RAM structure. */
+    xDescCopy.ulReserved = dstAddress; /* Backup bank's SPI Flash start address */
+    if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy,
+                        sizeof( BootImageDescriptor_t) ) == true )
+    {
+        LogInfo(( "[%s] Mark backup image address.\r\n", __FUNCTION__ ));
+        result = true;
+    }
+
+lexit:
+  return result;
+}
+
+static bool_t prvContextUpdateImageHeaderAndTrailer( OtaFileContext_t * C )
+{    
+
+    bool_t bProgResult;
+    BootImageHeader_t xImgHeader;
+    BootImageDescriptor_t * pxImgDesc;
+    BootImageDescriptor_t xImgDesc;    
+    BootImageTrailer_t xImgTrailer;
+
+    /* Pointer to the boot image header in the flash. */
+    pxImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+    xImgDesc = *pxImgDesc;
+    xImgDesc.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_NEW;
+    
+    /* Write Boot header to flash. */
+    bProgResult = prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, 
+                                    (uint8_t *)&xImgDesc, 
+                                    sizeof( BootImageDescriptor_t) );
+    
+    LogInfo(( "[%s] OTA Sequence Number: %d\r\n", __FUNCTION__, pxImgDesc->ulSequenceNum ));
+    LogInfo(( "[%s] Image - Start: 0x%08x, End: 0x%08x\r\n", __FUNCTION__,
+                pxImgDesc->pvStartAddr, pxImgDesc->pvEndAddr ));
+
+    /* If header write is successful write trailer. */
+    if( bProgResult )
+    {
+        /* Create image trailer. */
+        memcpy( xImgTrailer.aucSignatureType, OTA_JsonFileSignatureKey, sizeof( OTA_JsonFileSignatureKey ) );
+        xImgTrailer.ulSignatureSize =  C->pSignature->size;
+        memcpy( xImgTrailer.aucSignature, C->pSignature->data, C->pSignature->size );
+
+        /* Write trailer to flash. */
+        bProgResult = prvFLASH_update(NVT_BOOT_IMG_TRAIL_BASE, (uint8_t *)&xImgTrailer, sizeof( xImgTrailer));        
+        LogInfo(( "[%s] Writing Trailer at: 0x%08x\n", __FUNCTION__, NVT_BOOT_IMG_TRAIL_BASE ));
+    }
+
+    return bProgResult;
+}
+
+
+
+/* Attempt to create a new receive file for the file chunks as they come in. */
+
+OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C )
+{
+    OtaPalStatus_t result = OTA_PAL_COMBINE_ERR( OtaPalUninitialized, 0 );
+
+    if( C != NULL )
+    {
+        if( NVT_SPI_Flash_Init() == ( bool_t ) pdFALSE )
+        {
+            result = OTA_PAL_COMBINE_ERR( OtaPalRxFileCreateFailed, -1 );
+            LogError( ( "[%s] ERROR - Failed to init SPI Flash.\r\n", __FUNCTION__) );
+            return result;
+        }
+         
+        /* Erase SPI flash 512KB bank before program. */
+        if( prvSPI_FLASH_EraseBank() == false )
+        {
+            LogError(( "[%s] Error: Failed to erase the flash!\r\n", __FUNCTION__ ));
+            result = OTA_PAL_COMBINE_ERR( OtaPalRxFileCreateFailed, -1 );
+        }
+        else
+        {
+            pxCurOTADesc = &xCurOTAOpDesc;
+            pxCurOTADesc->pxCurOTAFile = C;
+            pxCurOTADesc->ulImageOffset = 0;
+            LogInfo( ("[%s] Receive file created.\r\n", __FUNCTION__ ));
+            C->pFile = ( uint8_t * ) pxCurOTADesc;
+            
+            /* Update Boot Descriptor */
+            BootImageDescriptor_t xDescCopy;
+            memcpy(xDescCopy.xImgHeader.cImgSignature, AWS_BOOT_IMAGE_SIGNATURE, AWS_BOOT_IMAGE_SIGNATURE_SIZE);
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+            xDescCopy.pvStartAddr = 0x00;
+            xDescCopy.pvEndAddr = xDescCopy.pvStartAddr + C->fileSize -1;
+            xDescCopy.pvExecAddr = 0x00;
+            xDescCopy.ulReserved = 0x00;
+
+            if( false == prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                            sizeof( BootImageDescriptor_t) ) )
+            {
+                LogError(( "[%s] ERROR - FMC write failed\r\n", __FUNCTION__ ));
+            } 
+            else 
+            {            
+                result = OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
+            }
+        }
+    }
+    else
+    {
+        result = OTA_PAL_COMBINE_ERR( OtaPalRxFileCreateFailed, -1 );
+        LogError(( "[%s] ERROR - Invalid context provided.\r\n", __FUNCTION__ ));
+    }
+
+    return result; /*lint !e480 !e481 Exiting function without calling fclose.
+                     * Context file handle state is managed by this API. */
+}
+
+
+/* Abort receiving the specified OTA update by closing the file. */
+
+OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C )
+{
+    OtaPalMainStatus_t mainErr = OtaPalUninitialized;
+    int32_t subErr = 0;
+
+    if( NULL != C )
+    {
+        /* Check for null file handle since we may call this before a file is actually opened. */
+        prvContextClose( C );
+        mainErr = OtaPalSuccess;
+        LogInfo(( "[%s] Abort - OK\r\n", __FUNCTION__ ));
+    }
+    else /* Context was not valid. */
+    {
+        LogError(( "[%s] Abort Input Context is NULL - Fail\r\n", __FUNCTION__ ));
+        mainErr = OtaPalFileAbort;
+    }
+    
+    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+}
+
+
+/* Write a block of data to the specified file. 
+   Returns the number of bytes written on success or negative error code.
+*/
+int16_t otaPal_WriteBlock( OtaFileContext_t * const C,
+                           uint32_t ulOffset,
+                           uint8_t * const pacData,
+                           uint32_t ulBlockSize )
+{
+
+    int32_t lResult = 0;
+
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+#if 0
+        /* If execute image not generate boot-descriptor by utility, 1st block will have no boot-desc info */
+        /* OTA image 1st block contain Boot Image Descriptor info */
+        if( ulOffset == 0 ) 
+        {
+            BootImageDescriptor_t xDescCopy;
+            const BootImageDescriptor_t * pxAppImgDesc;
+            pxAppImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+            xDescCopy = *pxAppImgDesc;           /* Copy image descriptor from flash into RAM struct. */
+            memcpy((uint8_t *)&(xDescCopy.ulSequenceNum), pacData, 
+            sizeof(xDescCopy) - sizeof(BootImageHeader_t) );
+            if( pdFALSE == prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                            sizeof( BootImageDescriptor_t) ) )
+            {
+                LogError(( "[%s] ERROR - FMC write failed\r\n", __FUNCTION__ ));
+            }
+        }
+#endif        
+        lResult = NVT_SPI_Flash_Block_Write(ulOffset, pacData, ulBlockSize);
+
+        if( lResult < 0 )
+        {
+                LogError(( "[%s] ERROR - SPI Flash write failed\r\n", __FUNCTION__ ));
+                /* Mask to return a negative value. */
+                lResult = -1; /*lint !e40 !e9027
+                                                                * Errno is being used in accordance with host API documentation.
+                                                                * Bitmasking is being used to preserve host API error with library status code. */
+        }
+    }
+    else /* Invalid context or file pointer provided. */
+    {
+        LogError(( "[%s] ERROR - Invalid context.\r\n", __FUNCTION__ ));
+        lResult = -1; /*TODO: Need a negative error code from the PAL here. */
+    }
+
+    return ( int16_t ) lResult;
+}
+
+/* Close the specified file. This shall authenticate the file if it is marked as secure. */
+
+OtaPalStatus_t otaPal_CloseFile( OtaFileContext_t * const C )
+{
+    OtaPalMainStatus_t mainErr = OtaPalSuccess;
+    OtaPalSubStatus_t subErr = 0;
+    OtaPalStatus_t result;
+    
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+        if( C->pSignature != NULL )
+        {
+            /* Verify the file signature, close the file and return the signature verification result. */
+            result = otaPal_CheckFileSignature( C );
+            mainErr = OTA_PAL_MAIN_ERR( result );
+            subErr = OTA_PAL_SUB_ERR( result );
+        }
+        else
+        {
+            LogError(( "[%s] ERROR - NULL OTA Signature structure.\r\n", __FUNCTION__ ));
+            mainErr = OtaPalSignatureCheckFailed;
+        }
+
+        if( mainErr == OtaPalSuccess )
+        {
+            LogInfo(( "[%s] %s signature verification passed.\r\n", __FUNCTION__, OTA_JsonFileSignatureKey ));
+            /* AFR implementation not set any image state here, just state keep on AWS_BOOT_FLAG_IMG_NEW */
+            //( void ) otaPal_SetPlatformImageState( C, OtaImageStateTesting );
+            /* Update Image state as  AWS_BOOT_FLAG_IMG_NEW and store Signature data */
+            if( prvContextUpdateImageHeaderAndTrailer( C ) == true ) 
+            {
+                LogInfo(( "[%s] Image header updated.\r\n", __FUNCTION__ ));
+            }
+            else
+            {
+                LogInfo(( "[%s] ERROR: Failed to update the image header.\r\n", __FUNCTION__ ));
+                mainErr = OtaPalFileClose;
+            }
+        }
+        else
+        {
+            LogError(( "[%s] ERROR - Failed to pass %s signature verification: %d.\r\n", __FUNCTION__,
+                        OTA_JsonFileSignatureKey, OTA_PAL_COMBINE_ERR( mainErr, subErr ) ));
+
+			/* If we fail to verify the file signature that means the image is not valid. We need to set the image state to aborted. */
+            ( void ) otaPal_SetPlatformImageState( C, OtaImageStateAborted );
+        }
+    }
+    else /* Invalid OTA Context. */
+    {
+        /* FIXME: Invalid error code for a null file context and file handle. */
+        LogInfo(( "[%s] ERROR - Invalid context.\r\n", __FUNCTION__ ));
+        mainErr = OtaPalFileClose;
+    }
+
+    prvContextClose( C );
+    return OTA_PAL_COMBINE_ERR( mainErr, subErr );
+}
+
+
+/* Verify the signature of the specified file. */
+
+static OtaPalStatus_t otaPal_CheckFileSignature( OtaFileContext_t * const C )
+{
+#ifdef __ICCARM__
+#pragma data_alignment=4
+    uint8_t  ucBuff[512];
+#else
+    uint8_t  ucBuff[512] __attribute__((aligned(4)));
+#endif
+
+    OtaPalMainStatus_t result = OtaPalSuccess; //OtaPalSignatureCheckFailed;
+    uint32_t ulBytesRead, ulOffset;
+    uint32_t ulSignerCertSize;
+    uint8_t * pucBuf, * pucSignerCert;
+    void * pvSigVerifyContext;
+    int ret;
+    
+    if( prvContextValidate( C ) == pdTRUE )
+    {
+        /* Verify an ECDSA-SHA256 signature. */
+        if( false == CRYPTO_SignatureVerificationStart( &pvSigVerifyContext, cryptoASYMMETRIC_ALGORITHM_ECDSA, cryptoHASH_ALGORITHM_SHA256 ) )
+        {
+            result = OtaPalSignatureCheckFailed;
+        }
+        else
+        {
+            LogInfo(( "[%s] Started %s signature verification, file: %s\r\n", __FUNCTION__,
+                        OTA_JsonFileSignatureKey, ( const char * ) C->pCertFilepath ));
+            pucSignerCert = otaPal_ReadAndAssumeCertificate( ( const uint8_t * const ) C->pCertFilepath, &ulSignerCertSize );
+
+            if( pucSignerCert != NULL )
+            {
+                /* if ulFileSize not correct, alternative by  xCurBootImgDesc.pvEndAddr - prvStAddr + (sizeof( BootImageDescriptor_t) - sizeof( BootImageHeader_t)) */
+                for( ulOffset=0; ulOffset < C->fileSize; ulOffset+= sizeof(ucBuff) )
+                {
+                    if( (C->fileSize - ulOffset) > sizeof(ucBuff) ) {
+                        ulBytesRead = sizeof(ucBuff);
+                    } else {
+                        ulBytesRead = (C->fileSize - ulOffset);
+                    }
+                    ulBytesRead = NVT_SPI_Flash_Block_Read(ulOffset, ucBuff, ulBytesRead );
+
+                    /* Include the file chunk in the signature validation. Zero size is OK. */
+                    CRYPTO_SignatureVerificationUpdate( pvSigVerifyContext, ucBuff, ulBytesRead );
+                }
+
+                if( CRYPTO_SignatureVerificationFinal( pvSigVerifyContext, ( char * ) pucSignerCert,
+                                                       ulSignerCertSize, C->pSignature->data, 
+                                                       C->pSignature->size ) == false )
+                {
+                    result = OtaPalSignatureCheckFailed;
+                    LogError(( "[%s] ERROR - Signature Verification Failed.\r\n", __FUNCTION__ ));
+                    /* Erase the image as signature verification failed.*/
+//                    prvSPI_FLASH_EraseBank();
+                }
+                else
+                {
+                    result = OtaPalSuccess;
+                }
+ 
+            }
+            else
+            {
+                result = OtaPalBadSignerCert;
+            }
+        }
+    }
+    else
+    {
+        /* FIXME: Invalid error code for a NULL file context. */
+        LogError(( "[%s] ERROR - Invalid OTA file context.\r\n", __FUNCTION__ ));
+        /* Invalid OTA context or file pointer. */
+        result = OtaPalNullFileContext;
+    }
+
+    /* Free the signer certificate that we now own after otaPal_ReadAndAssumeCertificate(). */
+    if( pucSignerCert != NULL )
+    {
+        free( pucSignerCert );
+    }
+ 
+    return OTA_PAL_COMBINE_ERR( result, 0 );;
+}
+
+
+static CK_RV prvGetCertificateHandle( CK_FUNCTION_LIST_PTR pxFunctionList,
+                                      CK_SESSION_HANDLE xSession,
+                                      const char * pcLabelName,
+                                      CK_OBJECT_HANDLE_PTR pxCertHandle )
+{
+    CK_ATTRIBUTE xTemplate;
+    CK_RV xResult = CKR_OK;
+    CK_ULONG ulCount = 0;
+    CK_BBOOL xFindInit = CK_FALSE;
+
+    /* Get the certificate handle. */
+    if( 0 == xResult )
+    {
+        xTemplate.type = CKA_LABEL;
+        xTemplate.ulValueLen = strlen( pcLabelName ) + 1;
+        xTemplate.pValue = ( char * ) pcLabelName;
+        xResult = pxFunctionList->C_FindObjectsInit( xSession, &xTemplate, 1 );
+    }
+
+    if( 0 == xResult )
+    {
+        xFindInit = CK_TRUE;
+        xResult = pxFunctionList->C_FindObjects( xSession,
+                                                 ( CK_OBJECT_HANDLE_PTR ) pxCertHandle,
+                                                 1,
+                                                 &ulCount );
+    }
+
+    if( CK_TRUE == xFindInit )
+    {
+        xResult = pxFunctionList->C_FindObjectsFinal( xSession );
+    }
+
+    return xResult;
+}
+
+/* Note that this function mallocs a buffer for the certificate to reside in,
+ * and it is the responsibility of the caller to free the buffer. */
+static CK_RV prvGetCertificate( const char * pcLabelName,
+                                uint8_t ** ppucData,
+                                uint32_t * pulDataSize )
+{
+    /* Find the certificate */
+    CK_OBJECT_HANDLE xHandle;
+    CK_RV xResult;
+    CK_FUNCTION_LIST_PTR xFunctionList;
+    CK_SLOT_ID xSlotId;
+    CK_ULONG xCount = 1;
+    CK_SESSION_HANDLE xSession;
+    CK_ATTRIBUTE xTemplate = { 0 };
+    uint8_t * pucCert = NULL;
+    CK_BBOOL xSessionOpen = CK_FALSE;
+
+    xResult = C_GetFunctionList( &xFunctionList );
+
+    if( CKR_OK == xResult )
+    {
+        xResult = xFunctionList->C_Initialize( NULL );
+    }
+
+    if( ( CKR_OK == xResult ) || ( CKR_CRYPTOKI_ALREADY_INITIALIZED == xResult ) )
+    {
+        xResult = xFunctionList->C_GetSlotList( CK_TRUE, &xSlotId, &xCount );
+    }
+
+    if( CKR_OK == xResult )
+    {
+        xResult = xFunctionList->C_OpenSession( xSlotId, CKF_SERIAL_SESSION, NULL, NULL, &xSession );
+    }
+
+    if( CKR_OK == xResult )
+    {
+        xSessionOpen = CK_TRUE;
+        xResult = prvGetCertificateHandle( xFunctionList, xSession, pcLabelName, &xHandle );
+    }
+
+    if( ( xHandle != 0 ) && ( xResult == CKR_OK ) ) /* 0 is an invalid handle */
+    {
+        /* Get the length of the certificate */
+        xTemplate.type = CKA_VALUE;
+        xTemplate.pValue = NULL;
+        xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
+
+        if( xResult == CKR_OK )
+        {
+            pucCert = pvPortMalloc( xTemplate.ulValueLen );
+        }
+
+        if( ( xResult == CKR_OK ) && ( pucCert == NULL ) )
+        {
+            xResult = CKR_HOST_MEMORY;
+        }
+
+        if( xResult == CKR_OK )
+        {
+            xTemplate.pValue = pucCert;
+            xResult = xFunctionList->C_GetAttributeValue( xSession, xHandle, &xTemplate, xCount );
+
+            if( xResult == CKR_OK )
+            {
+                *ppucData = pucCert;
+                *pulDataSize = xTemplate.ulValueLen;
+            }
+            else
+            {
+                vPortFree( pucCert );
+            }
+        }
+    }
+    else /* Certificate was not found. */
+    {
+        *ppucData = NULL;
+        *pulDataSize = 0;
+    }
+
+    if( xSessionOpen == CK_TRUE )
+    {
+        ( void ) xFunctionList->C_CloseSession( xSession );
+    }
+
+    return xResult;
+}
+
+
+/* Read the specified signer certificate from the FMC into a local buffer. The allocated
+ * memory becomes the property of the caller who is responsible for freeing it.
+ */
+
+static uint8_t * otaPal_ReadAndAssumeCertificate( const uint8_t * const pucCertName,
+                                                  uint32_t * const ulSignerCertSize )
+{
+
+    uint8_t * pucCertData;
+    uint32_t ulCertSize;
+    uint8_t * pucSignerCert = NULL;
+    CK_RV xResult;
+
+    xResult = prvGetCertificate( ( const char * ) pucCertName, &pucSignerCert, ulSignerCertSize );
+
+    if( ( xResult == CKR_OK ) && ( pucSignerCert != NULL ) )
+    {
+        LogInfo(( "[%s] Using cert with label: %s OK\r\n", __FUNCTION__, ( const char * ) pucCertName ));
+    }
+    else
+    {
+
+        LogInfo( ( "[%s] No such certificate file: %s. Using certificate in ota_demo_config.h." , __FUNCTION__,
+                 ( const char * ) pucCertName ));
+                    
+        /* Allocate memory for the signer certificate plus a terminating zero so we can copy it and return to the caller. */
+        ulCertSize = sizeof( codeSigningCertificatePEM );
+        pucSignerCert = pvPortMalloc( ulCertSize + 1 );                       /*lint !e9029 !e9079 !e838 malloc proto requires void*. */
+        pucCertData = ( uint8_t * ) codeSigningCertificatePEM; /*lint !e9005 we don't modify the cert but it could be set by PKCS11 so it's not const. */
+
+        if( pucSignerCert != NULL )
+        {
+            memcpy( pucSignerCert, pucCertData, ulCertSize );
+            /* The crypto code requires the terminating zero to be part of the length so add 1 to the size. */
+            pucSignerCert[ ulCertSize ] = 0U;
+            *ulSignerCertSize = ulCertSize + 1U;
+        }
+        else
+        {
+            LogError(( "[%s] Error: No memory for certificate of size %d!\r\n", __FUNCTION__, ulCertSize ));
+        }
+    }
+
+    return pucSignerCert;
+}
+
+
+/*-----------------------------------------------------------*/
+#define OTA_DELAY       ( ( portTickType ) 1000 / portTICK_RATE_MS )
+
+OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const C )
+{
+    ( void ) C;
+    
+    portTickType xLastExecutionTime = xTaskGetTickCount();
+    LogInfo(( "[%s] Resetting the device.\r\n", __FUNCTION__ ));
+
+    /* Short delay for debug log output before reset. */
+    vTaskDelayUntil( &xLastExecutionTime, OTA_DELAY );
+
+    /* Unlock protected registers before setting Brown-out detector function and Power-down mode */    
+    SYS_UnlockReg();
+    FMC_Open();
+    // Boot From LD-ROM
+    /*
+        CONFIG0[7:6]
+        00 = Boot from LDROM with IAP mode.
+        01 = Boot from LDROM without IAP mode.
+        10 = Boot from APROM with IAP mode.
+        11 = Boot from APROM without IAP mode.
+    */
+    uint32_t  au32Config[2];
+    if( FMC_ReadConfig(au32Config, 2) < 0)
+    {
+          LogError(( " Read FMC config failed.\r\n"));
+    }
+    if( (au32Config[0] & 0x40) )        /* Check if it's boot from APROM/LDROM with IAP. */
+    {
+        FMC_ENABLE_CFG_UPDATE();       /* Enable User Configuration update. */
+        au32Config[0] &= ~0x40;        /* Select IAP boot mode. */
+        FMC_WriteConfig(au32Config, 2);/* Update User Configuration CONFIG0 and CONFIG1. */
+        SYS_ResetChip();    /* Perform chip reset to make new User Config take effect. */
+    }
+    /* Remap to LD-ROM*/
+    FMC_SetVectorPageAddr(FMC_LDROM_BASE);    // Remap to LD-ROM address       
+    SYS_ResetCPU();
+    while(1);
+    
+    /* We shouldn't actually get here if the board supports the auto reset.
+     * But, it doesn't hurt anything if we do although someone will need to
+     * reset the device for the new image to boot. */
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
+}
+
+/*-----------------------------------------------------------*/
+
+OtaPalStatus_t otaPal_ActivateNewImage( OtaFileContext_t * const C )
+{
+#define APPLICATION_ADDR 0x00
+
+    LogInfo(( "[%s] Activating the new MCU image.\r\n", __FUNCTION__ ));
+
+    /* Backup current active image to SPI flash in the 2nd bank at (OTA_SPI_BANK_START + OTA_SPI_BANK_SIZE) */
+    /* Also mark FMC's image header reserved field as backup src-image SPI address  */
+#ifndef NVT_OTA_WITHOUT_BACKUP_BANK
+    prvSPI_FLASH_BackupBank((OTA_SPI_BANK_START + OTA_SPI_BANK_SIZE), APPLICATION_ADDR, (NVT_OTA_META_BASE - APPLICATION_ADDR) );
+#if 1 // Monitor header of Bank1 & Bank2
+    char buffer[64];
+    NVT_SPI_Flash_Block_Read(0x00, buffer, sizeof(buffer) );
+    LogInfo(("### Bank-1: 0x%x,%x, %x, %x\n", (uint32_t *)&buffer[0], (uint32_t *)&buffer[4],(uint32_t *)&buffer[8], (uint32_t *)&buffer[12]));
+    NVT_SPI_Flash_Block_Read(0x80000, buffer, sizeof(buffer) );
+    LogInfo(("### Bank-2: %s\n", buffer));
+#endif
+#endif
+    return otaPal_ResetDevice(C);
+}
+
+
+
+/*
+ * Set the final state of the last transferred (final) OTA file (or bundle).
+ * The state of the OTA image is stored in FMC header.
+ */
+
+OtaPalStatus_t otaPal_SetPlatformImageState( OtaFileContext_t * const C,
+                                             OtaImageState_t eState )
+{
+
+    BootImageDescriptor_t xDescCopy;
+    OtaPalMainStatus_t result = OtaPalUninitialized;
+    ( void ) C;
+    /* Descriptor handle for the image. */
+    const BootImageDescriptor_t * pxAppImgDesc;
+    pxAppImgDesc = ( BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE;
+    xDescCopy = *pxAppImgDesc;                    /* Copy image descriptor from flash into RAM structure. */
+
+    
+    if( (eState == OtaImageStateUnknown) || (eState > OtaLastImageState) )
+    {
+        LogError(( "[%s] ERROR - Invalid image state provided.\r\n", __FUNCTION__ ));
+        result = OtaPalBadImageState;
+    } /*lint !e481 Allow fopen and fclose calls in this context. */
+    else /* Image state valid. */    
+    /* This should be an image launched in self test mode! */
+//    if( xDescCopy.xImgHeader.ucImgFlags == AWS_BOOT_FLAG_IMG_PENDING_COMMIT )
+    {
+        if( eState == OtaImageStateAccepted )
+        {
+            /* Mark the image as valid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_VALID;
+
+            if( (xCurOTAOpDesc.pxCurOTAFile == NULL) &&
+                (prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == true) )
+            {
+                LogInfo(( "[%s] Accepted and committed final image.\r\n", __FUNCTION__ ));
+                result = OtaPalSuccess;
+            }
+            else
+            {
+                LogError(( "[%s] Accepted final image but commit failed (%d).\r\n", __FUNCTION__));
+                result = OtaPalCommitFailed;
+            }
+        }
+        else if( eState == OtaImageStateRejected )
+        {
+            /* Mark the image as invalid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == true )
+            {
+                LogInfo(( "[%s] Rejected image.\r\n", __FUNCTION__ ));
+
+                result = OtaPalSuccess;
+            }
+            else
+            {
+                LogError(( "[%s] Failed updating the flags.\r\n", __FUNCTION__ ));
+                result = OtaPalRejectFailed;
+            }
+        }
+        else if( eState == OtaImageStateAborted )
+        {
+            /* Mark the image as invalid */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_INVALID;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == true )
+            {
+                LogInfo(( "[%s] Aborted image.\r\n", __FUNCTION__ ));
+
+                result = OtaPalSuccess;
+            }
+            else
+            {
+                LogError(( "[%s] Failed updating the flags.\r\n", __FUNCTION__));
+                result = OtaPalAbortFailed ;
+            }
+        }
+        else if( eState == OtaImageStateTesting )
+        {
+            /* Mark the image as pending commit */
+            xDescCopy.xImgHeader.ucImgFlags = AWS_BOOT_FLAG_IMG_PENDING_COMMIT;
+
+            if( prvFLASH_update(NVT_BOOT_IMG_HEAD_BASE, (uint8_t *)&xDescCopy, 
+                                sizeof( BootImageDescriptor_t) ) == true )
+            {
+                LogInfo(( "[%s] Testing image.\r\n", __FUNCTION__ ));
+
+                result = OtaPalSuccess;
+            }
+            else
+            {
+                LogError(( "[%s] Failed updating the flags.\r\n", __FUNCTION__));
+                result = OtaPalCommitFailed ;
+            }
+            result = OtaPalSuccess;
+        }
+        else
+        {
+            LogError(( "[%s] Unknown state received %d.\r\n", __FUNCTION__, ( int32_t ) eState ));
+            result = OtaPalBadImageState;
+        }
+    }
+
+    LogInfo(( "[%s] image state [%d] ---Flag[0x%x].\r\n", __FUNCTION__, eState, xDescCopy.xImgHeader.ucImgFlags));
+ 
+    return OTA_PAL_COMBINE_ERR( result, 0 );
+}
+
+/* Get the state of the currently running image.
+ *
+ * This is simulated by looking for and reading the state from
+ * FMC Boot Image Header.
+ *
+ * We read this at OTA_Init time so we can tell if the MCU image is in self
+ * test mode. If it is, we expect a successful connection to the OTA services
+ * within a reasonable amount of time. If we don't satisfy that requirement,
+ * we assume there is something wrong with the firmware and reset the device,
+ * causing it to rollback to the previous code. On Windows, this is not
+ * fully simulated as there is no easy way to reset the simulated device.
+ */
+OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const C )
+{
+    BootImageDescriptor_t xDescCopy;
+    OtaPalImageState_t eImageState = OtaPalImageStateUnknown; 
+    const BootImageDescriptor_t * pxAppImgDesc;
+    ( void ) C;
+    pxAppImgDesc = ( const BootImageDescriptor_t * ) NVT_BOOT_IMG_HEAD_BASE; /*lint !e923 !e9027 !e9029 !e9033 !e9079 !e9078 !e9087 Please see earlier lint comment header. */
+    xDescCopy = *pxAppImgDesc;
+
+    /**
+     *  Check if valid magic code is present for the application image.
+     */
+    if( memcmp( pxAppImgDesc->xImgHeader.cImgSignature,
+                AWS_BOOT_IMAGE_SIGNATURE,
+                AWS_BOOT_IMAGE_SIGNATURE_SIZE ) == 0 )
+    {
+
+        switch( xDescCopy.xImgHeader.ucImgFlags )
+        {
+            case AWS_BOOT_FLAG_IMG_PENDING_COMMIT:
+                eImageState = OtaPalImageStatePendingCommit;
+                break;
+            case AWS_BOOT_FLAG_IMG_VALID:
+            case AWS_BOOT_FLAG_IMG_NEW:
+                eImageState = OtaPalImageStateValid;
+                break;
+
+            default:
+                eImageState = OtaPalImageStateInvalid;
+                break;
+        }
+            
+        
+    }
+    LogInfo(( "[%s] image state [%d] -- Flag[0x%x].\r\n", __FUNCTION__, eImageState, xDescCopy.xImgHeader.ucImgFlags));
+    return eImageState;
+}
+
+/*-----------------------------------------------------------*/
+
+/* Provide access to private members for testing. */
+#ifdef FREERTOS_ENABLE_UNIT_TESTS
+#include "aws_ota_pal_test_access_define.h"
+#endif

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal.h
@@ -1,0 +1,211 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file  ota_pal.h
+ * @brief Function declarations for the functions in ota_pal.c
+ */
+
+#ifndef OTA_PAL_H_
+#define OTA_PAL_H_
+
+#include "ota.h"
+
+typedef uint8_t         bool_t;
+
+/**
+ * @brief Abort an OTA transfer.
+ *
+ * Aborts access to an existing open file represented by the OTA file context pFileContext. This is
+ * only valid for jobs that started successfully.
+ *
+ * @note The input OtaFileContext_t pFileContext is checked for NULL by the OTA agent before this
+ * function is called.
+ * This function may be called before the file is opened, so the file pointer pFileContext->fileHandle
+ * may be NULL when this function is called.
+ *
+ * @param[in] pFileContext OTA file context information.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
+ * error codes information in ota.h.
+ *
+ * The file pointer will be set to NULL after this function returns.
+ * OtaPalSuccess is returned when aborting access to the open file was successful.
+ * OtaPalFileAbort is returned when aborting access to the open file context was unsuccessful.
+ */
+OtaPalStatus_t otaPal_Abort( OtaFileContext_t * const C );
+
+/**
+ * @brief Create a new receive file for the data chunks as they come in.
+ *
+ * @note Opens the file indicated in the OTA file context in the MCU file system.
+ *
+ * @note The previous image may be present in the designated image download partition or file, so the
+ * partition or file must be completely erased or overwritten in this routine.
+ *
+ * @note The input OtaFileContext_t pFileContext is checked for NULL by the OTA agent before this
+ * function is called.
+ * The device file path is a required field in the OTA job document, so pFileContext->pFilePath is
+ * checked for NULL by the OTA agent before this function is called.
+ *
+ * @param[in] pFileContext OTA file context information.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
+ * error codes information in ota.h.
+ *
+ * OtaPalSuccess is returned when file creation is successful.
+ * OtaPalRxFileTooLarge is returned if the file to be created exceeds the device's non-volatile memory size constraints.
+ * OtaPalBootInfoCreateFailed is returned if the bootloader information file creation fails.
+ * OtaPalRxFileCreateFailed is returned for other errors creating the file in the device's non-volatile memory.
+ */
+OtaPalStatus_t otaPal_CreateFileForRx( OtaFileContext_t * const C );
+
+/**
+ * @brief Authenticate and close the underlying receive file in the specified OTA context.
+ *
+ * @note The input OtaFileContext_t pFileContext is checked for NULL by the OTA agent before this
+ * function is called. This function is called only at the end of block ingestion.
+ * prvPAL_CreateFileForRx() must succeed before this function is reached, so
+ * pFileContext->fileHandle(or pFileContext->pFile) is never NULL.
+ * The certificate path on the device is a required job document field in the OTA Agent,
+ * so pFileContext->pCertFilepath is never NULL.
+ * The file signature key is required job document field in the OTA Agent, so pFileContext->pSignature will
+ * never be NULL.
+ *
+ * If the signature verification fails, file close should still be attempted.
+ *
+ * @param[in] pFileContext OTA file context information.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
+ * error codes information in ota.h.
+ *
+ * OtaPalSuccess is returned on success.
+ * OtaPalSignatureCheckFailed is returned when cryptographic signature verification fails.
+ * OtaPalBadSignerCert is returned for errors in the certificate itself.
+ * OtaPalFileClose is returned when closing the file fails.
+ */
+OtaPalStatus_t otaPal_CloseFile( OtaFileContext_t * const C );
+
+/**
+ * @brief Write a block of data to the specified file at the given offset.
+ *
+ * @note The input OtaFileContext_t pFileContext is checked for NULL by the OTA agent before this
+ * function is called.
+ * The file pointer/handle pFileContext->pFile, is checked for NULL by the OTA agent before this
+ * function is called.
+ * pData is checked for NULL by the OTA agent before this function is called.
+ * blockSize is validated for range by the OTA agent before this function is called.
+ * offset is validated by the OTA agent before this function is called.
+ *
+ * @param[in] pFileContext OTA file context information.
+ * @param[in] offset Byte offset to write to from the beginning of the file.
+ * @param[in] pData Pointer to the byte array of data to write.
+ * @param[in] blockSize The number of bytes to write.
+ *
+ * @return The number of bytes written on a success, or a negative error code from the platform
+ * abstraction layer.
+ */
+int16_t otaPal_WriteBlock( OtaFileContext_t * const C,
+                           uint32_t ulOffset,
+                           uint8_t * const pcData,
+                           uint32_t ulBlockSize );
+
+/**
+ * @brief Activate the newest MCU image received via OTA.
+ *
+ * This function shall do whatever is necessary to activate the newest MCU
+ * firmware received via OTA. It is typically just a reset of the device.
+ *
+ * @note This function SHOULD not return. If it does, the platform does not support
+ * an automatic reset or an error occurred.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
+ * error codes information in ota.h.
+ */
+OtaPalStatus_t otaPal_ActivateNewImage( OtaFileContext_t * const C );
+
+/**
+ * @brief Reset the device.
+ *
+ * This function shall reset the MCU and cause a reboot of the system.
+ *
+ * @note This function SHOULD not return. If it does, the platform does not support
+ * an automatic reset or an error occurred.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
+ * error codes information in ota.h.
+ */
+OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const C );
+
+/**
+ * @brief Attempt to set the state of the OTA update image.
+ *
+ * Do whatever is required by the platform to Accept/Reject the OTA update image (or bundle).
+ * Refer to the PAL implementation to determine what happens on your platform.
+ *
+ * @param[in] pFileContext File context of type OtaFileContext_t.
+ *
+ * @param[in] eState The desired state of the OTA update image.
+ *
+ * @return The OtaPalStatus_t error code combined with the MCU specific error code. See ota.h for
+ *         OTA major error codes and your specific PAL implementation for the sub error code.
+ *
+ * Major error codes returned are:
+ *
+ *   OtaPalSuccess on success.
+ *   OtaPalBadImageState: if you specify an invalid OtaImageState_t. No sub error code.
+ *   OtaPalAbortFailed: failed to roll back the update image as requested by OtaImageStateAborted.
+ *   OtaPalRejectFailed: failed to roll back the update image as requested by OtaImageStateRejected.
+ *   OtaPalCommitFailed: failed to make the update image permanent as requested by OtaImageStateAccepted.
+ */
+OtaPalStatus_t otaPal_SetPlatformImageState( OtaFileContext_t * const C,
+                                             OtaImageState_t eState );
+
+/**
+ * @brief Get the state of the OTA update image.
+ *
+ * We read this at OTA_Init time and when the latest OTA job reports itself in self
+ * test. If the update image is in the "pending commit" state, we start a self test
+ * timer to assure that we can successfully connect to the OTA services and accept
+ * the OTA update image within a reasonable amount of time (user configurable). If
+ * we don't satisfy that requirement, we assume there is something wrong with the
+ * firmware and automatically reset the device, causing it to roll back to the
+ * previously known working code.
+ *
+ * If the update image state is not in "pending commit," the self test timer is
+ * not started.
+ *
+ * @param[in] pFileContext File context of type OtaFileContext_t.
+ *
+ * @return An OtaPalImageState_t. One of the following:
+ *   OtaPalImageStatePendingCommit (the new firmware image is in the self test phase)
+ *   OtaPalImageStateValid         (the new firmware image is already committed)
+ *   OtaPalImageStateInvalid       (the new firmware image is invalid or non-existent)
+ *
+ *   NOTE: OtaPalImageStateUnknown should NEVER be returned and indicates an implementation error.
+ */
+OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const C );
+
+#endif /* ifndef OTA_PAL_H_ */

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal_spim.c
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/ports/ota_pal_for_aws/ota_pal_spim.c
@@ -1,0 +1,212 @@
+/*
+ * FreeRTOS OTA PAL for Nuvoton Numaker-IoT-M487
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+ /* OTA SPI Flash implementation for M487 platform. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "FreeRTOS.h"
+#include "ota_pal.h"
+
+#include "NuMicro.h"
+
+#define USE_4_BYTES_MODE            0            /* SPI Flash W25Q20 does not support 4-bytes address mode. */
+#if 0
+#define FLASH_BANK_UB               (8*64*1024)    /* Flash bank boundary. Depend on the physical flash. */
+#define FLASH_BLOCK_SIZE            (64*1024)
+#else		/* W25Q32 blokc size 4KB, chip size 4MB */
+#define FLASH_BANK_UB               (1024*4*1024)    /* Flash bank boundary. Depend on the physical flash. */
+#define FLASH_BLOCK_SIZE            (4*1024)
+#endif
+
+#define BUFFER_SIZE                 512//2048
+
+#ifdef __ICCARM__
+#pragma data_alignment=4
+static uint8_t  spi_buff[BUFFER_SIZE];
+#else
+static uint8_t  spi_buff[BUFFER_SIZE] __attribute__((aligned(4)));
+#endif
+
+
+bool_t NVT_SPI_Flash_Init(void)
+{
+    uint8_t     idBuf[3];
+    bool_t result = pdFALSE;
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    /* Enable SPIM module clock */
+    CLK_EnableModuleClock(SPIM_MODULE);
+    
+    /* Init SPIM multi-function pins, MOSI(PC.0), MISO(PC.1), CLK(PC.2), SS(PC.3), D3(PC.4), and D2(PC.5) */
+    SYS->GPC_MFPL &= ~(SYS_GPC_MFPL_PC0MFP_Msk | SYS_GPC_MFPL_PC1MFP_Msk | SYS_GPC_MFPL_PC2MFP_Msk |
+                       SYS_GPC_MFPL_PC3MFP_Msk | SYS_GPC_MFPL_PC4MFP_Msk | SYS_GPC_MFPL_PC5MFP_Msk);
+    SYS->GPC_MFPL |= SYS_GPC_MFPL_PC0MFP_SPIM_MOSI | SYS_GPC_MFPL_PC1MFP_SPIM_MISO |
+                     SYS_GPC_MFPL_PC2MFP_SPIM_CLK | SYS_GPC_MFPL_PC3MFP_SPIM_SS |
+                     SYS_GPC_MFPL_PC4MFP_SPIM_D3 | SYS_GPC_MFPL_PC5MFP_SPIM_D2;
+    PC->SMTEN |= GPIO_SMTEN_SMTEN2_Msk;
+
+    /* Set SPIM I/O pins as high slew rate up to 80 MHz. */
+    PC->SLEWCTL = (PC->SLEWCTL & 0xFFFFF000) |
+                  (0x1<<GPIO_SLEWCTL_HSREN0_Pos) | (0x1<<GPIO_SLEWCTL_HSREN1_Pos) |
+                  (0x1<<GPIO_SLEWCTL_HSREN2_Pos) | (0x1<<GPIO_SLEWCTL_HSREN3_Pos) |
+                  (0x1<<GPIO_SLEWCTL_HSREN4_Pos) | (0x1<<GPIO_SLEWCTL_HSREN5_Pos);
+
+    SPIM_SET_CLOCK_DIVIDER(1);        /* Set SPIM clock as HCLK divided by 2 */
+
+    SPIM_SET_RXCLKDLY_RDDLYSEL(0);    /* Insert 0 delay cycle. Adjust the sampling clock of received data to latch the correct data. */
+    SPIM_SET_RXCLKDLY_RDEDGE();       /* Use SPI input clock rising edge to sample received data. */
+
+    SPIM_SET_DCNUM(8);                /* Set 8 dummy cycle. */
+
+    if (SPIM_InitFlash(1) != 0)        /* Initialized SPI flash */
+    {
+        LogError(("[%s] SPIM flash initialize failed!\n", __FUNCTION__));
+        goto lexit;
+    }
+
+    SPIM_ReadJedecId(idBuf, sizeof (idBuf), 1);
+    LogInfo(("[%s] SPIM get JEDEC ID=0x%02X, 0x%02X, 0x%02X\n", __FUNCTION__, idBuf[0], idBuf[1], idBuf[2]));
+    if( (idBuf[0] != 0xef) || (idBuf[1] != 0x40) || (idBuf[2] != 0x16) )
+    {
+        LogError(("[%s] SPIM get wrong JEDEC ID\n", __FUNCTION__));
+        goto lexit;
+    }    
+    SPIM_Enable_4Bytes_Mode(USE_4_BYTES_MODE, 1);
+    result = pdTRUE;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();    
+    return result;
+}
+
+bool_t NVT_SPI_Flash_Bank_Erase(uint32_t startAddress, uint32_t bankSize)
+{
+    uint32_t    i, offset;             /* variables */
+    uint32_t    *pData;
+    bool_t result = pdFALSE;
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    /*
+     *  Erase flash page
+     */
+    if( (startAddress + bankSize) > FLASH_BANK_UB )
+    {
+        LogError(("[%s] FAILED!\n", __FUNCTION__));
+        LogError(("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", __FUNCTION__, (startAddress + bankSize), FLASH_BANK_UB));
+        goto lexit;
+    }
+    LogInfo(("[%s] Erase SPI flash bank 0x%x ~ 0x%x ...", __FUNCTION__, startAddress, (startAddress + bankSize)));
+    for (offset = 0; offset < bankSize; offset += FLASH_BLOCK_SIZE )
+    {
+      SPIM_EraseBlock(startAddress+offset, USE_4_BYTES_MODE, OPCODE_BE_64K, 1, 1);
+    }
+    LogInfo(("[%s] done.\n", __FUNCTION__));
+
+    /*
+     *  Verify flash page be erased
+     */
+    LogInfo(("[%s] Verify SPI flash block 0x%x be erased...", __FUNCTION__, startAddress));
+    for (offset = 0; offset < bankSize; offset += BUFFER_SIZE)
+    {
+        memset(spi_buff, 0, BUFFER_SIZE);
+        SPIM_IO_Read(startAddress+offset, USE_4_BYTES_MODE, BUFFER_SIZE, spi_buff, OPCODE_FAST_READ, 1, 1, 1, 1);
+
+        pData = (uint32_t *)spi_buff;
+        for (i = 0; i < BUFFER_SIZE; i += 4, pData++)
+        {
+            if (*pData != 0xFFFFFFFF)
+            {
+                LogError(("[%s] FAILED!\n", __FUNCTION__));
+                LogError(("[%s] Flash address 0x%x, read 0x%x!\n", __FUNCTION__, startAddress+offset+i, *pData));
+                goto lexit;
+            }
+        }
+    }
+    result = pdTRUE;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();    
+    return result;
+}
+
+/* Write a block of data to the specified file. 
+   Returns the number of bytes written on success or negative error code.
+*/
+int32_t NVT_SPI_Flash_Block_Write(uint32_t ulOffset,
+                           uint8_t * const pacData,
+                           uint32_t ulBlockSize )
+{
+    int32_t lResult = 0;
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    if( (ulOffset + ulBlockSize) > FLASH_BANK_UB )
+    {
+        LogError(("[%s] FAILED!\n", __FUNCTION__));
+        LogError(("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", __FUNCTION__, (ulOffset + ulBlockSize), FLASH_BANK_UB));
+        lResult = -1;
+        goto lexit;
+    }
+    SPIM_IO_Write(ulOffset, USE_4_BYTES_MODE, ulBlockSize, pacData, OPCODE_PP, 1, 1, 1);
+    lResult = ulBlockSize;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();   
+    return lResult;
+}
+
+/* Read a block of data to the specified file. 
+   Returns the number of bytes read on success or negative error code.
+*/
+int32_t NVT_SPI_Flash_Block_Read(uint32_t ulOffset,
+                           uint8_t* pacData,
+                           uint32_t ulBlockSize )
+{
+    int32_t lResult = 0;
+
+    
+    /* Unlock protected registers */
+    SYS_UnlockReg();
+    
+    if( (ulOffset + ulBlockSize) > FLASH_BANK_UB )
+    {
+        LogError(("[%s] FAILED!\n"));
+        LogError(("[%s] Exceed reserved Flash Bank boundary 0x%x > 0x%x \n", __FUNCTION__, (ulOffset + ulBlockSize), FLASH_BANK_UB));
+        lResult = -1;
+        goto lexit;
+    }
+    SPIM_IO_Read(ulOffset, USE_4_BYTES_MODE, ulBlockSize, pacData, OPCODE_FAST_DUAL_READ, 1, 1, 2, 1);
+    lResult = ulBlockSize;
+lexit:    
+    /* Lock protected registers */
+    SYS_LockReg();   
+    return lResult;
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR purpose is not to ask any qualification logo and not plan to process OCW.
It is one normal PR to support \ \amazon-freertos\vendors\vendor\boards\board\ports\ota_pal_for_aws for new OTA
changes from FreeRTOS.

<!--- Describe your changes in detail -->
This PR add ports of M487 ota and it could pass aws_demos with `CONFIG_OTA_MQTT_UPDATE_DEMO_ENABLED` & aws_tests including FULL_OTA_AGENT_ENABLED, FULL_OTA_PAL_ENABLED and MQTTv4_ENABLED.

To run aws_tests by cmake, the command line as: `$ cmake -DVENDOR=nuvoton -DBOARD=numaker_iot_m487_wifi -DCOMPILER=arm-keil -S. -Bbuild -G"Unix Makefiles" -DAFR_ENABLE_TESTS=1`

To run aws_demos by cmake, the command line as: `$ cmake -DVENDOR=nuvoton -DBOARD=numaker_iot_m487_wifi -DCOMPILER=arm-keil -S. -Bbuild -G"Unix Makefiles"`

Attached aws_demo & aws_test log files for your reference.
[afr_ota_v3_test.log](https://github.com/aws/amazon-freertos/files/6776133/afr_ota_v3_test.log)
[afr_ota_v3_demo.log](https://github.com/aws/amazon-freertos/files/6776134/afr_ota_v3_demo.log)


About loader part, we have one for customer reference and our chip has H/W secure boot capacity, it really depends on customer requirement. The loader’s major implementation is how to cooperate with OTA-client and secure boot could rely on M487 solution https://www.nuvoton.com/support/technical-support/technical-articles/TSNuvotonTechBlog-000086/.

The above loader part was mentioned  in #2754  for previous OTA support.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.

@yngki 
@aggarw13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.