### PR TITLE
Avoid race condition in ESP32+ECC608A causing provisioning issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ This release includes the new managed AWS IoT Over-the-Air update (OTA) library,
 
 - Updated the secure socket test suite to be simpler and more robust.
 
+### Dev Mode Key Provisioning
+
+ - Updated race-condition issue when provisioning ESP32-WROOM-32SE boards with [Dev Mode Key Provisioning](./demos/dev_mode_key_provisioning/) utility by adding delay with a new configuration macro, `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS`. Refer to PR #3315 for more information.
+
 #### Demos
 
 - Added coreMQTT-Agent Demo.

--- a/demos/dev_mode_key_provisioning/README.md
+++ b/demos/dev_mode_key_provisioning/README.md
@@ -23,6 +23,13 @@ Then build and run the demo project and continue to the next section.
 ### Public Key Extraction ###
 Since the device has not yet been provisioned with a private key and client certificate, the demo will fail to authenticate to AWS IoT. However, the Hello World MQTT demo starts by running developer-mode key provisioning, resulting in the creation of a private key if one was not already present. You should see something like the following near the beginning of the serial console output:
 
+
+> **NOTE**: For boards that reset the device before flashing a new image, it is possible that the provisioned credentials become stale due to unexpected re-generationg of keys when flashing
+a new image, that has the `keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR` configuration disabled, on the board. To mitigate this race condition between flashing a new image and re-execution
+of existing image that generate new key-pair, there exists a delay before logic of key-pair generation is executed on device. You can configure the default delay of **30 seconds** by setting
+the `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS` configuration macro.
+
+
 ```
 7 910 [IP-task] Device public key, 91 bytes:
 3059 3013 0607 2a86 48ce 3d02 0106 082a

--- a/demos/dev_mode_key_provisioning/README.md
+++ b/demos/dev_mode_key_provisioning/README.md
@@ -23,14 +23,10 @@ Then build and run the demo project and continue to the next section.
 ### Public Key Extraction ###
 Since the device has not yet been provisioned with a private key and client certificate, the demo will fail to authenticate to AWS IoT. However, the Hello World MQTT demo starts by running developer-mode key provisioning, resulting in the creation of a private key if one was not already present. You should see something like the following near the beginning of the serial console output:
 
+>**Note**: Depending on the configuration value of `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS`, the device will wait for a delay period before generating the key-pair and printing the
+device public key to the serial console.
 
-> **NOTE**: For boards that reset the device before flashing a new image, it is possible that the provisioned credentials become stale due to unexpected re-generationg of keys when flashing
-a new image, that has the `keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR` configuration disabled, on the board. To mitigate this race condition between flashing a new image and re-execution
-of existing image that generate new key-pair, there exists a delay before logic of key-pair generation is executed on device. You can configure the default delay of **30 seconds** by setting
-the `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS` configuration macro.
-
-
-```
+``````
 7 910 [IP-task] Device public key, 91 bytes:
 3059 3013 0607 2a86 48ce 3d02 0106 082a
 8648 ce3d 0301 0703 4200 04cd 6569 ceb8
@@ -57,6 +53,11 @@ Don't forget to disable the temporary key generation setting you enabled above. 
 ```
 #define keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR 0
 ```
+
+> **NOTE**: For boards that reset the device before flashing a new image, it is possible that the provisioned credentials become stale due to unexpected re-generationg of keys when flashing
+a new image, that has the `keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR` configuration disabled, on the board. To mitigate this race condition between flashing a new image and re-execution
+of existing image that generate new key-pair, there exists a delay before logic of key-pair generation is executed on device. You can configure the default delay of **30 seconds** by setting
+the `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS` configuration macro.
 
 ### Public Key Infrastructure Setup ###
 You can now use a variation of the instructions in [Use Your Own Certificate](https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html) to create an X.509 certificate hierarchy for your device lab certificate. Stop before executing the sequence described in the section Creating a Device Certificate Using Your CA Certificate. Also, since the device will not be signing the certificate request, a separate "issuance officer" key and certificate must be created for that purpose:

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -1205,8 +1205,8 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
          * Thus, by adding a delay, the possibility of hitting the race condition of the device executing an old
          * image that generates new key-pair is avoided because the logic of generating new key-pair is not executed
          * before the flashing process starts loading the new image onto the board.
-         * Note: The delay of 5 seconds is used based on testing with an ESP32+ECC608A board. */
-        configPRINTF( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS );
+         * Note: The delay of 30 seconds is used based on testing with an ESP32+ECC608A board. */
+        configPRINTF(( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS ));
         vTaskDelay( pdMS_TO_TICKS( keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS * 1000 ) );
 
         /* Generate a new default key pair. */

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -76,7 +76,7 @@ extern void vLoggingPrint( const char * pcFormat );
  * execution of an existing image on device generates key-pair on device and flashing of
  * new image on device. */
 #ifndef keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS
-    #define keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS    30
+    #define keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS    180
 #endif
 
 /* Internal structure for parsing RSA keys. */
@@ -1205,7 +1205,7 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
          * Thus, by adding a delay, the possibility of hitting the race condition of the device executing an old
          * image that generates new key-pair is avoided because the logic of generating new key-pair is not executed
          * before the flashing process starts loading the new image onto the board.
-         * Note: The delay of 30 seconds is used based on testing with an ESP32+ECC608A board. */
+         * Note: The delay of 150 seconds is used based on testing with an ESP32+ECC608A board. */
         configPRINTF( ( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS ) );
         vTaskDelay( pdMS_TO_TICKS( keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS * 1000 ) );
 

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -134,8 +134,8 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
 {
     CK_RV xResult = CKR_OK;
     CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-    CK_BYTE * pxD;              /* Private value D. */
-    CK_BYTE * pxEcParams = NULL;/* DER-encoding of an ANSI X9.62 Parameters value */
+    CK_BYTE * pxD;               /* Private value D. */
+    CK_BYTE * pxEcParams = NULL; /* DER-encoding of an ANSI X9.62 Parameters value */
     int lMbedResult = 0;
     CK_BBOOL xTrue = CK_TRUE;
     CK_KEY_TYPE xPrivateKeyType = CKK_EC;
@@ -1206,7 +1206,7 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
          * image that generates new key-pair is avoided because the logic of generating new key-pair is not executed
          * before the flashing process starts loading the new image onto the board.
          * Note: The delay of 30 seconds is used based on testing with an ESP32+ECC608A board. */
-        configPRINTF(( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS ));
+        configPRINTF( ( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS ) );
         vTaskDelay( pdMS_TO_TICKS( keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS * 1000 ) );
 
         /* Generate a new default key pair. */

--- a/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
+++ b/demos/dev_mode_key_provisioning/src/aws_dev_mode_key_provisioning.c
@@ -71,6 +71,14 @@ extern void vLoggingPrint( const char * pcFormat );
  * a new default key pair, regardless of whether an existing key pair is present. */
 #define keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR    0
 
+/* Delay before generating new key-pair, if keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR
+ * is enabled. This is to avoid possible race-condition (due to devce reset) between
+ * execution of an existing image on device generates key-pair on device and flashing of
+ * new image on device. */
+#ifndef keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS
+    #define keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS    30
+#endif
+
 /* Internal structure for parsing RSA keys. */
 
 /* Length parameters for importing RSA-2048 private keys. */
@@ -126,8 +134,8 @@ static CK_RV prvProvisionPrivateECKey( CK_SESSION_HANDLE xSession,
 {
     CK_RV xResult = CKR_OK;
     CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-    CK_BYTE * pxD;               /* Private value D. */
-    CK_BYTE * pxEcParams = NULL; /* DER-encoding of an ANSI X9.62 Parameters value */
+    CK_BYTE * pxD;              /* Private value D. */
+    CK_BYTE * pxEcParams = NULL;/* DER-encoding of an ANSI X9.62 Parameters value */
     int lMbedResult = 0;
     CK_BBOOL xTrue = CK_TRUE;
     CK_KEY_TYPE xPrivateKeyType = CKK_EC;
@@ -1183,6 +1191,24 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
 
     if( ( xResult == CKR_OK ) && ( CK_TRUE == xKeyPairGenerationMode ) )
     {
+        /* Add a delay before calling logic for generating new key-pair on device (if boards supports on-board key-pair
+         * generation) to avoid possible scenario of unexpectedly generating new keys on board during the flashing process
+         * of a new image on the board.
+         * If the flashing workflow of a device (for example, ESP32 boards) involves resetting the board before
+         * flashing a new image, then a race condition can occur between the execution of an already
+         * existing image on device (that is triggered by the device reset) and the flashing of the new image on the
+         * device. When the existing image present on the device is configured to generate new key-pair (through the
+         * keyprovisioningFORCE_GENERATE_NEW_KEY_PAIR config), then a possible scenario of unexpected key-pair
+         * generation on device can occur during flashing process, in which case, the certificate provisioned by
+         * user becomes stale and device cannot perform TLS connection with servers as the provisioned device certificate
+         * does not match the unexpectedly generated new key-pair.
+         * Thus, by adding a delay, the possibility of hitting the race condition of the device executing an old
+         * image that generates new key-pair is avoided because the logic of generating new key-pair is not executed
+         * before the flashing process starts loading the new image onto the board.
+         * Note: The delay of 5 seconds is used based on testing with an ESP32+ECC608A board. */
+        configPRINTF( "Waiting for %d seconds before generating key-pair", keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS );
+        vTaskDelay( pdMS_TO_TICKS( keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS * 1000 ) );
+
         /* Generate a new default key pair. */
         xResult = xProvisionGenerateKeyPairEC( xSession,
                                                ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
@@ -1216,6 +1242,17 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
         }
     }
 
+    /* Log the device public key if one exists for developer convenience.
+     * This can be useful for verifying that the provisioned certificate for the device
+     * matches the public key on the device. */
+    if( CK_INVALID_HANDLE != xProvisionedState.xPublicKey )
+    {
+        configPRINTF( ( "Printing device public key.\nMake sure that provisioned device certificate matches public key on device." ) );
+        prvWriteHexBytesToConsole( "Device public key",
+                                   xProvisionedState.pucDerPublicKey,
+                                   xProvisionedState.ulDerPublicKeyLength );
+    }
+
     /* Log the device public key for developer enrollment purposes, but only if
     * there's not already a certificate, or if a new key was just generated. */
     if( ( CKR_OK == xResult ) &&
@@ -1229,15 +1266,6 @@ CK_RV xProvisionDevice( CK_SESSION_HANDLE xSession,
         {
             configPRINTF( ( "Recommended certificate subject name: CN=%s\r\n", xProvisionedState.pcIdentifier ) );
         }
-
-        prvWriteHexBytesToConsole( "Device public key",
-                                   xProvisionedState.pucDerPublicKey,
-                                   xProvisionedState.ulDerPublicKeyLength );
-
-        /* Delay since the downstream demo code is likely to fail quickly if
-         * provisioning isn't complete, and device certificate creation in the
-         * lab may depend on the developer obtaining the public key. */
-        /*vTaskDelay( pdMS_TO_TICKS( 100 ) ); */
     }
 
     /* Free memory. */


### PR DESCRIPTION
### Issue
As part of flashing the ESP32 boards, the board is reset before flashing a new image. This behavior causes unexpected generation of key-pairs on device when an existing image on board, that generates key-pair on board, is replaced with new image that does not generate key-pair. Due to this the on-board key-pair generation based provisioning process (explained in the [Dev Mode Key Generation Mode README](https://github.com/aws/amazon-freertos/tree/main/demos/dev_mode_key_provisioning\#option-2-onboard-private-key-generation)) will become invalid from unexpected generation of new keys, and thus result in TLS connection failures with the supposedly provisioned device certificate. 

### Fix
This PR mitigates the race condition between execution of an old image, that generates key pair on device, and flashing of a new image by adding a delay before generation of new key-pair with a configurable macro, `keyprovisioningDELAY_BEFORE_KEY_PAIR_GENERATION_SECS`.