### PR TITLE
Set configUSE_TRACE_FACILITY to 1 for Cypress boards

### DIFF
--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/FreeRTOSConfig.h
@@ -73,7 +73,7 @@
     #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
-        #define configUSE_TRACE_FACILITY               ( 0 )
+        #define configUSE_TRACE_FACILITY               ( 1 )
     #endif /* configUSE_TRACE_FACILITY */
     #define configUSE_16_BIT_TICKS                     0
     #define configIDLE_SHOULD_YIELD                    1

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/FreeRTOSConfig.h
@@ -73,7 +73,7 @@
     #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
     #define configMAX_TASK_NAME_LEN                    ( 16 )
     #ifndef configUSE_TRACE_FACILITY
-        #define configUSE_TRACE_FACILITY               ( 0 )
+        #define configUSE_TRACE_FACILITY               ( 1 )
     #endif /* configUSE_TRACE_FACILITY */
     #define configUSE_16_BIT_TICKS                     0
     #define configIDLE_SHOULD_YIELD                    1


### PR DESCRIPTION
The Device Defender demo failed to build on Cypress boards as it uses vTaskGetInfo and uxTaskGetSystemState which require configUSE_TRACE_FACILITY set to 1 in FreeRTOSConfig.h. This adds the required config values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.