### PR TITLE
Fix WIFI_NetworkDelete() for cypress64

### DIFF
--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
@@ -501,12 +501,21 @@ WIFIReturnCode_t WIFI_NetworkDelete(uint16_t usIndex)
 
         /* Reading from the kvstore may result in an item not found error if
          * deleting a nonexisting network. */
-        if (((lookupResult != CY_RSLT_SUCCESS) && (lookupResult != MTB_KVSTORE_ITEM_NOT_FOUND_ERROR)) ||
-            (mtb_kvstore_delete(&kvstore_obj, wifi_profile_key) != CY_RSLT_SUCCESS))
+        if ((lookupResult != CY_RSLT_SUCCESS) && (lookupResult != MTB_KVSTORE_ITEM_NOT_FOUND_ERROR))
         {
             cy_rtos_set_mutex(&wifiMutex);
             return eWiFiFailure;
         }
+        else
+        {
+            /* Deletion is fine even if the key is not found. */
+            if (mtb_kvstore_delete(&kvstore_obj, wifi_profile_key) != CY_RSLT_SUCCESS)
+            {
+                cy_rtos_set_mutex(&wifiMutex);
+                return eWiFiFailure;
+            }
+        }
+
         if (cy_rtos_set_mutex(&wifiMutex) != CY_RSLT_SUCCESS)
         {
             return eWiFiFailure;

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/ports/wifi/iot_wifi.c
@@ -489,6 +489,7 @@ WIFIReturnCode_t WIFI_NetworkGet(WIFINetworkProfile_t *pxNetworkProfile, uint16_
 WIFIReturnCode_t WIFI_NetworkDelete(uint16_t usIndex)
 {
     char wifi_profile_key[WIFI_PROFILE_KEY_SIZE];
+    cy_rslt_t lookupResult = MTB_KVSTORE_ITEM_NOT_FOUND_ERROR;
 
     configASSERT(usIndex < CY_TOTAL_WIFI_PROFILES);
 
@@ -496,7 +497,11 @@ WIFIReturnCode_t WIFI_NetworkDelete(uint16_t usIndex)
 
     if (cy_rtos_get_mutex(&wifiMutex, wificonfigMAX_SEMAPHORE_WAIT_TIME_MS) == CY_RSLT_SUCCESS)
     {
-        if ((mtb_kvstore_read(&kvstore_obj, wifi_profile_key, NULL, NULL) != CY_RSLT_SUCCESS) ||
+        lookupResult = mtb_kvstore_read(&kvstore_obj, wifi_profile_key, NULL, NULL);
+
+        /* Reading from the kvstore may result in an item not found error if
+         * deleting a nonexisting network. */
+        if (((lookupResult != CY_RSLT_SUCCESS) && (lookupResult != MTB_KVSTORE_ITEM_NOT_FOUND_ERROR)) ||
             (mtb_kvstore_delete(&kvstore_obj, wifi_profile_key) != CY_RSLT_SUCCESS))
         {
             cy_rtos_set_mutex(&wifiMutex);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
The AFQP_WIFI_NetworkDelete_DeleteNonExistingNetwork was failing for cypress64, as WiFi_NetworkDelete() called `mtb_kvstore_read` and checked it for success.
However, `mtb_kvstore_read` will return `MTB_KVSTORE_ITEM_NOT_FOUND_ERROR` when the item is not in the RAM table: https://github.com/Infineon/kv-store/blob/bcf66dc713f9763a63b8ff7736eab9509c69dd9e/mtb_kvstore.c#L814 https://github.com/Infineon/kv-store/blob/bcf66dc713f9763a63b8ff7736eab9509c69dd9e/mtb_kvstore.c#L1525.
`mtb_kvstore_delete`, on the other hand, works fine if the entry is nonexistent: https://github.com/Infineon/kv-store/blob/bcf66dc713f9763a63b8ff7736eab9509c69dd9e/mtb_kvstore.c#L1279.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
