### PR TITLE
esp32/esp32s2: Fix .map file generated when building AFR as external project

### DIFF
--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -47,7 +47,12 @@ endif()
 
 afr_mcu_port(compiler)
 
-set(linker_flags "-Wl,--gc-sections" "-Wl,--cref" "-Wl,--Map=${exe_target}.map" "-Wl,--undefined=uxTopUsedPriority")
+# If external project is set do not link IDF components to aws target
+if (NOT IDF_PROJECT_EXECUTABLE)
+    set(IDF_PROJECT_EXECUTABLE ${exe_target})
+endif()
+
+set(linker_flags "-Wl,--gc-sections" "-Wl,--cref" "-Wl,--Map=${IDF_PROJECT_EXECUTABLE}.map" "-Wl,--undefined=uxTopUsedPriority")
 
 # Linker flags
 target_link_options(
@@ -464,11 +469,6 @@ afr_files_to_console_metadata(
 # FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------
 afr_glob_src(config_files DIRECTORY "${board_dir}/config_files")
-
-# If external project is set do not link IDF components to aws target
-if (NOT IDF_PROJECT_EXECUTABLE)
-    set(IDF_PROJECT_EXECUTABLE ${exe_target})
-endif()
 
 if (NOT IDF_EXECUTABLE_SRCS)
     set(IDF_EXECUTABLE_SRCS "${board_dir}/application_code/main.c" ${extra_exe_sources})

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -37,7 +37,12 @@ endif()
 
 afr_mcu_port(compiler)
 
-set(linker_flags "-Wl,--gc-sections" "-Wl,--cref" "-Wl,--Map=${exe_target}.map" "-Wl,--undefined=uxTopUsedPriority")
+# If external project is set do not link IDF components to aws target
+if (NOT IDF_PROJECT_EXECUTABLE)
+    set(IDF_PROJECT_EXECUTABLE ${exe_target})
+endif()
+
+set(linker_flags "-Wl,--gc-sections" "-Wl,--cref" "-Wl,--Map=${IDF_PROJECT_EXECUTABLE}.map" "-Wl,--undefined=uxTopUsedPriority")
 
 # Linker flags
 target_link_options(
@@ -400,11 +405,6 @@ endif()
 # FreeRTOS demos and tests
 # -------------------------------------------------------------------------------------------------
 afr_glob_src(config_files DIRECTORY "${board_dir}/config_files")
-
-# If external project is set do not link IDF components to aws target
-if (NOT IDF_PROJECT_EXECUTABLE)
-    set(IDF_PROJECT_EXECUTABLE ${exe_target})
-endif()
 
 if (NOT IDF_EXECUTABLE_SRCS)
     set(IDF_EXECUTABLE_SRCS "${board_dir}/application_code/main.c" ${extra_exe_sources})


### PR DESCRIPTION
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.