### PR TITLE
Fix Ota demo dependencies CMakefile

### DIFF
--- a/demos/ble/ota_ble/CMakeLists.txt
+++ b/demos/ble/ota_ble/CMakeLists.txt
@@ -22,7 +22,6 @@ afr_module_dependencies(
         AFR::ble
         AFR::ota
         AFR::ota::mcu_port
-        AFR::core_mqtt_agent_demo_dependencies
         # Add dependency on the ota_demo_dependencies metadata module
         # so that FreeRTOS console shows this demo ONLY when the OTA library
         # (or another library depending on OTA) is selected on the console.

--- a/libraries/core_mqtt_agent_demo_dependencies.cmake
+++ b/libraries/core_mqtt_agent_demo_dependencies.cmake
@@ -84,7 +84,8 @@ afr_module_dependencies(
         AFR::core_mqtt_agent
         AFR::backoff_algorithm
         AFR::mqtt_agent_interface
-        AFR::core_mqtt_demo_dependencies
+        AFR::transport_interface_secure_sockets
+        AFR::secure_sockets
 )
 
 # Add dependency on PKCS11 Helpers module, that is required
@@ -98,18 +99,6 @@ if(TARGET AFR::pkcs11_implementation::mcu_port)
     )
 endif()
 
-# Add more dependencies for Secure Sockets based MQTT demo
-# (at demos/coreMQTT folder) ONLY if the board supports
-# the Secure Sockets library.
-if(TARGET AFR::secure_sockets::mcu_port)
-    afr_module_dependencies(
-        ${AFR_CURRENT_MODULE}
-        PUBLIC
-            AFR::transport_interface_secure_sockets
-            AFR::secure_sockets
-    )
-endif()
-
 # Add dependency on WiFi module so that WiFi library is auto-included
 # when selecting core MQTT library on FreeRTOS console for boards that
 # support the WiFi library.
@@ -118,16 +107,5 @@ if(TARGET AFR::wifi::mcu_port)
         ${AFR_CURRENT_MODULE}
         PUBLIC
             AFR::wifi
-    )
-endif()
-
-# Add dependency on BLE module so that the BLE library is auto-included
-# when selecting core MQTT library on FreeRTOS console for boards that
-# support BLE.
-if(BLE_SUPPORTED)
-    afr_module_dependencies(
-        ${AFR_CURRENT_MODULE}
-        PUBLIC
-            AFR::ble
     )
 endif()

--- a/libraries/core_mqtt_agent_demo_dependencies.cmake
+++ b/libraries/core_mqtt_agent_demo_dependencies.cmake
@@ -84,6 +84,7 @@ afr_module_dependencies(
         AFR::core_mqtt_agent
         AFR::backoff_algorithm
         AFR::mqtt_agent_interface
+        AFR::core_mqtt_demo_dependencies
         AFR::transport_interface_secure_sockets
         AFR::secure_sockets
 )

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -91,8 +91,10 @@ afr_module_dependencies(
     PUBLIC
         AFR::ota
         AFR::ota_demo_version
+        AFR::core_mqtt
+        AFR::core_mqtt_agent
+        AFR::mqtt_agent_interface
         AFR::mqtt_subscription_manager
-        AFR::core_mqtt_agent_demo_dependencies
         AFR::ota::mcu_port
 )
 

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -104,6 +104,8 @@ if(TARGET AFR::secure_sockets::mcu_port)
     afr_module_dependencies(
         ${AFR_CURRENT_MODULE}
         PUBLIC
+            #Add a dependency on core MQTT agent demo only for non-BLE boards.
+            AFR::core_mqtt_agent_demo_dependencies
             AFR::core_http_demo_dependencies
             AFR::backoff_algorithm
     )

--- a/libraries/ota_demo_dependencies.cmake
+++ b/libraries/ota_demo_dependencies.cmake
@@ -91,7 +91,7 @@ afr_module_dependencies(
     PUBLIC
         AFR::ota
         AFR::ota_demo_version
-        AFR::core_mqtt
+        AFR::core_mqtt_demo_dependencies
         AFR::core_mqtt_agent
         AFR::mqtt_agent_interface
         AFR::mqtt_subscription_manager


### PR DESCRIPTION
Remove dependency on coremqtt agent demo from ota demo Cmakefile

Description
-----------

Remove direct dependency on coreMQTT agent demo from OTA demo so that the MQTT agent is not shown in OCW for BLE only boards.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.