### PR TITLE
Fix issue CertificateConfigurator tool

### DIFF
--- a/tools/certificate_configuration/PEM-to-C-string.py
+++ b/tools/certificate_configuration/PEM-to-C-string.py
@@ -28,10 +28,10 @@ def printCredentialAsCString(file_path, type=None):
         print("#define "+CREDS_MACRO_MAP[type]+" \\")
 
     # Format and print the PEM credential as C string.
-    split_cred_list = content.split("\n") 
-    for entry in split_cred_list[:-2]:
+    split_cred_list = content.rstrip('\n').split("\n")  
+    for entry in split_cred_list[:-1]:  # Iterate over all lines of credentials except last one.
         print("\""+entry+"\\n\" \\")
-    print("\""+split_cred_list[-2]+"\\n\"")
+    print("\""+split_cred_list[-1]+"\\n\"") # Print last line without the trailing '\'
 
     print('\n====================================================================\n\n')
 


### PR DESCRIPTION
The python script that was added in PR #3350 has a limitation of only supporting PEM files ending with explicit newline at the end of file. This PR updates the script to also support PEM files that do not end in newline character.