### PR TITLE
Wifi Provisioning: Fix length field for BSSID deserialization

### DIFF
--- a/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
+++ b/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
@@ -489,6 +489,7 @@ static bool IotBleWiFiProv_DeserializeAddNetworkRequestCbor( const uint8_t * pMe
 
         if( status == CborNoError )
         {
+            length = sizeof( pAddNetworkReq->info.network.ucBSSID );
             status = prvGetByteStringValueFromMap( &map, IOT_BLE_WIFI_PROV_BSSID_KEY, pAddNetworkReq->info.network.ucBSSID, &length );
 
             if( length != sizeof( pAddNetworkReq->info.network.ucBSSID ) )


### PR DESCRIPTION

Description
-----------
As noted in Issue #3362, the length field needs to be set to the buffer value before passing to the function to deserialize the BSSID value. The PR fixes it. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.