### PR TITLE
OTA demos crash fix.

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1259,7 +1259,7 @@ static void prvRegisterOTACallback( const char * pcTopicFilter,
             {
                 LogError( ( "Failed to register a publish callback for topic %.*s.",
                             usTopicFilterLength,
-                            pcTopicFilter) );
+                            pcTopicFilter ) );
             }
         }
     }

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1258,8 +1258,8 @@ static void prvRegisterOTACallback( const char * pcTopicFilter,
             if( xSubscriptionAdded == false )
             {
                 LogError( ( "Failed to register a publish callback for topic %.*s.",
-                            pcTopicFilter,
-                            usTopicFilterLength ) );
+                            usTopicFilterLength,
+                            pcTopicFilter) );
             }
         }
     }
@@ -1363,7 +1363,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
             xReturnStatus = pdPASS;
 
             LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
-                       ( pxRetryParams->attemptsDone + 1 ),
+                       pxRetryParams->attemptsDone,
                        pxRetryParams->maxRetryAttempts ) );
         }
     }

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1098,8 +1098,8 @@ static void prvRegisterOTACallback( const char * pcTopicFilter,
             if( xSubscriptionAdded == false )
             {
                 LogError( ( "Failed to register a publish callback for topic %.*s.",
-                            pcTopicFilter,
-                            usTopicFilterLength ) );
+				            usTopicFilterLength,
+                            pcTopicFilter) );
             }
         }
     }
@@ -1205,7 +1205,7 @@ static BaseType_t prvBackoffForRetry( BackoffAlgorithmContext_t * pxRetryParams 
             xReturnStatus = pdPASS;
 
             LogInfo( ( "Retry attempt %lu out of maximum retry attempts %lu.",
-                       ( pxRetryParams->attemptsDone + 1 ),
+                       pxRetryParams->attemptsDone,
                        pxRetryParams->maxRetryAttempts ) );
         }
     }
@@ -1933,6 +1933,7 @@ int RunOtaCoreMqttDemo( bool xAwsIotMqttMode,
      * Register a callback for receiving messages intended for OTA agent from broker,
      * for which the topic has not been subscribed for.
      */
+	
     prvRegisterOTACallback( otaexampleDEFAULT_TOPIC_FILTER, otaexampleDEFAULT_TOPIC_FILTER_LENGTH );
 
     /************************ Create MQTT Agent Task. ************************/

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1098,7 +1098,7 @@ static void prvRegisterOTACallback( const char * pcTopicFilter,
             if( xSubscriptionAdded == false )
             {
                 LogError( ( "Failed to register a publish callback for topic %.*s.",
-				            usTopicFilterLength,
+                            usTopicFilterLength,
                             pcTopicFilter) );
             }
         }
@@ -1933,7 +1933,6 @@ int RunOtaCoreMqttDemo( bool xAwsIotMqttMode,
      * Register a callback for receiving messages intended for OTA agent from broker,
      * for which the topic has not been subscribed for.
      */
-	
     prvRegisterOTACallback( otaexampleDEFAULT_TOPIC_FILTER, otaexampleDEFAULT_TOPIC_FILTER_LENGTH );
 
     /************************ Create MQTT Agent Task. ************************/

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1099,7 +1099,7 @@ static void prvRegisterOTACallback( const char * pcTopicFilter,
             {
                 LogError( ( "Failed to register a publish callback for topic %.*s.",
                             usTopicFilterLength,
-                            pcTopicFilter) );
+                            pcTopicFilter ) );
             }
         }
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Ota demos would crash due to argument order to a print function being wrong (string, string length) instead of (string length, string). Also fixed retry attempts printing wrong numbering (+1 unneccessary would print "6 out of 5 attempts").
