### PR TITLE
Fix debug message in iot_test_tcp.c

### DIFF
--- a/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+++ b/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
@@ -3059,9 +3059,9 @@ static void prvThreadSafeDifferentSocketsDifferentTasks( void * pvParameters )
             {
                 tcptestFAILUREPRINTF( ( "%s: Task %d failed to connect with error code %d on loop %d \r\n",
                                         __FUNCTION__,
+                                       ( int ) pxTcptestEchoClientsTaskParams->usTaskTag ),
                                         xResult,
-                                        lLoopCount,
-                                        ( int ) pxTcptestEchoClientsTaskParams->usTaskTag ) );
+                                        lLoopCount ) );
                 break;
             }
 


### PR DESCRIPTION
Fix debug message on line 3060 of secure_sockets/test/iot_test_tcp.c

Description
-----------
Resolves #3373

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.