### PR TITLE
Fix build combinations for wifi only combinations

### DIFF
--- a/libraries/abstractions/wifi/CMakeLists.txt
+++ b/libraries/abstractions/wifi/CMakeLists.txt
@@ -26,6 +26,7 @@ afr_module_include_dirs(
 afr_module_dependencies(
     ${AFR_CURRENT_MODULE}
     PRIVATE AFR::wifi::mcu_port
+    PUBLIC AFR::secure_sockets
 )
 
 # WiFi test


### PR DESCRIPTION
In a previous change, secure_sockets was removed from platform, so now wifi needs to explicitly depend on secure_sockets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.