### PR TITLE
Fixed compile-time warnings for ESP32 and ESP32-S2

### DIFF
--- a/demos/include/iot_config_common.h
+++ b/demos/include/iot_config_common.h
@@ -79,7 +79,10 @@
 #define IotMqtt_Assert( expression )           configASSERT( expression )
 #define AwsIotShadow_Assert( expression )      configASSERT( expression )
 #define AwsIotDefender_Assert( expression )    configASSERT( expression )
-#define IotBle_Assert( expression )            configASSERT( expression )
+
+#ifndef IotBle_Assert
+    #define IotBle_Assert( expression )        configASSERT( expression )
+#endif
 
 /* Control the usage of dynamic memory allocation. */
 #ifndef IOT_STATIC_MEMORY_ONLY

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -80,7 +80,10 @@
 #define IotMqtt_Assert( expression )           if( ( expression ) == 0 ) TEST_FAIL_MESSAGE( "Assertion failure" )
 #define AwsIotShadow_Assert( expression )      if( ( expression ) == 0 ) TEST_FAIL_MESSAGE( "Assertion failure" )
 #define AwsIotDefender_Assert( expression )    if( ( expression ) == 0 ) TEST_FAIL_MESSAGE( "Assertion failure" )
-#define IotBle_Assert( expression )            if( ( expression ) == 0 ) TEST_FAIL_MESSAGE( "Assertion failure" )
+
+#ifndef IotBle_Assert
+    #define IotBle_Assert( expression )        if( ( expression ) == 0 ) TEST_FAIL_MESSAGE( "Assertion failure" )
+#endif
 
 /* Control the usage of dynamic memory allocation. */
 #ifndef IOT_STATIC_MEMORY_ONLY

--- a/vendors/espressif/boards/esp32/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32/CMakeLists.txt
@@ -543,6 +543,53 @@ set_source_files_properties(${AFR_ROOT_DIR}/libraries/c_sdk/standard/mqtt/test/u
     PROPERTIES COMPILE_FLAGS
     "-Wno-restrict")
 
+set_source_files_properties(${AFR_ROOT_DIR}/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-array-bounds")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/ble/test/iot_test_ble_end_to_end.c
+    ${AFR_ROOT_DIR}/libraries/ble/test/iot_mqtt_ble_system_test.c
+    ${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/iot_init.c
+    ${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/iot_device_metrics.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-function")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_power.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_spi.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_sdio.c
+    ${AFR_ROOT_DIR}/tests/integration_test/shadow_system_test.c
+    ${AFR_ROOT_DIR}/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+    ${AFR_ROOT_DIR}/demos/coreMQTT_Agent/mqtt_agent_task.c
+    ${AFR_ROOT_DIR}/demos/device_shadow_for_aws/shadow_demo_main.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-variable")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/iot_test_common_io.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_perfcounter.c
+    ${AFR_ROOT_DIR}/demos/cli/cli_uart_demo.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-type-limits")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_flash.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_rtc.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-variable -Wno-overflow")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/coreJSON/source/core_json.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-type-limits -Wno-discarded-qualifiers")
+
 set(IDF_TARGET esp32)
 set(ENV{IDF_PATH} ${esp_idf_dir})
 

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -170,7 +170,6 @@ int app_main( void )
 extern void vApplicationIPInit( void );
 static void prvMiscInitialization( void )
 {
-    int32_t uartRet;
     /* Initialize NVS */
     esp_err_t ret = nvs_flash_init();
 
@@ -286,7 +285,6 @@ static void prvMiscInitialization( void )
                            uint32_t messageLength,
                            TickType_t timeoutTicks )
     {
-        BaseType_t xReturnMessage = pdFALSE;
         SemaphoreHandle_t xUartSem;
         int32_t status = 0;
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/ota_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/ota_demo_config.h
@@ -71,7 +71,9 @@
  * bytes are read from network interface. Keeping this timeout to a sufficiently
  * large value so as to account for delay of receipt of a large block of message.
  */
+#ifndef MQTT_RECV_POLLING_TIMEOUT_MS
 #define MQTT_RECV_POLLING_TIMEOUT_MS            ( 1000U )
+#endif
 
 /**
  * @brief The length of the queue used to hold commands for the agent.
@@ -91,6 +93,8 @@
  * responsiveness of MQTT agent while processing  pending MQTT operations as
  * well as receive packets from network.
  */
+#ifndef MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME
 #define MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME    ( 1U )
+#endif
 
 #endif /* OTA_DEMO_CONFIG_H_ */

--- a/vendors/espressif/boards/esp32s2/CMakeLists.txt
+++ b/vendors/espressif/boards/esp32s2/CMakeLists.txt
@@ -478,6 +478,50 @@ set_source_files_properties(${AFR_ROOT_DIR}/libraries/c_sdk/standard/mqtt/test/u
     PROPERTIES COMPILE_FLAGS
     "-Wno-restrict")
 
+set_source_files_properties(${AFR_ROOT_DIR}/libraries/abstractions/secure_sockets/test/iot_test_tcp.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-array-bounds")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/iot_init.c
+    ${AFR_ROOT_DIR}/libraries/c_sdk/standard/common/iot_device_metrics.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-function")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_power.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_spi.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_sdio.c
+    ${AFR_ROOT_DIR}/tests/integration_test/shadow_system_test.c
+    ${AFR_ROOT_DIR}/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+    ${AFR_ROOT_DIR}/demos/coreMQTT_Agent/mqtt_agent_task.c
+    ${AFR_ROOT_DIR}/demos/device_shadow_for_aws/shadow_demo_main.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-variable")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/iot_test_common_io.c
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_perfcounter.c
+    ${AFR_ROOT_DIR}/demos/cli/cli_uart_demo.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-type-limits")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_flash.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/abstractions/common_io/test/test_iot_rtc.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-unused-variable -Wno-overflow")
+
+set_source_files_properties(
+    ${AFR_ROOT_DIR}/libraries/coreJSON/source/core_json.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-type-limits -Wno-discarded-qualifiers")
+
 set(IDF_TARGET esp32)
 set(ENV{IDF_PATH} ${esp_idf_dir})
 

--- a/vendors/espressif/boards/esp32s2/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32s2/aws_demos/application_code/main.c
@@ -128,7 +128,6 @@ int app_main( void )
 extern void vApplicationIPInit( void );
 static void prvMiscInitialization( void )
 {
-    int32_t uartRet;
     /* Initialize NVS */
     esp_err_t ret = nvs_flash_init();
 

--- a/vendors/espressif/boards/esp32s2/aws_demos/config_files/ota_demo_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_demos/config_files/ota_demo_config.h
@@ -71,7 +71,9 @@
  * bytes are read from network interface. Keeping this timeout to a sufficiently
  * large value so as to account for delay of receipt of a large block of message.
  */
+#ifndef MQTT_RECV_POLLING_TIMEOUT_MS
 #define MQTT_RECV_POLLING_TIMEOUT_MS            ( 1000U )
+#endif
 
 /**
  * @brief The length of the queue used to hold commands for the agent.
@@ -91,6 +93,8 @@
  * responsiveness of MQTT agent while processing  pending MQTT operations as
  * well as receive packets from network.
  */
+#ifndef MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME
 #define MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME    ( 1U )
+#endif
 
 #endif /* OTA_DEMO_CONFIG_H_ */

--- a/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/espressif/boards/ports/ota_pal_for_aws/ota_pal.c
@@ -77,7 +77,6 @@ typedef struct
 } esp_sec_boot_sig_t;
 
 static esp_ota_context_t ota_ctx;
-static const char * TAG = "ota_pal";
 
 static const char codeSigningCertificatePEM[] = otapalconfigCODE_SIGNING_CERTIFICATE;
 

--- a/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/espressif/boards/ports/pkcs11/core_pkcs11_pal.c
@@ -230,7 +230,6 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
 {
     CK_OBJECT_HANDLE xHandle = eInvalidHandle;
     char * pcFileName = NULL;
-    CK_BYTE_PTR pxZeroedData = NULL;
     CK_BYTE_PTR pxObject = NULL;
     CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
     CK_ULONG ulObjectLength = sizeof( CK_BYTE );

--- a/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
+++ b/vendors/espressif/boards/ports/wifi/iot_softap_wifi_provisioning.c
@@ -149,16 +149,6 @@ static esp_err_t prvStartProtocomHTTP( void )
     return xReturnCode;
 }
 
-static void prvDeleteAllSavedNetworks()
-{
-    uint32_t ulCountSavedNetworks = IotWifiSoftAPProv_GetNumNetworks();
-
-    for( uint32_t i = 0; i < ulCountSavedNetworks; i++ )
-    {
-        WIFI_NetworkDelete( i );
-    }
-}
-
 static inline void prvNetworkProfile2Params( WIFINetworkProfile_t const * const pxNetworkProfile,
                                              WIFINetworkParams_t * pxNetworkParams )
 {
@@ -182,9 +172,9 @@ bool prvServiceStart()
         .xSecurity = wificonfigACCESS_POINT_SECURITY,
     };
 
-    char pcMAC[ wificonfigMAX_BSSID_LEN ] = { 0 };
+    uint8_t pcMAC[ wificonfigMAX_BSSID_LEN ] = { 0 };
 
-    WIFI_GetMAC( &pcMAC );
+    WIFI_GetMAC( pcMAC );
     xAPConfig.ucSSIDLength = snprintf( ( char * ) xAPConfig.ucSSID,
                                        sizeof( xAPConfig.ucSSID ),
                                        "%s%02X%02X%02X",


### PR DESCRIPTION
Description
-----------
Fixed the compile-time warnings which are observed when AFR is built for ESP32 and ESP32-S2. 

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.