### PR TITLE
Update GGD demo docs with regards to compatibility with V2 cores

### DIFF
--- a/demos/greengrass_connectivity/README.md
+++ b/demos/greengrass_connectivity/README.md
@@ -1,7 +1,10 @@
 ## Greengrass Discovery Demo
 In order to setup and run the FreeRTOS demo application for Greengrass discovery, please follow the instructions in [Greengrass Discovery Demo](https://docs.aws.amazon.com/freertos/latest/userguide/gg-demo.html).
 
-Please note that as of 02/17/2021, AWS IoT Greengrass V2 does not support connected devices and hence, this demo will not work with Greengrass V2. Please refer to the [aws documentation about running AWS IoT Greengrass V1 applications on AWS IoT Greengrass V2](https://docs.aws.amazon.com/greengrass/v2/developerguide/move-from-v1.html#run-v1-applications) to make sure that the connected devices are supported before running this demo with Greengrass V2.
+## Compatibility with V2 Greengrass devices
+AWS IoT Greengrass V2 support for client devices is backward-compatible with AWS IoT Greengrass V1, so you can connect V1 core devices to V2 core devices without changing their application code. To enable client devices to connect to a V2 core device, deploy Greengrass components that enable client device support, and associate the client devices to the core device. To relay messages between client devices, the AWS IoT Core cloud service, and Greengrass components (including Lambda functions), deploy and configure the [MQTT bridge component](https://docs.aws.amazon.com/greengrass/v2/developerguide/mqtt-bridge-component.html). You can deploy the [IP detector](https://docs.aws.amazon.com/greengrass/v2/developerguide/ip-detector-component.html) component to automatically detect connectivity information, or you can manually manage endpoints. For more information, see [Interact with local IoT devices](https://docs.aws.amazon.com/greengrass/v2/developerguide/interact-with-local-iot-devices.html).
+
+For more details, please refer to the AWS documentation about [running AWS IoT Greengrass V1 applications on AWS IoT Greengrass V2](https://docs.aws.amazon.com/greengrass/v2/developerguide/move-from-v1.html#connect-v1-greengrass-devices).
 
 ## Advanced Diagnostics
 


### PR DESCRIPTION

Description
-----------
<!--- Describe your changes in detail -->
As part of this issue https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1725, it has been confirmed that the GGD demo can work with V2 Greengrass Cores. The documentation of the demo is updated to state this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.