### PR TITLE
Check mqtt agent demo for NULL suback codes

### DIFF
--- a/demos/coreMQTT_Agent/mqtt_agent_task.c
+++ b/demos/coreMQTT_Agent/mqtt_agent_task.c
@@ -677,8 +677,9 @@ static void prvSubscriptionCommandCallback( MQTTAgentCommandContext_t * pxComman
     MQTTAgentSubscribeArgs_t * pxSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) pxCommandContext;
 
     /* If the return code is success, no further action is required as all the topic filters
-     * are already part of the subscription list. */
-    if( pxReturnInfo->returnCode != MQTTSuccess )
+     * are already part of the subscription list. Check that the return codes are not NULL in
+     * case the command errored for any reason. */
+    if( ( pxReturnInfo->returnCode != MQTTSuccess ) && ( pxReturnInfo->pSubackCodes != NULL ) )
     {
         /* Check through each of the suback codes and determine if there are any failures. */
         for( lIndex = 0; lIndex < pxSubscribeArgs->numSubscriptions; lIndex++ )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Adds a check for NULL in the resubscription of the MQTT agent demo, in case the connection gets disconnected again before the SUBACK is received and the command has to be canceled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
