### PR TITLE
Reduce memory usage of jobs demo

### DIFF
--- a/demos/demo_runner/iot_demo_freertos.c
+++ b/demos/demo_runner/iot_demo_freertos.c
@@ -430,7 +430,9 @@ void runDemoTask( void * pArgument )
     void vApplicationStackOverflowHook( TaskHandle_t xTask,
                                         char * pcTaskName )
     {
-        configPRINT_STRING( ( "ERROR: stack overflow\r\n" ) );
+        configPRINT_STRING( ( "ERROR: stack overflow in task " ) );
+        configPRINT_STRING( ( pcTaskName ) );
+        configPRINT_STRING( ( "\r\n" ) );
         portDISABLE_INTERRUPTS();
 
         /* Unused Parameters */

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -284,7 +284,7 @@ static uint8_t usMqttConnectionBuffer[ democonfigNETWORK_BUFFER_SIZE ];
  * connection context for sending status updates of a job while it is being
  * processed.
  */
-static uint8_t usJobIdBuffer[ democonfigNETWORK_BUFFER_SIZE ];
+static uint8_t usJobIdBuffer[ JOBS_JOBID_MAX_LENGTH ];
 
 /**
  * @brief Static buffer used to hold the job document of the single job that

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/aws_demo_config.h
@@ -57,6 +57,8 @@
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY + 5 )
 #define shadowDemoUPDATE_TASK_STACK_SIZE                             ( configMINIMAL_STACK_SIZE * 5 )
 
+#define democonfigJOBS_DEMO_TASK_STACK_SIZE                          ( 1024 )
+
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT                  pdMS_TO_TICKS( 12000 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                            ( tskIDLE_PRIORITY )
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/aws_demo_config.h
@@ -63,6 +63,8 @@
 #define democonfigSHADOW_DEMO_TASK_PRIORITY                          ( tskIDLE_PRIORITY + 5 )
 #define shadowDemoUPDATE_TASK_STACK_SIZE                             ( configMINIMAL_STACK_SIZE * 5 )
 
+#define democonfigJOBS_DEMO_TASK_STACK_SIZE                          ( 1024 )
+
 #define democonfigMQTT_ECHO_TLS_NEGOTIATION_TIMEOUT                  pdMS_TO_TICKS( 12000 )
 #define democonfigMQTT_ECHO_TASK_PRIORITY                            ( tskIDLE_PRIORITY )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->
Reduces the memory allocated for the jobs demo and increases the minimum task size to 1024 bytes to reduce the chances of a stack overflow. The `usJobIdBuffer` buffer is set to `democonfigNETWORK_BUFFER_SIZE`, which is usually 1024 bytes. However, the max length of a job ID is only 64 characters. ST and TI had the lowest stack allocated for this demo, at 90 * 8 = 720 bytes, with the next lowest being cypress at 1040. The stack size for the two boards is increased to 1024 to match that of the shadow demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
