### PR TITLE
Add method to remove callback from secure sockets implimentation

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -73,13 +73,13 @@
 
 /*-----------------------------------------------------------*/
 
-#define SS_STATUS_CONNECTED    ( 1 )
-#define SS_STATUS_SECURED      ( 2 )
+#define SS_STATUS_CONNECTED               ( 1 )
+#define SS_STATUS_SECURED                 ( 2 )
 
 #define SECURE_SOCKETS_SELECT_WAIT_SEC    ( 10 )
 
 #define SOCKETS_START_DELETION            ( 0x01 )
-#define SOCKETS_COMPLETE_DELETION            ( 0x02 )
+#define SOCKETS_COMPLETE_DELETION         ( 0x02 )
 
 /*
  * secure socket context.
@@ -102,7 +102,7 @@ typedef struct _ss_ctx_t
     int recv_flag;
 
     TaskHandle_t rx_handle;
-    void ( * rx_callback )( Socket_t pxSocket );
+    void ( *rx_callback )( Socket_t pxSocket );
     EventGroupHandle_t rx_EventGroup;
 
     bool enforce_tls;

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -45,6 +45,8 @@
 
 #include "task.h"
 
+#include "event_groups.h"
+
 #include <stdbool.h>
 
 /*
@@ -74,6 +76,11 @@
 #define SS_STATUS_CONNECTED    ( 1 )
 #define SS_STATUS_SECURED      ( 2 )
 
+#define SECURE_SOCKETS_SELECT_WAIT_SEC    ( 10 )
+
+#define SOCKETS_START_DELETION            ( 0x01 )
+#define SOCKETS_COMPLETE_DELETION            ( 0x02 )
+
 /*
  * secure socket context.
  */
@@ -96,6 +103,7 @@ typedef struct _ss_ctx_t
 
     TaskHandle_t rx_handle;
     void ( * rx_callback )( Socket_t pxSocket );
+    EventGroupHandle_t rx_EventGroup;
 
     bool enforce_tls;
     void * tls_ctx;
@@ -269,6 +277,7 @@ static void vTaskRxSelect( void * param )
 {
     ss_ctx_t * ctx = ( ss_ctx_t * ) param;
     int s = ctx->ip_socket;
+    struct timeval tv;
 
     fd_set read_fds;
     fd_set write_fds;
@@ -283,6 +292,9 @@ static void vTaskRxSelect( void * param )
 
     ctx->state = SST_RX_READY;
 
+    tv.tv_sec = SECURE_SOCKETS_SELECT_WAIT_SEC;
+    tv.tv_usec = 0;
+
     while( 1 )
     {
         if( ctx->state == SST_RX_CLOSING )
@@ -291,7 +303,7 @@ static void vTaskRxSelect( void * param )
             break;
         }
 
-        if( lwip_select( s + 1, &read_fds, &write_fds, &err_fds, NULL ) == -1 )
+        if( lwip_select( s + 1, &read_fds, &write_fds, &err_fds, &tv ) == -1 )
         {
             break;
         }
@@ -300,9 +312,17 @@ static void vTaskRxSelect( void * param )
         {
             ctx->rx_callback( ( Socket_t ) ctx );
         }
+
+        if( xEventGroupWaitBits( ctx->rx_EventGroup, SOCKETS_START_DELETION, pdTRUE, pdTRUE, 0 ) == SOCKETS_START_DELETION )
+        {
+            /* Inform the main task that the event has been received. */
+            ( void ) xEventGroupSetBits( ctx->rx_EventGroup, SOCKETS_COMPLETE_DELETION );
+            break;
+        }
     }
 
     prvDecrementRefCount( ctx );
+
     vTaskDelete( NULL );
 }
 
@@ -319,6 +339,12 @@ static void prvRxSelectSet( ss_ctx_t * ctx,
     ctx->rx_callback = ( void ( * )( Socket_t ) )pvOptionValue;
 
     prvIncrementRefCount( ctx );
+
+    ctx->rx_EventGroup = NULL;
+    ctx->rx_EventGroup = xEventGroupCreate();
+
+    configASSERT( ctx->rx_EventGroup != NULL );
+
     xReturned = xTaskCreate( vTaskRxSelect, /* pvTaskCode */
                              "rxs",         /* pcName */
                              xStackDepth,   /* usStackDepth */
@@ -336,7 +362,28 @@ static void prvRxSelectSet( ss_ctx_t * ctx,
 
 static void prvRxSelectClear( ss_ctx_t * ctx )
 {
-    /* TODO */
+    /* Inform the vTaskRxSelect to delete itself. */
+    xEventGroupSetBits( ctx->rx_EventGroup, SOCKETS_START_DELETION );
+
+    /* Wait for the task to delete itself. */
+    if( xEventGroupWaitBits( ctx->rx_EventGroup, SOCKETS_COMPLETE_DELETION, pdTRUE, pdTRUE, portMAX_DELAY ) == SOCKETS_COMPLETE_DELETION )
+    {
+        /* The task 'vTaskRxSelect' has started deleting itself. */
+    }
+    else
+    {
+        /* Control should never reach here as this task should wait on the event group bits indefinately. */
+        configASSERT( pdTRUE );
+    }
+
+    /* Reset the handle of the task to NULL. */
+    ctx->rx_handle = NULL;
+
+    /* Delete the event group. */
+    vEventGroupDelete( ctx->rx_EventGroup );
+
+    /* Remove the reference to the callback. */
+    ctx->rx_callback = NULL;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -340,7 +340,6 @@ static void prvRxSelectSet( ss_ctx_t * ctx,
 
     prvIncrementRefCount( ctx );
 
-    ctx->rx_EventGroup = NULL;
     ctx->rx_EventGroup = xEventGroupCreate();
 
     configASSERT( ctx->rx_EventGroup != NULL );
@@ -366,14 +365,14 @@ static void prvRxSelectClear( ss_ctx_t * ctx )
     xEventGroupSetBits( ctx->rx_EventGroup, SOCKETS_START_DELETION );
 
     /* Wait for the task to delete itself. */
-    if( xEventGroupWaitBits( ctx->rx_EventGroup, SOCKETS_COMPLETE_DELETION, pdTRUE, pdTRUE, portMAX_DELAY ) == SOCKETS_COMPLETE_DELETION )
+    while( xEventGroupWaitBits( ctx->rx_EventGroup,
+                                SOCKETS_COMPLETE_DELETION,
+                                pdTRUE,
+                                pdTRUE,
+                                pdMS_TO_TICKS( SECURE_SOCKETS_SELECT_WAIT_SEC * 1000 ) ) !=
+           SOCKETS_COMPLETE_DELETION )
     {
-        /* The task 'vTaskRxSelect' has started deleting itself. */
-    }
-    else
-    {
-        /* Control should never reach here as this task should wait on the event group bits indefinately. */
-        configASSERT( pdTRUE );
+        /* Continue waiting for the task to delete itself. */
     }
 
     /* Reset the handle of the task to NULL. */

--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -102,7 +102,7 @@ typedef struct _ss_ctx_t
     int recv_flag;
 
     TaskHandle_t rx_handle;
-    void ( *rx_callback )( Socket_t pxSocket );
+    void ( * rx_callback )( Socket_t pxSocket );
     EventGroupHandle_t rx_EventGroup;
 
     bool enforce_tls;

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/iot_secure_sockets_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/iot_secure_sockets_config.h
@@ -62,7 +62,7 @@
  * socket becomes ready.  This is the number of words (not bytes!) to allocate
  * for use as the task’s stack.
  */
-#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      1024u
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      1536u
 
 /**
  * @brief Default max socket number support

--- a/vendors/espressif/boards/esp32/aws_tests/config_files/iot_secure_sockets_config.h
+++ b/vendors/espressif/boards/esp32/aws_tests/config_files/iot_secure_sockets_config.h
@@ -62,7 +62,7 @@
  * socket becomes ready.  This is the number of words (not bytes!) to allocate
  * for use as the task’s stack.
  */
-#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      1024u
+#define socketsconfigRECEIVE_CALLBACK_TASK_STACK_DEPTH      1536u
 
 /**
  * @brief Default max socket number support


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In reference to https://github.com/aws/amazon-freertos/issues/1646, this PR fixes the callback removal issue which could cause an orphan task to be created.
Cleaning a callback requires the spawned task to be terminated before everything can be cleaned up. This requires two way communication/synchronization. Thus, event groups were used to allow both tasks to communicate with each other of the actions required.
Also, the `lwip_select` function was made to block for 10 seconds instead of infinite time - this would introduce overheads but was necessary. The time interval of 10 seconds can be changed by modifying the provided macro. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.