### PR TITLE
header: add marco wrapper

### DIFF
--- a/demos/include/aws_clientcredential.h
+++ b/demos/include/aws_clientcredential.h
@@ -26,12 +26,16 @@
 #ifndef __AWS_CLIENTCREDENTIAL__H__
 #define __AWS_CLIENTCREDENTIAL__H__
 
+/* @TEST_ANCHOR */
+
 /*
  * @brief MQTT Broker endpoint.
  *
  * @todo Set this to the fully-qualified DNS name of your MQTT broker.
  */
-#define clientcredentialMQTT_BROKER_ENDPOINT         ""
+#ifndef clientcredentialMQTT_BROKER_ENDPOINT
+    #define clientcredentialMQTT_BROKER_ENDPOINT         ""
+#endif
 
 /*
  * @brief Host name.
@@ -43,30 +47,39 @@
  * by software, such as a production serial number, rather
  * than a hard coded constant.
  */
-#define clientcredentialIOT_THING_NAME               ""
-
+#ifndef clientcredentialIOT_THING_NAME
+    #define clientcredentialIOT_THING_NAME               ""
+#endif
 /*
  * @brief Port number the MQTT broker is using.
  */
-#define clientcredentialMQTT_BROKER_PORT             8883
+#ifndef clientcredentialMQTT_BROKER_PORT
+    #define clientcredentialMQTT_BROKER_PORT             8883
+#endif
 
 /*
  * @brief Port number the Green Grass Discovery use for JSON retrieval from cloud is using.
  */
-#define clientcredentialGREENGRASS_DISCOVERY_PORT    8443
+#ifndef clientcredentialGREENGRASS_DISCOVERY_PORT
+    #define clientcredentialGREENGRASS_DISCOVERY_PORT    8443
+#endif
 
 /*
  * @brief Wi-Fi network to join.
  *
  * @todo If you are using Wi-Fi, set this to your network name.
  */
-#define clientcredentialWIFI_SSID                    ""
+#ifndef clientcredentialWIFI_SSID
+    #define clientcredentialWIFI_SSID                    ""
+#endif
 
 /*
  * @brief Password needed to join Wi-Fi network.
  * @todo If you are using WPA, set this to your network password.
  */
-#define clientcredentialWIFI_PASSWORD                ""
+#ifndef clientcredentialWIFI_PASSWORD
+    #define clientcredentialWIFI_PASSWORD                ""
+#endif
 
 /*
  * @brief Wi-Fi network security type.
@@ -76,6 +89,8 @@
  * @note Possible values are eWiFiSecurityOpen, eWiFiSecurityWEP, eWiFiSecurityWPA,
  * eWiFiSecurityWPA2 (depending on the support of your device Wi-Fi radio).
  */
-#define clientcredentialWIFI_SECURITY                eWiFiSecurityWPA2
+#ifndef clientcredentialWIFI_SECURITY
+    #define clientcredentialWIFI_SECURITY                eWiFiSecurityWPA2
+#endif
 
 #endif /* ifndef __AWS_CLIENTCREDENTIAL__H__ */

--- a/demos/include/aws_clientcredential.h
+++ b/demos/include/aws_clientcredential.h
@@ -34,7 +34,7 @@
  * @todo Set this to the fully-qualified DNS name of your MQTT broker.
  */
 #ifndef clientcredentialMQTT_BROKER_ENDPOINT
-    #define clientcredentialMQTT_BROKER_ENDPOINT         ""
+    #define clientcredentialMQTT_BROKER_ENDPOINT    ""
 #endif
 
 /*
@@ -48,13 +48,14 @@
  * than a hard coded constant.
  */
 #ifndef clientcredentialIOT_THING_NAME
-    #define clientcredentialIOT_THING_NAME               ""
+    #define clientcredentialIOT_THING_NAME    ""
 #endif
+
 /*
  * @brief Port number the MQTT broker is using.
  */
 #ifndef clientcredentialMQTT_BROKER_PORT
-    #define clientcredentialMQTT_BROKER_PORT             8883
+    #define clientcredentialMQTT_BROKER_PORT    8883
 #endif
 
 /*
@@ -70,7 +71,7 @@
  * @todo If you are using Wi-Fi, set this to your network name.
  */
 #ifndef clientcredentialWIFI_SSID
-    #define clientcredentialWIFI_SSID                    ""
+    #define clientcredentialWIFI_SSID    ""
 #endif
 
 /*
@@ -78,7 +79,7 @@
  * @todo If you are using WPA, set this to your network password.
  */
 #ifndef clientcredentialWIFI_PASSWORD
-    #define clientcredentialWIFI_PASSWORD                ""
+    #define clientcredentialWIFI_PASSWORD    ""
 #endif
 
 /*
@@ -90,7 +91,7 @@
  * eWiFiSecurityWPA2 (depending on the support of your device Wi-Fi radio).
  */
 #ifndef clientcredentialWIFI_SECURITY
-    #define clientcredentialWIFI_SECURITY                eWiFiSecurityWPA2
+    #define clientcredentialWIFI_SECURITY    eWiFiSecurityWPA2
 #endif
 
 #endif /* ifndef __AWS_CLIENTCREDENTIAL__H__ */

--- a/demos/include/aws_clientcredential_keys.h
+++ b/demos/include/aws_clientcredential_keys.h
@@ -37,6 +37,8 @@
 #ifndef AWS_CLIENT_CREDENTIAL_KEYS_H
 #define AWS_CLIENT_CREDENTIAL_KEYS_H
 
+/* @TEST_ANCHOR */
+
 /*
  * @brief PEM-encoded client certificate.
  *
@@ -48,7 +50,9 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyCLIENT_CERTIFICATE_PEM                   NULL
+#ifndef keyCLIENT_CERTIFICATE_PEM
+    #define keyCLIENT_CERTIFICATE_PEM                   NULL
+#endif
 
 /*
  * @brief PEM-encoded issuer certificate for AWS IoT Just In Time Registration (JITR).
@@ -69,7 +73,9 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
+#ifndef keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM
+    #define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
+#endif
 
 /*
  * @brief PEM-encoded client private key.
@@ -88,6 +94,8 @@
  * "...base64 data...\n"\
  * "-----END RSA PRIVATE KEY-----\n"
  */
-#define keyCLIENT_PRIVATE_KEY_PEM                   NULL
+#ifndef keyCLIENT_PRIVATE_KEY_PEM
+    #define keyCLIENT_PRIVATE_KEY_PEM                   NULL
+#endif
 
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H */

--- a/demos/include/aws_clientcredential_keys.h
+++ b/demos/include/aws_clientcredential_keys.h
@@ -51,7 +51,7 @@
  * "-----END CERTIFICATE-----\n"
  */
 #ifndef keyCLIENT_CERTIFICATE_PEM
-    #define keyCLIENT_CERTIFICATE_PEM                   NULL
+    #define keyCLIENT_CERTIFICATE_PEM    NULL
 #endif
 
 /*
@@ -95,7 +95,7 @@
  * "-----END RSA PRIVATE KEY-----\n"
  */
 #ifndef keyCLIENT_PRIVATE_KEY_PEM
-    #define keyCLIENT_PRIVATE_KEY_PEM                   NULL
+    #define keyCLIENT_PRIVATE_KEY_PEM    NULL
 #endif
 
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H */


### PR DESCRIPTION
the predefined macros do not have a wrapper to be easy overried,
add a wrapper will make the demos more easy to port to different
run settings

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>

add macro warpper in header files

Description
-----------
the predefined macros do not have a wrapper,
add wrapper will make the demos more easy to port to different run settings

the user cases is we have CFLAGS set in build time, which can enable the application with our test envrionment.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [x ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.