### PR TITLE
Fix build warnings in TI CCS projects

### DIFF
--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -716,7 +716,7 @@ void vHandleOtherIncomingPacket( MQTTPacketInfo_t * pxPacketInfo,
             configASSERT( xResult == MQTTSuccess );
             /* Only a single topic filter is expected for each SUBSCRIBE packet. */
             configASSERT( xSize == 1UL );
-            xTopicFilterContext.xSubAckStatus = *pucPayload;
+            xTopicFilterContext.xSubAckStatus = ( MQTTSubAckStatus_t ) *pucPayload;
 
             if( xTopicFilterContext.xSubAckStatus != MQTTSubAckFailure )
             {

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -863,7 +863,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = ( MQTTSubAckStatus_t ) ( pucPayload[ ulTopicCount ] );
     }
 }
 /*-----------------------------------------------------------*/

--- a/demos/coreMQTT_Agent/mqtt_agent_task.c
+++ b/demos/coreMQTT_Agent/mqtt_agent_task.c
@@ -442,13 +442,7 @@ int RunCoreMqttAgentDemo( bool awsIotMqttMode,
                           void * pNetworkCredentialInfo,
                           const void * pNetworkInterface )
 {
-    BaseType_t xNetworkStatus = pdFAIL;
-    BaseType_t xResult = pdFALSE;
-    BaseType_t xNetworkConnectionCreated = pdFALSE;
-    uint32_t ulNotification = 0UL;
-
     uint32_t ulDemoCount = 0UL;
-    uint32_t ulDemoSuccessCount = 0UL;
     int ret = EXIT_SUCCESS;
 
     ( void ) awsIotMqttMode;
@@ -842,7 +836,7 @@ static void prvIncomingPublishCallback( MQTTAgentContext_t * pMqttAgentContext,
 static void prvMQTTAgentTask( void * pvParameters )
 {
     BaseType_t xNetworkResult = pdFAIL;
-    MQTTStatus_t xMQTTStatus = MQTTSuccess, xConnectStatus = MQTTSuccess;
+    MQTTStatus_t xMQTTStatus = MQTTSuccess;
     MQTTContext_t * pMqttContext = &( xGlobalMqttAgentContext.mqttContext );
 
     ( void ) pvParameters;
@@ -866,7 +860,7 @@ static void prvMQTTAgentTask( void * pvParameters )
         else if( xMQTTStatus == MQTTSuccess )
         {
             /* MQTTAgent_Terminate() was called, but MQTT was not disconnected. */
-            xConnectStatus = MQTT_Disconnect( &( xGlobalMqttAgentContext.mqttContext ) );
+            ( void ) MQTT_Disconnect( &( xGlobalMqttAgentContext.mqttContext ) );
             xNetworkResult = prvSocketDisconnect( &xNetworkContext );
             break;
         }

--- a/demos/coreMQTT_Agent/mqtt_agent_task.c
+++ b/demos/coreMQTT_Agent/mqtt_agent_task.c
@@ -608,8 +608,10 @@ static MQTTStatus_t prvHandleResubscribe( void )
 
     /* These variables need to stay in scope until command completes. */
     static MQTTAgentSubscribeArgs_t xSubArgs = { 0 };
-    static MQTTSubscribeInfo_t xSubInfo[ SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS ] = { 0 };
+    static MQTTSubscribeInfo_t xSubInfo[ SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS ];
     static MQTTAgentCommandInfo_t xCommandParams = { 0 };
+
+    memset( &( xSubInfo[ 0 ] ), 0, SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS * sizeof( MQTTSubscribeInfo_t ) );
 
     /* Loop through each subscription in the subscription list and add a subscribe
      * command to the command queue. */

--- a/demos/coreMQTT_Agent/simple_sub_pub_demo.c
+++ b/demos/coreMQTT_Agent/simple_sub_pub_demo.c
@@ -365,8 +365,10 @@ static bool prvSubscribeToTopic( MQTTQoS_t xQoS,
     MQTTAgentSubscribeArgs_t xSubscribeArgs;
     MQTTSubscribeInfo_t xSubscribeInfo;
     static int32_t ulNextSubscribeMessageID = 0;
-    MQTTAgentCommandContext_t xApplicationDefinedContext = { 0 };
+    MQTTAgentCommandContext_t xApplicationDefinedContext;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
+
+    memset( &( xApplicationDefinedContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
 
     /* Create a unique number of the subscribe that is about to be sent.  The number
      * is used as the command context and is sent back to this task as a notification
@@ -446,7 +448,7 @@ static bool prvSubscribeToTopic( MQTTQoS_t xQoS,
 
 static void prvSimpleSubscribePublishTask( void * pvParameters )
 {
-    MQTTPublishInfo_t xPublishInfo = { 0 };
+    MQTTPublishInfo_t xPublishInfo;
     char payloadBuf[ mqttexampleSTRING_BUFFER_LENGTH ];
     char taskName[ mqttexampleSTRING_BUFFER_LENGTH ];
     MQTTAgentCommandContext_t xCommandContext;
@@ -459,6 +461,8 @@ static void prvSimpleSubscribePublishTask( void * pvParameters )
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
     char * pcTopicBuffer = topicBuf[ ulTaskNumber ];
     uint32_t numSuccesses = 0U;
+
+    memset( &( xPublishInfo ), 0, sizeof( MQTTPublishInfo_t ) );
 
     /* Have different tasks use different QoS.  0 and 1.  2 can also be used
      * if supported by the broker. */

--- a/demos/device_defender_for_aws/defender_demo.c
+++ b/demos/device_defender_for_aws/defender_demo.c
@@ -465,7 +465,7 @@ static BaseType_t collectDeviceMetrics( void )
             /* Include the stack high water mark value. */
             pdTRUE,
             /* Don't include the task state in the TaskStatus_t structure. */
-            0 );
+            eRunning );
 
         /* Get the task status information for all running tasks. The task IDs
          * of each task is then extracted to include in the report as a "list of

--- a/demos/device_shadow_for_aws/shadow_demo_main.c
+++ b/demos/device_shadow_for_aws/shadow_demo_main.c
@@ -56,6 +56,7 @@
 
 /* Standard includes. */
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -235,11 +236,6 @@ static MQTTContext_t xMqttContext;
  * @brief The network context used for TLS operation.
  */
 static NetworkContext_t xNetworkContext;
-
-/**
- * @brief The flag to indicate the mqtt session changed.
- */
-static BaseType_t mqttSessionEstablished = pdTRUE;
 
 /**
  * @brief Static buffer used to hold MQTT messages being sent and received.
@@ -781,7 +777,6 @@ int RunDeviceShadowDemo( bool awsIotMqttMode,
 {
     BaseType_t xDemoStatus = pdPASS;
     BaseType_t xDemoRunCount = 0UL;
-    BaseType_t xDeleteResponseLoopCount = 0UL;
 
     /* A buffer containing the update document. It has static duration to prevent
      * it from being placed on the call stack. */

--- a/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
+++ b/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
@@ -157,10 +157,6 @@ struct NetworkContext
  */
 static uint32_t ulGlobalEntryTimeMs;
 
-/* The maximum time to wait for an MQTT operation to complete.  Needs to be
- * long enough for the TLS negotiation to complete. */
-static const uint32_t _maxCommandTimeMs = 20000UL;
-
 static const uint32_t _timeBetweenPublishMs = 1500UL;
 
 static char pcJSONFile[ ggdDEMO_DISCOVERY_FILE_SIZE ];
@@ -486,7 +482,6 @@ static void sendMessageToGGC( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
     MQTTPublishInfo_t xMQTTPublishInfo;
-    BaseType_t xDemoStatus = pdPASS;
     uint32_t ulMessageCounter;
     char cBuffer[ ggdDEMO_MAX_MQTT_MSG_SIZE ];
     const char * pcTopic = ggdDEMO_MQTT_MSG_TOPIC;
@@ -510,7 +505,6 @@ static void sendMessageToGGC( MQTTContext_t * pxMQTTContext )
 
         if( xResult != MQTTSuccess )
         {
-            xDemoStatus = pdFAIL;
             LogError( ( "Failed to send PUBLISH message to broker: Topic=%s, Error=%s",
                         pcTopic,
                         MQTT_Status_strerror( xResult ) ) );
@@ -531,7 +525,6 @@ static int discoverGreengrassCore()
     NetworkContext_t xNetworkContext = { 0 };
     MQTTContext_t xMQTTContext = { 0 };
     MQTTStatus_t xMQTTStatus;
-    BaseType_t xIsConnectionEstablished = pdFALSE;
 
 
     memset( &xHostAddressData, 0, sizeof( xHostAddressData ) );
@@ -567,8 +560,6 @@ static int discoverGreengrassCore()
 
         if( xDemoStatus == pdPASS )
         {
-            xIsConnectionEstablished = pdTRUE;
-
             sendMessageToGGC( &xMQTTContext );
 
             LogInfo( ( "Disconnecting from broker." ) );

--- a/demos/jobs_for_aws/jobs_demo.c
+++ b/demos/jobs_for_aws/jobs_demo.c
@@ -485,13 +485,15 @@ static void prvProcessJobDocument( char * pcJobId,
     }
     else
     {
-        /* Send a status update to AWS IoT Jobs service for the next pending job. */
-        LogInfo( ( "Updating status of Job to IN_PROGRESS: JobId=%.*s", usJobIdLength, pcJobId ) );
-        prvSendUpdateForJob( pcJobId, usJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
-
         JobActionType xActionType = JOB_ACTION_UNKNOWN;
         char * pcMessage = NULL;
         size_t ulMessageLength = 0U;
+        char * pcTopic = NULL;
+        size_t ulTopicLength = 0U;
+
+        /* Send a status update to AWS IoT Jobs service for the next pending job. */
+        LogInfo( ( "Updating status of Job to IN_PROGRESS: JobId=%.*s", usJobIdLength, pcJobId ) );
+        prvSendUpdateForJob( pcJobId, usJobIdLength, MAKE_STATUS_REPORT( "IN_PROGRESS" ) );
 
         xActionType = prvGetAction( pcAction, uActionLength );
 
@@ -535,8 +537,6 @@ static void prvProcessJobDocument( char * pcJobId,
 
             case JOB_ACTION_PUBLISH:
                 LogInfo( ( "Received job contains \"publish\" action." ) );
-                char * pcTopic = NULL;
-                size_t ulTopicLength = 0U;
 
                 xJsonStatus = JSON_Search( pcJobDocument,
                                            jobDocumentLength,
@@ -660,9 +660,9 @@ static void prvNextJobHandler( MQTTPublishInfo_t * pxPublishInfo )
                 memcpy( usJobsDocumentBuffer, pcJobDocLoc, ulJobDocLength );
 
                 /* Process the Job document and execute the job. */
-                prvProcessJobDocument( usJobIdBuffer,
+                prvProcessJobDocument( ( char * ) usJobIdBuffer,
                                        ( uint16_t ) ulJobIdLength,
-                                       usJobsDocumentBuffer,
+                                       ( char * ) usJobsDocumentBuffer,
                                        ulJobDocLength );
             }
         }

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -40,6 +40,10 @@
 #include "aws_demo_config.h"
 #include "iot_network.h"
 
+/* OTA library and demo configuration macros. */
+#include "ota_config.h"
+#include "ota_demo_config.h"
+
 /* CoreMQTT-Agent APIS for running MQTT in a multithreaded environment. */
 #include "freertos_agent_message.h"
 #include "freertos_command_pool.h"
@@ -79,10 +83,6 @@
 
 /* OTA Library include. */
 #include "ota.h"
-
-/* OTA library and demo configuration macros. */
-#include "ota_config.h"
-#include "ota_demo_config.h"
 
 /* OTA Library Interface include. */
 #include "ota_os_freertos.h"
@@ -1616,7 +1616,6 @@ static int32_t prvConnectToS3Server( NetworkContext_t * pxNetworkContext,
                                      const char * pcUrl )
 {
     BaseType_t returnStatus = pdPASS;
-    BaseType_t xStatus = pdPASS;
     HTTPStatus_t xHttpStatus = HTTPSuccess;
     /* The location of the host address within the pre-signed URL. */
     const char * pcAddress = NULL;

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1583,9 +1583,11 @@ static BaseType_t prvConnectToMQTTBroker( void )
 
 static void prvDisconnectFromMQTTBroker( void )
 {
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
     MQTTStatus_t xCommandStatus;
+
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
 
     /* Disconnect from broker. */
     LogInfo( ( "Disconnecting the MQTT connection with %s.", democonfigMQTT_BROKER_ENDPOINT ) );
@@ -1905,7 +1907,7 @@ static OtaHttpStatus_t prvHttpRequest( uint32_t ulRangeStart,
         {
             xHttpConnectionStatus = pdTRUE;
 
-            xReturnStatus = HTTPSuccess;
+            xReturnStatus = OtaHttpSuccess;
         }
         else
         {
@@ -1941,15 +1943,17 @@ static OtaMqttStatus_t prvMqttSubscribe( const char * pcTopicFilter,
     OtaMqttStatus_t xMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTSubscribeInfo_t xSubscription = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTSubscribeInfo_t xSubscription;
     MQTTAgentSubscribeArgs_t xSubscribeArgs = { 0 };
 
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( xSubscription ), 0, sizeof( MQTTSubscribeInfo_t ) );
 
     assert( pcTopicFilter != NULL );
     assert( usTopicFilterLength > 0 );
 
-    xSubscription.qos = ucQOS;
+    xSubscription.qos = ( MQTTQoS_t ) ucQOS;
     xSubscription.pTopicFilter = pcTopicFilter;
     xSubscription.topicFilterLength = usTopicFilterLength;
     xSubscribeArgs.numSubscriptions = 1;
@@ -1997,13 +2001,16 @@ static OtaMqttStatus_t prvMqttPublish( const char * const pcTopic,
     OtaMqttStatus_t xMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTPublishInfo_t publishInfo = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTPublishInfo_t publishInfo;
+
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( publishInfo ), 0, sizeof( MQTTPublishInfo_t ) );
 
     /* Set the required publish parameters. */
     publishInfo.pTopicName = pcTopic;
     publishInfo.topicNameLength = usTopicLen;
-    publishInfo.qos = ucQOS;
+    publishInfo.qos = ( MQTTQoS_t ) ucQOS;
     publishInfo.pPayload = pcMsg;
     publishInfo.payloadLength = ulMsgSize;
 
@@ -2045,11 +2052,14 @@ static OtaMqttStatus_t prvMqttUnSubscribe( const char * pcTopicFilter,
     OtaMqttStatus_t xMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTSubscribeInfo_t xSubscription = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTSubscribeInfo_t xSubscription;
     MQTTAgentSubscribeArgs_t xSubscribeArgs = { 0 };
 
-    xSubscription.qos = ucQOS;
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( xSubscription ), 0, sizeof( MQTTSubscribeInfo_t ) );
+
+    xSubscription.qos = ( MQTTQoS_t ) ucQOS;
     xSubscription.pTopicFilter = pcTopicFilter;
     xSubscription.topicFilterLength = usTopicFilterLength;
     xSubscribeArgs.numSubscriptions = 1;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -33,6 +33,10 @@
 
 #include "aws_demo_config.h"
 
+/* OTA library and demo configuration macros. */
+#include "ota_config.h"
+#include "ota_demo_config.h"
+
 #include "FreeRTOS.h"
 #include "task.h"
 #include "semphr.h"
@@ -75,10 +79,6 @@
 
 /* OTA Library include. */
 #include "ota.h"
-
-/* OTA library and demo configuration macros. */
-#include "ota_config.h"
-#include "ota_demo_config.h"
 
 /* OTA Library Interface include. */
 #include "ota_os_freertos.h"

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1426,9 +1426,11 @@ static BaseType_t prvConnectToMQTTBroker( void )
 
 static void prvDisconnectFromMQTTBroker( void )
 {
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
     MQTTStatus_t xCommandStatus;
+
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
 
     /* Disconnect from broker. */
     LogInfo( ( "Disconnecting the MQTT connection with %s.", democonfigMQTT_BROKER_ENDPOINT ) );
@@ -1461,15 +1463,17 @@ static OtaMqttStatus_t prvMqttSubscribe( const char * pcTopicFilter,
     OtaMqttStatus_t xOtaMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTSubscribeInfo_t xSubscription = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTSubscribeInfo_t xSubscription;
     MQTTAgentSubscribeArgs_t xSubscribeArgs = { 0 };
 
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( xSubscription ), 0, sizeof( MQTTSubscribeInfo_t ) );
 
     assert( pcTopicFilter != NULL );
     assert( usTopicFilterLength > 0 );
 
-    xSubscription.qos = ucQOS;
+    xSubscription.qos = ( MQTTQoS_t ) ucQOS;
     xSubscription.pTopicFilter = pcTopicFilter;
     xSubscription.topicFilterLength = usTopicFilterLength;
     xSubscribeArgs.numSubscriptions = 1;
@@ -1517,13 +1521,16 @@ static OtaMqttStatus_t prvMqttPublish( const char * const pcTopic,
     OtaMqttStatus_t xOtaMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTPublishInfo_t xPublishInfo = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTPublishInfo_t xPublishInfo;
+
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( xPublishInfo ), 0, sizeof( MQTTPublishInfo_t ) );
 
     /* Set the required publish parameters. */
     xPublishInfo.pTopicName = pcTopic;
     xPublishInfo.topicNameLength = usTopicLen;
-    xPublishInfo.qos = ucQOS;
+    xPublishInfo.qos = ( MQTTQoS_t ) ucQOS;
     xPublishInfo.pPayload = pcMsg;
     xPublishInfo.payloadLength = ulMsgSize;
 
@@ -1565,11 +1572,14 @@ static OtaMqttStatus_t prvMqttUnSubscribe( const char * pcTopicFilter,
     OtaMqttStatus_t xOtaMqttStatus = OtaMqttSuccess;
     MQTTStatus_t xCommandStatus;
     MQTTAgentCommandInfo_t xCommandParams = { 0 };
-    MQTTAgentCommandContext_t xCommandContext = { 0 };
-    MQTTSubscribeInfo_t xSubscription = { 0 };
+    MQTTAgentCommandContext_t xCommandContext;
+    MQTTSubscribeInfo_t xSubscription;
     MQTTAgentSubscribeArgs_t xSubscribeArgs = { 0 };
 
-    xSubscription.qos = ucQOS;
+    memset( &( xCommandContext ), 0, sizeof( MQTTAgentCommandContext_t ) );
+    memset( &( xSubscription ), 0, sizeof( MQTTSubscribeInfo_t ) );
+
+    xSubscription.qos = ( MQTTQoS_t ) ucQOS;
     xSubscription.pTopicFilter = pcTopicFilter;
     xSubscription.topicFilterLength = usTopicFilterLength;
     xSubscribeArgs.numSubscriptions = 1;

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
@@ -31,6 +31,10 @@
 #ifndef TRANSPORT_SECURE_SOCKETS_H
 #define TRANSPORT_SECURE_SOCKETS_H
 
+/* Transport interface include. */
+#include "transport_interface.h"
+#include "iot_secure_sockets.h"
+
 /* bool is defined in only C99+. */
 #if defined( __cplusplus ) || ( defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) )
     #include <stdbool.h>
@@ -40,10 +44,6 @@
     #define true     ( int8_t ) 1
 #endif
 /** @endcond */
-
-/* Transport interface include. */
-#include "transport_interface.h"
-#include "iot_secure_sockets.h"
 
 /* Kernel include. */
 #include "FreeRTOS.h"

--- a/libraries/freertos_plus/standard/freertos_plus_cli/utest/iot_test_freertos_cli.c
+++ b/libraries/freertos_plus/standard/freertos_plus_cli/utest/iot_test_freertos_cli.c
@@ -23,6 +23,7 @@
  * http://aws.amazon.com/freertos
  *
  */
+#include <stdio.h>
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/projects/ti/cc3220_launchpad/ccs/aws_demos/.cproject
+++ b/projects/ti/cc3220_launchpad/ccs/aws_demos/.cproject
@@ -109,10 +109,8 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.1900164071" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER.937204773" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.1763087887" name="Level of printf/scanf support required (--printf_support)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.full" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.682014743" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1118240196" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
 									<listOptionValue builtIn="false" value="188"/>
-									<listOptionValue builtIn="false" value="190"/>
-									<listOptionValue builtIn="false" value="551"/>
 								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1403241110" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1490972185" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
@@ -147,87 +145,49 @@
 							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex"/>
 						</toolChain>
 					</folderInfo>
-					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.287057304" name="ota_mqtt.c" rcbsApplicability="disable" resourcePath="libraries/ota_for_aws/source/ota_mqtt.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.466119242">
-						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.466119242" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
-							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.2092282643" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
-								<listOptionValue builtIn="false" value="188"/>
-								<listOptionValue builtIn="false" value="552"/>
-								<listOptionValue builtIn="false" value="190"/>
-								<listOptionValue builtIn="false" value="551"/>
-							</option>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1200994442" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1477896812" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.2138216823" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.2135434601" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
-						</tool>
-						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.53438565" name="Resource Custom Build Step">
-							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.320039164" name="Resource Custom Build Step Input Type">
-								<additionalInput kind="additionalinputdependency" paths=""/>
-							</inputType>
-							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.27074320" name="Resource Custom Build Step Output Type"/>
-						</tool>
-					</fileInfo>
-					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.14787231" name="/" resourcePath="libraries/coreHTTP/source/dependency/3rdparty/http_parser">
-						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1754804276" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.972513289" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.1899464957" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.1861301283" name="/" resourcePath="libraries/coreHTTP/source/dependency/3rdparty/http_parser">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.2009324169" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.1052374579" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.616870153" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
 							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.178829012" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1788566585" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.1084269655" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.703276143" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" valueType="stringList">
+									<listOptionValue builtIn="false" value="225"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.683660753" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
 									<listOptionValue builtIn="false" value="112"/>
 									<listOptionValue builtIn="false" value="238"/>
 								</option>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.508569045" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.618742225" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.749363186" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.451023477" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1115621240" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1476724959" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.379968879" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1468125451" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
 							</tool>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1269419142" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1971348601" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1565042844" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.834874640" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
 						</toolChain>
 					</folderInfo>
-					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.743788512" name="/" resourcePath="libraries/3rdparty/tinycbor">
-						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.47193189" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.1682862701" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.1849345295" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.950662943" name="/" resourcePath="libraries/3rdparty/tinycbor">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1570433729" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.742098529" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.1069055833" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
 							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.1915453430" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1105504362" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
-									<listOptionValue builtIn="false" value="188"/>
-									<listOptionValue builtIn="false" value="64"/>
-									<listOptionValue builtIn="false" value="190"/>
-									<listOptionValue builtIn="false" value="551"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.1933158198" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.1915651392" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" valueType="stringList">
+									<listOptionValue builtIn="false" value="225"/>
 								</option>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1502315440" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1207936741" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.1549602756" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
-								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1039367776" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1761485685" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="64"/>
+								</option>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1370931359" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.912087448" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.1617595870" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.732814300" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
 							</tool>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1827251559" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
-							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.906627391" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1356803871" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1583678794" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
 						</toolChain>
 					</folderInfo>
-					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.1440695165" name="transport_secure_sockets.c" rcbsApplicability="disable" resourcePath="libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.1024048950">
-						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.1024048950" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE.958333836" name="Mode" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE.automatic" valueType="enumerated"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_ONLY.318809403" name="Preprocess only (--preproc_only, -ppo)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_ONLY" value="false" valueType="boolean"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMPILE.633722406" name="Continue compilation after using -pp&lt;X&gt; options. (--preproc_with_compile, -ppa)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMPILE" value="false" valueType="boolean"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMMENT.551938174" name="Preprocess only; maintain comments (--preproc_with_comment, -ppc)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMMENT" value="false" valueType="boolean"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_DEPENDENCY.293722140" name="Generate include file dependency information (--preproc_dependency, -ppd)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_DEPENDENCY" value="" valueType="string"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_INCLUDES.1971853350" name="Generate first-level include file list (--preproc_includes, -ppi)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_INCLUDES" value="" valueType="string"/>
-							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MACROS.836508986" name="Generate list of pre- &amp; user-defined macros (--preproc_macros, -ppm)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MACROS" value="" valueType="string"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.417408879" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.477552426" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.211329487" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
-							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1829576007" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
-						</tool>
-						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.1644107177" name="Resource Custom Build Step">
-							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.1071938259" name="Resource Custom Build Step Input Type">
-								<additionalInput kind="additionalinputdependency" paths=""/>
-							</inputType>
-							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.621233050" name="Resource Custom Build Step Output Type"/>
-						</tool>
-					</fileInfo>
 					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" name="aws_secure_sockets.c" rcbsApplicability="disable" resourcePath="Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.965051836">
 						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.965051836" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
 							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.378660803" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>

--- a/projects/ti/cc3220_launchpad/ccs/aws_demos/.cproject
+++ b/projects/ti/cc3220_launchpad/ccs/aws_demos/.cproject
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?fileVersion 4.0.0?>
-<cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule configRelations="2" moduleId="org.eclipse.cdt.core.settings">
 		<cconfiguration id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304" moduleId="org.eclipse.cdt.core.settings" name="Debug">
@@ -17,7 +16,7 @@
 				<configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304" name="Debug" parent="com.ti.ccstudio.buildDefinitions.TMS470.Debug" postbuildStep="${CCS_INSTALL_ROOT}/utils/tiobj2bin/tiobj2bin ${BuildArtifactFileName} ${BuildArtifactFileBaseName}.bin ${CG_TOOL_ROOT}/bin/armofd ${CG_TOOL_ROOT}/bin/armhex ${CCS_INSTALL_ROOT}/utils/tiobj2bin/mkhex4bin;">
 					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304." name="/" resourcePath="">
 						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1202859196" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419">
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" useByScannerDiscovery="false" valueType="stringList">
+							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" useByScannerDiscovery="false" valueType="stringList">
 								<listOptionValue builtIn="false" value="DEVICE_CONFIGURATION_ID=Cortex M.CC3220SF"/>
 								<listOptionValue builtIn="false" value="DEVICE_ENDIANNESS=little"/>
 								<listOptionValue builtIn="false" value="OUTPUT_FORMAT=ELF"/>
@@ -32,7 +31,7 @@
 							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug.360757488" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
 							<builder buildPath="${BuildDirectory}" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.builderDebug.709560529" keepEnvironmentInBuildfile="false" name="GNU Make" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.builderDebug"/>
 							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug">
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE.1149275802" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE.1149275802" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="MBEDTLS_CONFIG_FILE=&quot;&lt;aws_mbedtls_config.h&gt;&quot;"/>
 									<listOptionValue builtIn="false" value="CONFIG_MEDTLS_USE_AFR_MEMORY"/>
 									<listOptionValue builtIn="false" value="CC3220sf"/>
@@ -41,8 +40,8 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE.995647985" name="Designate code state, 16-bit (thumb) or 32-bit (--code_state)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE.16" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI.1465385469" name="Application binary interface. (--abi)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI.eabi" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT.554673149" name="Specify floating point support (--float_support)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT.vfplib" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN.2031715668" name="Little endian code [See &apos;General&apos; page to edit] (--little_endian, -me)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN" value="true" valueType="boolean"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH.1680333660" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH" valueType="includePath">
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN.2031715668" name="Little endian code [See 'General' page to edit] (--little_endian, -me)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH.1680333660" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH" valueType="includePath">
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
 									<listOptionValue builtIn="false" value="${PROJECT_ROOT}"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../freertos_kernel/include"/>
@@ -104,12 +103,17 @@
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../libraries/3rdparty/tinycbor/src"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL.902230565" name="Debugging model" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL.SYMDEBUG__DWARF" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.444922035" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.444922035" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="225"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.1900164071" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER.937204773" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.1763087887" name="Level of printf/scanf support required (--printf_support)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.full" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.682014743" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="188"/>
+									<listOptionValue builtIn="false" value="190"/>
+									<listOptionValue builtIn="false" value="551"/>
+								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1403241110" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1490972185" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.283332974" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
@@ -120,17 +124,17 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.HEAP_SIZE.1360390015" name="Heap size for C/C++ dynamic memory allocation (--heap_size, -heap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.HEAP_SIZE" useByScannerDiscovery="false" value="0x0" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.MAP_FILE.1509122356" name="Link information (map) listed into &lt;file&gt; (--map_file, -m)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.MAP_FILE" useByScannerDiscovery="false" value="&quot;${ProjName}.map&quot;" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE.809721442" name="Specify output file name (--output_file, -o)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE" useByScannerDiscovery="false" value="${ProjName}.out" valueType="string"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY.559734136" name="Include library file or command file as input (--library, -l)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY" useByScannerDiscovery="false" valueType="libs">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY.559734136" name="Include library file or command file as input (--library, -l)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY" useByScannerDiscovery="false" valueType="libs">
 									<listOptionValue builtIn="false" value="libc.a"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/devices/cc32xx/driverlib/ccs/Release/driverlib.a"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/lib/drivers_cc32xx.aem4"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/net/wifi/ccs/rtos/simplelink.a"/>
 								</option>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH.882890543" name="Add &lt;dir&gt; to library search path (--search_path, -i)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH" useByScannerDiscovery="false" valueType="libPaths">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH.882890543" name="Add &lt;dir&gt; to library search path (--search_path, -i)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${CG_TOOL_ROOT}/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${CG_TOOL_ROOT}/include&quot;"/>
 								</option>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS.181966124" name="Suppress diagnostic &lt;id&gt; (--diag_suppress)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS.181966124" name="Suppress diagnostic &lt;id&gt; (--diag_suppress)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="10063"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP.154909932" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP" useByScannerDiscovery="false" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP.off" valueType="enumerated"/>
@@ -143,12 +147,85 @@
 							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex"/>
 						</toolChain>
 					</folderInfo>
-					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.226099389" name="base64.h" rcbsApplicability="disable" resourcePath="modules/libraries/3rdparty/mbedtls/include/mbedtls/base64.h" toolsToInvoke="">
-						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.1851883409" name="Resource Custom Build Step">
-							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.527576642" name="Resource Custom Build Step Input Type">
+					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.287057304" name="ota_mqtt.c" rcbsApplicability="disable" resourcePath="libraries/ota_for_aws/source/ota_mqtt.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.466119242">
+						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.466119242" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.2092282643" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+								<listOptionValue builtIn="false" value="188"/>
+								<listOptionValue builtIn="false" value="552"/>
+								<listOptionValue builtIn="false" value="190"/>
+								<listOptionValue builtIn="false" value="551"/>
+							</option>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1200994442" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1477896812" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.2138216823" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.2135434601" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+						</tool>
+						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.53438565" name="Resource Custom Build Step">
+							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.320039164" name="Resource Custom Build Step Input Type">
 								<additionalInput kind="additionalinputdependency" paths=""/>
 							</inputType>
-							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.8973357" name="Resource Custom Build Step Output Type"/>
+							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.27074320" name="Resource Custom Build Step Output Type"/>
+						</tool>
+					</fileInfo>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.14787231" name="/" resourcePath="libraries/coreHTTP/source/dependency/3rdparty/http_parser">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1754804276" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.972513289" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.1899464957" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
+							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.178829012" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1788566585" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="112"/>
+									<listOptionValue builtIn="false" value="238"/>
+								</option>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.508569045" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.618742225" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.749363186" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.451023477" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+							</tool>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1269419142" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1971348601" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
+						</toolChain>
+					</folderInfo>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.743788512" name="/" resourcePath="libraries/3rdparty/tinycbor">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.47193189" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444.1682862701" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1095113444"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535.1849345295" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.242431535"/>
+							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.1915453430" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1105504362" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="188"/>
+									<listOptionValue builtIn="false" value="64"/>
+									<listOptionValue builtIn="false" value="190"/>
+									<listOptionValue builtIn="false" value="551"/>
+								</option>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1502315440" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1207936741" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.1549602756" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1039367776" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+							</tool>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1827251559" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.140450419"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.906627391" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1802233196"/>
+						</toolChain>
+					</folderInfo>
+					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.1440695165" name="transport_secure_sockets.c" rcbsApplicability="disable" resourcePath="libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.1024048950">
+						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.1024048950" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463">
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE.958333836" name="Mode" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MODE.automatic" valueType="enumerated"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_ONLY.318809403" name="Preprocess only (--preproc_only, -ppo)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_ONLY" value="false" valueType="boolean"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMPILE.633722406" name="Continue compilation after using -pp&lt;X&gt; options. (--preproc_with_compile, -ppa)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMPILE" value="false" valueType="boolean"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMMENT.551938174" name="Preprocess only; maintain comments (--preproc_with_comment, -ppc)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_WITH_COMMENT" value="false" valueType="boolean"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_DEPENDENCY.293722140" name="Generate include file dependency information (--preproc_dependency, -ppd)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_DEPENDENCY" value="" valueType="string"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_INCLUDES.1971853350" name="Generate first-level include file list (--preproc_includes, -ppi)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_INCLUDES" value="" valueType="string"/>
+							<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MACROS.836508986" name="Generate list of pre- &amp; user-defined macros (--preproc_macros, -ppm)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PREPROC_MACROS" value="" valueType="string"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.417408879" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.477552426" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.211329487" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1829576007" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+						</tool>
+						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.1644107177" name="Resource Custom Build Step">
+							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.1071938259" name="Resource Custom Build Step Input Type">
+								<additionalInput kind="additionalinputdependency" paths=""/>
+							</inputType>
+							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.621233050" name="Resource Custom Build Step Output Type"/>
 						</tool>
 					</fileInfo>
 					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" name="aws_secure_sockets.c" rcbsApplicability="disable" resourcePath="Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.998481463.965051836">
@@ -163,6 +240,14 @@
 								<additionalInput kind="additionalinputdependency" paths=""/>
 							</inputType>
 							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.1283480675.1801883080.1657032300.1406013757" name="Resource Custom Build Step Output Type"/>
+						</tool>
+					</fileInfo>
+					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.226099389" name="base64.h" rcbsApplicability="disable" resourcePath="modules/libraries/3rdparty/mbedtls/include/mbedtls/base64.h" toolsToInvoke="">
+						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.1851883409" name="Resource Custom Build Step">
+							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.527576642" name="Resource Custom Build Step Input Type">
+								<additionalInput kind="additionalinputdependency" paths=""/>
+							</inputType>
+							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.8973357" name="Resource Custom Build Step Output Type"/>
 						</tool>
 					</fileInfo>
 					<sourceEntries>
@@ -193,4 +278,5 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 	<storageModule moduleId="scannerConfiguration"/>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 </cproject>

--- a/projects/ti/cc3220_launchpad/ccs/aws_tests/.cproject
+++ b/projects/ti/cc3220_launchpad/ccs/aws_tests/.cproject
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?fileVersion 4.0.0?>
-<cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule configRelations="2" moduleId="org.eclipse.cdt.core.settings">
 		<cconfiguration id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304" moduleId="org.eclipse.cdt.core.settings" name="Debug">
@@ -17,7 +16,7 @@
 				<configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304" name="Debug" parent="com.ti.ccstudio.buildDefinitions.TMS470.Debug" postbuildStep="${CCS_INSTALL_ROOT}/utils/tiobj2bin/tiobj2bin ${BuildArtifactFileName} ${BuildArtifactFileBaseName}.bin ${CG_TOOL_ROOT}/bin/armofd ${CG_TOOL_ROOT}/bin/armhex ${CCS_INSTALL_ROOT}/utils/tiobj2bin/mkhex4bin;">
 					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304." name="/" resourcePath="">
 						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.169515157" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1504862427">
-							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
 								<listOptionValue builtIn="false" value="DEVICE_CONFIGURATION_ID=Cortex M.CC3220SF"/>
 								<listOptionValue builtIn="false" value="DEVICE_ENDIANNESS=little"/>
 								<listOptionValue builtIn="false" value="OUTPUT_FORMAT=ELF"/>
@@ -32,7 +31,7 @@
 							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug.1298778267" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
 							<builder buildPath="${BuildDirectory}" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.builderDebug.1018806495" keepEnvironmentInBuildfile="false" name="GNU Make" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.builderDebug"/>
 							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug">
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE.1418291706" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE.1418291706" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEFINE" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="FREERTOS_ENABLE_UNIT_TESTS"/>
 									<listOptionValue builtIn="false" value="UNITY_INCLUDE_CONFIG_H"/>
 									<listOptionValue builtIn="false" value="CC3220sf"/>
@@ -43,8 +42,8 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE.1251104812" name="Designate code state, 16-bit (thumb) or 32-bit (--code_state)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.CODE_STATE.16" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI.2071140859" name="Application binary interface. (--abi)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.ABI.eabi" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT.339681752" name="Specify floating point support (--float_support)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.FLOAT_SUPPORT.vfplib" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN.700088682" name="Little endian code [See &apos;General&apos; page to edit] (--little_endian, -me)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN" value="true" valueType="boolean"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH.588385244" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH" valueType="includePath">
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN.700088682" name="Little endian code [See 'General' page to edit] (--little_endian, -me)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.LITTLE_ENDIAN" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH.588385244" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.INCLUDE_PATH" valueType="includePath">
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
 									<listOptionValue builtIn="false" value="${PROJECT_ROOT}"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../../../../../freertos_kernel/include"/>
@@ -110,11 +109,14 @@
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL.1257131903" name="Debugging model" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DEBUGGING_MODEL.SYMDEBUG__DWARF" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.1620303454" name="Level of printf/scanf support required (--printf_support)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.PRINTF_SUPPORT.full" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.1385508346" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING.1385508346" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WARNING" valueType="stringList">
 									<listOptionValue builtIn="false" value="225"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.2050796851" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER.43769799" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DISPLAY_ERROR_NUMBER" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1734352090" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="188"/>
+								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1780549437" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.2035953204" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.52280335" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
@@ -124,19 +126,19 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.STACK_SIZE.1116959894" name="Set C system stack size (--stack_size, -stack)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.STACK_SIZE" value="0x512" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.HEAP_SIZE.806790008" name="Heap size for C/C++ dynamic memory allocation (--heap_size, -heap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.HEAP_SIZE" value="0x0" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.MAP_FILE.321472469" name="Link information (map) listed into &lt;file&gt; (--map_file, -m)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.MAP_FILE" value="&quot;${ProjName}.map&quot;" valueType="string"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE.39250041" name="Specify output file name (--output_file, -o)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE" value="&quot;${ProjName}.out&quot;" valueType="string"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY.212434667" name="Include library file or command file as input (--library, -l)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY" valueType="libs">
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE.39250041" name="Specify output file name (--output_file, -o)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.OUTPUT_FILE" useByScannerDiscovery="false" value="${ProjName}.out" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY.212434667" name="Include library file or command file as input (--library, -l)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.LIBRARY" valueType="libs">
 									<listOptionValue builtIn="false" value="libc.a"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/devices/cc32xx/driverlib/ccs/Release/driverlib.a"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/lib/drivers_cc32xx.aem4"/>
 									<listOptionValue builtIn="false" value="${BASE_DIR_ROOT}/vendors/ti/SimpleLink_CC32xx/v2_10_00_04/source/ti/drivers/net/wifi/ccs/rtos/simplelink.a"/>
 									<listOptionValue builtIn="false" value="&quot;libc.a&quot;"/>
 								</option>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH.1801030930" name="Add &lt;dir&gt; to library search path (--search_path, -i)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH" valueType="libPaths">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH.1801030930" name="Add &lt;dir&gt; to library search path (--search_path, -i)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.SEARCH_PATH" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${CG_TOOL_ROOT}/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${CG_TOOL_ROOT}/include&quot;"/>
 								</option>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS.458508293" name="Suppress diagnostic &lt;id&gt; (--diag_suppress)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS.458508293" name="Suppress diagnostic &lt;id&gt; (--diag_suppress)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_SUPPRESS" valueType="stringList">
 									<listOptionValue builtIn="false" value="10063"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP.1508706809" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_16.9.linkerID.DIAG_WRAP.off" valueType="enumerated"/>
@@ -147,6 +149,61 @@
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exeLinker.inputType__GEN_CMDS.297233510" name="Generated Linker Command Files" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exeLinker.inputType__GEN_CMDS"/>
 							</tool>
 							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1797280613" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex"/>
+						</toolChain>
+					</folderInfo>
+					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.2018646885" name="iot_test_posix_utils.c" rcbsApplicability="disable" resourcePath="libraries/freertos_plus/standard/freertos_plus_posix/test/iot_test_posix_utils.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466.70766084">
+						<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466.70766084" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466">
+							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.899525433" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+								<listOptionValue builtIn="false" value="188"/>
+								<listOptionValue builtIn="false" value="69"/>
+							</option>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.904092358" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.605705146" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.7128817" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+							<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.561217328" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+						</tool>
+						<tool customBuildStep="true" id="org.eclipse.cdt.managedbuilder.ui.rcbs.2062384870" name="Resource Custom Build Step">
+							<inputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.inputtype.723790740" name="Resource Custom Build Step Input Type">
+								<additionalInput kind="additionalinputdependency" paths=""/>
+							</inputType>
+							<outputType id="org.eclipse.cdt.managedbuilder.ui.rcbs.outputtype.123077141" name="Resource Custom Build Step Output Type"/>
+						</tool>
+					</fileInfo>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.266432632" name="/" resourcePath="libraries/coreHTTP/source/dependency/3rdparty/http_parser">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1679045295" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399.1377454976" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.430336191.1908953729" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.430336191"/>
+							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.986186868" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.1590419871" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="112"/>
+									<listOptionValue builtIn="false" value="238"/>
+								</option>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.1000466360" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.2082319343" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.1718522197" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.441239501" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+							</tool>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.975743433" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1504862427"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1827758825" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1797280613"/>
+						</toolChain>
+					</folderInfo>
+					<folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.1249965403" name="/" resourcePath="libraries/3rdparty/tinycbor">
+						<toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain.1661362527" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.DebugToolchain" unusedChildren="">
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399.1932254889" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.414403399"/>
+							<option id="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.430336191.2127033771" name="Compiler version" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_CODEGEN_VERSION.430336191"/>
+							<targetPlatform id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug" name="Platform" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.targetPlatformDebug"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.1693557252" name="ARM Compiler" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS.507781001" name="Suppress diagnostic &lt;id&gt; (--diag_suppress, -pds)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compilerID.DIAG_SUPPRESS" valueType="stringList">
+									<listOptionValue builtIn="false" value="64"/>
+								</option>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS.776142714" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__C_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS.1719618881" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__CPP_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS.1460367054" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM_SRCS"/>
+								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS.1595490724" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.compiler.inputType__ASM2_SRCS"/>
+							</tool>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.37233665" name="ARM Linker" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.linkerDebug.1504862427"/>
+							<tool id="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.802289951" name="ARM Hex Utility" superClass="com.ti.ccstudio.buildDefinitions.TMS470_16.9.hex.1797280613"/>
 						</toolChain>
 					</folderInfo>
 					<fileInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Debug.362742304.Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" name="aws_secure_sockets.c" rcbsApplicability="disable" resourcePath="Libraries/AWS/SecureSockets/source/aws_secure_sockets.c" toolsToInvoke="com.ti.ccstudio.buildDefinitions.TMS470_16.9.exe.compilerDebug.392983466.1891517778">
@@ -199,4 +256,5 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 	<storageModule moduleId="scannerConfiguration"/>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 </cproject>

--- a/tests/common/iot_tests_network.c
+++ b/tests/common/iot_tests_network.c
@@ -42,5 +42,8 @@ static uint16_t _IotTestNetworkType = AWSIOT_NETWORK_TYPE_WIFI;
 bool IotTestNetwork_SelectNetworkType( uint16_t networkType )
 {
     _IotTestNetworkType = networkType;
+
+    ( void ) _IotTestNetworkType;
+
     return true;
 }

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -854,7 +854,7 @@ static void eventCallback( MQTTContext_t * pContext,
             incomingInfo.pPayload = NULL;
             /* Copy information of topic name and payload. */
             memcpy( ( void * ) incomingTopicBuffer, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
-            incomingInfo.pTopicName = ( const char * )incomingTopicBuffer;
+            incomingInfo.pTopicName = ( const char * ) incomingTopicBuffer;
             memcpy( ( void * ) incomingPayloadBuffer, pPublishInfo->pPayload, pPublishInfo->payloadLength );
             incomingInfo.pPayload = incomingPayloadBuffer;
 

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -854,7 +854,7 @@ static void eventCallback( MQTTContext_t * pContext,
             incomingInfo.pPayload = NULL;
             /* Copy information of topic name and payload. */
             memcpy( ( void * ) incomingTopicBuffer, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
-            incomingInfo.pTopicName = incomingTopicBuffer;
+            incomingInfo.pTopicName = ( const char * )incomingTopicBuffer;
             memcpy( ( void * ) incomingPayloadBuffer, pPublishInfo->pPayload, pPublishInfo->payloadLength );
             incomingInfo.pPayload = incomingPayloadBuffer;
 

--- a/tests/integration_test/ota_pal/aws_test_ota_pal.c
+++ b/tests/integration_test/ota_pal/aws_test_ota_pal.c
@@ -119,8 +119,10 @@ static uint8_t ucDummyData[] =
  * all zeros before every test. */
 static OtaFileContext_t xOtaFile;
 
-/* Certificate used for validating code signing signatures in the tests. */
-static const char codeSigningCertificatePEM[] = otapalconfigCODE_SIGNING_CERTIFICATE;
+#if ( otatestpalREAD_CERTIFICATE_FROM_NVM_WITH_PKCS11 == 1 )
+    /* Certificate used for validating code signing signatures in the tests. */
+    static const char codeSigningCertificatePEM[] = otapalconfigCODE_SIGNING_CERTIFICATE;
+#endif
 
 #ifdef CC3220sf
 

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -214,13 +214,6 @@ struct NetworkContext
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Global variable used by the pseudo random number generator.
- * The random number generator is used for calculating exponential back-off
- * with jitter for retry attempts of failed network operations with the broker.
- */
-static uint32_t nextRand;
-
-/**
  * @brief Packet Identifier generated when Subscribe request was sent to the broker;
  * it is used to match received Subscribe ACK to the transmitted subscribe.
  */
@@ -497,6 +490,10 @@ static void eventCallback( MQTTContext_t * pContext,
     uint16_t packetIdentifier;
 
     ( void ) pContext;
+    ( void ) receivedPubComp;
+    ( void ) receivedPubRec;
+    ( void ) receivedPubRel;
+
 
     assert( pDeserializedInfo != NULL );
     assert( pContext != NULL );

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/application_code/ti_code/uart_term.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/application_code/ti_code/uart_term.h
@@ -7,9 +7,11 @@
 
 //Defines
 
-#define UART_PRINT Report
-#define DBG_PRINT  Report
-#define ERR_PRINT(x) Report("Error [%d] at line [%d] in function [%s]  \n\r",x,__LINE__,__FUNCTION__)
+extern void vLoggingPrintf( const char * pcFormat,
+                            ... );
+#define UART_PRINT      vLoggingPrintf
+#define DBG_PRINT       vLoggingPrintf
+#define ERR_PRINT( x )  vLoggingPrintf( "Error [%d] at line [%d] in function [%s]  \n\r",x,__LINE__,__FUNCTION__ )
 
 /* API */
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/FreeRTOSConfig.h
@@ -26,14 +26,9 @@
 #ifndef FREERTOS_CONFIG_H
 #define FREERTOS_CONFIG_H
 
-
-#ifndef UART_PRINT
-
 /* Ensure stdint (needed by UART.h) is only used by the compiler, and not the assembler. */
 #ifndef __ASSEMBLER__
     #include "uart_term.h"
-#endif
-    #define UART_PRINT    Report
 #endif
 
 /*-----------------------------------------------------------
@@ -104,7 +99,7 @@ extern void vLoggingPrintf( const char * pcFormat,
 
 
 /* Map the logging task's printf to the board specific output function. */
-#define configPRINT_STRING( x )    UART_PRINT( x );
+#define configPRINT_STRING( x )    Message( x );
 
 /* Sets the length of the buffers into which logging messages are written - so
  * also defines the maximum length of each log message. */

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/application_code/ti_code/uart_term.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/application_code/ti_code/uart_term.h
@@ -7,9 +7,11 @@
 
 //Defines
 
-#define UART_PRINT Report
-#define DBG_PRINT  Report
-#define ERR_PRINT(x) Report("Error [%d] at line [%d] in function [%s]  \n\r",x,__LINE__,__FUNCTION__)
+extern void vLoggingPrintf( const char * pcFormat,
+                            ... );
+#define UART_PRINT      vLoggingPrintf
+#define DBG_PRINT       vLoggingPrintf
+#define ERR_PRINT( x )  vLoggingPrintf( "Error [%d] at line [%d] in function [%s]  \n\r",x,__LINE__,__FUNCTION__ )
 
 /* API */
 

--- a/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSConfig.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_tests/config_files/FreeRTOSConfig.h
@@ -34,10 +34,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     extern int DbgConsole_Printf( const char *fmt_s, ... );
     extern void vLoggingPrint( const char * pcMessage );
     extern void vLoggingPrintf( const char * pcFormat, ... );
-    #ifndef UART_PRINT
-      #include "uart_term.h"
-      #define UART_PRINT    Report
-    #endif
+    #include "uart_term.h"
 #endif
 
 
@@ -106,7 +103,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define configPRINT( X )     vLoggingPrint( X )
 
 /* Map the logging task's printf to the board specific output function. */
-#define configPRINT_STRING( x )    Report( x );
+#define configPRINT_STRING( x )    Message( x );
 
 /* Sets the length of the buffers into which logging messages are written - so
  * also defines the maximum length of each log message. */

--- a/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/ota_pal_for_aws/ota_pal.c
@@ -36,6 +36,10 @@
 #include <ti/devices/cc32xx/inc/hw_types.h>
 #include <ti/devices/cc32xx/driverlib/prcm.h>
 
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
 /* Specify the OTA signature algorithm we support on this platform. */
 const char OTA_JsonFileSignatureKey[ OTA_FILE_SIG_KEY_STR_MAX_LENGTH ] = "sig-sha1-rsa";
 

--- a/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/pkcs11/core_pkcs11_pal.c
@@ -410,7 +410,6 @@ CK_OBJECT_HANDLE PKCS11_PAL_FindObject( CK_BYTE_PTR pxLabel,
     char * pcFileName = NULL;
     int16_t iStatus = 0;
     SlFsFileInfo_t FsFileInfo = { 0 };
-    CK_BYTE_PTR pxZeroedData = NULL;
     CK_BYTE_PTR pxObject = NULL;
     CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
     CK_ULONG ulObjectLength = sizeof( CK_BYTE );

--- a/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
+++ b/vendors/ti/boards/cc3220_launchpad/ports/wifi/iot_wifi.c
@@ -1127,7 +1127,7 @@ WIFIReturnCode_t WIFI_ConfigureAP( const WIFINetworkParams_t * const pxNetworkPa
             sRetCode = sl_WlanSet( SL_WLAN_CFG_AP_ID,
                                    SL_WLAN_AP_OPT_SSID,
                                    strlen( cSSID ),
-                                   cSSID );
+                                   ( const  _u8 *) cSSID );
         }
 
         /* Print error, if there is one. */


### PR DESCRIPTION
Description
-----------
This PR also fixes mangled log issue - Logging messages printed to the UART are serialized via logging task to ensure that they are not mangled. Network logging messages were written to UART directly which occasionally would result in mangled messages like the following:

```
137 30980 [iot_thread] [INFO ][DEMO][30980] Demo completedDevice
disconnected from the AP on application's request successfully.
```
As a result CI would detect a demo/test failure even though it succeded. This commit redirects network logging message via logging task to ensure that they are not mangled with other logging messages.

Testing
--------

************************************
Build Warnings: Total warnings: 0
************************************

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.