### PR TITLE
Add logging to indicate when exceeding max ADV PDU data size

### DIFF
--- a/libraries/ble/src/iot_ble_gap.c
+++ b/libraries/ble/src/iot_ble_gap.c
@@ -652,6 +652,7 @@ BTStatus_t IotBle_On( void )
             if( status == eBTStatusSuccess )
             {
                 status = prvSetAdvData( &_scanRespParams );
+
                 if( status == eBTStatusNoMem )
                 {
                     IotLogError( "Exceeded max advertisement PDU data size. Please reduce advertised data." );

--- a/libraries/ble/src/iot_ble_gap.c
+++ b/libraries/ble/src/iot_ble_gap.c
@@ -652,6 +652,14 @@ BTStatus_t IotBle_On( void )
             if( status == eBTStatusSuccess )
             {
                 status = prvSetAdvData( &_scanRespParams );
+                if( status == eBTStatusNoMem )
+                {
+                    IotLogError( "Exceeded max advertisement PDU data size. Please reduce advertised data." );
+                }
+            }
+            else if( status == eBTStatusNoMem )
+            {
+                IotLogError( "Exceeded max advertisement PDU data size. Please reduce advertised data." );
             }
         }
 

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/iot_ble_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/iot_ble_config.h
@@ -34,6 +34,7 @@
 
 /* Device name for this peripheral device. */
 #define IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME                      "ESP32"
+#define IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE                    ( 5 )
 
 /* Include BLE default config at bottom to set the default values for the configurations which are not overridden */
 #include "iot_ble_config_defaults.h"

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/iot_ble_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/iot_ble_config.h
@@ -33,8 +33,8 @@
 #define _IOT_BLE_CONFIG_H_
 
 /* Device name for this peripheral device. */
-#define IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME                      "ESP32"
-#define IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE                    ( 5 )
+#define IOT_BLE_DEVICE_COMPLETE_LOCAL_NAME      "ESP32"
+#define IOT_BLE_DEVICE_SHORT_LOCAL_NAME_SIZE    ( 5 )
 
 /* Include BLE default config at bottom to set the default values for the configurations which are not overridden */
 #include "iot_ble_config_defaults.h"

--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
@@ -1,5 +1,5 @@
 /*
-* FreeRTOS
+ * FreeRTOS
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -238,9 +238,9 @@ BTStatus_t prvToggleBondableFlag( bool bEnable )
 
     ble_hs_cfg.sm_bonding = bEnable;
 
-    if ( bEnable )
+    if( bEnable )
     {
-        ble_hs_cfg.sm_our_key_dist   = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
+        ble_hs_cfg.sm_our_key_dist = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
         ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ID | BLE_SM_PAIR_KEY_DIST_ENC;
     }
 
@@ -565,7 +565,7 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
      *     o Discoverability in forthcoming advertisement (general)
      *     o BLE-only (BR/EDR unsupported).
      */
-    if ( !pxParams->bSetScanRsp )
+    if( !pxParams->bSetScanRsp )
     {
         fields.flags = BLE_HS_ADV_F_DISC_GEN |
                        BLE_HS_ADV_F_BREDR_UNSUP;
@@ -748,6 +748,7 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
         case BLE_HS_EMSGSIZE:
             xStatus = eBTStatusNoMem;
             break;
+
         default:
             xStatus = eBTStatusFail;
     }

--- a/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
+++ b/vendors/espressif/boards/ports/ble/nimble/iot_ble_hal_gap.c
@@ -743,9 +743,13 @@ BTStatus_t prvBTSetAdvData( uint8_t ucAdapterIf,
         xESPStatus = ble_gap_adv_set_fields( &fields );
     }
 
-    if( xESPStatus != 0 )
+    switch( xESPStatus )
     {
-        xStatus = eBTStatusFail;
+        case BLE_HS_EMSGSIZE:
+            xStatus = eBTStatusNoMem;
+            break;
+        default:
+            xStatus = eBTStatusFail;
     }
 
     if( xBTBleAdapterCallbacks.pxSetAdvDataCb != NULL )

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_internals.h
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_internals.h
@@ -140,6 +140,7 @@ static inline const BTStatus_t BTNRFError( const ret_code_t xErrCode )
             break;
 
         case NRF_ERROR_NO_MEM:
+        case NRF_ERROR_DATA_SIZE:
             xStatus = eBTStatusNoMem;
             break;
 

--- a/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_internals.h
+++ b/vendors/nordic/boards/nrf52840-dk/ports/ble/iot_ble_hal_internals.h
@@ -1,5 +1,5 @@
 /*
-* FreeRTOS
+ * FreeRTOS
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Description
-----------
Add logging when user attempts setting BT/BLE advertising data over the max ADV PDU data size, for our stack (BT/BLE v4.2). This mitigates issues like [this](https://github.com/aws/amazon-freertos/issues/3417). 

Also increases default length for esp32 ble demos, so that if fully displays default device name in advertisement, instead of truncating it as it was.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.