### PR TITLE
common-io UART fixes for Espressif's SoCs

### DIFF
--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -114,7 +114,14 @@ static void iot_uart_init( void )
     xUartConfig.ulBaudrate = 115200;
     xUartConfig.xParity = eUartParityNone;
     xUartConfig.xStopbits = eUartStopBitsOne;
-    xUartConfig.ucFlowControl = true;
+/*
+ * Application does not boot if flow control is enabled on
+ * the same UART port as that of IDF console. Hence, disable
+ * flow control if IDF console is set to UART 0.
+ */
+#if (CONFIG_ESP_CONSOLE_UART_NUM != 0)
+        xUartConfig.ucFlowControl = true;
+#endif
 
     status = iot_uart_ioctl( xConsoleUart, eUartSetConfig, &xUartConfig );
     configASSERT( status == IOT_UART_SUCCESS );

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -160,7 +160,14 @@ static void iot_uart_init( void )
     xUartConfig.ulBaudrate = 115200;
     xUartConfig.xParity = eUartParityNone;
     xUartConfig.xStopbits = eUartStopBitsOne;
-    xUartConfig.ucFlowControl = true;
+/*
+ * Application does not boot if flow control is enabled on
+ * the same UART port as that of IDF console. Hence, disable
+ * flow control if IDF console is set to UART 0.
+ */
+#if (CONFIG_ESP_CONSOLE_UART_NUM != 0)
+        xUartConfig.ucFlowControl = true;
+#endif
 
     status = iot_uart_ioctl( xConsoleUart, eUartSetConfig, &xUartConfig );
     configASSERT( status == IOT_UART_SUCCESS );

--- a/vendors/espressif/boards/esp32s2/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32s2/aws_demos/application_code/main.c
@@ -88,7 +88,14 @@ static void iot_uart_init( void )
     xUartConfig.ulBaudrate = 115200;
     xUartConfig.xParity = eUartParityNone;
     xUartConfig.xStopbits = eUartStopBitsOne;
-    xUartConfig.ucFlowControl = true;
+/*
+ * Application does not boot if flow control is enabled on
+ * the same UART port as that of IDF console. Hence, disable
+ * flow control if IDF console is set to UART 0.
+ */
+#if (CONFIG_ESP_CONSOLE_UART_NUM != 0)
+        xUartConfig.ucFlowControl = true;
+#endif
 
     status = iot_uart_ioctl( xConsoleUart, eUartSetConfig, &xUartConfig );
     configASSERT( status == IOT_UART_SUCCESS );

--- a/vendors/espressif/boards/ports/common_io/include/iot_board_gpio.h
+++ b/vendors/espressif/boards/ports/common_io/include/iot_board_gpio.h
@@ -57,8 +57,8 @@ struct esp_spi_pin_config {
 #define ESP_UART_PIN_MAP  {       \
     /* UART 0 */                  \
     { GPIO_NUM_1, GPIO_NUM_3 },   \
-    /* UART 1: this ACK team's preference */  \
-    { GPIO_NUM_19, GPIO_NUM_20 }, \
+    /* UART 1 */                  \
+    { GPIO_NUM_33, GPIO_NUM_34 }, \
     /* UART 2 */                  \
     { GPIO_NUM_17, GPIO_NUM_16 }, \
 }

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -308,7 +308,6 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
             case eUartSetConfig : {
                 int32_t uart_port_num = uart_ctx->uart_port_num;
                 IotUARTConfig_t *iot_uart_config = (IotUARTConfig_t *) pvBuffer;
-                memcpy(&uart_ctx->iot_uart_conf, iot_uart_config, sizeof(IotUARTConfig_t));
                 uart_config_t uart_config = {0};
                 uart_config.baud_rate = iot_uart_config->ulBaudrate;
                 if (iot_uart_config->ucWordlength == 5) {
@@ -372,7 +371,8 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
                     return IOT_UART_INVALID_VALUE;
                 }
 
-                return (ret == ESP_OK) ? IOT_UART_SUCCESS : IOT_UART_INVALID_VALUE;
+                memcpy(&uart_ctx->iot_uart_conf, iot_uart_config, sizeof(IotUARTConfig_t));
+                return IOT_UART_SUCCESS;
             }
             case eUartGetConfig : {
                 IotUARTConfig_t *iot_uart_config = (IotUARTConfig_t *) pvBuffer;

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -311,7 +311,18 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
                 memcpy(&uart_ctx->iot_uart_conf, iot_uart_config, sizeof(IotUARTConfig_t));
                 uart_config_t uart_config = {0};
                 uart_config.baud_rate = iot_uart_config->ulBaudrate;
-                uart_config.data_bits = iot_uart_config->ucWordlength;
+                if (iot_uart_config->ucWordlength == 5) {
+                    uart_config.data_bits = UART_DATA_5_BITS;
+                } else if (iot_uart_config->ucWordlength == 6) {
+                    uart_config.data_bits = UART_DATA_6_BITS;
+                } else if (iot_uart_config->ucWordlength == 7) {
+                    uart_config.data_bits = UART_DATA_7_BITS;
+                } else if (iot_uart_config->ucWordlength == 8) {
+                    uart_config.data_bits = UART_DATA_8_BITS;
+                } else {
+                    return IOT_UART_INVALID_VALUE;
+                }
+
                 if (iot_uart_config->ucFlowControl == true) {
                     uart_config.flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
                     uart_config.rx_flow_ctrl_thresh = UART_FIFO_LEN;

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -267,6 +267,13 @@ IotUARTHandle_t iot_uart_open(int32_t lUartInstance)
             return NULL;
         }
 
+        /* Set default config in UART context before returning */
+        uart_ctx->iot_uart_conf.ulBaudrate = IOT_UART_BAUD_RATE_DEFAULT;
+        uart_ctx->iot_uart_conf.xParity = eUartParityNone;
+        uart_ctx->iot_uart_conf.xStopbits = eUartStopBitsOne;
+        uart_ctx->iot_uart_conf.ucWordlength = 8;
+        uart_ctx->iot_uart_conf.ucFlowControl = 0;
+
         IotUARTHandle_t iot_uart_handler = (void *) uart_ctx;
         uart_bit_mask = uart_bit_mask | BIT(lUartInstance);
         return iot_uart_handler;

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -356,9 +356,22 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
                     uart_config.baud_rate = IOT_UART_BAUD_RATE_DEFAULT;
                 }
                 ret = uart_driver_delete(uart_port_num);
-                ret |= iot_uart_driver_install(uart_port_num, uart_config);
+                if (ret != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to delete UART driver");
+                    return IOT_UART_INVALID_VALUE;
+                }
+                ret = iot_uart_driver_install(uart_port_num, uart_config);
+                if (ret != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to install UART driver");
+                    return IOT_UART_INVALID_VALUE;
+                }
                 //Create a callback function to handle UART event from ISR
                 ret = uart_register_callback_with_isr(uart_port_num, uart_event_cb, (void *)iot_uart_handler);
+                if (ret != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to register callback");
+                    return IOT_UART_INVALID_VALUE;
+                }
+
                 return (ret == ESP_OK) ? IOT_UART_SUCCESS : IOT_UART_INVALID_VALUE;
             }
             case eUartGetConfig : {

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -309,7 +309,7 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
                 int32_t uart_port_num = uart_ctx->uart_port_num;
                 IotUARTConfig_t *iot_uart_config = (IotUARTConfig_t *) pvBuffer;
                 memcpy(&uart_ctx->iot_uart_conf, iot_uart_config, sizeof(IotUARTConfig_t));
-                uart_config_t uart_config;
+                uart_config_t uart_config = {0};
                 uart_config.baud_rate = iot_uart_config->ulBaudrate;
                 uart_config.data_bits = iot_uart_config->ucWordlength;
                 if (iot_uart_config->ucFlowControl == true) {

--- a/vendors/espressif/boards/ports/common_io/iot_uart.c
+++ b/vendors/espressif/boards/ports/common_io/iot_uart.c
@@ -325,7 +325,9 @@ int32_t iot_uart_ioctl(IotUARTHandle_t const pxUartPeripheral, IotUARTIoctlReque
 
                 if (iot_uart_config->ucFlowControl == true) {
                     uart_config.flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
-                    uart_config.rx_flow_ctrl_thresh = UART_FIFO_LEN;
+                    uart_config.rx_flow_ctrl_thresh = (UART_FIFO_LEN / 2);
+                } else {
+                    uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
                 }
                 switch (iot_uart_config->xParity) {
                     case eUartParityNone:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* Minor changes to the fixes from https://github.com/aws/amazon-freertos/pull/3394
* Disables flow control in aws_demos and aws_tests application for ESP32 and ESP32-S2
* Unifies pin map for ESP32-S2

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.