### PR TITLE
[Posix] Add pthread_detach API and tests

### DIFF
--- a/libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h
+++ b/libraries/abstractions/posix/include/FreeRTOS_POSIX/pthread.h
@@ -358,6 +358,18 @@ int pthread_getschedparam( pthread_t thread,
 int pthread_join( pthread_t thread,
                   void ** retval );
 
+
+/**
+ * @brief  Marks the thread identified by thread as detached.
+ *
+ * @see https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_detach.html
+ *
+ * @retval 0 - Upon successful completion.
+ * @retval EINVAL - The implementation has detected that the value specified by thread does not refer
+ *                  to a joinable thread.
+ */
+int pthread_detach( pthread_t thread );
+
 /**
  * @brief Destroy a mutex.
  *


### PR DESCRIPTION
Add pthread_detach API and tests

Description
-----------

This merges changes from [PR](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-POSIX/pull/11) which adds a new API to detach a joinable thread.
This PR adds tests for the changes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.