### PR TITLE
Update timeout tolerance for lpc54018iotmodule

### DIFF
--- a/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_tcp_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_tests/config_files/aws_test_tcp_config.h
@@ -43,7 +43,7 @@
  * This value can be used to compensate for clock differences, and other
  * code overhead.
  */
-#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      200
+#define         integrationtestportableTIMEOUT_OVER_TOLERANCE      500
 
 /**
  * @brief Indicates how much less time than the specified timeout is acceptable for


### PR DESCRIPTION
AFQP_SECURE_SOCKETS_NonBlocking_Test for the lpc54018iotmodule has been failing for a while now because the timeout tolerance is not high enough.