### PR TITLE
modify the handling of the return value of C_Login() function to avoi…

### DIFF
--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -522,7 +522,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                                     sizeof( configPKCS11_DEFAULT_USER_PIN ) - 1 );
     }
 
-    if( CKR_OK == xResult || CKR_USER_ALREADY_LOGGED_IN == xResult )
+    if( ( CKR_OK == xResult ) || ( CKR_USER_ALREADY_LOGGED_IN == xResult ) )
     {
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
@@ -712,7 +712,7 @@ BaseType_t TLS_Init( void ** ppvContext,
             xResult = xInitializePkcs11Session( &pxCtx->xP11Session );
 
             /* It is ok if the module was previously initialized. */
-            if( xResult == CKR_CRYPTOKI_ALREADY_INITIALIZED || CKR_USER_ALREADY_LOGGED_IN == xResult )
+            if( ( xResult == CKR_CRYPTOKI_ALREADY_INITIALIZED ) || ( CKR_USER_ALREADY_LOGGED_IN == xResult ) )
             {
                 xResult = CKR_OK;
             }

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -522,7 +522,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
                                                                     sizeof( configPKCS11_DEFAULT_USER_PIN ) - 1 );
     }
 
-    if( CKR_OK == xResult )
+    if( CKR_OK == xResult || CKR_USER_ALREADY_LOGGED_IN == xResult )
     {
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
@@ -712,7 +712,7 @@ BaseType_t TLS_Init( void ** ppvContext,
             xResult = xInitializePkcs11Session( &pxCtx->xP11Session );
 
             /* It is ok if the module was previously initialized. */
-            if( xResult == CKR_CRYPTOKI_ALREADY_INITIALIZED )
+            if( xResult == CKR_CRYPTOKI_ALREADY_INITIALIZED || CKR_USER_ALREADY_LOGGED_IN == xResult )
             {
                 xResult = CKR_OK;
             }


### PR DESCRIPTION

Description
-----------
I found an issue related to the handling of return value of C_Login() function in AFR.
When the MQTT demo project is run, the AFR call TLS_Init () in iot_tls.c,   and call xInitializePkcs11Session() to initialize the PKCS11 session, C_Login() is called in this function for the first time.
After this, the program call prvInitializeClientCredential() , C_Login() is called in this function for the second time. 
As the session is already login in xInitializePkcs11Session(), the return value of C_Login() in prvInitializeClientCredential() is CKR_USER_ALREADY_LOGGED_IN (0x100), not CKR_OK (0x0)
This make the xInitializePkcs11Session got fail and also fail to create the TLS connection for MQTT connection.


