### PR TITLE
iot_wifi.c: Clear `wifi_config` immediately after usage

### DIFF
--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -514,6 +514,7 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
         ret = esp_wifi_get_mode( &xCurMode );
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Failed to get wifi mode %d", __func__, ret);
+            memset(&wifi_config, 0x00, sizeof(wifi_config_t));
             xSemaphoreGive( xWiFiSem );
         	return eWiFiFailure;
         }
@@ -523,6 +524,7 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
             ret = esp_wifi_set_mode(WIFI_MODE_STA);
             if (ret != ESP_OK) {
         		ESP_LOGE(TAG, "%s: Failed to set wifi mode %d", __func__, ret);
+                memset(&wifi_config, 0x00, sizeof(wifi_config_t));
                 xSemaphoreGive( xWiFiSem );
                 return wifi_ret;
             }
@@ -531,12 +533,15 @@ WIFIReturnCode_t WIFI_ConnectAP( const WIFINetworkParams_t * const pxNetworkPara
             ret = esp_hal_wifi_start();
             if (ret != ESP_OK) {
                 ESP_LOGE(TAG, "%s: Failed to start wifi %d", __func__, ret);
+                memset(&wifi_config, 0x00, sizeof(wifi_config_t));
                 xSemaphoreGive( xWiFiSem );
                 return wifi_ret;
             }
         }
 
         ret = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config);
+        memset(&wifi_config, 0x00, sizeof(wifi_config_t));
+
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Failed to set wifi config %d", __func__, ret);
             xSemaphoreGive( xWiFiSem );
@@ -1467,6 +1472,7 @@ WIFIReturnCode_t WIFI_ConfigureAP( const WIFINetworkParams_t * const pxNetworkPa
         ret = WIFI_SetSecurity(pxNetworkParams->xSecurity, &wifi_config.ap.authmode);
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Invalid security mode %d", __func__, ret);
+            memset(&wifi_config, 0x00, sizeof(wifi_config_t));
             xSemaphoreGive( xWiFiSem );
             return wifi_ret;
         }
@@ -1474,11 +1480,14 @@ WIFIReturnCode_t WIFI_ConfigureAP( const WIFINetworkParams_t * const pxNetworkPa
         ret = esp_wifi_set_mode(WIFI_MODE_AP);
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Failed to set wifi mode %d", __func__, ret);
+            memset(&wifi_config, 0x00, sizeof(wifi_config_t));
             xSemaphoreGive( xWiFiSem );
             return wifi_ret;
         }
 
         ret = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config);
+        memset(&wifi_config, 0x00, sizeof(wifi_config_t));
+
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "%s: Failed to set wifi config %d", __func__, ret);
             xSemaphoreGive( xWiFiSem );


### PR DESCRIPTION
Description
-----------
`vendors/espressif -> iot_wifi.c` : Clear the `wifi_config` struct (containing the SSID/Passphrase) immediately after usage or before returning from the concerned function.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.