### PR TITLE
Modified in TI code to use Starfield root CA for CORE_HTTP_S3_xxx demos.

### DIFF
--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -89,6 +89,9 @@
 /* HTTP API header. */
 #include "core_http_client.h"
 
+/* Include header for root CA certificates. */
+#include "iot_default_root_certificates.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */

--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -99,6 +99,9 @@
 /* HTTP API header. */
 #include "core_http_client.h"
 
+/* Include header for root CA certificates. */
+#include "iot_default_root_certificates.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */

--- a/demos/coreHTTP/http_demo_s3_upload.c
+++ b/demos/coreHTTP/http_demo_s3_upload.c
@@ -82,6 +82,9 @@
 /* HTTP API header. */
 #include "core_http_client.h"
 
+/* Include header for root CA certificates. */
+#include "iot_default_root_certificates.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_config.h
@@ -83,7 +83,8 @@
  *
  */
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM                                        \
+    #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+    /*#define democonfigROOT_CA_PEM                                        \
     "-----BEGIN CERTIFICATE-----\n"                                      \
     "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
     "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
@@ -103,7 +104,7 @@
     "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
     "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
     "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"
+    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_config.h
@@ -69,10 +69,18 @@
     #define democonfigHTTPS_PORT    443
 #endif
 
-/*
+/**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Amazon Root CA Certificate is defined below.
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below for
+ * information about server root CAs.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ * 
+ * @note The TI C3220 Launchpad board requires that the root CA have its
+ * certificate self-signed. As specified in the link above, the Amazon Root CAs
+ * are cross-signed by the Starfield Root CA. Thus, ONLY the Starfield Root CA
+ * can be used to connect to the ATS endpoints on AWS IoT, for the TI board.
  *
  * @note This certificate should be PEM-encoded.
  *
@@ -84,27 +92,6 @@
  */
 #ifndef democonfigROOT_CA_PEM
     #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
-    /*#define democonfigROOT_CA_PEM                                        \
-    "-----BEGIN CERTIFICATE-----\n"                                      \
-    "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
-    "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
-    "b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n" \
-    "MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n" \
-    "b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n" \
-    "ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n" \
-    "9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n" \
-    "IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n" \
-    "VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n" \
-    "93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n" \
-    "jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n" \
-    "AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n" \
-    "A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n" \
-    "U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n" \
-    "N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n" \
-    "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
-    "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
-    "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -83,6 +83,8 @@
  *
  */
 #ifndef democonfigROOT_CA_PEM
+    #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+    /*
     #define democonfigROOT_CA_PEM                                        \
     "-----BEGIN CERTIFICATE-----\n"                                      \
     "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
@@ -103,7 +105,7 @@
     "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
     "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
     "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"
+    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_download_multithreaded_config.h
@@ -69,10 +69,18 @@
     #define democonfigHTTPS_PORT    443
 #endif
 
-/*
+/**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Amazon Root CA Certificate is defined below.
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below for
+ * information about server root CAs.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ * 
+ * @note The TI C3220 Launchpad board requires that the root CA have its
+ * certificate self-signed. As specified in the link above, the Amazon Root CAs
+ * are cross-signed by the Starfield Root CA. Thus, ONLY the Starfield Root CA
+ * can be used to connect to the ATS endpoints on AWS IoT, for the TI board.
  *
  * @note This certificate should be PEM-encoded.
  *
@@ -84,28 +92,6 @@
  */
 #ifndef democonfigROOT_CA_PEM
     #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
-    /*
-    #define democonfigROOT_CA_PEM                                        \
-    "-----BEGIN CERTIFICATE-----\n"                                      \
-    "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
-    "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
-    "b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n" \
-    "MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n" \
-    "b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n" \
-    "ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n" \
-    "9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n" \
-    "IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n" \
-    "VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n" \
-    "93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n" \
-    "jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n" \
-    "AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n" \
-    "A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n" \
-    "U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n" \
-    "N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n" \
-    "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
-    "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
-    "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
@@ -92,27 +92,6 @@
  */
 #ifndef democonfigROOT_CA_PEM
     #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
-    /*#define democonfigROOT_CA_PEM                                        \
-    "-----BEGIN CERTIFICATE-----\n"                                      \
-    "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
-    "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
-    "b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n" \
-    "MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n" \
-    "b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n" \
-    "ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n" \
-    "9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n" \
-    "IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n" \
-    "VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n" \
-    "93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n" \
-    "jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n" \
-    "AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n" \
-    "A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n" \
-    "U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n" \
-    "N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n" \
-    "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
-    "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
-    "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
@@ -83,7 +83,8 @@
  *
  */
 #ifndef democonfigROOT_CA_PEM
-    #define democonfigROOT_CA_PEM                                        \
+    #define democonfigROOT_CA_PEM  tlsSTARFIELD_ROOT_CERTIFICATE_PEM
+    /*#define democonfigROOT_CA_PEM                                        \
     "-----BEGIN CERTIFICATE-----\n"                                      \
     "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
     "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
@@ -103,7 +104,7 @@
     "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
     "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
     "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
-    "-----END CERTIFICATE-----"
+    "-----END CERTIFICATE-----"*/
 #endif /* ifndef democonfigROOT_CA_PEM */
 
 /**

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/http_demo_s3_upload_config.h
@@ -69,11 +69,19 @@
     #define democonfigHTTPS_PORT    443
 #endif
 
-/*
+/**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Amazon Root CA Certificate is defined below.
- *
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below for
+ * information about server root CAs.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ * 
+ * @note The TI C3220 Launchpad board requires that the root CA have its
+ * certificate self-signed. As specified in the link above, the Amazon Root CAs
+ * are cross-signed by the Starfield Root CA. Thus, ONLY the Starfield Root CA
+ * can be used to connect to the ATS endpoints on AWS IoT, for the TI board.
+ * 
  * @note This certificate should be PEM-encoded.
  *
  * Must include the PEM header and footer:


### PR DESCRIPTION
Description
-----------
TI board needs to use Starfield root CA to connect AWS iot endpoint.  For pre-signed url access demos, this is also the case. 
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.