### PR TITLE
tests: add macro warpper in header files

### DIFF
--- a/tests/include/aws_clientcredential.h
+++ b/tests/include/aws_clientcredential.h
@@ -26,42 +26,56 @@
 #ifndef __AWS_CLIENTCREDENTIAL__H__
 #define __AWS_CLIENTCREDENTIAL__H__
 
+/* @TEST_ANCHOR */
+
 /*
  * @brief MQTT Broker endpoint.
  *
  * @todo Set this to the fully-qualified DNS name of your MQTT broker.
  */
-#define clientcredentialMQTT_BROKER_ENDPOINT         ""
+#ifndef clientcredentialMQTT_BROKER_ENDPOINT
+    #define clientcredentialMQTT_BROKER_ENDPOINT    ""
+#endif
 
 /*
  * @brief Host name.
  *
  * @todo Set this to the unique name of your IoT Thing.
  */
-#define clientcredentialIOT_THING_NAME               ""
+#ifndef clientcredentialIOT_THING_NAME
+    #define clientcredentialIOT_THING_NAME    ""
+#endif
 
 /*
  * @brief Port number the MQTT broker is using.
  */
-#define clientcredentialMQTT_BROKER_PORT             8883
+#ifndef clientcredentialMQTT_BROKER_PORT
+    #define clientcredentialMQTT_BROKER_PORT    8883
+#endif
 
 /*
  * @brief Port number the Green Grass Discovery use for JSON retrieval from cloud is using.
  */
-#define clientcredentialGREENGRASS_DISCOVERY_PORT    8443
+#ifndef clientcredentialGREENGRASS_DISCOVERY_PORT
+    #define clientcredentialGREENGRASS_DISCOVERY_PORT    8443
+#endif
 
 /*
  * @brief Wi-Fi network to join.
  *
  * @todo If you are using Wi-Fi, set this to your network name.
  */
-#define clientcredentialWIFI_SSID                    ""
+#ifndef clientcredentialWIFI_SSID
+    #define clientcredentialWIFI_SSID    ""
+#endif
 
 /*
  * @brief Password needed to join Wi-Fi network.
  * @todo If you are using WPA, set this to your network password.
  */
-#define clientcredentialWIFI_PASSWORD                ""
+#ifndef clientcredentialWIFI_PASSWORD
+    #define clientcredentialWIFI_PASSWORD    ""
+#endif
 
 /*
  * @brief Wi-Fi network security type.
@@ -71,6 +85,8 @@
  * @note Possible values are eWiFiSecurityOpen, eWiFiSecurityWEP, eWiFiSecurityWPA,
  * eWiFiSecurityWPA2 (depending on the support of your device Wi-Fi radio).
  */
-#define clientcredentialWIFI_SECURITY                eWiFiSecurityWPA2
+#ifndef clientcredentialWIFI_SECURITY
+    #define clientcredentialWIFI_SECURITY    eWiFiSecurityWPA2
+#endif
 
 #endif /* ifndef __AWS_CLIENTCREDENTIAL__H__ */

--- a/tests/include/aws_clientcredential_keys.h
+++ b/tests/include/aws_clientcredential_keys.h
@@ -26,6 +26,8 @@
 #ifndef AWS_CLIENT_CREDENTIAL_KEYS_H
 #define AWS_CLIENT_CREDENTIAL_KEYS_H
 
+/* @TEST_ANCHOR */
+
 /*
  * @brief PEM-encoded client certificate.
  *
@@ -37,7 +39,9 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyCLIENT_CERTIFICATE_PEM                   NULL
+#ifndef keyCLIENT_CERTIFICATE_PEM
+    #define keyCLIENT_CERTIFICATE_PEM    NULL
+#endif
 
 /*
  * @brief PEM-encoded issuer certificate for AWS IoT Just In Time Registration (JITR).
@@ -58,7 +62,9 @@
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  */
-#define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
+#ifndef keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM
+    #define keyJITR_DEVICE_CERTIFICATE_AUTHORITY_PEM    NULL
+#endif
 
 /*
  * @brief PEM-encoded client private key.
@@ -71,6 +77,8 @@
  * "...base64 data...\n"\
  * "-----END RSA PRIVATE KEY-----\n"
  */
-#define keyCLIENT_PRIVATE_KEY_PEM                   NULL
+#ifndef keyCLIENT_PRIVATE_KEY_PEM
+    #define keyCLIENT_PRIVATE_KEY_PEM    NULL
+#endif
 
 #endif /* AWS_CLIENT_CREDENTIAL_KEYS_H */


### PR DESCRIPTION
Description
the predefined macros do not have a wrapper,
add wrapper will make the test flexible to different run settings

the user cases is we have CFLAGS set in build time, which can enable the application with our test envrionment.

Checklist:
[ x] I have tested my changes. No regression in existing tests.
[x ] My code is Linted.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.