### PR TITLE
Increase log buffer size in ecc608a_plus_winsim

### DIFF
--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/application_code/aws_demo_logging.c
@@ -61,7 +61,7 @@
 #define dlLOGGING_FILE_SIZE             ( 40 * 1024 * 1024 )
 
 /* Dimensions the arrays into which print messages are created. */
-#define dlMAX_PRINT_STRING_LENGTH       255
+#define dlMAX_PRINT_STRING_LENGTH       1024
 
 /* The size of the stream buffer used to pass messages from FreeRTOS tasks to
  * the Win32 thread that is responsible for making any Win32 system calls that are


### PR DESCRIPTION
Increasing the log buffer since demos can cause it to overflow, causing our testing to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.