### PR TITLE
ble_wifi_prov: Add end of the list marker for list network response

### DIFF
--- a/libraries/ble/include/iot_ble_wifi_provisioning.h
+++ b/libraries/ble/include/iot_ble_wifi_provisioning.h
@@ -116,6 +116,7 @@ typedef struct
     bool isSavedNetwork : 1;                  /**< A flag to signify whether this network is a saved network or scanned network. */
     bool isConnected : 1;                     /**< A flag to signify whether this network is connected. */
     bool isHidden : 1;                        /**< A flag to signify whether this is an hidden network. */
+    bool isLast : 1;                          /**< A flag to signify if this is last in the list of scanned or saved networks. */
 } IotBleWifiProvNetworkInfo_t;
 
 /**

--- a/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -457,7 +457,8 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
 
 
 static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork,
-                                 uint16_t priority, bool isLast )
+                                 uint16_t priority,
+                                 bool isLast )
 {
     IotBleWifiProvResponse_t response = { 0 };
 
@@ -474,7 +475,8 @@ static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork,
 
 /*-----------------------------------------------------------*/
 
-static void prvSendScanNetwork( WIFIScanResult_t * pNetwork, bool isLast )
+static void prvSendScanNetwork( WIFIScanResult_t * pNetwork,
+                                bool isLast )
 {
     IotBleWifiProvResponse_t response = { 0 };
 
@@ -696,6 +698,7 @@ static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * 
             {
                 isLast = false;
             }
+
             prvSendSavedNetwork( &profile, idx, isLast );
         }
     }
@@ -730,6 +733,7 @@ static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * 
                 {
                     isLast = false;
                 }
+
                 prvSendScanNetwork( &scanNetworks[ idx ], isLast );
             }
         }

--- a/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -457,13 +457,14 @@ static void prvSendListNetworkResponse( IotBleWifiProvResponse_t * pResponse )
 
 
 static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork,
-                                 uint16_t priority )
+                                 uint16_t priority, bool isLast )
 {
     IotBleWifiProvResponse_t response = { 0 };
 
     response.requestType = IotBleWiFiProvRequestListNetwork;
     response.networkInfo.isSavedNetwork = true;
     response.networkInfo.isHidden = false;
+    response.networkInfo.isLast = isLast;
     response.networkInfo.isConnected = ( wifiProvisioning.connectedIdx == priority );
     response.networkInfo.info.pSavedNetwork = pNetwork;
     response.networkInfo.index = priority;
@@ -473,7 +474,7 @@ static void prvSendSavedNetwork( WIFINetworkProfile_t * pNetwork,
 
 /*-----------------------------------------------------------*/
 
-static void prvSendScanNetwork( WIFIScanResult_t * pNetwork )
+static void prvSendScanNetwork( WIFIScanResult_t * pNetwork, bool isLast )
 {
     IotBleWifiProvResponse_t response = { 0 };
 
@@ -481,6 +482,7 @@ static void prvSendScanNetwork( WIFIScanResult_t * pNetwork )
     response.networkInfo.isSavedNetwork = false;
     response.networkInfo.isHidden = false;
     response.networkInfo.isConnected = false;
+    response.networkInfo.isLast = isLast;
     response.networkInfo.info.pScannedNetwork = pNetwork;
 
     prvSendListNetworkResponse( &response );
@@ -674,9 +676,9 @@ WIFIReturnCode_t _insertNetwork( uint16_t index,
 static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * pRequest )
 {
     WIFINetworkProfile_t profile;
-    uint16_t idx;
+    uint16_t idx, numNetworks;
     WIFIReturnCode_t status;
-    uint32_t networks_found = 0;
+    bool isLast = false;
 
     ( void ) pRequest->scanTimeoutMS;
 
@@ -686,7 +688,15 @@ static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * 
 
         if( status == eWiFiSuccess )
         {
-            prvSendSavedNetwork( &profile, idx );
+            if( idx == wifiProvisioning.numNetworks - 1 )
+            {
+                isLast = true;
+            }
+            else
+            {
+                isLast = false;
+            }
+            prvSendSavedNetwork( &profile, idx, isLast );
         }
     }
 
@@ -696,18 +706,32 @@ static void prvProcessListNetworkRequest( IotBleWifiProvListNetworksRequest_t * 
 
     if( status == eWiFiSuccess )
     {
-        for( idx = 0; idx < pRequest->scanSize; idx++ )
+        for( numNetworks = 0; numNetworks < pRequest->scanSize; numNetworks++ )
         {
-            if( scanNetworks[ idx ].ucSSIDLength > 0 )
+            if( scanNetworks[ numNetworks ].ucSSIDLength == 0 )
             {
-                networks_found++;
-                prvSendScanNetwork( &scanNetworks[ idx ] );
+                break;
             }
         }
 
-        if( networks_found == 0 )
+        if( numNetworks == 0 )
         {
             prvSendStatusResponse( IotBleWiFiProvRequestListNetwork, status );
+        }
+        else
+        {
+            for( idx = 0; idx < numNetworks; idx++ )
+            {
+                if( idx == numNetworks - 1 )
+                {
+                    isLast = true;
+                }
+                else
+                {
+                    isLast = false;
+                }
+                prvSendScanNetwork( &scanNetworks[ idx ], isLast );
+            }
         }
     }
     else

--- a/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
+++ b/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning_serializer.c
@@ -76,6 +76,7 @@
 #define IOT_BLE_WIFI_PROV_INDEX_KEY            "g"
 #define IOT_BLE_WIFI_PROV_NEWINDEX_KEY         "j"
 #define IOT_BLE_WIFI_PROV_CONNECT_KEY          "y"
+#define IOT_BLE_WIFI_PROV_END_MARKER_KEY       "l"
 
 /**
  * @brief Defines the serialized values for WiFi security types.
@@ -98,7 +99,7 @@
  * @brief Number of parameters in a list network response.
  * This defines the  size of the CBOR map used to serialize the list network response messages.
  */
-#define IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS    ( 9 )
+#define IOT_BLE_WIFI_PROV_NETWORK_INFO_RESPONSE_NUM_PARAMS    ( 10 )
 
 /**
  * @brief Number of parameters in status response message.
@@ -794,6 +795,16 @@ static bool prvSerializeResponseCbor( const IotBleWifiProvResponse_t * pResponse
                 {
                     status = cbor_encode_int( &mapEncoder, IOT_BLE_WIFI_PROV_NETWORK_INDEX_DONT_USE );
                 }
+            }
+        }
+
+        if( SERIALIZER_STATUS( status, pBuffer ) == true )
+        {
+            status = cbor_encode_text_string( &mapEncoder, IOT_BLE_WIFI_PROV_END_MARKER_KEY, strlen( IOT_BLE_WIFI_PROV_END_MARKER_KEY ) );
+
+            if( SERIALIZER_STATUS( status, pBuffer ) == true )
+            {
+                status = cbor_encode_boolean( &mapEncoder, pResponse->networkInfo.isLast );
             }
         }
     }


### PR DESCRIPTION
Add end of the list marker for list network response

Description
-----------

Added a boolean field to denote end of the list of scanned/saved networks returned from the IoT device.  This will enable mobile app to not wait for a timeout value to check if all networks are received.
A corresponding  change is made in Android/IOS BLE SDKs in following PRs:
https://github.com/aws/amazon-freertos-ble-android-sdk/pull/47
https://github.com/aws/amazon-freertos-ble-ios-sdk/pull/29

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.