### PR TITLE
[lwip] Fix SOCKETS_SO_WAKEUP_CALLBACK 

### DIFF
--- a/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
+++ b/libraries/abstractions/secure_sockets/lwip/iot_secure_sockets.c
@@ -279,16 +279,17 @@ static void vTaskRxSelect( void * param )
     int s = ctx->ip_socket;
     struct timeval tv;
 
+    fd_set s_fds;
     fd_set read_fds;
     fd_set write_fds;
     fd_set err_fds;
 
+    FD_ZERO( &s_fds );
     FD_ZERO( &read_fds );
     FD_ZERO( &write_fds );
     FD_ZERO( &err_fds );
 
-    FD_SET( s, &read_fds );
-    FD_SET( s, &err_fds );
+    FD_SET( s, &s_fds );
 
     ctx->state = SST_RX_READY;
 
@@ -302,6 +303,9 @@ static void vTaskRxSelect( void * param )
             ctx->state = SST_RX_CLOSED;
             break;
         }
+
+        read_fds = s_fds;
+        err_fds = s_fds;
 
         if( lwip_select( s + 1, &read_fds, &write_fds, &err_fds, &tv ) == -1 )
         {


### PR DESCRIPTION
A comment in the MQTT Agent demo suggests that the author at one point planned to use lwip's `SOCKETS_SO_WAKEUP_CALLBACK` socket option to set a callback to be
executed when the socket is ready for reading, but the option is not actually set. I suspect this is because the implementation of the option was broken. So:

1. Fix the implementation of SOCKETS_SO_WAKEUP_CALLBACK
2. Follow the lead helpfully provided in #3460 to add a callback  to the MQTT Agent demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.