### PR TITLE
TraceAlyzer recorder: Add /config to include path

### DIFF
--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -217,9 +217,12 @@ if(EXISTS "${AFR_3RDPARTY_DIR}/tracealyzer_recorder")
     target_include_directories(
         3rdparty::tracealyzer_recorder INTERFACE
         "${AFR_3RDPARTY_DIR}/tracealyzer_recorder/Include"
+        "${AFR_3RDPARTY_DIR}/tracealyzer_recorder/config"
     )
+endif()
 
-    # WinPcap - pcap port for windows
+# WinPcap - pcap port for windows
+if(EXISTS "${AFR_3RDPARTY_DIR}/win_pcap")
     afr_3rdparty_module(win_pcap)
     target_include_directories(3rdparty::win_pcap INTERFACE "${AFR_3RDPARTY_DIR}/win_pcap")
     if(MSVC)


### PR DESCRIPTION
Description
-----------
* When building the 3rd party library tracealyzer_recorder the config directory is missing in include path.
* Also separate the library from the WinPcap library.

This was originally contributed in this PR - https://github.com/aws/amazon-freertos/pull/3492


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.