### PR TITLE
Setup timeouts before TLS starting TLS handshake

### DIFF
--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -457,13 +457,6 @@ static TransportSocketStatus_t establishConnect( NetworkContext_t * pNetworkCont
 
     if( returnStatus == TRANSPORT_SOCKET_STATUS_SUCCESS )
     {
-        /* Establish the TCP connection. */
-        returnStatus = connectToServer( tcpSocket,
-                                        pServerInfo );
-    }
-
-    if( returnStatus == TRANSPORT_SOCKET_STATUS_SUCCESS )
-    {
         /* Configure send and receive timeouts for the socket. */
         secureSocketStatus = transportTimeoutSetup( tcpSocket, pSocketsConfig->sendTimeoutMs, pSocketsConfig->recvTimeoutMs );
 
@@ -472,6 +465,13 @@ static TransportSocketStatus_t establishConnect( NetworkContext_t * pNetworkCont
             LogError( ( "Failed to configure send and receive timeouts for socket: secureSocketStatus=%d.", secureSocketStatus ) );
             returnStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
         }
+    }
+
+    if( returnStatus == TRANSPORT_SOCKET_STATUS_SUCCESS )
+    {
+        /* Establish the TCP connection. */
+        returnStatus = connectToServer( tcpSocket,
+                                        pServerInfo );
     }
 
     if( returnStatus == TRANSPORT_SOCKET_STATUS_SUCCESS )


### PR DESCRIPTION
Description
-----------
Setup socket timeouts before TLS starting TLS handshake. This was reported here - https://github.com/aws/amazon-freertos/issues/3458

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.