### PR TITLE
Add Missing Include stddef.h in bt_hal_manager.h

### DIFF
--- a/libraries/abstractions/ble_hal/include/bt_hal_manager.h
+++ b/libraries/abstractions/ble_hal/include/bt_hal_manager.h
@@ -41,6 +41,7 @@
 #define _BT_HAL_MANAGER_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 #include "bt_hal_manager_types.h"
 


### PR DESCRIPTION
bt_hal_manager.h uses size_t type but doesn't include stddef.h

Description
-----------
Add stddef.h include to bt_hal_manager.h

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.