### PR TITLE
Support for dynamic credential switching

### DIFF
--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -62,6 +62,9 @@
 /* Include the secure sockets implementation of the transport interface. */
 #include "transport_secure_sockets.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -442,6 +445,10 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
     xSocketConfig.disableSni = false;
     xSocketConfig.sendTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketConfig.recvTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &xReconnectParams,

--- a/demos/coreHTTP/http_demo_mutual_auth.c
+++ b/demos/coreHTTP/http_demo_mutual_auth.c
@@ -83,6 +83,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /** Note: The device client certificate and private key credentials are
@@ -375,6 +378,10 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
     xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
     xSocketsConfig.sendTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Establish a TLS session with the HTTP server. This example connects to
      * the HTTP server as specified in democonfigAWS_IOT_ENDPOINT and

--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -92,6 +92,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */
@@ -313,6 +316,10 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
         xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
         xSocketsConfig.sendTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
         xSocketsConfig.recvTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
+        xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+        xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+        xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+        xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
         /* Establish a TLS session with the HTTP server. This example connects
          * to the server host located in democonfigPRESIGNED_GET_URL and

--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -102,6 +102,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */
@@ -396,6 +399,10 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
     xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
     xSocketsConfig.sendTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Establish a TLS session with the HTTP server. This example connects
      * to the server host located in democonfigPRESIGNED_GET_URL and

--- a/demos/coreHTTP/http_demo_s3_upload.c
+++ b/demos/coreHTTP/http_demo_s3_upload.c
@@ -85,6 +85,9 @@
 /* Include header for root CA certificates. */
 #include "iot_default_root_certificates.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /* Check that the TLS port of the server is defined. */
@@ -346,6 +349,10 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
         xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
         xSocketsConfig.sendTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
         xSocketsConfig.recvTimeoutMs = democonfigTRANSPORT_SEND_RECV_TIMEOUT_MS;
+        xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+        xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+        xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+        xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
         /* Establish a TLS session with the HTTP server. This example connects
          * to the server host located in democonfigPRESIGNED_GET_URL and

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -84,6 +84,9 @@
 /* Include AWS IoT metrics macros header. */
 #include "aws_iot_metrics.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /** Note: The device client certificate and private key credentials are
@@ -742,6 +745,10 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
     xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
     xSocketsConfig.sendTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &xReconnectParams,

--- a/demos/coreMQTT_Agent/mqtt_agent_task.c
+++ b/demos/coreMQTT_Agent/mqtt_agent_task.c
@@ -88,6 +88,9 @@
 /* Include AWS IoT metrics macros header. */
 #include "aws_iot_metrics.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /**
  * These configuration settings are required to run the demo.
  */
@@ -776,6 +779,10 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
     xSocketConfig.recvTimeoutMs = mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketConfig.pRootCa = democonfigROOT_CA_PEM;
     xSocketConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
+    xSocketConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Establish a TCP connection with the MQTT broker. This example connects to
      * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and

--- a/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
+++ b/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
@@ -77,6 +77,9 @@
 /* Retry utilities include. */
 #include "backoff_algorithm.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 #define ggdDEMO_MAX_MQTT_MESSAGES              3
 #define ggdDEMO_MAX_MQTT_MSG_SIZE              500
 #define ggdDEMO_DISCOVERY_FILE_SIZE            2500
@@ -415,6 +418,10 @@ static BaseType_t prvConnectToServerWithBackoffRetries( GGD_HostAddressData_t * 
     xSocketsConfig.rootCaSize = ( size_t ) pxHostAddressData->ulCertificateSize;
     xSocketsConfig.sendTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &xReconnectParams,

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -94,6 +94,9 @@
 /* Includes the OTA Application version number. */
 #include "ota_appversion32.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /** Note: The device client certificate and private key credentials are
@@ -1437,6 +1440,10 @@ static BaseType_t prvCreateSocketConnectionToMQTTBroker( NetworkContext_t * pxNe
     xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
     xSocketsConfig.sendTimeoutMs = otaexampleMQTT_TRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = otaexampleMQTT_TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &xReconnectParams,

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -90,6 +90,9 @@
 /* Includes the OTA Application version number. */
 #include "ota_appversion32.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /*------------- Demo configurations -------------------------*/
 
 /** Note: The device client certificate and private key credentials are
@@ -1303,6 +1306,10 @@ static BaseType_t prvCreateSocketConnectionToMQTTBroker( NetworkContext_t * pxNe
     xSocketsConfig.rootCaSize = sizeof( democonfigROOT_CA_PEM );
     xSocketsConfig.sendTimeoutMs = otaexampleMQTT_TRANSPORT_SEND_RECV_TIMEOUT_MS;
     xSocketsConfig.recvTimeoutMs = otaexampleMQTT_TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    xSocketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    xSocketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    xSocketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    xSocketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &xReconnectParams,

--- a/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
+++ b/libraries/abstractions/secure_sockets/include/iot_secure_sockets.h
@@ -171,6 +171,8 @@ typedef struct xSOCKET * Socket_t; /**< @brief Socket handle data type. */
 #define SOCKETS_SO_TCPKEEPALIVE_INTERVAL         ( 19 ) /**< Set the time in seconds between individual TCP keep-alive probes. */
 #define SOCKETS_SO_TCPKEEPALIVE_COUNT            ( 20 ) /**< Set the maximum number of keep-alive probes TCP should send before dropping the connection. */
 #define SOCKETS_SO_TCPKEEPALIVE_IDLE_TIME        ( 21 ) /**< Set the time in seconds for which the connection needs to remain idle before TCP starts sending keep-alive probes. */
+#define SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE    ( 30 ) /**< Set client certificate index. Must be a label name managed by PKCS#11. */
+#define SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY    ( 31 ) /**< Set client private key index. Must be a label name managed by PKCS#11. */
 
 /**@} */
 

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -308,6 +308,36 @@ static int32_t tlsSetup( const SocketsConfig_t * pSocketsConfig,
         }
     }
 
+    /* Set custom client certificate. */
+    if( ( secureSocketStatus == SOCKETS_ERROR_NONE ) && ( pSocketsConfig->pClientCertIndex != NULL ) )
+    {
+        secureSocketStatus = SOCKETS_SetSockOpt( tcpSocket,
+                                                 0,
+                                                 SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE,
+                                                 pSocketsConfig->pClientCertIndex,
+                                                 pSocketsConfig->clientCertIndexSize );
+
+        if( secureSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
+        {
+            LogError( ( "Failed to set client certificate option for socket. secureSocketStatus=%d", secureSocketStatus ) );
+        }
+    }
+
+    /* Set custom client private key. */
+    if( ( secureSocketStatus == SOCKETS_ERROR_NONE ) && ( pSocketsConfig->pClientPrvKeyIndex != NULL ) )
+    {
+        secureSocketStatus = SOCKETS_SetSockOpt( tcpSocket,
+                                                 0,
+                                                 SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY,
+                                                 pSocketsConfig->pClientPrvKeyIndex,
+                                                 pSocketsConfig->clientPrvKeyIndexSize );
+
+        if( secureSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
+        {
+            LogError( ( "Failed to set client private key option for socket. secureSocketStatus=%d", secureSocketStatus ) );
+        }
+    }
+
     return secureSocketStatus;
 }
 

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
@@ -136,6 +136,12 @@ typedef struct SocketsConfig
 
     const char * pRootCa; /**< @brief String representing a trusted server Root CA certificate. */
     size_t rootCaSize;    /**< @brief Size associated with #SocketsConfig_t.pRootCa. */
+
+    const char * pClientCertIndex; /**< @brief String representing a trusted client certificate index. */
+    size_t clientCertIndexSize; /**< @brief Size associated with #SocketsConfig_t.pClientCertIndex. */
+
+    const char * pClientPrvKeyIndex; /**< @brief String representing a trusted client private key index. */
+    size_t clientPrvKeyIndexSize; /**< @brief Size associated with #SocketsConfig_t.pClientPrvKeyIndex. */
 } SocketsConfig_t;
 
 

--- a/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
+++ b/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
@@ -46,6 +46,8 @@
 #define ALPN_PROTOS                 "x-amzn-mqtt-ca"
 
 #define MOCK_ROOT_CA                "mockRootCA"
+#define MOCK_CLIENT_CERT            "mockClientCert"
+#define MOCK_CLIENT_PRV_KEY         "mockClientPrvKey"
 #define MOCK_SERVER_ADDRESS         ( 100 )
 #define MOCT_TCP_SOCKET             ( 100 )
 #define MOCK_SECURE_SOCKET_ERROR    ( -1 )
@@ -94,14 +96,18 @@ static ServerInfo_t serverInfo =
 };
 static SocketsConfig_t socketsConfig =
 {
-    .enableTls         = true,
-    .pAlpnProtos       = ALPN_PROTOS,
-    .maxFragmentLength = MFLN,
-    .disableSni        = false,
-    .pRootCa           = NULL,
-    .rootCaSize        = 0,
-    .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-    .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+    .enableTls             = true,
+    .pAlpnProtos           = ALPN_PROTOS,
+    .maxFragmentLength     = MFLN,
+    .disableSni            = false,
+    .pRootCa               = NULL,
+    .rootCaSize            = 0,
+    .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+    .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+    .pClientCertIndex      = NULL,
+    .clientCertIndexSize   = 0,
+    .pClientPrvKeyIndex    = NULL,
+    .clientPrvKeyIndexSize = 0
 };
 
 static uint8_t networkBuffer[ BUFFER_LEN ] = { 0 };
@@ -261,14 +267,18 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_AlpnProtos( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = true,
-        .pAlpnProtos       = ALPN_PROTOS,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = true,
+        .pAlpnProtos           = ALPN_PROTOS,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -310,14 +320,18 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_SNI( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = true,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = true,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -359,14 +373,18 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_RootCA( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = true,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = MOCK_ROOT_CA,
-        .rootCaSize        = strlen( MOCK_ROOT_CA ),
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = true,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = MOCK_ROOT_CA,
+        .rootCaSize            = strlen( MOCK_ROOT_CA ),
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = MOCK_CLIENT_CERT,
+        .clientCertIndexSize   = strlen( MOCK_CLIENT_CERT ),
+        .pClientPrvKeyIndex    = MOCK_CLIENT_PRV_KEY,
+        .clientPrvKeyIndexSize = strlen( MOCK_CLIENT_PRV_KEY)
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -384,6 +402,22 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_RootCA( void )
     SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
                                         0,
                                         SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE,
+                                        NULL,
+                                        0,
+                                        MOCK_SECURE_SOCKET_ERROR );
+    SOCKETS_SetSockOpt_IgnoreArg_pvOptionValue();
+    SOCKETS_SetSockOpt_IgnoreArg_xOptionLength();
+    SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
+                                        0,
+                                        SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE,
+                                        NULL,
+                                        0,
+                                        MOCK_SECURE_SOCKET_ERROR );
+    SOCKETS_SetSockOpt_IgnoreArg_pvOptionValue();
+    SOCKETS_SetSockOpt_IgnoreArg_xOptionLength();
+    SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
+                                        0,
+                                        SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY,
                                         NULL,
                                         0,
                                         MOCK_SECURE_SOCKET_ERROR );
@@ -408,14 +442,18 @@ void test_SecureSocketsTransport_Connect_Dns_Failure( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -443,14 +481,18 @@ void test_SecureSocketsTransport_Connect_Fail_to_Connect( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -483,14 +525,18 @@ void test_SecureSocketsTransport_Connect_TimeOutSetup_Failure_Send( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = 0XFFFFFFFF,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = 0XFFFFFFFF,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -539,14 +585,18 @@ void test_SecureSocketsTransport_Connect_TimeOutSetup_Failure_Recv( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = 0XFFFFFFFF
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = 0XFFFFFFFF,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -586,14 +636,18 @@ void test_SecureSocketsTransport_Connect_Succeeds_without_TLS( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -640,14 +694,18 @@ void test_SecureSocketsTransport_Connect_Succeeds_Set_Timeout_Zero( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = false,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = 0,
-        .recvTimeoutMs     = 0
+        .enableTls             = false,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = 0,
+        .recvTimeoutMs         = 0,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -693,14 +751,18 @@ void test_SecureSocketsTransport_Connect_Succeeds_with_TLS( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = true,
-        .pAlpnProtos       = ALPN_PROTOS,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = MOCK_ROOT_CA,
-        .rootCaSize        = strlen( MOCK_ROOT_CA ),
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = true,
+        .pAlpnProtos           = ALPN_PROTOS,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = MOCK_ROOT_CA,
+        .rootCaSize            = strlen( MOCK_ROOT_CA ),
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = MOCK_CLIENT_CERT,
+        .clientCertIndexSize   = strlen( MOCK_CLIENT_CERT ),
+        .pClientPrvKeyIndex    = MOCK_CLIENT_PRV_KEY,
+        .clientPrvKeyIndexSize = strlen( MOCK_CLIENT_PRV_KEY)
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,
@@ -734,6 +796,22 @@ void test_SecureSocketsTransport_Connect_Succeeds_with_TLS( void )
     SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
                                         0,
                                         SOCKETS_SO_TRUSTED_SERVER_CERTIFICATE,
+                                        NULL,
+                                        0,
+                                        SOCKETS_ERROR_NONE );
+    SOCKETS_SetSockOpt_IgnoreArg_pvOptionValue();
+    SOCKETS_SetSockOpt_IgnoreArg_xOptionLength();
+    SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
+                                        0,
+                                        SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE,
+                                        NULL,
+                                        0,
+                                        SOCKETS_ERROR_NONE );
+    SOCKETS_SetSockOpt_IgnoreArg_pvOptionValue();
+    SOCKETS_SetSockOpt_IgnoreArg_xOptionLength();
+    SOCKETS_SetSockOpt_ExpectAndReturn( mockTcpSocket,
+                                        0,
+                                        SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY,
                                         NULL,
                                         0,
                                         SOCKETS_ERROR_NONE );
@@ -779,14 +857,18 @@ void test_SecureSocketsTransport_Connect_Credentials_NotSet( void )
     TransportSocketStatus_t returnStatus;
     SocketsConfig_t localSocketsConfig =
     {
-        .enableTls         = true,
-        .pAlpnProtos       = NULL,
-        .maxFragmentLength = MFLN,
-        .disableSni        = false,
-        .pRootCa           = NULL,
-        .rootCaSize        = 0,
-        .sendTimeoutMs     = TEST_TRANSPORT_SND_TIMEOUT_MS,
-        .recvTimeoutMs     = TEST_TRANSPORT_RCV_TIMEOUT_MS
+        .enableTls             = true,
+        .pAlpnProtos           = NULL,
+        .maxFragmentLength     = MFLN,
+        .disableSni            = false,
+        .pRootCa               = NULL,
+        .rootCaSize            = 0,
+        .sendTimeoutMs         = TEST_TRANSPORT_SND_TIMEOUT_MS,
+        .recvTimeoutMs         = TEST_TRANSPORT_RCV_TIMEOUT_MS,
+        .pClientCertIndex      = NULL,
+        .clientCertIndexSize   = 0,
+        .pClientPrvKeyIndex    = NULL,
+        .clientPrvKeyIndexSize = 0
     };
 
     SOCKETS_Socket_ExpectAndReturn( SOCKETS_AF_INET,

--- a/libraries/freertos_plus/standard/tls/include/iot_tls.h
+++ b/libraries/freertos_plus/standard/tls/include/iot_tls.h
@@ -97,6 +97,11 @@ typedef struct xTLS_PARAMS
     NetworkRecv_t pxNetworkRecv;
     NetworkSend_t pxNetworkSend;
     void * pvCallerContext;
+
+    const char * pcClientCertificateIndex;
+    uint32_t ulClientCertificateIndexLength;
+    const char * pcClientPrivateKeyIndex;
+    uint32_t ulClientPrivateKeyIndexLength;
 } TLSParams_t;
 
 /**

--- a/libraries/freertos_plus/standard/tls/src/iot_tls.c
+++ b/libraries/freertos_plus/standard/tls/src/iot_tls.c
@@ -111,6 +111,10 @@ typedef struct TLSContext
     const char * pcDestination;
     const char * pcServerCertificate;
     uint32_t ulServerCertificateLength;
+    const char * pcClientCertificateIndex;
+    uint32_t ulClientCertificateIndexLength;
+    const char * pcClientPrivateKeyIndex;
+    uint32_t ulClientPrivateKeyIndexLength;
     const char ** ppcAlpnProtocols;
     uint32_t ulAlpnProtocolsCount;
 
@@ -526,8 +530,8 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     {
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
-                                                pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-                                                sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) - 1,
+                                                (char *)pxCtx->pcClientPrivateKeyIndex,
+                                                pxCtx->ulClientPrivateKeyIndexLength - 1,
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }
@@ -583,7 +587,7 @@ static int prvInitializeClientCredential( TLSContext_t * pxCtx )
     if( xResult == CKR_OK )
     {
         xResult = prvReadCertificateIntoContext( pxCtx,
-                                                 pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                                 (char *)pxCtx->pcClientCertificateIndex,
                                                  CKO_CERTIFICATE,
                                                  &pxCtx->xMbedX509Cli );
     }
@@ -701,6 +705,10 @@ BaseType_t TLS_Init( void ** ppvContext,
         pxCtx->xNetworkRecv = pxParams->pxNetworkRecv;
         pxCtx->xNetworkSend = pxParams->pxNetworkSend;
         pxCtx->pvCallerContext = pxParams->pvCallerContext;
+        pxCtx->pcClientCertificateIndex = pxParams->pcClientCertificateIndex;
+        pxCtx->ulClientCertificateIndexLength = pxParams->ulClientCertificateIndexLength;
+        pxCtx->pcClientPrivateKeyIndex = pxParams->pcClientPrivateKeyIndex;
+        pxCtx->ulClientPrivateKeyIndexLength = pxParams->ulClientPrivateKeyIndexLength;
 
         /* Get the function pointer list for the PKCS#11 module. */
         xCkGetFunctionList = C_GetFunctionList;

--- a/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
+++ b/libraries/freertos_plus/standard/tls/test/iot_test_tls.c
@@ -148,6 +148,12 @@ static void prvConnectWithProvisioning( ProvisioningParams_t * pxProvisioningPar
         xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_SERVER_NAME_INDICATION, pcAWSIoTAddress, 1u + strlen( pcAWSIoTAddress ) );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt server name indication failed" );
 
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client certificate failed" );
+
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client private key failed" );
+
         /* DNS Lookup. */
         xMQTTServerAddress.ulAddress = SOCKETS_GetHostByName( pcAWSIoTAddress );
 
@@ -234,6 +240,12 @@ static void prvExpectFailAfterDataSentWithProvisioning( ProvisioningParams_t * p
         xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_SERVER_NAME_INDICATION, pcAWSIoTAddress, 1u + strlen( pcAWSIoTAddress ) );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt server name indication failed" );
 
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client certificate failed" );
+
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client private key failed" );
+
         /* Connect. */
         xMQTTServerAddress.usPort = SOCKETS_htons( usAWSIoTPort );
         xMQTTServerAddress.ucSocketDomain = SOCKETS_AF_INET;
@@ -295,6 +307,12 @@ TEST( Full_TLS, AFQP_TLS_ConnectDefault )
     {
         xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_SERVER_NAME_INDICATION, pcAWSIoTAddress, 1u + strlen( pcAWSIoTAddress ) );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt server name indication failed" );
+
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_CERTIFICATE, pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client certificate failed" );
+
+        xResult = SOCKETS_SetSockOpt( xSocket, 0, SOCKETS_SO_TRUSTED_CLIENT_PRIVATE_KEY, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) );
+        TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket set sock opt client private key failed" );
 
         xResult = SOCKETS_Connect( xSocket, &xMQTTServerAddress, sizeof( xMQTTServerAddress ) );
         TEST_ASSERT_EQUAL_INT32_MESSAGE( SOCKETS_ERROR_NONE, xResult, "Socket connect failed" );

--- a/tests/integration_test/core_http_system_test.c
+++ b/tests/integration_test/core_http_system_test.c
@@ -53,6 +53,9 @@
 /* Retry parameters. */
 #include "backoff_algorithm.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/
 /**************************************************/
@@ -402,6 +405,10 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     socketsConfig.rootCaSize = sizeof( ROOT_CA_CERT );
     socketsConfig.sendTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
     socketsConfig.recvTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    socketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    socketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    socketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    socketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Set the AWS IoT Core connection configurations, if we are testing against
      * AWS IoT core. */

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -54,6 +54,9 @@
  * exponential backoff and jitter.*/
 #include "backoff_algorithm.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/
 /**************************************************/
@@ -1053,6 +1056,10 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     socketsConfig.rootCaSize = strlen( SERVER_ROOT_CA_CERT ) + 1U;
     socketsConfig.sendTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
     socketsConfig.recvTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    socketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    socketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    socketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    socketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &reconnectParams,

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -64,6 +64,9 @@
  * exponential backoff and jitter.*/
 #include "backoff_algorithm.h"
 
+/* Include header for client certificates and client private key label. */
+#include "core_pkcs11_config.h"
+
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/
@@ -842,6 +845,10 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     socketsConfig.rootCaSize = strlen( SERVER_ROOT_CA_CERT ) + 1U;
     socketsConfig.sendTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
     socketsConfig.recvTimeoutMs = TRANSPORT_SEND_RECV_TIMEOUT_MS;
+    socketsConfig.pClientCertIndex = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    socketsConfig.clientCertIndexSize = sizeof( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+    socketsConfig.pClientPrvKeyIndex = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+    socketsConfig.clientPrvKeyIndexSize = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
 
     /* Initialize reconnect attempts and interval. */
     BackoffAlgorithm_InitializeParams( &reconnectParams,


### PR DESCRIPTION
Description
-----------
Supports dynamic credential switching.
Fleet Provisioning uses the claim certificate and private key to connect to AWS the first time, and then uses the device-specific claim certificate and private key to connect to AWS next time.
However, the current FreeRTOS library cannot support Fleet Provisioning because it uses fixed credential information.
Therefore, the FreeRTOS library source code has been updated to allow dynamic credential switching.
The IDT test items FullSecureSockets, FullTLS, and FulMQTT have passed.

![idt_1](https://user-images.githubusercontent.com/59954281/187384869-02826c22-f4d2-43b8-9953-7b577d4302d0.png)
![idt_2](https://user-images.githubusercontent.com/59954281/187384880-853228d9-5311-4b1d-b9ac-68ed10da89f4.png)
![idt_3](https://user-images.githubusercontent.com/59954281/187384885-3fa205aa-926f-41cc-986c-babc548a09a9.png)



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.