### PR TITLE
Update github apt repository signing key id

### DIFF
--- a/.github/workflows/update-checksum.yml
+++ b/.github/workflows/update-checksum.yml
@@ -38,7 +38,7 @@ jobs:
             git commit -am 'Generate new checksums.json file for commit $COMMIT'
             git push --set-upstream origin job/update-checksum-file
             export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059
             sudo apt-add-repository https://cli.github.com/packages
             sudo apt update
             sudo apt-get install gh


### PR DESCRIPTION
Update github apt repository signing key id

Description
-----------
Update github apt repository signing key id
from C99B11DEB97541F0 to 23F3D4EA75716059

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.