### PR TITLE
Fix expectation and use of SocketsConfig_t::pAlpnProtos

### DIFF
--- a/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
+++ b/demos/common/mqtt_demo_helpers/mqtt_demo_helpers.c
@@ -419,6 +419,7 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
     BaseType_t xBackoffStatus = pdPASS;
     ServerInfo_t xServerInfo = { 0 };
     SocketsConfig_t xSocketConfig = { 0 };
+    char * ppcAlpnProtocols[] = { socketsAWS_IOT_ALPN_MQTT };
 
     /* Initialize information to connect to the MQTT broker. */
     xServerInfo.pHostName = democonfigMQTT_BROKER_ENDPOINT;
@@ -435,7 +436,8 @@ static TransportSocketStatus_t prvConnectToServerWithBackoffRetries( NetworkCont
      */
     if( xServerInfo.port == 443 )
     {
-        xSocketConfig.pAlpnProtos = socketsAWS_IOT_ALPN_MQTT;
+        xSocketConfig.ppcAlpnProtos = ppcAlpnProtocols;
+        xSocketConfig.ulAlpnProtosCount = sizeof(ppcAlpnProtocols) / sizeof( char * );
     }
 
     xSocketConfig.maxFragmentLength = 0;

--- a/demos/coreHTTP/http_demo_mutual_auth.c
+++ b/demos/coreHTTP/http_demo_mutual_auth.c
@@ -368,7 +368,7 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -306,7 +306,7 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
 
         /* Configure credentials for TLS server-authenticated session. */
         xSocketsConfig.enableTls = true;
-        xSocketsConfig.pAlpnProtos = NULL;
+        xSocketsConfig.ppcAlpnProtos = NULL;
         xSocketsConfig.maxFragmentLength = 0;
         xSocketsConfig.disableSni = false;
         xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -389,7 +389,7 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
 
     /* Configure credentials for TLS server-authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/demos/coreHTTP/http_demo_s3_upload.c
+++ b/demos/coreHTTP/http_demo_s3_upload.c
@@ -339,7 +339,7 @@ static BaseType_t prvConnectToServer( NetworkContext_t * pxNetworkContext )
 
         /* Configure credentials for TLS server-authenticated session. */
         xSocketsConfig.enableTls = true;
-        xSocketsConfig.pAlpnProtos = NULL;
+        xSocketsConfig.ppcAlpnProtos = NULL;
         xSocketsConfig.maxFragmentLength = 0;
         xSocketsConfig.disableSni = false;
         xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -735,7 +735,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNet
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
+++ b/demos/greengrass_connectivity/aws_greengrass_discovery_demo.c
@@ -408,7 +408,7 @@ static BaseType_t prvConnectToServerWithBackoffRetries( GGD_HostAddressData_t * 
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = pxHostAddressData->pcCertificate;

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1430,7 +1430,7 @@ static BaseType_t prvCreateSocketConnectionToMQTTBroker( NetworkContext_t * pxNe
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;
@@ -1605,7 +1605,7 @@ static int32_t prvConnectToS3Server( NetworkContext_t * pxNetworkContext,
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigHTTPS_ROOT_CA_PEM;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1296,7 +1296,7 @@ static BaseType_t prvCreateSocketConnectionToMQTTBroker( NetworkContext_t * pxNe
 
     /* Configure credentials for TLS mutual authenticated session. */
     xSocketsConfig.enableTls = true;
-    xSocketsConfig.pAlpnProtos = NULL;
+    xSocketsConfig.ppcAlpnProtos = NULL;
     xSocketsConfig.maxFragmentLength = 0;
     xSocketsConfig.disableSni = false;
     xSocketsConfig.pRootCa = democonfigROOT_CA_PEM;

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -258,13 +258,13 @@ static int32_t tlsSetup( const SocketsConfig_t * pSocketsConfig,
     }
 
     /* Set ALPN option. */
-    if( ( secureSocketStatus == SOCKETS_ERROR_NONE ) && ( pSocketsConfig->pAlpnProtos != NULL ) )
+    if( ( secureSocketStatus == SOCKETS_ERROR_NONE ) && ( pSocketsConfig->ppcAlpnProtos != NULL ) )
     {
         secureSocketStatus = SOCKETS_SetSockOpt( tcpSocket,
                                                  0,
                                                  SOCKETS_SO_ALPN_PROTOCOLS,
-                                                 pSocketsConfig->pAlpnProtos,
-                                                 sizeof( pSocketsConfig->pAlpnProtos ) );
+                                                 pSocketsConfig->ppcAlpnProtos,
+                                                 pSocketsConfig->ulAlpnProtosCount );
 
         if( secureSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
         {

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.h
@@ -110,15 +110,14 @@ typedef struct SocketsConfig
     uint32_t recvTimeoutMs; /**< @brief Timeout for transport recv. */
 
     /**
-     * @brief Set this to a non-NULL value to use ALPN.
-     *
-     * This string must be NULL-terminated.
+     * @brief Set this to a non-NULL value to use ALPN as an array of char pointers ex. {"h2", "ftp" }
      *
      * See [this link]
      * (https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/)
      * for more information.
      */
-    const char * pAlpnProtos;
+    const char ** ppcAlpnProtos;
+    uint32_t ulAlpnProtosCount;
 
     /**
      * @brief Disable server name indication (SNI) for a TLS session.

--- a/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
+++ b/libraries/abstractions/transport/utest/transport_secure_sockets_utest.c
@@ -43,7 +43,7 @@
 
 /* Configuration parameters for the TLS connection. */
 #define MFLN                        ( 42 )
-#define ALPN_PROTOS                 "x-amzn-mqtt-ca"
+#define ALPN_PROTOS                 {"x-amzn-mqtt-ca"}
 
 #define MOCK_ROOT_CA                "mockRootCA"
 #define MOCK_SERVER_ADDRESS         ( 100 )
@@ -92,10 +92,12 @@ static ServerInfo_t serverInfo =
     .hostNameLength = strlen( HOSTNAME ),
     .port           = PORT
 };
+
 static SocketsConfig_t socketsConfig =
 {
     .enableTls         = true,
-    .pAlpnProtos       = ALPN_PROTOS,
+    .ppcAlpnProtos     = (char * [])ALPN_PROTOS,
+    .ulAlpnProtosCount = 0,
     .maxFragmentLength = MFLN,
     .disableSni        = false,
     .pRootCa           = NULL,
@@ -262,7 +264,7 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_AlpnProtos( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = true,
-        .pAlpnProtos       = ALPN_PROTOS,
+        .ppcAlpnProtos       = (char * [])ALPN_PROTOS,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -311,7 +313,7 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_SNI( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = true,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -360,7 +362,7 @@ void test_SecureSocketsTransport_Connect_Invalid_Credentials_RootCA( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = true,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = MOCK_ROOT_CA,
@@ -409,7 +411,7 @@ void test_SecureSocketsTransport_Connect_Dns_Failure( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -444,7 +446,7 @@ void test_SecureSocketsTransport_Connect_Fail_to_Connect( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -484,7 +486,7 @@ void test_SecureSocketsTransport_Connect_TimeOutSetup_Failure_Send( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -540,7 +542,7 @@ void test_SecureSocketsTransport_Connect_TimeOutSetup_Failure_Recv( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -587,7 +589,7 @@ void test_SecureSocketsTransport_Connect_Succeeds_without_TLS( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -641,7 +643,7 @@ void test_SecureSocketsTransport_Connect_Succeeds_Set_Timeout_Zero( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = false,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,
@@ -694,7 +696,7 @@ void test_SecureSocketsTransport_Connect_Succeeds_with_TLS( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = true,
-        .pAlpnProtos       = ALPN_PROTOS,
+        .ppcAlpnProtos       = (char * [])LPN_PROTOS,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = MOCK_ROOT_CA,
@@ -780,7 +782,7 @@ void test_SecureSocketsTransport_Connect_Credentials_NotSet( void )
     SocketsConfig_t localSocketsConfig =
     {
         .enableTls         = true,
-        .pAlpnProtos       = NULL,
+        .ppcAlpnProtos       = NULL,
         .maxFragmentLength = MFLN,
         .disableSni        = false,
         .pRootCa           = NULL,

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -265,23 +265,23 @@ typedef struct IotNetworkCredentials   IotTestNetworkCredentials_t;
 /* Define the credentials initializer based on the server port. Use ALPN if on
  * 443, otherwise disable ALPN. */
 #if clientcredentialMQTT_BROKER_PORT == 443
-    #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER           \
-    {                                                          \
-        .disableSni = false,                                   \
-        .ppcAlpnProtos = (char * []){ socketsAWS_IOT_ALPN_MQTT },  \
-        .maxFragmentLength = 0,                                \
-        .pRootCa = NULL,                                       \
-        .pClientCert = keyCLIENT_CERTIFICATE_PEM,              \
-        .pPrivateKey = keyCLIENT_PRIVATE_KEY_PEM,              \
-        .rootCaSize = 0,                                       \
-        .clientCertSize = sizeof( keyCLIENT_CERTIFICATE_PEM ), \
-        .privateKeySize = sizeof( keyCLIENT_PRIVATE_KEY_PEM )  \
+    #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER                \
+    {                                                               \
+        .disableSni = false,                                        \
+        .ppcAlpnProtos = ( char *[] ) { socketsAWS_IOT_ALPN_MQTT }, \
+        .maxFragmentLength = 0,                                     \
+        .pRootCa = NULL,                                            \
+        .pClientCert = keyCLIENT_CERTIFICATE_PEM,                   \
+        .pPrivateKey = keyCLIENT_PRIVATE_KEY_PEM,                   \
+        .rootCaSize = 0,                                            \
+        .clientCertSize = sizeof( keyCLIENT_CERTIFICATE_PEM ),      \
+        .privateKeySize = sizeof( keyCLIENT_PRIVATE_KEY_PEM )       \
     }
 #else /* if clientcredentialMQTT_BROKER_PORT == 443 */
     #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER           \
     {                                                          \
         .disableSni = false,                                   \
-        .ppcAlpnProtos = NULL,                                   \
+        .ppcAlpnProtos = NULL,                                 \
         .pRootCa = NULL,                                       \
         .pClientCert = keyCLIENT_CERTIFICATE_PEM,              \
         .pPrivateKey = keyCLIENT_PRIVATE_KEY_PEM,              \

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -268,7 +268,7 @@ typedef struct IotNetworkCredentials   IotTestNetworkCredentials_t;
     #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER           \
     {                                                          \
         .disableSni = false,                                   \
-        .pAlpnProtos = socketsAWS_IOT_ALPN_MQTT,               \
+        .ppcAlpnProtos = (char * [])socketsAWS_IOT_ALPN_MQTT,  \
         .maxFragmentLength = 0,                                \
         .pRootCa = NULL,                                       \
         .pClientCert = keyCLIENT_CERTIFICATE_PEM,              \
@@ -281,7 +281,7 @@ typedef struct IotNetworkCredentials   IotTestNetworkCredentials_t;
     #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER           \
     {                                                          \
         .disableSni = false,                                   \
-        .pAlpnProtos = NULL,                                   \
+        .ppcAlpnProtos = NULL,                                   \
         .pRootCa = NULL,                                       \
         .pClientCert = keyCLIENT_CERTIFICATE_PEM,              \
         .pPrivateKey = keyCLIENT_PRIVATE_KEY_PEM,              \

--- a/tests/include/iot_config_common.h
+++ b/tests/include/iot_config_common.h
@@ -268,7 +268,7 @@ typedef struct IotNetworkCredentials   IotTestNetworkCredentials_t;
     #define IOT_TEST_NETWORK_CREDENTIALS_INITIALIZER           \
     {                                                          \
         .disableSni = false,                                   \
-        .ppcAlpnProtos = (char * [])socketsAWS_IOT_ALPN_MQTT,  \
+        .ppcAlpnProtos = (char * []){ socketsAWS_IOT_ALPN_MQTT },  \
         .maxFragmentLength = 0,                                \
         .pRootCa = NULL,                                       \
         .pClientCert = keyCLIENT_CERTIFICATE_PEM,              \

--- a/tests/integration_test/core_http_system_test.c
+++ b/tests/integration_test/core_http_system_test.c
@@ -395,7 +395,7 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
     /* Configure credentials for TLS server-authenticated session. */
     socketsConfig.enableTls = true;
-    socketsConfig.pAlpnProtos = NULL;
+    socketsConfig.ppcAlpnProtos = NULL;
     socketsConfig.maxFragmentLength = 0;
     socketsConfig.disableSni = false;
     socketsConfig.pRootCa = ROOT_CA_CERT;

--- a/tests/integration_test/core_mqtt_system_test.c
+++ b/tests/integration_test/core_mqtt_system_test.c
@@ -1042,7 +1042,8 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
     /* Initialize SocketsConfig. */
     socketsConfig.enableTls = true;
-    socketsConfig.pAlpnProtos = NULL;
+    socketsConfig.ppcAlpnProtos = NULL;
+    socketsConfig.ulAlpnProtosCount = 0;
     socketsConfig.maxFragmentLength = 0;
     #if ( testConfigDISABLE_SNI == 1 )
         socketsConfig.disableSni = true;

--- a/tests/integration_test/shadow_system_test.c
+++ b/tests/integration_test/shadow_system_test.c
@@ -835,7 +835,8 @@ static bool connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
     /* Initialize SocketsConfig. */
     socketsConfig.enableTls = true;
-    socketsConfig.pAlpnProtos = NULL;
+    socketsConfig.ppcAlpnProtos = NULL;
+    socketsConfig.ulAlpnProtosCount = 0;
     socketsConfig.maxFragmentLength = 0;
     socketsConfig.disableSni = false;
     socketsConfig.pRootCa = SERVER_ROOT_CA_CERT;

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/shadow_demo_config.h
+++ b/vendors/cypress/boards/CY8CKIT_064S0S2_4343W/aws_demos/config_files/shadow_demo_config.h
@@ -88,7 +88,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/cypress/boards/CYW943907AEVAL1F/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/cypress/boards/CYW954907AEVAL1F/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/espressif/boards/esp32/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/espressif/boards/esp32s2/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/espressif/boards/esp32s2/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_iotkit/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/infineon/boards/xmc4800_plus_optiga_trust_x/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/marvell/boards/mw300_rd/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/mediatek/boards/mt7697hx-dev-kit/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/microchip/boards/ecc608a_plus_winsim/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/nordic/boards/nrf52840-dk/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/nuvoton/boards/numaker_iot_m487_wifi/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/nxp/boards/lpc54018iotmodule/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/pc/boards/windows/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/pc/boards/windows/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/renesas/boards/rx65n-rsk/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/st/boards/stm32l475_discovery/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/ti/boards/cc3220_launchpad/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/vendor/boards/board/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/vendor/boards/board/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )

--- a/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_agent_demo_config.h
+++ b/vendors/xilinx/boards/microzed/aws_demos/config_files/mqtt_agent_demo_config.h
@@ -86,7 +86,7 @@
  *
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. Using ALPN with this demo would require additional changes, including
- * setting the `pAlpnProtos` member of the `NetworkCredentials_t` struct before
+ * setting the `ppcAlpnProtos` member of the `NetworkCredentials_t` struct before
  * forming the TLS connection. When using port 8883, ALPN is not required.
  *
  * #define democonfigMQTT_BROKER_PORT    ( insert here. )


### PR DESCRIPTION
Description
-----------
As detailed in #3516, the expectation and use of `pAlpnProtos` was that of a string, but it's propagated to lower layers as an array of strings instead. Incorrectly calculating the number of separate protocols as the demos set `pAlpnProtos` as a string, yet [transport_secure_sockets.c#L267](https://github.com/aws/amazon-freertos/blob/main/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c#L267) assumes the number of separate protocols is the length of this string.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.