### PR TITLE
add wpa3 support for ble provisioning and esp wifi

### DIFF
--- a/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
+++ b/libraries/ble/src/services/wifi_provisioning/iot_ble_wifi_provisioning.c
@@ -583,7 +583,7 @@ WIFIReturnCode_t _connectNetwork( WIFINetworkProfile_t * pProfile )
     networkParams.ucSSIDLength = pProfile->ucSSIDLength;
     networkParams.xSecurity = pProfile->xSecurity;
 
-    if( ( networkParams.xSecurity == eWiFiSecurityWPA2 ) || ( networkParams.xSecurity == eWiFiSecurityWPA ) )
+    if( ( networkParams.xSecurity == eWiFiSecurityWPA2 ) || ( networkParams.xSecurity == eWiFiSecurityWPA ) || ( networkParams.xSecurity == eWiFiSecurityWPA3 ) )
     {
         memcpy( networkParams.xPassword.xWPA.cPassphrase, pProfile->cPassword, pProfile->ucPasswordLength );
         networkParams.xPassword.xWPA.ucLength = pProfile->ucPasswordLength;

--- a/vendors/espressif/boards/ports/wifi/iot_wifi.c
+++ b/vendors/espressif/boards/ports/wifi/iot_wifi.c
@@ -266,6 +266,9 @@ static void sc_callback(void* arg, esp_event_base_t event_base, int32_t event_id
                 memcpy(wifi_config.sta.bssid, evt->bssid, sizeof(wifi_config.sta.bssid));
             }
 
+            /* Ensure WPA3 is supported. PMF is a prerequisite feature for a WPA3 connection, it needs to be explicitly configured before attempting connection. */
+            wifi_config.sta.pmf_cfg.capable = true;
+
             memcpy(ssid, evt->ssid, sizeof(evt->ssid));
             memcpy(password, evt->password, sizeof(evt->password));
             ESP_LOGI(TAG, "SSID:%s", ssid);
@@ -640,6 +643,8 @@ WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
     };
 
     wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    /* Ensure WPA3 is supported. PMF is a prerequisite feature for a WPA3 connection, it needs to be explicitly configured before attempting connection. */
+    wifi_config.sta.pmf_cfg.capable = true;
 
     /* Try to acquire the semaphore. */
     if( xSemaphoreTake( xWiFiSem, xSemaphoreWaitTicks ) == pdTRUE )
@@ -716,6 +721,10 @@ WIFIReturnCode_t WIFI_Scan( WIFIScanResult_t * pxBuffer,
                     case WIFI_AUTH_WPA2_PSK:
                     	pxBuffer[i].xSecurity =  eWiFiSecurityWPA2;
                     	break;
+                    case WIFI_AUTH_WPA2_WPA3_PSK:
+                    case WIFI_AUTH_WPA3_PSK:
+                        pxBuffer[i].xSecurity =  eWiFiSecurityWPA3;
+                        break;
                     case WIFI_AUTH_WPA2_ENTERPRISE:
                     default:
                     	pxBuffer[i].xSecurity  = eWiFiSecurityNotSupported;
@@ -1429,6 +1438,9 @@ static esp_err_t WIFI_SetSecurity( WIFISecurity_t securityMode, wifi_auth_mode_t
             break;
         case eWiFiSecurityWPA2:
             *authmode = WIFI_AUTH_WPA2_PSK;
+            break;
+        case eWiFiSecurityWPA3:
+            *authmode = WIFI_AUTH_WPA3_PSK;
             break;
         default:
             return ESP_FAIL;


### PR DESCRIPTION
I recently added support for WPA3 only routers/networks to my project and found it simple (maybe to easy to be true?) It made me wonder why this wasn't already upstream so I am opening this PR. It would be very useful for many people as more routers have this setting enabled by default these days. I have tested this on ESP32 and it works well. I realize there is likely more work to do to fully support this, but want to get an initial review. Please lmk what else needs to be done to fully add support and I can improve/extend this PR accordingly!

Before this PR when provisioning a device via ble WPA3 networks would be filtered out/not displayed. Now we show those networks and allow the user to connect to them.

Once connected everything seems very similar to WPA2. In fact, router can switch b/w WPA2 and WPA3 after device is already provisioned and everything continues to work (no re-provisioning needed)